### PR TITLE
feat: add derivation to build a static kubectl-plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "common-lib",
  "ctrlp-tests",
  "gag",
  "git-version",

--- a/kubectl-plugin/Cargo.toml
+++ b/kubectl-plugin/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openapi = { path = "../openapi", features = [ "tower-client", "tower-trace" ] }
-tokio = { version = "1.12.0", features = [ "full" ] }
+openapi = { path = "../openapi", default-features = false, features = [ "tower-client", "tower-trace" ] }
+tokio = { version = "1.12.0" }
 anyhow = "1.0.44"
 async-trait = "0.1.51"
 once_cell = "1.8.0"
@@ -22,11 +22,8 @@ lazy_static = "1.4.0"
 serde = "1.0.130"
 serde_json = "1.0.68"
 serde_yaml = "0.8.21"
-git-version = "0.3.5"
 humantime = "2.1.0"
-common-lib = { path = "../common" }
-gag = "1.0.0"
-ctrlp-tests = { path = "../tests/tests-mayastor" }
+git-version = "0.3.5"
 
 # Tracing
 tracing = "0.1.28"
@@ -36,4 +33,7 @@ opentelemetry = { version = "0.16.0", features = ["rt-tokio-current-thread"] }
 opentelemetry-jaeger = { version = "0.15.0", features = ["rt-tokio-current-thread"] }
 
 [dev-dependencies]
+# Test dependencies
 shutdown_hooks = "0.1.0"
+ctrlp-tests = { path = "../tests/tests-mayastor" }
+gag = "1.0.0"

--- a/kubectl-plugin/src/main.rs
+++ b/kubectl-plugin/src/main.rs
@@ -79,10 +79,12 @@ fn init_tracing() {
     match CliArgs::args().jaeger {
         Some(jaeger) => {
             global::set_text_map_propagator(TraceContextPropagator::new());
-            let tags = opentelemetry_helper::default_tracing_tags(
-                git_version::git_version!(args = ["--abbrev=12", "--always"]),
-                env!("CARGO_PKG_VERSION"),
-            );
+            let git_version = option_env!("GIT_VERSION").unwrap_or(git_version::git_version!(
+                args = ["--abbrev=12", "--always"],
+                fallback = "unknown"
+            ));
+            let tags =
+                opentelemetry_helper::default_tracing_tags(git_version, env!("CARGO_PKG_VERSION"));
             let tracer = opentelemetry_jaeger::new_pipeline()
                 .with_agent_endpoint(jaeger)
                 .with_service_name("kubectl-plugin")

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -2,8 +2,13 @@
 let
   pkgs =
     import sources.nixpkgs { overlays = [ (import sources.rust-overlay) ]; };
+  static_target = pkgs.rust.toRustTargetSpec pkgs.pkgsStatic.stdenv.hostPlatform;
 in
-with pkgs; rec  {
-  nightly = rust-bin.nightly."2021-06-22".default;
-  stable = rust-bin.stable.latest.default;
+rec {
+  rust_default = { override ? { } }: rec {
+    nightly = pkgs.rust-bin.nightly."2021-06-22".default.override (override);
+    stable = pkgs.rust-bin.stable.latest.default.override (override);
+  };
+  default = rust_default { };
+  static = rust_default { override = { targets = [ "${static_target}" ]; }; };
 }

--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     cd $src
     vers=`${git}/bin/git tag --points-at HEAD`
     if [ -z "$vers" ]; then
-      vers=`${git}/bin/git rev-parse --short HEAD`
+      vers=`${git}/bin/git rev-parse --short=12 HEAD`
     fi
     echo -n $vers >$out
   '';

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,5 +1,6 @@
 self: super: {
   images = super.callPackage ./pkgs/images { };
   control-plane = super.callPackage ./pkgs/control-plane { };
+  utils = super.callPackage ./pkgs/utils { };
   openapi-generator = super.callPackage ./pkgs/openapi-generator { };
 }

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -16,8 +16,8 @@
 let
   channel = import ../../lib/rust.nix { inherit sources; };
   rustPlatform = makeRustPlatform {
-    rustc = channel.stable;
-    cargo = channel.stable;
+    rustc = channel.default.stable;
+    cargo = channel.default.stable;
   };
   whitelistSource = src: allowedPrefixes:
     builtins.filterSource

--- a/nix/pkgs/utils/default.nix
+++ b/nix/pkgs/utils/default.nix
@@ -1,0 +1,59 @@
+{ git, lib, stdenv, clang, openapi-generator, pkgs, which, sources }:
+let
+  versionDrv = import ../../lib/version.nix { inherit lib stdenv git; };
+  version = builtins.readFile "${versionDrv}";
+  channel = import ../../lib/rust.nix { inherit sources; };
+
+  whitelistSource = src: allowedPrefixes:
+    builtins.filterSource
+      (path: type:
+        lib.any
+          (allowedPrefix: lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
+          allowedPrefixes)
+      src;
+  src = whitelistSource ../../../. [
+    ".git"
+    "Cargo.lock"
+    "Cargo.toml"
+    "common"
+    "composer"
+    "control-plane"
+    "deployer"
+    "kubectl-plugin"
+    "openapi"
+    "rpc"
+    "tests"
+    "scripts"
+  ];
+
+  naersk = pkgs.callPackage sources.naersk {
+    rustc = channel.static.stable;
+    cargo = channel.static.stable;
+  };
+
+  components = { release ? false }: {
+    kubectl-plugin = naersk.buildPackage {
+      inherit release src;
+      preBuild = ''
+        # don't run during the dependency build phase
+        if [ ! -f build.rs ]; then
+          patchShebangs ./scripts/generate-openapi-bindings.sh
+          ./scripts/generate-openapi-bindings.sh
+        fi
+        sed -i '/ctrlp-tests.*=/d' ./kubectl-plugin/Cargo.toml
+      '';
+      cargoBuildOptions = attrs: attrs ++ [ "-p" "kubectl-plugin" ];
+      CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+      CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+      nativeBuildInputs = [ clang openapi-generator which git ];
+      doCheck = false;
+      usePureFromTOML = true;
+    };
+  };
+in
+{
+  inherit version;
+
+  release = components { release = true; };
+  debug = components { release = false; };
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "naersk": {
+        "branch": "master",
+        "description": "Build rust crates in Nix. No configuration, no code generation, no IFD. Sandbox friendly. [maintainer: @nmattia]",
+        "homepage": "",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "ee7edec50b49ab6d69b06d62f1de554efccb1ccd",
+        "sha256": "06g37l34hzi81lc7hmk91mzapsa1iak7yi3agxgdzfc69qk9wp17",
+        "type": "tarball",
+        "url": "https://github.com/nmattia/naersk/archive/ee7edec50b49ab6d69b06d62f1de554efccb1ccd.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,7 +17,7 @@ dockerhub_tag_exists() {
 get_tag() {
   vers=`git tag --points-at HEAD`
   if [ -z "$vers" ]; then
-    vers=`git rev-parse --short HEAD`
+    vers=`git rev-parse --short=12 HEAD`
   fi
   echo -n $vers
 }

--- a/shell.nix
+++ b/shell.nix
@@ -38,12 +38,11 @@ mkShell {
     which
     tini
     nvme-cli
-  ] ++ pkgs.lib.optional (!norust) channel.nightly;
+  ] ++ pkgs.lib.optional (!norust) channel.default.nightly;
 
   LIBCLANG_PATH = "${llvmPackages_11.libclang.lib}/lib";
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";
-
 
   # variables used to easily create containers with docker files
   ETCD_BIN = "${pkgs.etcd}/bin/etcd";


### PR DESCRIPTION
Adds the naersk crate build support to the sources
Add a "static" channel to the rust channel derivation
Add a new utils/kubectl-plugin package which makes use of the static
rust channel and naersk to build a static version of kubectl-plugin