### PR TITLE
fix(replica destroy): disown when node not found

### DIFF
--- a/tests/bdd/common.py
+++ b/tests/bdd/common.py
@@ -5,6 +5,7 @@ from openapi.openapi_client.api.volumes_api import VolumesApi
 from openapi.openapi_client.api.pools_api import PoolsApi
 from openapi.openapi_client.api.specs_api import SpecsApi
 from openapi.openapi_client.api.replicas_api import ReplicasApi
+from openapi.openapi_client.api.nodes_api import NodesApi
 from openapi.openapi_client import api_client
 from openapi.openapi_client import configuration
 import docker
@@ -42,6 +43,11 @@ def get_pools_api():
 # Return a SpecsApi object which can be used for performing spec related REST calls.
 def get_specs_api():
     return SpecsApi(get_api_client())
+
+
+# Return a NodesApi object which can be used for performing node related REST calls.
+def get_nodes_api():
+    return NodesApi(get_api_client())
 
 
 # Return a ReplicasApi object which can be used for performing replica related REST calls.

--- a/tests/bdd/features/volume/delete.feature
+++ b/tests/bdd/features/volume/delete.feature
@@ -15,11 +15,12 @@ Feature: Volume deletion
     When a user attempts to delete a volume
     Then the volume should be deleted
 
-  Scenario: delete a shared/published volume whilst a replica node is inaccessible
+  Scenario: delete a shared/published volume whilst a replica node is inaccessible and offline
     Given a volume that is shared/published
     And an inaccessible node with a volume replica on it
     When a user attempts to delete a volume
     Then the volume should be deleted
+    And the replica on the inaccessible node should become orphaned
 
   Scenario: delete a shared/published volume whilst the nexus node is inaccessible
     Given a volume that is shared/published

--- a/tests/bdd/test_volume_delete.py
+++ b/tests/bdd/test_volume_delete.py
@@ -10,13 +10,16 @@ from pytest_bdd import (
 import pytest
 import requests
 import common
+from retrying import retry
 
 from openapi.openapi_client.model.create_pool_body import CreatePoolBody
 from openapi.openapi_client.model.create_volume_body import CreateVolumeBody
 from openapi.openapi_client.model.protocol import Protocol
 from openapi_client.model.volume_policy import VolumePolicy
+from openapi_client.model.node_status import NodeStatus
 
-POOL_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
+POOL1_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
+POOL2_UUID = "4cc6ee64-7232-497d-a26f-38284a444990"
 VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
 NODE1_NAME = "mayastor-1"
 NODE2_NAME = "mayastor-2"
@@ -30,10 +33,13 @@ VOLUME_CTX_KEY = "volume"
 def init():
     common.deployer_start(2)
     common.get_pools_api().put_node_pool(
-        NODE1_NAME, POOL_UUID, CreatePoolBody(["malloc:///disk?size_mb=50"])
+        NODE1_NAME, POOL1_UUID, CreatePoolBody(["malloc:///disk?size_mb=50"])
+    )
+    common.get_pools_api().put_node_pool(
+        NODE2_NAME, POOL2_UUID, CreatePoolBody(["malloc:///disk?size_mb=50"])
     )
     common.get_volumes_api().put_volume(
-        VOLUME_UUID, CreateVolumeBody(VolumePolicy(False), 1, 10485761)
+        VOLUME_UUID, CreateVolumeBody(VolumePolicy(False), 2, 10485761)
     )
     yield
     common.deployer_stop()
@@ -47,10 +53,10 @@ def volume_ctx():
 
 @scenario(
     "features/volume/delete.feature",
-    "delete a shared/published volume whilst a replica node is inaccessible",
+    "delete a shared/published volume whilst a replica node is inaccessible and offline",
 )
-def test_delete_a_sharedpublished_volume_whilst_a_replica_node_is_inaccessible():
-    """delete a shared/published volume whilst a replica node is inaccessible."""
+def test_delete_a_sharedpublished_volume_whilst_a_replica_node_is_inaccessible_and_offline():
+    """delete a shared/published volume whilst a replica node is inaccessible and offline."""
 
 
 @scenario(
@@ -102,7 +108,9 @@ def an_existing_volume(volume_ctx):
 def an_inaccessible_node_with_a_volume_replica_on_it():
     """an inaccessible node with a volume replica on it."""
     # Nexus is located on node 1 so make node 2 inaccessible as we don't want to disrupt the nexus.
+    # Wait for the node to go offline before proceeding.
     common.kill_container(NODE2_NAME)
+    wait_offline_node(NODE2_NAME)
 
 
 @given("an inaccessible node with the volume nexus on it")
@@ -118,6 +126,19 @@ def a_user_attempts_to_delete_a_volume():
     common.get_volumes_api().del_volume(VOLUME_UUID)
 
 
+@then("the replica on the inaccessible node should become orphaned")
+def the_replica_on_the_inaccessible_node_should_become_orphaned():
+    """the replica on the inaccessible node should become orphaned."""
+    replicas = common.get_specs_api().get_specs()["replicas"]
+    assert len(replicas) == 1
+
+    # The replica is orphaned if it doesn't have any owners.
+    replica = replicas[0]
+    assert replica["managed"]
+    assert len(replica["owners"]["nexuses"]) == 0
+    assert "volume" not in replica["owners"]
+
+
 @then("the volume should be deleted")
 def the_volume_should_be_deleted():
     """the volume should be deleted."""
@@ -126,3 +147,9 @@ def the_volume_should_be_deleted():
     except Exception as e:
         exception_info = e.__dict__
         assert exception_info["status"] == requests.codes["not_found"]
+
+
+@retry(wait_fixed=1000, stop_max_attempt_number=15)
+def wait_offline_node(name):
+    node = common.get_nodes_api().get_node(name)
+    assert node["state"]["status"] == NodeStatus("Offline")


### PR DESCRIPTION
Ensure that when a replica node cannot be found (due to it being
offline) the replica is disowned so that it can be garbage collected.

Resolves: CAS-1202

TODO: Add reconcile loop to disown replicas whose owners no longer exist (CAS-1203)