### PR TITLE
fix: make sure multiple states are viewed consistently

### DIFF
--- a/control-plane/agents/core/src/core/resource_map.rs
+++ b/control-plane/agents/core/src/core/resource_map.rs
@@ -6,14 +6,14 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct ResourceMap<I, S> {
     map: HashMap<I, Arc<Mutex<S>>>,
 }
 
 impl<I, S> ResourceMap<I, S>
 where
-    I: Eq + Hash,
+    I: Eq + Hash + Clone,
     S: Clone + ResourceUuid<Id = I>,
 {
     /// Get the resource with the given key.

--- a/control-plane/agents/core/src/core/states.rs
+++ b/control-plane/agents/core/src/core/states.rs
@@ -25,7 +25,7 @@ impl Deref for ResourceStatesLocked {
 }
 
 /// Resource States
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub(crate) struct ResourceStates {
     nexuses: ResourceMap<NexusId, NexusState>,
     pools: ResourceMap<PoolId, PoolState>,

--- a/control-plane/agents/core/src/node/service.rs
+++ b/control-plane/agents/core/src/node/service.rs
@@ -99,7 +99,12 @@ impl Service {
         let mut nodes = self.registry.nodes().write().await;
         match nodes.get_mut(&node.id) {
             None => {
-                let mut node = NodeWrapper::new(&node, self.deadline, self.comms_timeouts.clone());
+                let mut node = NodeWrapper::new(
+                    &node,
+                    self.deadline,
+                    self.comms_timeouts.clone(),
+                    self.registry.snapshot_lock().clone(),
+                );
                 if node.load().await.is_ok() {
                     node.watchdog_mut().arm(self.clone());
                     nodes.insert(node.id.clone(), Arc::new(tokio::sync::RwLock::new(node)));


### PR DESCRIPTION
When we fetch multiple specs and state objects, things might change "in between"
as a result of current operations leading to potentially confusing results.

Add RW access to the states to make sure we get a consistent picture across
the cluster and its various resources.

When we start to get the volume spec don't allow anyone else to attempt modify it
If an update is in progress, return the stale but consistent value of the spec