### PR TITLE
fix: allow volume destruction whilst node offline

### DIFF
--- a/common/src/types/v0/message_bus/replica.rs
+++ b/common/src/types/v0/message_bus/replica.rs
@@ -208,6 +208,10 @@ impl ReplicaOwners {
             .cloned()
             .collect();
     }
+    pub fn disown_all(&mut self) {
+        self.volume.take();
+        self.nexuses.clear();
+    }
     /// Add new nexus owner
     pub fn add_owner(&mut self, new: &NexusId) {
         match self.nexuses.iter().find(|nexus| nexus == &new) {

--- a/control-plane/agents/core/src/core/specs.rs
+++ b/control-plane/agents/core/src/core/specs.rs
@@ -289,8 +289,9 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject + OperationSequ
         let spec_clone = {
             let mut spec = locked_spec.lock();
 
-            // once we've started, there's no going back...
+            // once we've started, there's no going back, so disown completely
             spec.set_status(SpecStatus::Deleting);
+            spec.disown_all();
 
             spec.start_destroy_op();
             spec.clone()
@@ -576,6 +577,8 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject + OperationSequ
     }
     /// Disown resource by owners
     fn disown(&mut self, _owner: &Self::Owners) {}
+    /// Remove all owners from the resource
+    fn disown_all(&mut self) {}
 }
 
 /// Operations are locked

--- a/control-plane/agents/core/src/nexus/specs.rs
+++ b/control-plane/agents/core/src/nexus/specs.rs
@@ -105,6 +105,9 @@ impl SpecOperations for NexusSpec {
     fn owners(&self) -> Option<String> {
         self.owner.clone().map(|o| format!("{:?}", o))
     }
+    fn disown_all(&mut self) {
+        self.owner.take();
+    }
 }
 
 /// Implementation of the ResourceSpecs which is retrieved from the ResourceSpecsLocked

--- a/control-plane/agents/core/src/pool/specs.rs
+++ b/control-plane/agents/core/src/pool/specs.rs
@@ -146,6 +146,9 @@ impl SpecOperations for ReplicaSpec {
     fn disown(&mut self, owner: &Self::Owners) {
         self.owners.disown(owner)
     }
+    fn disown_all(&mut self) {
+        self.owners.disown_all();
+    }
 }
 
 /// Implementation of the ResourceSpecs which is retrieved from the ResourceSpecsLocked

--- a/tests/bdd/features/volume/delete.feature
+++ b/tests/bdd/features/volume/delete.feature
@@ -14,3 +14,15 @@ Feature: Volume deletion
     Given a volume that is shared/published
     When a user attempts to delete a volume
     Then the volume should be deleted
+
+  Scenario: delete a shared/published volume whilst a replica node is inaccessible
+    Given a volume that is shared/published
+    And an inaccessible node with a volume replica on it
+    When a user attempts to delete a volume
+    Then the volume should be deleted
+
+  Scenario: delete a shared/published volume whilst the nexus node is inaccessible
+    Given a volume that is shared/published
+    And an inaccessible node with the volume nexus on it
+    When a user attempts to delete a volume
+    Then the volume should be deleted

--- a/tests/bdd/test_volume_delete.py
+++ b/tests/bdd/test_volume_delete.py
@@ -18,7 +18,8 @@ from openapi_client.model.volume_policy import VolumePolicy
 
 POOL_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
 VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
-NODE_NAME = "mayastor-1"
+NODE1_NAME = "mayastor-1"
+NODE2_NAME = "mayastor-2"
 VOLUME_CTX_KEY = "volume"
 
 
@@ -27,9 +28,9 @@ VOLUME_CTX_KEY = "volume"
 # A pool and volume are created for convenience such that it is available for use by the tests.
 @pytest.fixture(autouse=True)
 def init():
-    common.deployer_start(1)
+    common.deployer_start(2)
     common.get_pools_api().put_node_pool(
-        NODE_NAME, POOL_UUID, CreatePoolBody(["malloc:///disk?size_mb=50"])
+        NODE1_NAME, POOL_UUID, CreatePoolBody(["malloc:///disk?size_mb=50"])
     )
     common.get_volumes_api().put_volume(
         VOLUME_UUID, CreateVolumeBody(VolumePolicy(False), 1, 10485761)
@@ -42,6 +43,22 @@ def init():
 @pytest.fixture(scope="function")
 def volume_ctx():
     return {}
+
+
+@scenario(
+    "features/volume/delete.feature",
+    "delete a shared/published volume whilst a replica node is inaccessible",
+)
+def test_delete_a_sharedpublished_volume_whilst_a_replica_node_is_inaccessible():
+    """delete a shared/published volume whilst a replica node is inaccessible."""
+
+
+@scenario(
+    "features/volume/delete.feature",
+    "delete a shared/published volume whilst the nexus node is inaccessible",
+)
+def test_delete_a_sharedpublished_volume_whilst_the_nexus_node_is_inaccessible():
+    """delete a shared/published volume whilst the nexus node is inaccessible."""
 
 
 @scenario(
@@ -68,7 +85,7 @@ def a_volume_that_is_not_sharedpublished(volume_ctx):
 def a_volume_that_is_sharedpublished():
     """a volume that is shared/published."""
     volume = common.get_volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_NAME, Protocol("nvmf")
+        VOLUME_UUID, NODE1_NAME, Protocol("nvmf")
     )
     assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))
 
@@ -79,6 +96,20 @@ def an_existing_volume(volume_ctx):
     volume = common.get_volumes_api().get_volume(VOLUME_UUID)
     assert volume.spec.uuid == VOLUME_UUID
     volume_ctx[VOLUME_CTX_KEY] = volume
+
+
+@given("an inaccessible node with a volume replica on it")
+def an_inaccessible_node_with_a_volume_replica_on_it():
+    """an inaccessible node with a volume replica on it."""
+    # Nexus is located on node 1 so make node 2 inaccessible as we don't want to disrupt the nexus.
+    common.kill_container(NODE2_NAME)
+
+
+@given("an inaccessible node with the volume nexus on it")
+def an_inaccessible_node_with_the_volume_nexus_on_it():
+    """an inaccessible node with the volume nexus on it."""
+    # Nexus is located on node 1.
+    common.kill_container(NODE1_NAME)
 
 
 @when("a user attempts to delete a volume")


### PR DESCRIPTION
Volume destruction will now complete successfully even if a node with a
replica or nexus on it is offline. In the event that the node is
inaccessible the volume resources (replicas and nexus) are completely
disowned allowing them to be garbage collected at a later time.

Resolves: CAS-1180