### PR TITLE
fix(nodes): use a RwLock to protect the node wrappers

### DIFF
--- a/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
@@ -107,7 +107,7 @@ async fn destroy_disowned_nexus(
 
     let nexus_clone = nexus_spec.lock().clone();
     if nexus_clone.managed && !nexus_clone.owned() {
-        let node_online = matches!(context.registry().get_node_wrapper(&nexus_clone.node).await, Ok(node) if node.lock().await.is_online());
+        let node_online = matches!(context.registry().get_node_wrapper(&nexus_clone.node).await, Ok(node) if node.read().await.is_online());
         if node_online {
             nexus_clone.warn_span(|| tracing::warn!("Attempting to destroy disowned nexus"));
             let request = DestroyNexus::from(nexus_clone.clone());

--- a/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
@@ -244,8 +244,8 @@ pub(super) async fn missing_nexus_recreate(
     };
 
     let node = match context.registry().get_node_wrapper(&nexus.node).await {
-        Ok(node) if !node.lock().await.is_online() => {
-            let node_status = node.lock().await.status().clone();
+        Ok(node) if !node.read().await.is_online() => {
+            let node_status = node.read().await.status().clone();
             warn_missing(&nexus, node_status);
             return PollResult::Ok(PollerState::Idle);
         }

--- a/control-plane/agents/core/src/core/reconciler/pool/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/pool/mod.rs
@@ -81,8 +81,8 @@ async fn missing_pool_state_reconciler(
             });
         };
         let node = match context.registry().get_node_wrapper(&pool.node).await {
-            Ok(node) if !node.lock().await.is_online() => {
-                let node_status = node.lock().await.status().clone();
+            Ok(node) if !node.read().await.is_online() => {
+                let node_status = node.read().await.status().clone();
                 warn_missing(&pool_spec, node_status);
                 return PollResult::Ok(PollerState::Idle);
             }

--- a/control-plane/agents/core/src/core/scheduling/resources/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/resources/mod.rs
@@ -28,7 +28,7 @@ impl PoolItemLister {
         let nodes = registry.get_node_wrappers().await;
         let mut raw_nodes = vec![];
         for node in nodes {
-            let node = node.lock().await;
+            let node = node.read().await;
             raw_nodes.push(node.clone());
         }
         raw_nodes

--- a/control-plane/agents/core/src/node/registry.rs
+++ b/control-plane/agents/core/src/node/registry.rs
@@ -3,11 +3,11 @@ use common::errors::SvcError;
 use common_lib::types::v0::message_bus::{NodeId, NodeState, Register};
 
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 impl Registry {
     /// Get all node wrappers
-    pub(crate) async fn get_node_wrappers(&self) -> Vec<Arc<Mutex<NodeWrapper>>> {
+    pub(crate) async fn get_node_wrappers(&self) -> Vec<Arc<RwLock<NodeWrapper>>> {
         let nodes = self.nodes().read().await;
         nodes.values().cloned().collect()
     }
@@ -17,7 +17,7 @@ impl Registry {
         let nodes = self.nodes().read().await;
         let mut nodes_vec = vec![];
         for node in nodes.values() {
-            nodes_vec.push(node.lock().await.node_state().clone());
+            nodes_vec.push(node.read().await.node_state().clone());
         }
         nodes_vec
     }
@@ -26,7 +26,7 @@ impl Registry {
     pub(crate) async fn get_node_wrapper(
         &self,
         node_id: &NodeId,
-    ) -> Result<Arc<Mutex<NodeWrapper>>, SvcError> {
+    ) -> Result<Arc<RwLock<NodeWrapper>>, SvcError> {
         match self.nodes().read().await.get(node_id).cloned() {
             None => {
                 if self.specs().get_node(node_id).is_ok() {
@@ -57,7 +57,7 @@ impl Registry {
                     })
                 }
             }
-            Some(node) => Ok(node.lock().await.node_state().clone()),
+            Some(node) => Ok(node.read().await.node_state().clone()),
         }
     }
 

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -606,7 +606,7 @@ impl ResourceSpecsLocked {
                     Err(error) => {
                         let node_online = match registry.get_node_wrapper(&nexus_clone.node).await {
                             Ok(node) => {
-                                let mut node = node.lock().await;
+                                let mut node = node.write().await;
                                 node.is_online() && node.liveness_probe().await.is_ok()
                             }
                             _ => false,
@@ -1379,7 +1379,7 @@ async fn get_volume_target_node(
             // auto select a node
             let nodes = registry.get_node_wrappers().await;
             for locked_node in nodes {
-                let node = locked_node.lock().await;
+                let node = locked_node.read().await;
                 // todo: use other metrics in order to make the "best" choice
                 if node.is_online() {
                     return Ok(node.id.clone());
@@ -1391,7 +1391,7 @@ async fn get_volume_target_node(
             // make sure the requested node is available
             // todo: check the max number of nexuses per node is respected
             let node = registry.get_node_wrapper(node).await?;
-            let node = node.lock().await;
+            let node = node.read().await;
             if node.is_online() {
                 Ok(node.id.clone())
             } else {


### PR DESCRIPTION
This allows for a concurrent "read" usages of the node object.