### PR TITLE
fix(csi): determine volume locality based on volume config

### DIFF
--- a/control-plane/csi-controller/src/main.rs
+++ b/control-plane/csi-controller/src/main.rs
@@ -8,7 +8,7 @@ mod client;
 mod config;
 mod controller;
 mod identity;
-use client::{ApiClientError, MayastorApiClient};
+use client::{ApiClientError, CreateVolumeTopology, MayastorApiClient};
 use config::CsiControllerConfig;
 
 mod server;

--- a/tests/bdd/features/csi/controller.feature
+++ b/tests/bdd/features/csi/controller.feature
@@ -101,3 +101,16 @@ Scenario: republish volume on a different node
     When a ControllerPublishVolume request is sent to CSI controller to re-publish volume on a different node
     Then a ControllerPublishVolume request should fail with FAILED_PRECONDITION error mentioning node mismatch
     And volume should report itself as published
+
+Scenario: create 1 replica local nvmf volume
+    Given 2 Mayastor nodes with one pool on each node
+    When a CreateVolume request is sent to create a 1 replica local nvmf volume (local=true)
+    Then a new local volume of requested size should be successfully created
+    And local volume must be accessible only from all existing Mayastor nodes
+
+Scenario: list local volume
+    Given 2 existing volumes
+    Given an existing unpublished local volume
+    When a ListVolumesRequest is sent to CSI controller
+    Then listed local volume must be accessible only from all existing Mayastor nodes
+    And no topology restrictions should be imposed to non-local volumes


### PR DESCRIPTION
Volume locality and accessible topology is now calculated based
on 'local' flag provided upon volume creation.

Resolves: CAS-1126, CAS-1162