### PR TITLE
fix(replica): decrementing volume replica count

### DIFF
--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -503,7 +503,7 @@ impl From<SvcError> for ReplyError {
                 extra: error.full_string(),
             },
             SvcError::ReplicaRemovalNoCandidates { .. } => ReplyError {
-                kind: ReplyErrorKind::ReplicaIncrease,
+                kind: ReplyErrorKind::ReplicaChangeCount,
                 resource: ResourceKind::Volume,
                 source: desc.to_string(),
                 extra: error.full_string(),

--- a/tests/bdd/common/docker.py
+++ b/tests/bdd/common/docker.py
@@ -22,6 +22,13 @@ class Docker(object):
         container = docker_client.containers.get(name)
         container.kill()
 
+    # Stop a container with the given name.
+    @staticmethod
+    def stop_container(name):
+        docker_client = docker.from_env()
+        container = docker_client.containers.get(name)
+        container.stop()
+
     # Pause a container with the given name.
     @staticmethod
     def pause_container(name):

--- a/tests/bdd/features/volume/replicas.feature
+++ b/tests/bdd/features/volume/replicas.feature
@@ -16,6 +16,13 @@ Feature: Adjusting the volume replicas
   Scenario: setting volume replicas to zero
     Then setting the number of replicas to zero should fail with a suitable error
 
+  Scenario: decreasing the replica count when the runtime replica count matches the desired count
+    Given a volume with 2 replicas
+    And no available pools for replacement replicas
+    When the number of runtime replicas is 1
+    And a user attempts to decrease the number of volume replicas from 2 to 1
+    Then the volume spec should show 1 replica
+
   # TODO: Enable this after handling the simple cases
 #  Scenario: replacing a faulted replica
 #    When Mayastor has marked a replica as faulted

--- a/tests/bdd/test_volume_replicas.py
+++ b/tests/bdd/test_volume_replicas.py
@@ -1,4 +1,5 @@
 """Adjusting the volume replicas feature tests."""
+import time
 
 from pytest_bdd import (
     given,
@@ -8,9 +9,11 @@ from pytest_bdd import (
 )
 
 import pytest
+from retrying import retry
 
 from common.deployer import Deployer
 from common.apiclient import ApiClient
+from common.docker import Docker
 
 from openapi.model.create_pool_body import CreatePoolBody
 from openapi.model.create_volume_body import CreateVolumeBody
@@ -19,21 +22,49 @@ from openapi.model.volume_policy import VolumePolicy
 
 POOL_1_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
 POOL_2_UUID = "91a60318-bcfe-4e36-92cb-ddc7abf212ea"
+POOL_3_UUID = "0b6cd331-60d9-48ae-ac00-dbe0430d6c1f"
 VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
 NODE_1_NAME = "mayastor-1"
 NODE_2_NAME = "mayastor-2"
-VOLUME_CTX_KEY = "volume"
+NODE_3_NAME = "mayastor-3"
 VOLUME_SIZE = 10485761
-NUM_MAYASTORS = 2
+NUM_MAYASTORS = 3
+NUM_VOLUME_REPLICAS = 2
 REPLICA_CONTEXT_KEY = "replica"
 
 
-# This fixture will be automatically used by all tests.
-# It starts the deployer which launches all the necessary containers.
-# A pool and volume are created for convenience such that it is available for use by the tests.
-@pytest.fixture(autouse=True)
+# Initialisation function to setup system for test cases.
+# The deployer uses the default parameterisation.
+@pytest.fixture()
 def init():
     Deployer.start(num_mayastors=NUM_MAYASTORS)
+    init_resources()
+    yield
+    Deployer.stop()
+
+
+# Initialisation function to setup system for test cases.
+# The deployer uses a custom parameterisation.
+@pytest.fixture()
+def init_parameterised_deployer():
+    # Shorten the reconcile periods and cache period to speed up the tests.
+    Deployer.start_with_args(
+        [
+            "-j",
+            f"-m={NUM_MAYASTORS}",
+            "-w=10s",
+            "--reconcile-idle-period=1s",
+            "--reconcile-period=1s",
+            "--cache-period=1s",
+        ]
+    )
+    init_resources()
+    yield
+    Deployer.stop()
+
+
+# Create pools and a volume for use in the test cases.
+def init_resources():
     ApiClient.pools_api().put_node_pool(
         NODE_1_NAME, POOL_1_UUID, CreatePoolBody(["malloc:///disk?size_mb=50"])
     )
@@ -41,17 +72,18 @@ def init():
         NODE_2_NAME, POOL_2_UUID, CreatePoolBody(["malloc:///disk?size_mb=50"])
     )
     ApiClient.volumes_api().put_volume(
-        VOLUME_UUID, CreateVolumeBody(VolumePolicy(False), 1, VOLUME_SIZE)
+        VOLUME_UUID,
+        CreateVolumeBody(VolumePolicy(True), NUM_VOLUME_REPLICAS, VOLUME_SIZE),
     )
-
+    ApiClient.pools_api().put_node_pool(
+        NODE_3_NAME, POOL_3_UUID, CreatePoolBody(["malloc:///disk?size_mb=50"])
+    )
     # Publish volume so that there is a nexus to add a replica to.
     volume = ApiClient.volumes_api().put_volume_target(
         VOLUME_UUID, NODE_1_NAME, Protocol("nvmf")
     )
     assert hasattr(volume.spec, "target")
     assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))
-    yield
-    Deployer.stop()
 
 
 # Fixture used to pass the replica context between test steps.
@@ -60,18 +92,28 @@ def replica_ctx():
     return {}
 
 
+@scenario(
+    "features/volume/replicas.feature",
+    "decreasing the replica count when the runtime replica count matches the desired count",
+)
+def test_decreasing_the_replica_count_when_the_runtime_replica_count_matches_the_desired_count(
+    init_parameterised_deployer,
+):
+    """removing a replica when the runtime replica count matches the desired count."""
+
+
 @scenario("features/volume/replicas.feature", "setting volume replicas to zero")
-def test_setting_volume_replicas_to_zero():
+def test_setting_volume_replicas_to_zero(init):
     """setting volume replicas to zero."""
 
 
 @scenario("features/volume/replicas.feature", "successfully adding a replica")
-def test_successfully_adding_a_replica():
+def test_successfully_adding_a_replica(init):
     """successfully adding a replica."""
 
 
 @scenario("features/volume/replicas.feature", "successfully removing a replica")
-def test_successfully_removing_a_replica():
+def test_successfully_removing_a_replica(init):
     """successfully removing a replica."""
 
 
@@ -79,7 +121,13 @@ def test_successfully_removing_a_replica():
 def a_suitable_available_pool():
     """a suitable available pool."""
     pools = ApiClient.pools_api().get_pools()
-    assert len(pools) == 2
+    assert len(pools) == 3
+
+
+@given("a volume with 2 replicas")
+def a_volume_with_2_replicas():
+    """a volume with 2 replicas."""
+    assert num_runtime_volume_replicas() == 2
 
 
 @given("an existing volume")
@@ -89,51 +137,69 @@ def an_existing_volume():
     assert volume.spec.uuid == VOLUME_UUID
 
 
+@given("no available pools for replacement replicas")
+def no_available_pools_for_replacement_replicas():
+    """no available pools for replacement replicas."""
+    pool_api = ApiClient.pools_api()
+    pools = pool_api.get_pools()
+    assert len(pools) == 3
+
+    # Delete the additional pool so that a replacement replica cannot be created.
+    pool_api.del_pool(POOL_3_UUID)
+    pools = pool_api.get_pools()
+    assert len(pools) == 2
+
+
 @given("the number of volume replicas is greater than one")
 def the_number_of_volume_replicas_is_greater_than_one():
     """the number of volume replicas is greater than one."""
-    volumes_api = ApiClient.volumes_api()
-    volume = volumes_api.put_volume_replica_count(VOLUME_UUID, 2)
+    volume = set_num_volume_replicas(NUM_VOLUME_REPLICAS + 1)
     assert volume.spec.num_replicas > 1
 
 
 @when("a user attempts to decrease the number of volume replicas")
 def a_user_attempts_to_decrease_the_number_of_volume_replicas(replica_ctx):
     """a user attempts to decrease the number of volume replicas."""
-    volumes_api = ApiClient.volumes_api()
-    volume = volumes_api.get_volume(VOLUME_UUID)
-    num_replicas = volume.spec.num_replicas
-    volume = volumes_api.put_volume_replica_count(VOLUME_UUID, num_replicas - 1)
+    volume = set_num_volume_replicas(num_desired_volume_replicas() - 1)
     replica_ctx[REPLICA_CONTEXT_KEY] = volume.spec.num_replicas
+
+
+@when("a user attempts to decrease the number of volume replicas from 2 to 1")
+def a_user_attempts_to_decrease_the_number_of_volume_replicas_from_2_to_1():
+    """a user attempts to decrease the number of volume replicas from 2 to 1."""
+    assert num_desired_volume_replicas() == 2
+    volume = set_num_volume_replicas(1)
+    assert volume.spec.num_replicas == 1
 
 
 @when("a user attempts to increase the number of volume replicas")
 def a_user_attempts_to_increase_the_number_of_volume_replicas(replica_ctx):
     """a user attempts to increase the number of volume replicas."""
-    volumes_api = ApiClient.volumes_api()
-    volume = volumes_api.get_volume(VOLUME_UUID)
-    num_replicas = volume.spec.num_replicas
-    volume = volumes_api.put_volume_replica_count(VOLUME_UUID, num_replicas + 1)
+    volume = ApiClient.volumes_api().put_volume_replica_count(
+        VOLUME_UUID, NUM_VOLUME_REPLICAS + 1
+    )
     replica_ctx[REPLICA_CONTEXT_KEY] = volume.spec.num_replicas
+
+
+@when("the number of runtime replicas is 1")
+def the_number_of_runtime_replicas_is_1():
+    """the number of runtime replicas is 1."""
+    # Stopping a mayastor instance will cause a replica to be faulted and removed from the volume.
+    Docker.stop_container(NODE_2_NAME)
+    # Wait for the replica to be removed from the volume.
+    wait_for_volume_replica_count(1)
 
 
 @then("a replica should be removed from the volume")
 def a_replica_should_be_removed_from_the_volume(replica_ctx):
     """a replica should be removed from the volume."""
-    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
-    assert hasattr(volume.state, "target")
-    nexus = volume.state.target
-    assert replica_ctx[REPLICA_CONTEXT_KEY] == len(nexus["children"])
+    assert replica_ctx[REPLICA_CONTEXT_KEY] == num_runtime_volume_replicas()
 
 
 @then("an additional replica should be added to the volume")
 def an_additional_replica_should_be_added_to_the_volume(replica_ctx):
     """an additional replica should be added to the volume."""
-    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
-    print(volume.state)
-    assert hasattr(volume.state, "target")
-    nexus = volume.state.target
-    assert replica_ctx[REPLICA_CONTEXT_KEY] == len(nexus["children"])
+    assert replica_ctx[REPLICA_CONTEXT_KEY] == num_runtime_volume_replicas()
 
 
 @then("setting the number of replicas to zero should fail with a suitable error")
@@ -147,3 +213,36 @@ def setting_the_number_of_replicas_to_zero_should_fail_with_a_suitable_error():
     except Exception as e:
         # TODO: Return a proper error rather than asserting for a substring
         assert "ApiValueError" in str(type(e))
+
+
+@then("the volume spec should show 1 replica")
+def the_volume_spec_should_show_1_replica():
+    """the volume spec should show 1 replica."""
+    assert num_desired_volume_replicas() == 1
+
+
+# Wait for the number of runtime volume replicas to reach the expected number of replicas.
+@retry(wait_fixed=1000, stop_max_attempt_number=10)
+def wait_for_volume_replica_count(expected_num_replicas):
+    assert num_runtime_volume_replicas() == expected_num_replicas
+
+
+# Get the number of replicas from the volume state.
+def num_runtime_volume_replicas():
+    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
+    assert hasattr(volume.state, "target")
+    nexus = volume.state.target
+    return len(nexus["children"])
+
+
+# Get the number of replicase from the volume spec.
+def num_desired_volume_replicas():
+    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
+    return volume.spec.num_replicas
+
+
+# Set the volume spec to have the desired number of replicas.
+def set_num_volume_replicas(num_replicas):
+    volumes_api = ApiClient.volumes_api()
+    volume = volumes_api.put_volume_replica_count(VOLUME_UUID, num_replicas)
+    return volume


### PR DESCRIPTION
When decrementing the number of volume replicas, it is possible that the
runtime number of replicas already matches the desired number of
replicas. In this case no replica removal candidates will be identified
and the operation can simply be completed successfully (ensuring the
persistent store is updated).

Resolves: CAS-1251