### PR TITLE
fix(hotspare): schedule replicas individually

### DIFF
--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -669,32 +669,50 @@ impl ResourceSpecsLocked {
         &self,
         registry: &Registry,
         volume_spec: &VolumeSpec,
-        candidates: Vec<CreateReplica>,
         count: usize,
         mode: OperationMode,
-    ) -> usize {
-        let mut created = 0;
-        for attempt in candidates.into_iter() {
-            if created >= count {
+    ) -> Result<Vec<ReplicaId>, SvcError> {
+        let mut created_replicas = Vec::with_capacity(count);
+        let mut candidate_error = None;
+
+        for iter in 0 .. count {
+            let candidates = match get_volume_replica_candidates(registry, volume_spec).await {
+                Ok(candidates) => candidates,
+                Err(error) => {
+                    candidate_error = Some(error);
+                    break;
+                }
+            };
+
+            for attempt in candidates.into_iter() {
+                match self.create_replica(registry, &attempt, mode).await {
+                    Ok(replica) => {
+                        volume_spec
+                            .debug(&format!("Successfully created replica '{}'", replica.uuid));
+                        created_replicas.push(replica.uuid);
+                        break;
+                    }
+                    Err(error) => {
+                        volume_spec.error(&format!(
+                            "Failed to create replica '{:?}', error: '{}'",
+                            attempt,
+                            error.full_string(),
+                        ));
+                    }
+                }
+            }
+
+            if created_replicas.len() <= iter {
                 break;
             }
+        }
 
-            match self.create_replica(registry, &attempt, mode).await {
-                Ok(replica) => {
-                    volume_spec.debug(&format!("Successfully created replica '{}'", replica.uuid));
-
-                    created += 1;
-                }
-                Err(error) => {
-                    volume_spec.error(&format!(
-                        "Failed to created replica '{:?}', error: '{}'",
-                        attempt,
-                        error.full_string(),
-                    ));
-                }
+        if created_replicas.is_empty() {
+            if let Some(error) = candidate_error {
+                return Err(error);
             }
         }
-        created
+        Ok(created_replicas)
     }
 
     /// Add the given replica to the nexus of the given volume
@@ -1168,7 +1186,6 @@ impl ResourceSpecsLocked {
         let mut candidates =
             get_nexus_child_remove_candidates(&vol_spec_clone, &nexus_spec_clone, registry).await?;
 
-        let mut result = Ok(());
         while let Some(candidate) = candidates.next() {
             if nexus_replica_children <= volume_children {
                 break;
@@ -1194,11 +1211,11 @@ impl ResourceSpecsLocked {
                         child_uri,
                         error.full_string()
                     ));
-                    result = Err(error);
+                    return Err(error);
                 }
             }
         }
-        result
+        Ok(())
     }
 
     /// Disown replica from its volume

--- a/control-plane/agents/core/src/volume/tests.rs
+++ b/control-plane/agents/core/src/volume/tests.rs
@@ -75,7 +75,7 @@ async fn hotspare() {
         .with_rest(true)
         .with_agents(vec!["core"])
         .with_mayastors(3)
-        .with_pools(1)
+        .with_pools(2)
         .with_cache_period("1s")
         .with_reconcile_period(Duration::from_secs(1), Duration::from_secs(1))
         .build()
@@ -88,6 +88,7 @@ async fn hotspare() {
     hotspare_unknown_children(&cluster).await;
     hotspare_missing_children(&cluster).await;
     hotspare_replica_count(&cluster).await;
+    hotspare_replica_count_spread(&cluster).await;
     hotspare_nexus_replica_count(&cluster).await;
 }
 
@@ -604,6 +605,85 @@ async fn hotspare_missing_children(cluster: &Cluster) {
     assert_eq!(children.len(), 2);
     // the missing child should have been replaced!
     assert!(!children.iter().any(|c| c.uri == missing_child));
+
+    DestroyVolume::new(volume.uuid()).request().await.unwrap();
+}
+
+/// When more than 1 replicas are faulted at the same time, the new replicas should be spread
+/// across the existing pools, and no pool nor any node should be reused
+async fn hotspare_replica_count_spread(cluster: &Cluster) {
+    let nodes = cluster.rest_v00().nodes_api().get_nodes().await.unwrap();
+    assert!(
+        nodes.len() >= 3,
+        "We need enough nodes to be able to add at least 2 replicas"
+    );
+    let pools = cluster.rest_v00().pools_api().get_pools().await.unwrap();
+    assert!(
+        pools.len() >= nodes.len() * 2,
+        "We need at least 2 pools per node to be able to test the failure case"
+    );
+
+    let replica_count = nodes.len();
+    let volume = CreateVolume {
+        uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
+        size: 5242880,
+        replicas: 1,
+        ..Default::default()
+    }
+    .request()
+    .await
+    .unwrap();
+
+    // stop the core agent, so we can simulate `replica_count-1` data replicas being faulted at once
+    // by increasing the replica count from 1 to `replica_count` under the core agent
+    cluster.composer().stop("core").await.unwrap();
+
+    let mut store = Etcd::new("0.0.0.0:2379")
+        .await
+        .expect("Failed to connect to etcd.");
+
+    let mut volume_spec: VolumeSpec = store.get_obj(&volume.spec().key()).await.unwrap();
+    volume_spec.num_replicas = replica_count as u8;
+    tracing::info!("VolumeSpec: {:?}", volume_spec);
+    store.put_obj(&volume_spec).await.unwrap();
+
+    cluster.restart_core().await;
+
+    let timeout_opts = TimeoutOptions::default()
+        .with_max_retries(10)
+        .with_timeout(Duration::from_millis(200))
+        .with_timeout_backoff(Duration::from_millis(50));
+    Liveness::default()
+        .request_on_ext(ChannelVs::Volume, timeout_opts.clone())
+        .await
+        .expect("Should have restarted by now");
+
+    // check we have the new replica_count
+    wait_till_volume(volume.uuid(), replica_count).await;
+
+    {
+        let volume = cluster
+            .rest_v00()
+            .volumes_api()
+            .get_volume(volume.uuid())
+            .await
+            .unwrap();
+
+        tracing::info!("Replicas: {:?}", volume.state.replica_topology);
+
+        assert_eq!(volume.spec.num_replicas, replica_count as u8);
+        assert_eq!(volume.state.replica_topology.len(), replica_count);
+
+        for node in 0 .. nodes.len() {
+            let node = cluster.node(node as u32);
+            let replicas = volume
+                .state
+                .replica_topology
+                .values()
+                .filter(|r| r.node == Some(node.to_string()));
+            assert_eq!(replicas.count(), 1, "each node should have 1 replica");
+        }
+    }
 
     DestroyVolume::new(volume.uuid()).request().await.unwrap();
 }


### PR DESCRIPTION
When >1 replicas fail at the same time, the core agent was running the
scheduling algorithm once and then using the result to create new replicas.

The fix is to run the scheduling algorithm for each new replica we're adding.
This way we always make sure that we respect the scheduling rules.