### PR TITLE
fix(msp cr status): add fix for msp cr going to error state on node down

### DIFF
--- a/control-plane/agents/core/src/pool/registry.rs
+++ b/control-plane/agents/core/src/pool/registry.rs
@@ -37,14 +37,15 @@ impl Registry {
             }
             Some(node_id) => {
                 let mut pools = vec![];
-                let pools_from_state =
-                    self.get_node_pools(&node_id)
-                        .await?
-                        .into_iter()
-                        .map(|state| {
-                            let spec = self.specs().get_pool(&state.id).ok();
-                            Pool::from_state(state, spec)
-                        });
+                let pools_from_state = self
+                    .get_node_pools(&node_id)
+                    .await
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|state| {
+                        let spec = self.specs().get_pool(&state.id).ok();
+                        Pool::from_state(state, spec)
+                    });
 
                 pools.extend(pools_from_state);
 

--- a/control-plane/msp-operator/src/main.rs
+++ b/control-plane/msp-operator/src/main.rs
@@ -356,6 +356,7 @@ impl ResourceContext {
     fn pools_api(&self) -> &dyn openapi::apis::pools_api::tower::client::Pools {
         self.ctx.http.pools_api()
     }
+
     fn block_devices_api(
         &self,
     ) -> &dyn openapi::apis::block_devices_api::tower::client::BlockDevices {
@@ -435,77 +436,93 @@ impl ResourceContext {
             // we updated the resource as an error stop reconciliation
             return Err(Error::ReconcileError { name: self.name() });
         }
-
-        if !self
+        match self
             .block_devices_api()
             .get_node_block_devices(&self.spec.node, Some(true))
-            .await?
-            .into_body()
-            .into_iter()
-            .any(|b| {
-                b.devname == normalize_disk(&self.spec.disks[0])
-                    || b.devlinks
-                        .iter()
-                        .any(|d| *d == normalize_disk(&self.spec.disks[0]))
-            })
-        {
-            self.k8s_notify(
-                "Create or import",
-                "Missing",
-                &format!(
-                    "The block device(s): {} can not be found",
-                    &self.spec.disks[0]
-                ),
-                "Warn",
-            )
-            .await;
-
-            return Err(Error::SpecError {
-                value: self.spec.disks[0].clone(),
-                timeout: u32::pow(2, self.num_retries),
-            });
-        }
-
-        let mut labels: HashMap<String, String> = HashMap::new();
-        labels.insert(
-            String::from(constants::OPENEBS_CREATED_BY_KEY),
-            String::from(constants::MSP_OPERATOR),
-        );
-
-        let body = CreatePoolBody::new_all(self.spec.disks.clone(), labels);
-        match self
-            .pools_api()
-            .put_node_pool(&self.spec.node, &self.name(), body)
             .await
         {
-            Ok(_) => {}
-            Err(clients::tower::Error::Response(response))
-                if response.status() == clients::tower::StatusCode::UNPROCESSABLE_ENTITY =>
-            {
-                // UNPROCESSABLE_ENTITY indicates that the pool spec already exists in the control
-                // plane. So we want to update the CRD to 'Created' to reflect this.
+            Ok(response) => {
+                if !response.into_body().into_iter().any(|b| {
+                    b.devname == normalize_disk(&self.spec.disks[0])
+                        || b.devlinks
+                            .iter()
+                            .any(|d| *d == normalize_disk(&self.spec.disks[0]))
+                }) {
+                    self.k8s_notify(
+                        "Create or import",
+                        "Missing",
+                        &format!(
+                            "The block device(s): {} can not be found",
+                            &self.spec.disks[0]
+                        ),
+                        "Warn",
+                    )
+                    .await;
+
+                    return Err(Error::SpecError {
+                        value: self.spec.disks[0].clone(),
+                        timeout: u32::pow(2, self.num_retries),
+                    });
+                }
+
+                let mut labels: HashMap<String, String> = HashMap::new();
+                labels.insert(
+                    String::from(constants::OPENEBS_CREATED_BY_KEY),
+                    String::from(constants::MSP_OPERATOR),
+                );
+
+                let body = CreatePoolBody::new_all(self.spec.disks.clone(), labels);
+                match self
+                    .pools_api()
+                    .put_node_pool(&self.spec.node, &self.name(), body)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(clients::tower::Error::Response(response))
+                        if response.status()
+                            == clients::tower::StatusCode::UNPROCESSABLE_ENTITY =>
+                    {
+                        // UNPROCESSABLE_ENTITY indicates that the pool spec already exists in the
+                        // control plane. So we want to update the CRD to
+                        // 'Created' to reflect this.
+                    }
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                };
+
+                self.k8s_notify(
+                    "Create or Import",
+                    "Created",
+                    "Created or imported pool",
+                    "Normal",
+                )
+                .await;
+
+                let _ = self.patch_status(MayastorPoolStatus::created()).await?;
+
+                // We are done creating the pool, we patched to created which triggers a
+                // new loop. Any error in the loop will call our error handler where we
+                // decide what to do
+                Ok(ReconcilerAction {
+                    requeue_after: None,
+                })
             }
-            Err(e) => {
-                return Err(e.into());
-            }
-        };
-
-        self.k8s_notify(
-            "Create or Import",
-            "Created",
-            "Created or imported pool",
-            "Normal",
-        )
-        .await;
-
-        let _ = self.patch_status(MayastorPoolStatus::created()).await?;
-
-        // We are done creating the pool, we patched to created which triggers a
-        // new loop. Any error in the loop will call our error handler where we
-        // decide what to do
-        Ok(ReconcilerAction {
-            requeue_after: None,
-        })
+            // We would land here if some error occurred ex, precondition failed, i.e. node
+            // down, in that case we check for pool existence before setting a status.
+            Err(_) => match self.pools_api().get_pool(&self.name()).await {
+                Ok(response) => {
+                    let pool = response.into_body();
+                    // As pool exists, set the status based on the presence of pool state.
+                    self.set_status_or_unknown(pool).await
+                }
+                Err(_) => {
+                    // If we don't find the pool, i.e. its not present or not yet created
+                    // so, set the status to Creating to retry creation.
+                    return self.mark_error().await;
+                }
+            },
+        }
     }
 
     /// Delete the pool from the mayastor instance
@@ -615,20 +632,25 @@ impl ResourceContext {
                         return self.mark_error().await;
                     }
                 } else {
-                    // any other error is not expected
-                    self.k8s_notify(
-                        "Missing",
-                        "Check",
-                        &format!("The pool information is not available: {}", response),
-                        "Warning",
-                    )
-                        .await;
-                    return self.is_missing().await;
+                        self.k8s_notify(
+                            "Missing",
+                            "Check",
+                            &format!("The pool information is not available: {}", response),
+                            "Warning",
+                        )
+                            .await;
+                        return self.is_missing().await;
                 }
             }
             error => error,
         }?.into_body();
+        // As pool exists, set the status based on the presence of pool state.
+        self.set_status_or_unknown(pool).await
+    }
 
+    /// If the pool, has a state we set that status to the CR and if it does not have a state
+    /// we set the status as unknown so that we can try again later.
+    async fn set_status_or_unknown(&self, pool: Pool) -> Result<ReconcilerAction, Error> {
         if pool.state.is_some() {
             if let Some(status) = &self.status {
                 let new_status = MayastorPoolStatus::from(pool);


### PR DESCRIPTION
Fix for the bug which causes the CR status to go from CREATING to ERROR.
Added checks to handle PRECONDITION_FAILED errors.

Resolves [CAS-1244](https://mayadata.atlassian.net/browse/CAS-1244)