### PR TITLE
chore(nix): update sources to the latest

### DIFF
--- a/common/src/mbus_api/mod.rs
+++ b/common/src/mbus_api/mod.rs
@@ -527,23 +527,27 @@ impl Default for TimeoutOptions {
 
 impl TimeoutOptions {
     /// New options with default values
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
 
     /// New options with default values but with no retries
+    #[must_use]
     pub fn new_no_retries() -> Self {
         Self::new().with_max_retries(0)
     }
 
     /// Timeout after which we'll either fail the request or start retrying
     /// if max_retries is greater than 0 or None
+    #[must_use]
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self
     }
 
     /// Timeout multiplied at each iteration
+    #[must_use]
     pub fn with_timeout_backoff(mut self, timeout: Duration) -> Self {
         self.timeout_step = timeout;
         self
@@ -551,12 +555,14 @@ impl TimeoutOptions {
 
     /// Specify a max number of retries before giving up
     /// None for unlimited retries
+    #[must_use]
     pub fn with_max_retries<M: Into<Option<u32>>>(mut self, max_retries: M) -> Self {
         self.max_retries = max_retries.into();
         self
     }
 
     /// Minimum timeouts for specific requests
+    #[must_use]
     pub fn with_req_timeout(mut self, timeout: impl Into<Option<RequestMinTimeout>>) -> Self {
         self.request_timeout = timeout.into();
         self

--- a/common/src/store/etcd_keep_alive.rs
+++ b/common/src/store/etcd_keep_alive.rs
@@ -148,7 +148,7 @@ impl EtcdSingletonLock {
 
         let lock_key =
             String::from_utf8(lock_resp.key().to_vec()).map_err(|e| StoreError::FailedLock {
-                reason: format!("Invalid etcd lock key, error: '{}'", e.to_string()),
+                reason: format!("Invalid etcd lock key, error: '{}'", e),
             })?;
         let lease_id = lease_resp.id();
 
@@ -332,6 +332,7 @@ struct Locked {
 }
 #[derive(Debug)]
 struct KeepAlive {
+    #[allow(dead_code)]
     lock_key: String,
     keeper: LeaseKeeper,
     stream: LeaseKeepAliveStream,
@@ -543,7 +544,7 @@ impl LeaseLockKeeperClocking<Replaced> for EtcdSingletonLock {
     async fn clock(&mut self, _state: Replaced) -> LockStatesResult {
         panic!(
             "Lost lock to another service instance: {}. Giving up...",
-            self.service_name.to_string()
+            self.service_name
         );
     }
 }

--- a/common/src/types/v0/message_bus/volume.rs
+++ b/common/src/types/v0/message_bus/volume.rs
@@ -184,7 +184,7 @@ pub struct Topology {
 impl Topology {
     /// Get a reference to the explicit topology
     pub fn explicit(&self) -> Option<&ExplicitNodeTopology> {
-        self.node.as_ref().map(|n| n.explicit()).flatten()
+        self.node.as_ref().and_then(|n| n.explicit())
     }
 }
 impl From<Topology> for models::Topology {

--- a/common/src/types/v0/message_bus/watch.rs
+++ b/common/src/types/v0/message_bus/watch.rs
@@ -75,19 +75,19 @@ impl Default for WatchResourceId {
 impl ToString for WatchResourceId {
     fn to_string(&self) -> String {
         match self {
-            WatchResourceId::Node(id) => format!("nodes/{}", id.to_string()),
-            WatchResourceId::Pool(id) => format!("pools/{}", id.to_string()),
+            WatchResourceId::Node(id) => format!("nodes/{}", id),
+            WatchResourceId::Pool(id) => format!("pools/{}", id),
             WatchResourceId::Replica(id) => {
-                format!("replicas/{}", id.to_string())
+                format!("replicas/{}", id)
             }
             WatchResourceId::ReplicaState(id) => {
-                format!("replicas_state/{}", id.to_string())
+                format!("replicas_state/{}", id)
             }
             WatchResourceId::ReplicaSpec(id) => {
-                format!("replicas_spec/{}", id.to_string())
+                format!("replicas_spec/{}", id)
             }
-            WatchResourceId::Nexus(id) => format!("nexuses/{}", id.to_string()),
-            WatchResourceId::Volume(id) => format!("volumes/{}", id.to_string()),
+            WatchResourceId::Nexus(id) => format!("nexuses/{}", id),
+            WatchResourceId::Volume(id) => format!("volumes/{}", id),
         }
     }
 }

--- a/common/src/types/v0/store/definitions.rs
+++ b/common/src/types/v0/store/definitions.rs
@@ -163,7 +163,7 @@ pub fn key_prefix(obj_type: StorableObjectType) -> String {
     format!(
         "/namespace/{}/control-plane/{}",
         std::env::var("MY_POD_NAMESPACE").unwrap_or_else(|_| "default".into()),
-        obj_type.to_string()
+        obj_type
     )
 }
 

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -556,7 +556,7 @@ fn grpc_to_reply_error(error: SvcError) -> ReplyError {
                 Code::DataLoss => ReplyErrorKind::Internal,
                 Code::Unauthenticated => ReplyErrorKind::Unauthenticated,
             };
-            let extra = format!("{}::{}", request, source.to_string());
+            let extra = format!("{}::{}", request, source);
             ReplyError {
                 kind,
                 resource,

--- a/control-plane/agents/common/src/lib.rs
+++ b/control-plane/agents/common/src/lib.rs
@@ -188,6 +188,7 @@ impl Service {
     }
 
     /// Setup default `channel` where `with_subscription` will listen on
+    #[must_use]
     pub fn with_channel(mut self, channel: impl Into<Channel>) -> Self {
         self.channel = channel.into();
         self
@@ -210,6 +211,7 @@ impl Service {
     ///    let more: &More = args.context.get_state()?;
     /// # Ok(())
     /// # }
+    #[must_use]
     pub fn with_shared_state<T: Send + Sync + 'static>(self, state: T) -> Self {
         let type_name = std::any::type_name::<T>();
         tracing::debug!("Adding shared type: {}", type_name);
@@ -249,6 +251,7 @@ impl Service {
     /// # async fn alive() -> bool {
     ///    Liveness{}.request().await.is_ok()
     /// # }
+    #[must_use]
     pub fn with_default_liveness(self) -> Self {
         #[derive(Clone, Default)]
         struct ServiceHandler<T> {
@@ -270,6 +273,7 @@ impl Service {
     }
 
     /// Configure `self` through a configure closure
+    #[must_use]
     pub fn configure<F>(self, configure: F) -> Self
     where
         F: FnOnce(Service) -> Service,
@@ -287,12 +291,14 @@ impl Service {
     }
 
     /// Add a new subscriber on the default channel
+    #[must_use]
     pub fn with_subscription(self, service_subscriber: impl ServiceSubscriber + 'static) -> Self {
         let channel = self.channel.clone();
         self.with_subscription_channel(channel, service_subscriber)
     }
 
     /// Add a new subscriber on the given `channel`
+    #[must_use]
     pub fn with_subscription_channel(
         mut self,
         channel: Channel,

--- a/control-plane/agents/core/src/core/grpc.rs
+++ b/control-plane/agents/core/src/core/grpc.rs
@@ -70,6 +70,7 @@ impl GrpcContext {
 /// Wrapper over all gRPC Clients types
 #[derive(Clone)]
 pub(crate) struct GrpcClient {
+    #[allow(dead_code)]
     context: GrpcContext,
     /// gRPC Mayastor Client
     pub(crate) client: MayaClient,

--- a/control-plane/agents/core/src/core/scheduling/resources/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/resources/mod.rs
@@ -37,14 +37,13 @@ impl PoolItemLister {
         let pools = Self::nodes(registry)
             .await
             .iter()
-            .map(|n| {
+            .flat_map(|n| {
                 n.pool_wrappers()
                     .iter()
                     .filter(|p| registry.specs().get_pool(&p.id).is_ok())
                     .map(|p| PoolItem::new(n.clone(), p.clone()))
                     .collect::<Vec<_>>()
             })
-            .flatten()
             .collect();
         pools
     }

--- a/control-plane/agents/core/src/core/wrapper.rs
+++ b/control-plane/agents/core/src/core/wrapper.rs
@@ -401,14 +401,13 @@ impl NodeWrapper {
         let rpc_replicas = &rpc_replicas.get_ref().replicas;
         let pools = rpc_replicas
             .iter()
-            .map(|p| match rpc_replica_to_bus(p, &self.id) {
+            .filter_map(|p| match rpc_replica_to_bus(p, &self.id) {
                 Ok(r) => Some(r),
                 Err(error) => {
                     tracing::error!(error=%error, "Could not convert rpc replica");
                     None
                 }
             })
-            .flatten()
             .collect();
         Ok(pools)
     }
@@ -444,14 +443,13 @@ impl NodeWrapper {
         let rpc_nexuses = &rpc_nexuses.get_ref().nexus_list;
         let nexuses = rpc_nexuses
             .iter()
-            .map(|n| match rpc_nexus_v2_to_bus(n, &self.id) {
+            .filter_map(|n| match rpc_nexus_v2_to_bus(n, &self.id) {
                 Ok(n) => Some(n),
                 Err(error) => {
                     tracing::error!(error=%error, "Could not convert rpc nexus");
                     None
                 }
             })
-            .flatten()
             .collect();
         Ok(nexuses)
     }

--- a/control-plane/agents/core/src/watcher/service.rs
+++ b/control-plane/agents/core/src/watcher/service.rs
@@ -14,7 +14,6 @@ use tokio::sync::Mutex;
 
 #[derive(Clone, Debug)]
 pub(super) struct Service {
-    registry: Registry,
     watcher: Arc<Mutex<StoreWatcher>>,
 }
 
@@ -22,8 +21,7 @@ pub(super) struct Service {
 impl Service {
     pub(super) fn new(registry: Registry) -> Self {
         Self {
-            watcher: Arc::new(Mutex::new(StoreWatcher::new(registry.clone()))),
-            registry,
+            watcher: Arc::new(Mutex::new(StoreWatcher::new(registry))),
         }
     }
 

--- a/control-plane/agents/core/src/watcher/watch.rs
+++ b/control-plane/agents/core/src/watcher/watch.rs
@@ -65,8 +65,9 @@ struct WatchParams {
 struct WatchParamsCfg {
     /// inner configurable watch parameters
     params: WatchParams,
-    /// handle to the watcher
+    /// handle to the watcher (logic on the drop)
     #[serde(skip)]
+    #[allow(dead_code)]
     handle: Option<WatchHandle>,
 }
 

--- a/control-plane/agents/jsongrpc/src/server.rs
+++ b/control-plane/agents/jsongrpc/src/server.rs
@@ -19,14 +19,6 @@ struct CliArgs {
     #[structopt(long, short, default_value = "nats://127.0.0.1:4222")]
     nats: String,
 
-    /// The timeout for every node connection (gRPC)
-    #[structopt(long, default_value = common_lib::DEFAULT_CONN_TIMEOUT)]
-    pub(crate) connect: humantime::Duration,
-
-    /// The default timeout for node request timeouts (gRPC)
-    #[structopt(long, short, default_value = common_lib::DEFAULT_REQ_TIMEOUT)]
-    pub(crate) request: humantime::Duration,
-
     /// Don't use minimum timeouts for specific requests
     #[structopt(long)]
     no_min_timeouts: bool,

--- a/control-plane/csi-controller/src/server.rs
+++ b/control-plane/csi-controller/src/server.rs
@@ -118,7 +118,8 @@ impl CsiServer {
             }
 
             async_stream::stream! {
-                while let item = uds.accept().map_ok(|(st, _)| UnixStream(st)).await {
+                loop {
+                    let item = uds.accept().map_ok(|(st, _)| UnixStream(st)).await;
                     yield item;
                 }
             }

--- a/control-plane/rest/src/lib.rs
+++ b/control-plane/rest/src/lib.rs
@@ -21,7 +21,6 @@ use common_lib::types::v0::openapi::client;
 #[derive(Clone)]
 pub struct RestClient {
     openapi_client_v0: client::direct::ApiClient,
-    trace: bool,
 }
 
 impl RestClient {
@@ -65,7 +64,6 @@ impl RestClient {
 
         Ok(Self {
             openapi_client_v0: openapi_client,
-            trace,
         })
     }
     /// creates a new client
@@ -81,7 +79,6 @@ impl RestClient {
         let openapi_client = client::direct::ApiClient::new(openapi_client_config);
         Ok(Self {
             openapi_client_v0: openapi_client,
-            trace,
         })
     }
 }

--- a/deployer/bin/src/deployer.rs
+++ b/deployer/bin/src/deployer.rs
@@ -12,7 +12,7 @@ fn rust_log_add_quiet_defaults(
         }
         Some(level) => match level.to_string().as_str() {
             "debug" | "trace" => {
-                format!("{},{}", level.to_string(), RUST_LOG_QUIET_DEFAULTS)
+                format!("{},{}", level, RUST_LOG_QUIET_DEFAULTS)
             }
             _ => return level,
         },

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -19,7 +19,7 @@ pub struct CliArgs {
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Deployment actions")]
 pub(crate) enum Action {
-    Start(StartOptions),
+    Start(Box<StartOptions>),
     Stop(StopOptions),
     List(ListOptions),
 }
@@ -277,83 +277,102 @@ impl KeyValues {
 }
 
 impl StartOptions {
+    #[must_use]
     pub fn with_agents(mut self, agents: Vec<&str>) -> Self {
         let agents: ControlPlaneAgents = agents.try_into().unwrap();
         self.agents = agents.into_inner();
         self
     }
+    #[must_use]
     pub fn with_cache_period(mut self, period: &str) -> Self {
         self.cache_period = Some(humantime::Duration::from_str(period).unwrap());
         self
     }
+    #[must_use]
     pub fn with_node_deadline(mut self, deadline: &str) -> Self {
         self.node_deadline = Some(humantime::Duration::from_str(deadline).unwrap());
         self
     }
+    #[must_use]
     pub fn with_store_timeout(mut self, timeout: Duration) -> Self {
         self.store_timeout = Some(timeout.into());
         self
     }
+    #[must_use]
     pub fn with_store_lease_ttl(mut self, ttl: Duration) -> Self {
         self.store_lease_ttl = Some(ttl.into());
         self
     }
+    #[must_use]
     pub fn with_reconcile_period(mut self, busy: Duration, idle: Duration) -> Self {
         self.reconcile_period = Some(busy.into());
         self.reconcile_idle_period = Some(idle.into());
         self
     }
+    #[must_use]
     pub fn with_req_timeouts(mut self, no_min: bool, connect: Duration, request: Duration) -> Self {
         self.no_min_timeouts = no_min;
         self.node_conn_timeout = Some(connect.into());
         self.request_timeout = Some(request.into());
         self
     }
+    #[must_use]
     pub fn with_rest(mut self, enabled: bool, jwk: Option<String>) -> Self {
         self.no_rest = !enabled;
         self.rest_jwk = jwk;
         self
     }
+    #[must_use]
     pub fn with_csi(mut self, enabled: bool) -> Self {
         self.csi = enabled;
         self
     }
+    #[must_use]
     pub fn with_jaeger(mut self, jaeger: bool) -> Self {
         self.jaeger = jaeger;
         self
     }
+    #[must_use]
     pub fn with_nats(mut self, nats: bool) -> Self {
         self.no_nats = !nats;
         self
     }
+    #[must_use]
     pub fn with_build(mut self, build: bool) -> Self {
         self.build = build;
         self
     }
+    #[must_use]
     pub fn with_build_all(mut self, build: bool) -> Self {
         self.build_all = build;
         self
     }
+    #[must_use]
     pub fn with_mayastors(mut self, mayastors: u32) -> Self {
         self.mayastors = mayastors;
         self
     }
+    #[must_use]
     pub fn with_show_info(mut self, show_info: bool) -> Self {
         self.show_info = show_info;
         self
     }
+    #[must_use]
     pub fn with_cluster_name(mut self, cluster_name: &str) -> Self {
         self.cluster_label = format!(".{}", cluster_name).parse().unwrap();
         self
     }
+    #[must_use]
     pub fn with_base_image(mut self, base_image: impl Into<Option<String>>) -> Self {
         self.base_image = base_image.into();
         self
     }
+    #[must_use]
     pub fn with_tags(mut self, tags: Vec<KeyValue>) -> Self {
         self.tracing_tags.extend(tags);
         self
     }
+    #[must_use]
     pub fn with_env_tags(mut self, env: Vec<&str>) -> Self {
         env.iter().for_each(|env| {
             if let Ok(val) = std::env::var(env) {

--- a/kubectl-plugin/src/resources/node.rs
+++ b/kubectl-plugin/src/resources/node.rs
@@ -57,10 +57,7 @@ impl List for Nodes {
 
 /// Node resource.
 #[derive(StructOpt, Debug)]
-pub(crate) struct Node {
-    /// ID of the node.
-    id: NodeId,
-}
+pub(crate) struct Node {}
 
 #[async_trait(?Send)]
 impl Get for Node {

--- a/kubectl-plugin/src/resources/pool.rs
+++ b/kubectl-plugin/src/resources/pool.rs
@@ -75,10 +75,7 @@ impl List for Pools {
 
 /// Pool resource.
 #[derive(StructOpt, Debug)]
-pub(crate) struct Pool {
-    /// ID of the pool.
-    id: PoolId,
-}
+pub(crate) struct Pool {}
 
 #[async_trait(?Send)]
 impl Get for Pool {

--- a/kubectl-plugin/src/resources/utils.rs
+++ b/kubectl-plugin/src/resources/utils.rs
@@ -82,8 +82,7 @@ where
     T: CreateRows,
 {
     fn create_rows(&self) -> Vec<Row> {
-        let rows = self.iter().map(|i| i.create_rows()).flatten().collect();
-        rows
+        self.iter().flat_map(|i| i.create_rows()).collect()
     }
 }
 

--- a/kubectl-plugin/src/resources/volume.rs
+++ b/kubectl-plugin/src/resources/volume.rs
@@ -1,6 +1,6 @@
 use crate::{
     operations::{Get, List, Scale},
-    resources::{utils, ReplicaCount, VolumeId},
+    resources::{utils, VolumeId},
     rest_wrapper::RestClient,
 };
 use async_trait::async_trait;
@@ -26,7 +26,7 @@ impl CreateRows for openapi::models::Volume {
             state.uuid,
             self.spec.num_replicas,
             optional_cell(state.target.clone().map(|t| t.node)),
-            optional_cell(state.target.as_ref().map(|t| target_protocol(t)).flatten()),
+            optional_cell(state.target.as_ref().and_then(target_protocol)),
             state.status,
             state.size
         ]];
@@ -67,12 +67,7 @@ impl List for Volumes {
 
 /// Volume resource.
 #[derive(StructOpt, Debug)]
-pub(crate) struct Volume {
-    /// ID of the volume.
-    id: VolumeId,
-    /// Number of replicas.
-    replica_count: Option<ReplicaCount>,
-}
+pub(crate) struct Volume {}
 
 #[async_trait(?Send)]
 impl Get for Volume {

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -6,7 +6,7 @@ let
 in
 rec {
   rust_default = { override ? { } }: rec {
-    nightly = pkgs.rust-bin.nightly."2021-06-22".default.override (override);
+    nightly = pkgs.rust-bin.nightly."2021-12-22".default.override (override);
     stable = pkgs.rust-bin.stable.latest.default.override (override);
   };
   default = rust_default { };

--- a/nix/pkgs/openapi-generator/source.json
+++ b/nix/pkgs/openapi-generator/source.json
@@ -1,6 +1,6 @@
 {
   "owner": "openebs",
   "repo": "openapi-generator",
-  "rev": "0653f4f244be508913dff8ff1f38ceb73ea8c7ed",
-  "sha256": "1lsfacfr3sync5mmrlv6hbwm3daf8c6fbs4y12v6mvlhffgwk428"
+  "rev": "3ddad752d394abdfbac431edf3ce191c14b850d4",
+  "sha256": "0nn3560604cl3wzl08bawk0ml18v71yvalmqbccsslziza8pw6kd"
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -3,12 +3,12 @@
         "branch": "master",
         "description": "Build rust crates in Nix. No configuration, no code generation, no IFD. Sandbox friendly. [maintainer: @nmattia]",
         "homepage": "",
-        "owner": "nmattia",
+        "owner": "nix-community",
         "repo": "naersk",
-        "rev": "0d2ce479df4633dbeb53a8ea96e5098ed37fbcc6",
-        "sha256": "1hry9kxsa59g0z116m7x5zf0l7q1rfqw7a1icv4818bh8j8dhbfp",
+        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
+        "sha256": "1jhagazh69w7jfbrchhdss54salxc66ap1a1yd7xasc92vr0qsx4",
         "type": "tarball",
-        "url": "https://github.com/nmattia/naersk/archive/0d2ce479df4633dbeb53a8ea96e5098ed37fbcc6.tar.gz",
+        "url": "https://github.com/nmattia/naersk/archive/2fc8ce9d3c025d59fee349c1f80be9785049d653.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e",
-        "sha256": "17mirpsx5wyw262fpsd6n6m47jcgw8k2bwcp1iwdnrlzy4dhcgqh",
+        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
+        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -29,10 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8f8adc5ec85a444618da8280d666af760925b24",
-        "sha256": "073ykvc5i023a8r1wi14b40fkqvj58jssi3na8mm8kmn4x0sdja2",
+        "rev": "c6dcfb8f7b4532cdaa42164cd48129139378b9e7",
+        "sha256": "07wmkvx8y5c23mgk77yj4l8al9c29mlyzzjpf1l30v841rvksagi",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c8f8adc5ec85a444618da8280d666af760925b24.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c6dcfb8f7b4532cdaa42164cd48129139378b9e7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "aa5f9c64c8865966b36726787721d6dc9f4948b5",
-        "sha256": "0pzaiqx4k43i3vfc74d25ins4k5zvwadqmijakkfpl4l5qr30sc6",
+        "rev": "1efeb891b85c70ded412eb78a04bccb9badb14c6",
+        "sha256": "0wx7dg4p9gvjvmh9v208rd0wz6i7y6mqfkwqmzz232mb7rvg25sx",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/aa5f9c64c8865966b36726787721d6dc9f4948b5.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/1efeb891b85c70ded412eb78a04bccb9badb14c6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -10,6 +10,7 @@ extern crate tonic;
 #[allow(clippy::unit_arg)]
 #[allow(clippy::redundant_closure)]
 #[allow(clippy::upper_case_acronyms)]
+#[allow(clippy::return_self_not_must_use)]
 pub mod mayastor {
     use std::str::FromStr;
 
@@ -39,6 +40,7 @@ pub mod mayastor {
     include!(concat!(env!("OUT_DIR"), "/mayastor.rs"));
 }
 
+#[allow(clippy::return_self_not_must_use)]
 pub mod csi {
     include!(concat!(env!("OUT_DIR"), "/csi.v1.rs"));
 }

--- a/scripts/rust/generate-openapi-bindings.sh
+++ b/scripts/rust/generate-openapi-bindings.sh
@@ -68,7 +68,8 @@ fi
 if [ -f "$RUST_FMT" ]; then
   cp "$RUST_FMT" "$tmpd"
   ( cd "$tmpd" && cargo fmt --all )
-  ( cd "$tmpd"; rm Cargo.lock "$(basename "$RUST_FMT")" )
+  # Cargo.lock is no longer generated when running cargo fmt
+  ( cd "$tmpd"; rm Cargo.lock || true; rm "$(basename "$RUST_FMT")" )
 fi
 
 if [[ "$skip_if_md5_same" = "yes" ]]; then

--- a/shell.nix
+++ b/shell.nix
@@ -26,19 +26,20 @@ mkShell {
     cowsay
     docker
     etcd
+    fio
+    git
     llvmPackages_11.libclang
     nats-server
+    nvme-cli
     openssl
     pkg-config
     pkgs.openapi-generator
     pre-commit
     pytest_inputs
     python3
+    tini
     utillinux
     which
-    tini
-    nvme-cli
-    fio
   ] ++ pkgs.lib.optional (!norust) channel.default.nightly;
 
   LIBCLANG_PATH = "${llvmPackages_11.libclang.lib}/lib";

--- a/tests/tests-mayastor/src/lib.rs
+++ b/tests/tests-mayastor/src/lib.rs
@@ -298,7 +298,7 @@ impl TmpDiskFileInner {
             uri: format!(
                 "aio:///host{}?blk_size=512&uuid={}",
                 path,
-                message_bus::PoolId::new().to_string()
+                message_bus::PoolId::new()
             ),
             path,
         }
@@ -342,6 +342,7 @@ fn bus_timeout_opts() -> TimeoutOptions {
 
 impl ClusterBuilder {
     /// Cluster Builder with default options
+    #[must_use]
     pub fn builder() -> Self {
         ClusterBuilder {
             opts: default_options(),
@@ -354,6 +355,7 @@ impl ClusterBuilder {
         }
     }
     /// Update the start options
+    #[must_use]
     pub fn with_options<F>(mut self, set: F) -> Self
     where
         F: Fn(StartOptions) -> StartOptions,
@@ -362,16 +364,19 @@ impl ClusterBuilder {
         self
     }
     /// Enable/Disable jaeger tracing
+    #[must_use]
     pub fn with_tracing(mut self, enabled: bool) -> Self {
         self.trace = enabled;
         self
     }
     /// Rest request timeout
+    #[must_use]
     pub fn with_rest_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.rest_timeout = timeout;
         self
     }
     /// Add `count` malloc pools (100MiB size) to each node
+    #[must_use]
     pub fn with_pools(mut self, count: u32) -> Self {
         for _ in 0 .. count {
             for node in 0 .. self.opts.mayastors {
@@ -386,6 +391,7 @@ impl ClusterBuilder {
         self
     }
     /// Add pool URI with `disk` to the node `index`
+    #[must_use]
     pub fn with_pool(mut self, index: u32, disk: &str) -> Self {
         if let Some(pools) = self.pools.get_mut(&index) {
             pools.push(PoolDisk::Uri(disk.to_string()));
@@ -396,6 +402,7 @@ impl ClusterBuilder {
         self
     }
     /// Add a tmpfs img pool with `disk` to each mayastor node with the specified `size`
+    #[must_use]
     pub fn with_tmpfs_pool(mut self, size: u64) -> Self {
         for node in 0 .. self.opts.mayastors {
             let disk = TmpDiskFile::new(&Uuid::new_v4().to_string(), size);
@@ -408,28 +415,33 @@ impl ClusterBuilder {
         self
     }
     /// Specify `count` replicas to add to each node per pool
+    #[must_use]
     pub fn with_replicas(mut self, count: u32, size: u64, share: message_bus::Protocol) -> Self {
         self.replicas = Replica { count, size, share };
         self
     }
     /// Specify `count` mayastors for the cluster
+    #[must_use]
     pub fn with_mayastors(mut self, count: u32) -> Self {
         self.opts = self.opts.with_mayastors(count);
         self
     }
     /// Specify which agents to use
+    #[must_use]
     pub fn with_agents(mut self, agents: Vec<&str>) -> Self {
         self.opts = self.opts.with_agents(agents);
         self
     }
     /// Specify the node deadline for the node agent
     /// eg: 2s
+    #[must_use]
     pub fn with_node_deadline(mut self, deadline: &str) -> Self {
         self.opts = self.opts.with_node_deadline(deadline);
         self
     }
     /// The period at which the registry updates its cache of all
     /// resources from all nodes
+    #[must_use]
     pub fn with_cache_period(mut self, period: &str) -> Self {
         self.opts = self.opts.with_cache_period(period);
         self
@@ -438,25 +450,31 @@ impl ClusterBuilder {
     /// With reconcile periods:
     /// `busy` for when there's work that needs to be retried on the next poll
     /// `idle` when there's no work pending
+    #[must_use]
     pub fn with_reconcile_period(mut self, busy: Duration, idle: Duration) -> Self {
         self.opts = self.opts.with_reconcile_period(busy, idle);
         self
     }
     /// With store operation timeout
+    #[must_use]
     pub fn with_store_timeout(mut self, timeout: Duration) -> Self {
         self.opts = self.opts.with_store_timeout(timeout);
         self
     }
+    /// With store lease ttl
+    #[must_use]
     pub fn with_store_lease_ttl(mut self, ttl: Duration) -> Self {
         self.opts = self.opts.with_store_lease_ttl(ttl);
         self
     }
     /// Specify the node connect and request timeouts
+    #[must_use]
     pub fn with_req_timeouts(mut self, connect: Duration, request: Duration) -> Self {
         self.opts = self.opts.with_req_timeouts(true, connect, request);
         self
     }
     /// Specify the node connect and request timeouts and whether to use minimum timeouts or not
+    #[must_use]
     pub fn with_req_timeouts_min(
         mut self,
         no_min: bool,
@@ -467,36 +485,43 @@ impl ClusterBuilder {
         self
     }
     /// Specify the message bus timeout options
+    #[must_use]
     pub fn with_bus_timeouts(mut self, timeout: TimeoutOptions) -> Self {
         self.bus_timeout = timeout;
         self
     }
     /// Specify whether rest is enabled or not
+    #[must_use]
     pub fn with_rest(mut self, enabled: bool) -> Self {
         self.opts = self.opts.with_rest(enabled, None);
         self
     }
     /// Specify whether nats is enabled or not
+    #[must_use]
     pub fn with_nats(mut self, enabled: bool) -> Self {
         self.opts = self.opts.with_nats(enabled);
         self
     }
     /// Specify whether jaeger is enabled or not
+    #[must_use]
     pub fn with_jaeger(mut self, enabled: bool) -> Self {
         self.opts = self.opts.with_jaeger(enabled);
         self
     }
     /// Specify whether rest is enabled or not and wether to use authentication or not
+    #[must_use]
     pub fn with_rest_auth(mut self, enabled: bool, jwk: Option<String>) -> Self {
         self.opts = self.opts.with_rest(enabled, jwk);
         self
     }
     /// Specify whether the components should be cargo built or not
+    #[must_use]
     pub fn with_build(mut self, enabled: bool) -> Self {
         self.opts = self.opts.with_build(enabled);
         self
     }
     /// Specify whether the workspace binaries should be cargo built or not
+    #[must_use]
     pub fn with_build_all(mut self, enabled: bool) -> Self {
         self.opts = self.opts.with_build_all(enabled);
         self

--- a/tests/tests-mayastor/src/rest_client.rs
+++ b/tests/tests-mayastor/src/rest_client.rs
@@ -4,7 +4,6 @@ use openapi::tower::{client, client::Url};
 #[derive(Clone)]
 pub(crate) struct RestClient {
     openapi_client_v0: client::direct::ApiClient,
-    trace: bool,
 }
 
 impl RestClient {
@@ -47,7 +46,6 @@ impl RestClient {
 
         Ok(Self {
             openapi_client_v0: openapi_client,
-            trace,
         })
     }
     /// creates a new client
@@ -63,7 +61,6 @@ impl RestClient {
         let openapi_client = client::direct::ApiClient::new(openapi_client_config);
         Ok(Self {
             openapi_client_v0: openapi_client,
-            trace,
         })
     }
 }


### PR DESCRIPTION
Updated Cargo to 1.59.0.
The nightly channel is now at 22-12-2021.

Make sure to update your local version of clippy and perhaps even clean the target folder to avoid conflicts.