### PR TITLE
fix(nats): set tcp read timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,6 @@ dependencies = [
  "humantime",
  "itertools",
  "lazy_static",
- "nats 0.15.2",
  "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -397,16 +396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-nats"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dae854440faecce70f0664f41f09a588de1e7a4366931ec3962ded3d8f903c5"
-dependencies = [
- "blocking",
- "nats 0.10.1",
 ]
 
 [[package]]
@@ -767,7 +756,6 @@ dependencies = [
 name = "common-lib"
 version = "0.1.0"
 dependencies = [
- "async-nats",
  "async-trait",
  "composer",
  "dyn-clonable",
@@ -775,7 +763,7 @@ dependencies = [
  "etcd-client",
  "humantime",
  "log",
- "nats 0.15.2",
+ "nats",
  "once_cell",
  "oneshot",
  "openapi",
@@ -1141,7 +1129,6 @@ dependencies = [
  "composer",
  "futures",
  "humantime",
- "nats 0.15.2",
  "once_cell",
  "paste",
  "reqwest",
@@ -2267,35 +2254,8 @@ dependencies = [
 
 [[package]]
 name = "nats"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0cfa3903c3e613edddaa4a2f86b2053a1d6fbcf315a3ff352c25ba9f0a8585"
-dependencies = [
- "base64 0.13.0",
- "base64-url",
- "crossbeam-channel",
- "fastrand",
- "itoa",
- "json",
- "libc",
- "log",
- "memchr",
- "nkeys",
- "nuid",
- "once_cell",
- "parking_lot",
- "regex",
- "rustls",
- "rustls-native-certs",
- "webpki",
- "winapi",
-]
-
-[[package]]
-name = "nats"
 version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3097b182107db2cf690280d61f23f17ee31d49f3994ad152ee6a10261f77c3"
+source = "git+https://github.com/openebs/nats.rs?branch=main_fixes#6fc96e7923b9489cccfa38ebe8d44c1ccf46014d"
 dependencies = [
  "base64 0.13.0",
  "base64-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,3 @@
-[patch.crates-io]
-# Update nix/overlay.nix with the sha256:
-# nix-prefetch-url https://github.com/openebs/Mayastor/tarball/$rev --print-path --unpack
-
 [profile.dev]
 panic = "abort"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# Nats with the tcp stream timeout fix: CAS-1192
+nats = { git = "https://github.com/openebs/nats.rs", branch="main_fixes" }
 url = "2.2.2"
 uuid = { version = "0.8.2", features = ["v4"] }
 strum = "0.21.0"
@@ -17,18 +19,14 @@ tokio = { version = "1.12.0", features = [ "full" ] }
 snafu = "0.6.10"
 etcd-client = "0.7.2"
 serde = { version = "1.0.130", features = ["derive"] }
-nats = "0.15.2"
 structopt = "0.3.23"
 log = "0.4.14"
 env_logger = "0.9.0"
-# Version is pinned due to incompatibilities with the instrument crate in the newer versions
-# https://github.com/tokio-rs/tracing/issues/1219
 async-trait = "0.1.51"
 dyn-clonable = "0.9.0"
 once_cell = "1.8.0"
 openapi = { path = "../openapi", features = [ "actix-server", "tower-client", "tower-trace" ] }
 parking_lot = "0.11.2"
-async-nats = "0.10.1"
 humantime = "2.1.0"
 
 # Tracing

--- a/common/src/mbus_api/mbus_nats.rs
+++ b/common/src/mbus_api/mbus_nats.rs
@@ -1,5 +1,5 @@
 use super::*;
-use async_nats::Connection;
+use nats::asynk::Connection;
 use once_cell::sync::OnceCell;
 use tracing::{info, warn};
 

--- a/common/src/mbus_api/mod.rs
+++ b/common/src/mbus_api/mod.rs
@@ -449,6 +449,10 @@ pub struct TimeoutOptions {
     pub(crate) timeout_step: std::time::Duration,
     /// max number of retries following the initial attempt's timeout
     pub(crate) max_retries: Option<u32>,
+    /// Server tcp read timeout when no messages are received.
+    /// Shen this timeout is triggered we attempt to send a Ping to the server. If a Pong is not
+    /// received within the same timeout the nats client disconnects from the server.
+    tcp_read_timeout: std::time::Duration,
 
     /// Request specific minimum timeouts
     request_timeout: Option<RequestMinTimeout>,
@@ -483,17 +487,29 @@ impl RequestMinTimeout {
 }
 
 impl TimeoutOptions {
+    /// Default timeout waiting for a reply.
     pub(crate) fn default_timeout() -> Duration {
         Duration::from_secs(6)
     }
+    /// Default time between retries when a timeout is hit.
     pub(crate) fn default_timeout_step() -> Duration {
         Duration::from_secs(1)
     }
+    /// Default max number of retries until the request is given up on.
     pub(crate) fn default_max_retries() -> u32 {
         6
     }
+    /// Default `RequestMinTimeout` which specified timeouts for specific operations.
     pub(crate) fn default_request_timeouts() -> Option<RequestMinTimeout> {
         Some(RequestMinTimeout::default())
+    }
+    /// Default Server tcp read timeout when no messages are received.
+    pub(crate) fn default_tcp_read_timeout() -> Duration {
+        Duration::from_secs(6)
+    }
+    /// Get the tcp read timeout
+    pub(crate) fn tcp_read_timeout(&self) -> Duration {
+        self.tcp_read_timeout
     }
 }
 
@@ -503,6 +519,7 @@ impl Default for TimeoutOptions {
             timeout: Self::default_timeout(),
             timeout_step: Self::default_timeout_step(),
             max_retries: Some(Self::default_max_retries()),
+            tcp_read_timeout: Self::default_tcp_read_timeout(),
             request_timeout: Self::default_request_timeouts(),
         }
     }

--- a/common/src/mbus_api/mod.rs
+++ b/common/src/mbus_api/mod.rs
@@ -431,11 +431,11 @@ pub struct ReplyPayload<T>(pub Result<T, ReplyError>);
 
 // todo: implement thin wrappers on these
 /// MessageBus raw Message
-pub type BusMessage = async_nats::Message;
+pub type BusMessage = nats::asynk::Message;
 /// MessageBus subscription
-pub type BusSubscription = async_nats::Subscription;
+pub type BusSubscription = nats::asynk::Subscription;
 /// MessageBus configuration options
-pub type BusOptions = async_nats::Options;
+pub type BusOptions = nats::asynk::Options;
 /// Save on typing
 pub type DynBus = Box<dyn Bus>;
 

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -17,7 +17,6 @@ name = "common"
 path = "common/src/lib.rs"
 
 [dependencies]
-nats = "0.15.2"
 structopt = "0.3.23"
 tokio = { version = "1.12.0", features = ["full"] }
 tonic = "0.5.2"

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/lib.rs"
 [dependencies]
 composer = { path = "../composer" }
 common-lib = { path = "../common" }
-nats = "0.15.2"
 structopt = "0.3.23"
 tokio = { version = "1.12.0", features = ["full"] }
 tonic = "0.5.2"

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -52,6 +52,9 @@ let
 
     cargoLock = {
       lockFile = ../../../Cargo.lock;
+      outputHashes = {
+        "nats-0.15.2" = "sha256:1whr0v4yv31q5zwxhcqmx4qykgn5cgzvwlaxgq847mymzajpcsln";
+      };
     };
 
     preBuild = "patchShebangs ./scripts/generate-openapi-bindings.sh";

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "ee7edec50b49ab6d69b06d62f1de554efccb1ccd",
-        "sha256": "06g37l34hzi81lc7hmk91mzapsa1iak7yi3agxgdzfc69qk9wp17",
+        "rev": "0d2ce479df4633dbeb53a8ea96e5098ed37fbcc6",
+        "sha256": "1hry9kxsa59g0z116m7x5zf0l7q1rfqw7a1icv4818bh8j8dhbfp",
         "type": "tarball",
-        "url": "https://github.com/nmattia/naersk/archive/ee7edec50b49ab6d69b06d62f1de554efccb1ccd.tar.gz",
+        "url": "https://github.com/nmattia/naersk/archive/0d2ce479df4633dbeb53a8ea96e5098ed37fbcc6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "1819632b5823e0527da28ad82fecd6be5136c1e9",
-        "sha256": "08jz17756qchq0zrqmapcm33nr4ms9f630mycc06i6zkfwl5yh5i",
+        "rev": "65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e",
+        "sha256": "17mirpsx5wyw262fpsd6n6m47jcgw8k2bwcp1iwdnrlzy4dhcgqh",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/1819632b5823e0527da28ad82fecd6be5136c1e9.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -29,10 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3600a82711987ac1267a96fd97974437b69f6806",
-        "sha256": "0pyxcf2vb30maw1rnzw1y949q5mq304jbkgjj0rrkp4ibzzyglai",
+        "rev": "c8f8adc5ec85a444618da8280d666af760925b24",
+        "sha256": "073ykvc5i023a8r1wi14b40fkqvj58jssi3na8mm8kmn4x0sdja2",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/3600a82711987ac1267a96fd97974437b69f6806.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c8f8adc5ec85a444618da8280d666af760925b24.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {


### PR DESCRIPTION
chore(nats): use the nats with a stuck tcp stream fix

The tcp stream to the nats-server can get stuck if the server is not
shutdown gracefully. Even the connection lost callback does not get
triggered because the stream is somehow stuck.

----------------
fix(nats): set tcp read timeouts

The tcp stream to the nats-server can get stuck if the server is not
shutdown gracefully. As such Even the connection lost callback does not get
triggered because the stream is somehow stuck.

Adding the timeout if we do not receive a message with a timeout helps
address the issue: when the timeout expires the client now sends a ping
to the server and expects to receive a pong within the same timeout.
If a pong does not arrive in time then the connection is deemed lost.

As a side effect this may cause additional strain on the nats server when
too many clients are idle as the timeouts will be fired.

Don't cache connect_url's returned by the NATS INFO message as they may
get outdated and point to bogus IP addresses.

Also add connection handlers to highlight whenever the services connection
to the NATS server changes.

Resolves CAS-1192