### PR TITLE
update generate-openapi-bindings.sh

### DIFF
--- a/scripts/generate-openapi-bindings.sh
+++ b/scripts/generate-openapi-bindings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
modified generate-openapi-bindings script to use bash because it contains bash syntax