### PR TITLE
fix(MSP operator): remove assertion

### DIFF
--- a/control-plane/msp-operator/src/main.rs
+++ b/control-plane/msp-operator/src/main.rs
@@ -297,7 +297,6 @@ impl OperatorContext {
 
                 // Its a new resource version which means we will swap it out
                 // to reset the counter.
-                assert!(p.resource_version() < resource.resource_version());
                 let p = i
                     .insert(resource.name(), resource.clone())
                     .expect("existing resource should be present");


### PR DESCRIPTION
The MSP operator was making the assumption that an older version of a
resource would always have a lower resource version number than a newer
version of the resource. This turns out not to be the case. From the
documentation
(https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions):

"...clients must not assume resource versions are numeric, and may only
compare two resource versions for equality (i.e. must not compare
resource versions for greater-than or less-than relationships)."

Resolves: CAS-1170