### PR TITLE
fix(bug): don't disown unused replicas

### DIFF
--- a/common/src/types/v0/store/nexus_persistence.rs
+++ b/common/src/types/v0/store/nexus_persistence.rs
@@ -1,5 +1,5 @@
 use crate::types::v0::{
-    message_bus::NexusId,
+    message_bus::{NexusId, ReplicaId},
     store::definitions::{ObjectKey, StorableObject, StorableObjectType},
 };
 use serde::{Deserialize, Serialize};
@@ -16,6 +16,16 @@ pub struct NexusInfo {
     pub clean_shutdown: bool,
     /// Information about children.
     pub children: Vec<ChildInfo>,
+}
+
+impl NexusInfo {
+    /// Check if the provided replica is healthy or not
+    pub fn is_replica_healthy(&self, replica: &ReplicaId) -> bool {
+        match self.children.iter().find(|c| c.uuid == replica.as_str()) {
+            Some(info) => info.healthy,
+            None => false,
+        }
+    }
 }
 
 /// Definition of the child information that gets saved in the persistent

--- a/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
@@ -8,6 +8,7 @@ use common_lib::types::v0::{
     store::{nexus::NexusSpec, OperationMode, TraceSpan},
 };
 
+use crate::core::task_poller::PollTriggerEvent;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -41,7 +42,7 @@ impl TaskPoller for GarbageCollector {
 
     async fn poll_event(&mut self, context: &PollContext) -> bool {
         match context.event() {
-            PollEvent::TimedRun => true,
+            PollEvent::TimedRun | PollEvent::Triggered(PollTriggerEvent::Start) => true,
             PollEvent::Shutdown | PollEvent::Triggered(_) => false,
         }
     }

--- a/control-plane/agents/core/src/core/reconciler/poller.rs
+++ b/control-plane/agents/core/src/core/reconciler/poller.rs
@@ -1,7 +1,10 @@
 use crate::core::{
     reconciler::{nexus, persistent_store::PersistentStoreReconciler, pool, replica, volume},
     registry::Registry,
-    task_poller::{squash_results, PollContext, PollEvent, PollResult, PollerState, TaskPoller},
+    task_poller::{
+        squash_results, PollContext, PollEvent, PollResult, PollTriggerEvent, PollerState,
+        TaskPoller,
+    },
 };
 
 /// Reconciliation worker that polls all reconciliation loops
@@ -60,7 +63,7 @@ impl ReconcilerWorker {
     /// The polling will continue until we receive the shutdown signal
     pub(super) async fn poller(mut self, registry: Registry) {
         // kick-off the first run
-        let mut event = PollEvent::TimedRun;
+        let mut event = PollEvent::Triggered(PollTriggerEvent::Start);
         loop {
             let result = match &event {
                 PollEvent::Shutdown => {

--- a/control-plane/agents/core/src/core/reconciler/replica/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/replica/mod.rs
@@ -3,7 +3,9 @@ mod tests;
 
 use crate::core::{
     specs::{OperationSequenceGuard, SpecOperations},
-    task_poller::{PollContext, PollEvent, PollResult, PollTimer, PollerState, TaskPoller},
+    task_poller::{
+        PollContext, PollEvent, PollResult, PollTimer, PollTriggerEvent, PollerState, TaskPoller,
+    },
 };
 use common_lib::types::v0::{message_bus::ReplicaOwners, store::OperationMode};
 use std::ops::Deref;
@@ -38,7 +40,7 @@ impl TaskPoller for ReplicaReconciler {
 
     async fn poll_event(&mut self, context: &PollContext) -> bool {
         match context.event() {
-            PollEvent::TimedRun => true,
+            PollEvent::TimedRun | PollEvent::Triggered(PollTriggerEvent::Start) => true,
             PollEvent::Shutdown | PollEvent::Triggered(_) => false,
         }
     }

--- a/control-plane/agents/core/src/core/task_poller.rs
+++ b/control-plane/agents/core/src/core/task_poller.rs
@@ -22,6 +22,8 @@ pub(crate) enum PollTriggerEvent {
     /// A volume has been published in a Degraded state
     /// eg: may need replicas to be carved and/or added
     VolumeDegraded,
+    /// The Agent is starting up
+    Start,
 }
 
 /// State of a poller


### PR DESCRIPTION
When the nexus is not in the created phase don't disown replicas, wait
until the nexus is created so that we have a clear picture of what's
unused.

Also, make sure we don't disown healthy replicas.