### PR TITLE
feat(replicas): garbage collector

### DIFF
--- a/control-plane/agents/core/src/core/reconciler/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/mod.rs
@@ -2,6 +2,7 @@ mod nexus;
 mod persistent_store;
 pub mod poller;
 mod pool;
+mod replica;
 mod volume;
 
 pub(crate) use crate::core::task_poller::PollTriggerEvent;

--- a/control-plane/agents/core/src/core/reconciler/poller.rs
+++ b/control-plane/agents/core/src/core/reconciler/poller.rs
@@ -1,5 +1,5 @@
 use crate::core::{
-    reconciler::{nexus, persistent_store::PersistentStoreReconciler, pool, volume},
+    reconciler::{nexus, persistent_store::PersistentStoreReconciler, pool, replica, volume},
     registry::Registry,
     task_poller::{squash_results, PollContext, PollEvent, PollResult, PollerState, TaskPoller},
 };
@@ -28,6 +28,7 @@ impl ReconcilerWorker {
             Box::new(nexus::NexusReconciler::new()),
             Box::new(volume::VolumeReconciler::new()),
             Box::new(PersistentStoreReconciler::new()),
+            Box::new(replica::ReplicaReconciler::new()),
         ];
 
         let event_channel = tokio::sync::mpsc::channel(poll_targets.len());

--- a/control-plane/agents/core/src/core/reconciler/replica/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/replica/mod.rs
@@ -1,0 +1,73 @@
+use crate::core::{
+    specs::{OperationSequenceGuard, SpecOperations},
+    task_poller::{PollContext, PollEvent, PollResult, PollTimer, PollerState, TaskPoller},
+};
+use common_lib::types::v0::{message_bus::ReplicaOwners, store::OperationMode};
+use std::ops::Deref;
+
+/// Replica reconciler
+#[derive(Debug)]
+pub struct ReplicaReconciler {
+    counter: PollTimer,
+}
+
+impl ReplicaReconciler {
+    /// Return a new `Self`
+    pub fn new() -> Self {
+        Self {
+            counter: PollTimer::from(1),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for ReplicaReconciler {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        destroy_orphaned_replicas(context).await
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        self.counter.poll()
+    }
+
+    async fn poll_event(&mut self, context: &PollContext) -> bool {
+        match context.event() {
+            PollEvent::TimedRun => true,
+            PollEvent::Shutdown | PollEvent::Triggered(_) => false,
+        }
+    }
+}
+
+/// Destroy orphaned replicas.
+/// Orphaned replicas are those that are managed but which don't have any owners.
+async fn destroy_orphaned_replicas(context: &PollContext) -> PollResult {
+    for replica in context.specs().get_replicas() {
+        let _guard = match replica.operation_guard(OperationMode::ReconcileStart) {
+            Ok(guard) => guard,
+            Err(_) => return PollResult::Ok(PollerState::Busy),
+        };
+
+        let replica_spec = replica.lock().deref().clone();
+        if replica_spec.managed && !replica_spec.owned() {
+            match context
+                .specs()
+                .destroy_replica_spec(
+                    context.registry(),
+                    &replica_spec,
+                    ReplicaOwners::default(),
+                    false,
+                    OperationMode::ReconcileStep,
+                )
+                .await
+            {
+                Ok(_) => {
+                    tracing::info!(replica.uuid=%replica_spec.uuid, "Successfully destroyed orphaned replica");
+                }
+                Err(e) => {
+                    tracing::trace!(replica.uuid=%replica_spec.uuid, error=%e, "Failed to destroy orphaned replica");
+                }
+            }
+        }
+    }
+    PollResult::Ok(PollerState::Idle)
+}


### PR DESCRIPTION
Add a garbage collector which destroys orphaned replicas. Orphaned
replicas are replicas that are managed (i.e. have been created through
the control plane) but are not owned by anything (and therefore are no
longer used).

Resolves: CAS-992, CAS-1159