### PR TITLE
fix(replica destruction): issue to correct node

### DIFF
--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -1179,7 +1179,7 @@ impl ResourceSpecsLocked {
     }
 
     /// Disown replica from its volume
-    async fn disown_volume_replica(
+    pub(crate) async fn disown_volume_replica(
         &self,
         registry: &Registry,
         replica: &Arc<Mutex<ReplicaSpec>>,


### PR DESCRIPTION
When removing a nexus child we try to destroy the underlying replica.
However, we were always issuing the destroy call to the node with the
nexus. This change ensures that the destroy call is issued to the node
that actually hosts the replica.

Resolves: CAS-1167