### PR TITLE
fix(csi): fixed volume unpublishing for offlined nexuses

### DIFF
--- a/control-plane/csi-controller/src/client.rs
+++ b/control-plane/csi-controller/src/client.rs
@@ -254,11 +254,15 @@ impl MayastorApiClient {
 
     /// Unpublish volume (i.e. destroy a target which exposes the volume).
     #[instrument(fields(volume.uuid = %volume_id), skip(volume_id))]
-    pub async fn unpublish_volume(&self, volume_id: &uuid::Uuid) -> Result<(), ApiClientError> {
+    pub async fn unpublish_volume(
+        &self,
+        volume_id: &uuid::Uuid,
+        force: bool,
+    ) -> Result<(), ApiClientError> {
         Self::delete_idempotent(
             self.rest_client
                 .volumes_api()
-                .del_volume_target(volume_id, Some(false))
+                .del_volume_target(volume_id, Some(force))
                 .await,
             true,
         )?;

--- a/tests/bdd/features/csi/controller.feature
+++ b/tests/bdd/features/csi/controller.feature
@@ -114,3 +114,9 @@ Scenario: list local volume
     When a ListVolumesRequest is sent to CSI controller
     Then listed local volume must be accessible only from all existing Mayastor nodes
     And no topology restrictions should be imposed to non-local volumes
+
+Scenario: unpublish volume when nexus node is offline
+    Given a volume published on a node
+    When a node that hosts the nexus becomes offline
+    Then a ControllerUnpublishVolume request should succeed as if nexus node was online
+    And volume should be successfully republished on the other node


### PR DESCRIPTION
ControllerUnpublishVolume() now successfully unpublishes the volumes
whose nexuses are located on offline nodes.

Resolves: CAS-1236