### PR TITLE
feat(volume): add volume nexus/replica garbage collector

### DIFF
--- a/common/src/types/v0/message_bus/replica.rs
+++ b/common/src/types/v0/message_bus/replica.rs
@@ -181,6 +181,10 @@ impl ReplicaOwners {
     pub fn owned_by_nexus(&self, id: &NexusId) -> bool {
         self.nexuses.iter().any(|n| n == id)
     }
+    /// Check if this replica is owned by a nexus
+    pub fn owned_by_a_nexus(&self) -> bool {
+        !self.nexuses.is_empty()
+    }
     /// Create new owners from the volume Id
     pub fn from_volume(volume: &VolumeId) -> Self {
         Self {

--- a/common/src/types/v0/store/nexus.rs
+++ b/common/src/types/v0/store/nexus.rs
@@ -109,6 +109,10 @@ impl NexusSpec {
             NexusChild::Uri(_) => false,
         })
     }
+    /// Disown nexus by its volume owner
+    pub fn disowned_by_volume(&mut self) {
+        let _ = self.owner.take();
+    }
 }
 
 macro_rules! nexus_log {

--- a/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
@@ -1,0 +1,123 @@
+use crate::core::{
+    reconciler::{PollContext, TaskPoller},
+    specs::{OperationSequenceGuard, SpecOperations},
+    task_poller::{PollEvent, PollResult, PollTimer, PollerState},
+};
+use common_lib::types::v0::{
+    message_bus::DestroyNexus,
+    store::{nexus::NexusSpec, OperationMode, TraceSpan},
+};
+
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Nexus Garbage Collector reconciler
+#[derive(Debug)]
+pub(super) struct GarbageCollector {
+    counter: PollTimer,
+}
+impl GarbageCollector {
+    /// Return a new `Self`
+    pub(super) fn new() -> Self {
+        Self {
+            counter: PollTimer::from(5),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for GarbageCollector {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        let nexuses = context.specs().get_nexuses();
+        for nexus in nexuses {
+            let _ = nexus_garbage_collector(&nexus, context).await;
+        }
+        PollResult::Ok(PollerState::Idle)
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        self.counter.poll()
+    }
+
+    async fn poll_event(&mut self, context: &PollContext) -> bool {
+        match context.event() {
+            PollEvent::TimedRun => true,
+            PollEvent::Shutdown | PollEvent::Triggered(_) => false,
+        }
+    }
+}
+
+async fn nexus_garbage_collector(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let mode = OperationMode::ReconcileStep;
+    let results = vec![
+        destroy_orphaned_nexus(nexus_spec, context).await,
+        destroy_disowned_nexus(nexus_spec, context, mode).await,
+    ];
+    GarbageCollector::squash_results(results)
+}
+
+/// Given a control plane managed nexus
+/// When a nexus is owned by a volume which no longer exists
+/// Then the nexus should be disowned
+/// And it should eventually be destroyed
+#[tracing::instrument(level = "debug", skip(nexus_spec, context), fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
+async fn destroy_orphaned_nexus(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let _guard = match nexus_spec.operation_guard(OperationMode::ReconcileStart) {
+        Ok(guard) => guard,
+        Err(_) => return PollResult::Ok(PollerState::Busy),
+    };
+    let nexus_clone = nexus_spec.lock().clone();
+
+    if !nexus_clone.managed {
+        return PollResult::Ok(PollerState::Idle);
+    }
+    if let Some(owner) = &nexus_clone.owner {
+        if context.specs().get_volume(owner).is_err() {
+            nexus_clone.warn_span(|| tracing::warn!("Attempting to disown orphaned nexus"));
+            context
+                .specs()
+                .disown_nexus(context.registry(), nexus_spec)
+                .await?;
+            nexus_clone.info_span(|| tracing::info!("Successfully disowned orphaned nexus"));
+        }
+    }
+
+    PollResult::Ok(PollerState::Idle)
+}
+
+/// Given a control plane managed nexus
+/// When a nexus is not owned by a volume
+/// Then it should eventually be destroyed
+#[tracing::instrument(level = "debug", skip(nexus_spec, context, mode), fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
+async fn destroy_disowned_nexus(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    let _guard = match nexus_spec.operation_guard(OperationMode::ReconcileStart) {
+        Ok(guard) => guard,
+        Err(_) => return PollResult::Ok(PollerState::Busy),
+    };
+
+    let nexus_clone = nexus_spec.lock().clone();
+    if nexus_clone.managed && !nexus_clone.owned() {
+        let node_online = matches!(context.registry().get_node_wrapper(&nexus_clone.node).await, Ok(node) if node.lock().await.is_online());
+        if node_online {
+            nexus_clone.warn_span(|| tracing::warn!("Attempting to destroy disowned nexus"));
+            let request = DestroyNexus::from(nexus_clone.clone());
+            context
+                .specs()
+                .destroy_nexus(context.registry(), &request, true, mode)
+                .await?;
+            nexus_clone.info_span(|| tracing::info!("Successfully destroyed disowned nexus"));
+        }
+    }
+
+    PollResult::Ok(PollerState::Idle)
+}

--- a/control-plane/agents/core/src/core/reconciler/pool/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/pool/mod.rs
@@ -72,8 +72,8 @@ async fn missing_pool_state_reconciler(
 
         let warn_missing = |pool_spec: &Arc<Mutex<PoolSpec>>, node_status: NodeStatus| {
             let node_id = pool_spec.lock().node.clone();
-            pool.debug_span(|| {
-                tracing::debug!(
+            pool.trace_span(|| {
+                tracing::trace!(
                     node.uuid = %node_id,
                     node.status = %node_status.to_string(),
                     "Attempted to recreate missing pool state, but the node is not online"

--- a/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
@@ -3,6 +3,7 @@ use crate::core::{
     specs::OperationSequenceGuard,
     task_poller::{PollEvent, PollResult, PollTimer, PollTriggerEvent, PollerState},
 };
+
 use common_lib::types::v0::store::{volume::VolumeSpec, OperationMode, TraceSpan};
 
 use parking_lot::Mutex;
@@ -28,6 +29,7 @@ impl TaskPoller for GarbageCollector {
         let mut results = vec![];
         for volume in context.specs().get_locked_volumes() {
             results.push(disown_unused_nexuses(&volume, context).await);
+            results.push(disown_unused_replicas(&volume, context).await);
         }
         Self::squash_results(results)
     }
@@ -81,6 +83,59 @@ async fn disown_unused_nexuses(
             Err(error) => {
                 nexus_clone.error_span(|| tracing::error!("Failed to disown unused nexus"));
                 results.push(Err(error));
+            }
+        }
+    }
+
+    GarbageCollector::squash_results(results)
+}
+
+/// Given a published volume
+/// When some of its replicas are not online and not used by a nexus
+/// Then they should be disowned
+#[tracing::instrument(level = "debug", skip(context, volume), fields(volume.uuid = %volume.lock().uuid, request.reconcile = true))]
+async fn disown_unused_replicas(
+    volume: &Arc<Mutex<VolumeSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let _guard = match volume.operation_guard(OperationMode::ReconcileStart) {
+        Ok(guard) => guard,
+        Err(_) => return PollResult::Ok(PollerState::Busy),
+    };
+    if volume.lock().target.is_none() {
+        // if the volume is not published, then leave the replicas around as they might
+        // still reappear as online by the time we publish
+        return PollResult::Ok(PollerState::Busy);
+    }
+    let mut results = vec![];
+
+    let volume_clone = volume.lock().clone();
+    for replica in context.specs().get_volume_replicas(&volume_clone.uuid) {
+        let _guard = match replica.operation_guard(OperationMode::ReconcileStart) {
+            Ok(guard) => guard,
+            Err(_) => return PollResult::Ok(PollerState::Busy),
+        };
+        let replica_clone = replica.lock().clone();
+
+        let replica_online = matches!(context.registry().get_replica(&replica_clone.uuid).await, Ok(state) if state.online());
+        if !replica_online
+            && (replica_clone.owners.owned_by(&volume_clone.uuid)
+                && !replica_clone.owners.owned_by_a_nexus())
+        {
+            volume_clone.warn_span(|| tracing::warn!(replica.uuid = %replica_clone.uuid, "Attempting to disown unused replica"));
+            // the replica garbage collector will destroy the disowned replica
+            match context
+                .specs()
+                .disown_volume_replica(context.registry(), &replica)
+                .await
+            {
+                Ok(_) => {
+                    volume_clone.info_span(|| tracing::info!(replica.uuid = %replica_clone.uuid, "Successfully disowned unused replica"));
+                }
+                Err(error) => {
+                    volume_clone.error_span(|| tracing::error!(replica.uuid = %replica_clone.uuid, "Failed to disown unused replica"));
+                    results.push(Err(error));
+                }
             }
         }
     }

--- a/control-plane/agents/core/src/core/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/hot_spare.rs
@@ -105,7 +105,7 @@ async fn hot_spare_nexus_reconcile(
     squash_results(results)
 }
 
-#[tracing::instrument(skip(context, nexus_spec, mode), fields(nexus.uuid = %nexus_spec.lock().uuid))]
+#[tracing::instrument(skip(context, nexus_spec, mode), fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
 async fn generic_nexus_reconciler(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
@@ -157,7 +157,7 @@ async fn missing_children_remover(
 /// Given a degraded volume
 /// When the nexus spec has a different number of children to the number of volume replicas
 /// Then the nexus spec should eventually have as many children as the number of volume replicas
-#[tracing::instrument(skip(context, volume_spec, nexus_spec, mode), fields(nexus.uuid = %nexus_spec.lock().uuid))]
+#[tracing::instrument(skip(context, volume_spec, nexus_spec, mode), fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
 async fn nexus_replica_count_reconciler(
     volume_spec: &Arc<Mutex<VolumeSpec>>,
     nexus_spec: &Arc<Mutex<NexusSpec>>,
@@ -237,7 +237,7 @@ async fn nexus_replica_count_reconciler(
 /// When the number of created volume replicas is different to the required number of replicas
 /// Then the number of created volume replicas should eventually match the required number of
 /// replicas
-#[tracing::instrument(level = "debug", skip(context, volume_spec), fields(volume.uuid = %volume_spec.lock().uuid))]
+#[tracing::instrument(level = "debug", skip(context, volume_spec), fields(volume.uuid = %volume_spec.lock().uuid, request.reconcile = true))]
 async fn volume_replica_count_reconciler(
     volume_spec: &Arc<Mutex<VolumeSpec>>,
     context: &PollContext,

--- a/control-plane/agents/core/src/volume/registry.rs
+++ b/control-plane/agents/core/src/volume/registry.rs
@@ -84,10 +84,7 @@ impl Registry {
         match self.get_replica(&spec.uuid).await {
             Ok(state) => ReplicaTopology::new(Some(state.node), Some(state.pool), state.status),
             Err(_) => {
-                tracing::error!(
-                    "Replica {} not found. Constructing default replica topology.",
-                    spec.uuid
-                );
+                tracing::trace!(replica.uuid = %spec.uuid, "Replica not found. Constructing default replica topology");
                 ReplicaTopology::default()
             }
         }

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -1189,6 +1189,17 @@ impl ResourceSpecsLocked {
         registry.store_obj(&clone).await
     }
 
+    /// Disown nexus from its owner
+    pub(crate) async fn disown_nexus(
+        &self,
+        registry: &Registry,
+        nexus: &Arc<Mutex<NexusSpec>>,
+    ) -> Result<(), SvcError> {
+        nexus.lock().disowned_by_volume();
+        let clone = nexus.lock().clone();
+        registry.store_obj(&clone).await
+    }
+
     /// Destroy the replica from its volume
     pub(crate) async fn destroy_volume_replica(
         &self,

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -912,21 +912,35 @@ impl ResourceSpecsLocked {
                 nodes.push(item.state().node.clone());
             }
         }
+        nexus_replicas.truncate(vol_spec.num_replicas as usize);
 
         // Create the nexus on the requested node
-        self.create_nexus(
-            registry,
-            &CreateNexus::new(
-                target_node,
-                nexus_id,
-                vol_spec.size,
-                &nexus_replicas,
-                true,
-                Some(&vol_spec.uuid),
-            ),
-            mode,
-        )
-        .await
+        let nexus = self
+            .create_nexus(
+                registry,
+                &CreateNexus::new(
+                    target_node,
+                    nexus_id,
+                    vol_spec.size,
+                    &nexus_replicas,
+                    true,
+                    Some(&vol_spec.uuid),
+                ),
+                mode,
+            )
+            .await?;
+
+        if nexus.children.len() < vol_spec.num_replicas as usize {
+            vol_spec.warn_span(|| {
+                tracing::warn!(
+                    "Recreated volume target with only {} out of {} desired replicas",
+                    nexus.children.len(),
+                    vol_spec.num_replicas
+                )
+            });
+        }
+
+        Ok(nexus)
     }
 
     /// Attach the specified replica to the volume nexus

--- a/deployer/src/infra/csi.rs
+++ b/deployer/src/infra/csi.rs
@@ -13,7 +13,7 @@ const CSI_SOCKET: &str = "/var/tmp/csi.sock";
 #[async_trait]
 impl ComponentAction for Csi {
     fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
-        Ok(if options.no_csi {
+        Ok(if !options.csi {
             cfg
         } else {
             if options.build {
@@ -36,14 +36,14 @@ impl ComponentAction for Csi {
         })
     }
     async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
-        if !options.no_csi {
+        if options.csi {
             cfg.start("csi-controller").await?;
         }
         Ok(())
     }
 
     async fn wait_on(&self, options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
-        if options.no_csi {
+        if !options.csi {
             return Ok(());
         }
 

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -109,9 +109,9 @@ pub struct StartOptions {
     #[structopt(long)]
     pub no_rest: bool,
 
-    /// Disable the CSI Controller
+    /// Enable the CSI Controller
     #[structopt(long)]
-    pub no_csi: bool,
+    pub csi: bool,
 
     /// Rest Path to JSON Web KEY file used for authenticating REST requests.
     /// Otherwise, no authentication is used
@@ -296,7 +296,7 @@ impl StartOptions {
         self
     }
     pub fn with_csi(mut self, enabled: bool) -> Self {
-        self.no_csi = !enabled;
+        self.csi = enabled;
         self
     }
     pub fn with_jaeger(mut self, jaeger: bool) -> Self {

--- a/tests/bdd/common.py
+++ b/tests/bdd/common.py
@@ -47,7 +47,7 @@ def deployer_start(num_mayastors):
     deployer_path = os.environ["ROOT_DIR"] + "/target/debug/deployer"
     # Start containers and wait for them to become active.
     subprocess.run(
-        [deployer_path, "start", "-j", "-m", str(num_mayastors), "-w", "10s"]
+        [deployer_path, "start", "--csi", "-j", "-m", str(num_mayastors), "-w", "10s"]
     )
 
 

--- a/tests/bdd/test_csi_controller.py
+++ b/tests/bdd/test_csi_controller.py
@@ -39,7 +39,6 @@ VOLUME2_SIZE = 1024 * 1024 * 32
 
 @pytest.fixture(scope="module")
 def setup():
-    common.deployer_stop()
     common.deployer_start(2)
     subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi.sock"], check=True)
 


### PR DESCRIPTION
feat(nexus): add garbage collector

Nexuses which belong to a volume which no longer exists are disowned
Nexuses which are no longer used by a volume are disowned
Nexuses with no owner are deleted

--------
fix(replica): disown unused replicas

When a volume is published with offline replicas they are not used by the
nexus. In this case we should disown these replicas since we'll have to
do a full rebuild anyway.

Disowned replicas will then garbage collected when they reappear.

--------
chore(deployer): make the csi deployment optional

The csi is not usually needed when we use the deployer so disable it by default.
It has been explicitly enabled in the bdd tests.

--------
test: add volume garbage collection cargo tests 