### PR TITLE
refactor(images): fix debug images and allow for faster incremental builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 [[package]]
 name = "composer"
 version = "0.1.0"
-source = "git+https://github.com/mayadata-io/composer?branch=develop#d1d2f731c39f43b1ff7bd9bfcaf55db57ad755de"
+source = "git+https://github.com/mayadata-io/composer?branch=develop#9a5e3669f1e70d42c1d8ba33a4799e7c2d69a176"
 dependencies = [
  "bollard",
  "crossbeam",

--- a/control-plane/msp-operator/Cargo.toml
+++ b/control-plane/msp-operator/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0.68"
 serde_yaml = "0.8.21"
 snafu = "0.6.10"
 tokio = { version = "1.12.0", features = ["full"] }
-openapi = { path = "../../openapi", features = [ "tower-client", "tower-trace" ] }
+openapi = { path = "../../openapi", default-features = false, features = [ "tower-client", "tower-trace" ] }
 humantime = "2.1.0"
 git-version = "0.3.5"
 

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,7 @@
 let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
-    overlays = [
-      (_: _: { inherit sources; })
-      (import ./nix/overlay.nix)
-    ];
+    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix) ];
   };
 in
 pkgs

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,8 @@
+{ allInOne ? true, incremental ? false }:
 let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
-    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix) ];
+    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { inherit allInOne incremental; }) ];
   };
 in
 pkgs

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -2,7 +2,8 @@
 let
   pkgs =
     import sources.nixpkgs { overlays = [ (import sources.rust-overlay) ]; };
-  static_target = pkgs.rust.toRustTargetSpec pkgs.pkgsStatic.stdenv.hostPlatform;
+  static_target =
+    pkgs.rust.toRustTargetSpec pkgs.pkgsStatic.stdenv.hostPlatform;
 in
 rec {
   rust_default = { override ? { } }: rec {

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -7,7 +7,7 @@ let
 in
 rec {
   rust_default = { override ? { } }: rec {
-    nightly = pkgs.rust-bin.nightly."2021-12-22".default.override (override);
+    nightly = pkgs.rust-bin.nightly."2021-11-22".default.override (override);
     stable = pkgs.rust-bin.stable.latest.default.override (override);
   };
   default = rust_default { };

--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -4,8 +4,7 @@ let
     builtins.filterSource
       (path: type:
         lib.any
-          (allowedPrefix:
-            lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
+          (allowedPrefix: lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
           allowedPrefixes)
       src;
 in

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,6 +1,7 @@
+{ allInOne ? true, incremental ? false }:
 self: super: {
   images = super.callPackage ./pkgs/images { };
-  control-plane = super.callPackage ./pkgs/control-plane { };
+  control-plane = super.callPackage ./pkgs/control-plane { inherit allInOne incremental; };
   utils = super.callPackage ./pkgs/utils { };
   openapi-generator = super.callPackage ./pkgs/openapi-generator { };
 }

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -23,8 +23,7 @@ let
     builtins.filterSource
       (path: type:
         lib.any
-          (allowedPrefix:
-            lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
+          (allowedPrefix: lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
           allowedPrefixes)
       src;
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
@@ -47,43 +46,35 @@ let
       "tests"
       "scripts"
     ];
-    cargoBuildFlags = [ "-p rpc" "-p agents" "-p rest" "-p msp-operator" "-p csi-controller" ];
+    cargoBuildFlags =
+      [ "-p rpc" "-p agents" "-p rest" "-p msp-operator" "-p csi-controller" ];
 
     cargoLock = {
       lockFile = ../../../Cargo.lock;
       outputHashes = {
-        "nats-0.15.2" = "sha256:1whr0v4yv31q5zwxhcqmx4qykgn5cgzvwlaxgq847mymzajpcsln";
-        "composer-0.1.0" = "sha256:0hrrg9cnbscrrw8f8qbn4nrip56ymbmb5grsycm01i5fi7m4cf3w";
+        "nats-0.15.2" =
+          "sha256:1whr0v4yv31q5zwxhcqmx4qykgn5cgzvwlaxgq847mymzajpcsln";
+        "composer-0.1.0" =
+          "sha256:0hrrg9cnbscrrw8f8qbn4nrip56ymbmb5grsycm01i5fi7m4cf3w";
       };
     };
 
     preBuild = "patchShebangs ./scripts/rust/generate-openapi-bindings.sh";
 
     inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE;
-    nativeBuildInputs = [
-      clang
-      pkg-config
-      openapi-generator
-      which
-    ];
-    buildInputs = [
-      llvmPackages.libclang
-      protobuf
-      openssl
-    ];
+    nativeBuildInputs = [ clang pkg-config openapi-generator which ];
+    buildInputs = [ llvmPackages.libclang protobuf openssl ];
     doCheck = false;
   };
 in
 {
   inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE version;
-  release = rustPlatform.buildRustPackage
-    (buildProps // {
-      buildType = "release";
-      buildInputs = buildProps.buildInputs;
-    });
-  debug = rustPlatform.buildRustPackage
-    (buildProps // {
-      buildType = "debug";
-      buildInputs = buildProps.buildInputs;
-    });
+  release = rustPlatform.buildRustPackage (buildProps // {
+    buildType = "release";
+    buildInputs = buildProps.buildInputs;
+  });
+  debug = rustPlatform.buildRustPackage (buildProps // {
+    buildType = "debug";
+    buildInputs = buildProps.buildInputs;
+  });
 }

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -12,12 +12,30 @@
 , version
 , openapi-generator
 , which
+  # with allInOne set to true all components are built as part of the same "cargo build" derivation
+  # this allows for a quicker build of all components but slower single components
+  # with allInOne set to false each component gets its own "cargo build" derivation allowing for faster
+  # individual builds but making the build of all components at once slower
+, allInOne ? true
+  # EXPERIMENTAL incremental allows for faster incremental builds as the build dependencies are cached
+  # it might make the initial build slightly slower as it's done in two steps
+  # for this we use naersk which is not as fully fledged as the builtin rustPlatform so it should only be used
+  # for development and not for CI
+, incremental ? false
 }:
 let
   channel = import ../../lib/rust.nix { inherit sources; };
-  rustPlatform = makeRustPlatform {
+  stable_channel = {
     rustc = channel.default.stable;
     cargo = channel.default.stable;
+  };
+  rustPlatform = makeRustPlatform {
+    rustc = stable_channel.rustc;
+    cargo = stable_channel.cargo;
+  };
+  naersk = pkgs.callPackage sources.naersk {
+    rustc = stable_channel.rustc;
+    cargo = stable_channel.cargo;
   };
   whitelistSource = src: allowedPrefixes:
     builtins.filterSource
@@ -29,6 +47,7 @@ let
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";
+
   buildProps = rec {
     name = "control-plane-${version}";
     inherit version;
@@ -46,35 +65,55 @@ let
       "tests"
       "scripts"
     ];
-    cargoBuildFlags =
-      [ "-p rpc" "-p agents" "-p rest" "-p msp-operator" "-p csi-controller" ];
-
-    cargoLock = {
-      lockFile = ../../../Cargo.lock;
-      outputHashes = {
-        "nats-0.15.2" =
-          "sha256:1whr0v4yv31q5zwxhcqmx4qykgn5cgzvwlaxgq847mymzajpcsln";
-        "composer-0.1.0" =
-          "sha256:0hrrg9cnbscrrw8f8qbn4nrip56ymbmb5grsycm01i5fi7m4cf3w";
-      };
-    };
-
-    preBuild = "patchShebangs ./scripts/rust/generate-openapi-bindings.sh";
 
     inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE;
-    nativeBuildInputs = [ clang pkg-config openapi-generator which ];
+    nativeBuildInputs = [ clang pkg-config openapi-generator which git pkgs.breakpointHook ];
     buildInputs = [ llvmPackages.libclang protobuf openssl ];
     doCheck = false;
   };
+  release_build = { "release" = true; "debug" = false; };
+in
+let
+  build_with_naersk = { buildType, cargoBuildFlags }:
+    naersk.buildPackage (buildProps // {
+      release = release_build.${buildType};
+      cargoBuildOptions = attrs: attrs ++ cargoBuildFlags;
+      preBuild = ''
+        # don't run during the dependency build phase
+        if [ ! -f build.rs ]; then
+          patchShebangs ./scripts/rust/generate-openapi-bindings.sh
+          ./scripts/rust/generate-openapi-bindings.sh
+        fi
+        # remove the tests lib dependency since we don't run tests during this build
+        find . -name \*.toml | xargs -I% sed -i '/^ctrlp-tests.*=/d' %
+      '';
+      doCheck = false;
+      usePureFromTOML = true;
+    });
+  build_with_default = { buildType, cargoBuildFlags }:
+    rustPlatform.buildRustPackage (buildProps // {
+      inherit buildType cargoBuildFlags;
+
+      preBuild = "patchShebangs ./scripts/rust/generate-openapi-bindings.sh";
+
+      cargoLock = {
+        lockFile = ../../../Cargo.lock;
+        outputHashes = {
+          "nats-0.15.2" =
+            "sha256:1whr0v4yv31q5zwxhcqmx4qykgn5cgzvwlaxgq847mymzajpcsln";
+          "composer-0.1.0" =
+            "sha256:0ffpdr0aik2bl63vjr6h3grz78xza025wg1c45djx9hqckh46qm0";
+        };
+      };
+    });
+  builder = if incremental then build_with_naersk else build_with_default;
 in
 {
   inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE version;
-  release = rustPlatform.buildRustPackage (buildProps // {
-    buildType = "release";
-    buildInputs = buildProps.buildInputs;
-  });
-  debug = rustPlatform.buildRustPackage (buildProps // {
-    buildType = "debug";
-    buildInputs = buildProps.buildInputs;
-  });
+
+  build = { buildType, cargoBuildFlags ? [ ] }:
+    if allInOne then
+      builder { inherit buildType; cargoBuildFlags = [ "-p rpc" "-p agents" "-p rest" "-p msp-operator" "-p csi-controller" ]; }
+    else
+      builder { inherit buildType cargoBuildFlags; };
 }

--- a/nix/pkgs/control-plane/default.nix
+++ b/nix/pkgs/control-plane/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, git, lib, pkgs }:
+{ stdenv, git, lib, pkgs, allInOne, incremental }:
 let
   versionDrv = import ../../lib/version.nix { inherit lib stdenv git; };
   version = builtins.readFile "${versionDrv}";
   project-builder =
-    pkgs.callPackage ../control-plane/cargo-project.nix { inherit version; };
-  agent = { name, src, suffix ? "agent" }:
+    pkgs.callPackage ../control-plane/cargo-project.nix { inherit version allInOne incremental; };
+  installer = { name, src, suffix }:
     stdenv.mkDerivation {
       inherit src;
       name = "${name}-${version}";
@@ -14,27 +14,44 @@ let
         cp $src/bin/${name} $out/bin/${name}-${suffix}
       '';
     };
-  components = { src }: {
-    jsongrpc = agent {
-      inherit src;
-      name = "jsongrpc";
+
+  components = { buildType, builder }: rec {
+    agents = rec {
+      recurseForDerivations = true;
+      agents_builder = { buildType, builder }: builder.build { inherit buildType; cargoBuildFlags = [ "-p agents" ]; };
+      agent_installer = { name, src }: installer { inherit name src; suffix = "agent"; };
+      jsongrpc = agent_installer {
+        src = agents_builder { inherit buildType builder; };
+        name = "jsongrpc";
+      };
+      core = agent_installer {
+        src = agents_builder { inherit buildType builder; };
+        name = "core";
+      };
     };
-    core = agent {
-      inherit src;
-      name = "core";
-    };
-    rest = agent {
-      inherit src;
+
+    rest = installer {
+      src = builder.build { inherit buildType; cargoBuildFlags = [ "-p rest" ]; };
       name = "rest";
       suffix = "api";
     };
-    msp-operator = agent {
-      inherit src;
-      name = "msp-operator";
+
+    operators = rec {
+      operator_installer = { name, src }: installer { inherit name src; suffix = "operator"; };
+      msp = operator_installer {
+        src = builder.build { inherit buildType; cargoBuildFlags = [ "-p msp-operator" ]; };
+        name = "msp-operator";
+      };
+      recurseForDerivations = true;
     };
-    csi-controller = agent {
-      inherit src;
-      name = "csi-controller";
+
+    csi = rec {
+      csi_installer = { name, src }: installer { inherit name src; suffix = "csi"; };
+      controller = csi_installer {
+        src = builder.build { inherit buildType; cargoBuildFlags = [ "-p csi-controller" ]; };
+        name = "csi-controller";
+      };
+      recurseForDerivations = true;
     };
   };
 in
@@ -44,6 +61,6 @@ in
   PROTOC_INCLUDE = project-builder.PROTOC_INCLUDE;
   inherit version;
 
-  release = components { src = project-builder.release; };
-  debug = components { src = project-builder.debug; };
+  release = components { builder = project-builder; buildType = "release"; };
+  debug = components { builder = project-builder; buildType = "debug"; };
 }

--- a/nix/pkgs/control-plane/default.nix
+++ b/nix/pkgs/control-plane/default.nix
@@ -1,27 +1,41 @@
-{ stdenv
-, git
-, lib
-, pkgs
-}:
+{ stdenv, git, lib, pkgs }:
 let
   versionDrv = import ../../lib/version.nix { inherit lib stdenv git; };
   version = builtins.readFile "${versionDrv}";
-  project-builder = pkgs.callPackage ../control-plane/cargo-project.nix { inherit version; };
-  agent = { name, src, suffix ? "agent" }: stdenv.mkDerivation {
-    inherit src;
-    name = "${name}-${version}";
-    binary = "${name}-${suffix}";
-    installPhase = ''
-      mkdir -p $out/bin
-      cp $src/bin/${name} $out/bin/${name}-${suffix}
-    '';
-  };
+  project-builder =
+    pkgs.callPackage ../control-plane/cargo-project.nix { inherit version; };
+  agent = { name, src, suffix ? "agent" }:
+    stdenv.mkDerivation {
+      inherit src;
+      name = "${name}-${version}";
+      binary = "${name}-${suffix}";
+      installPhase = ''
+        mkdir -p $out/bin
+        cp $src/bin/${name} $out/bin/${name}-${suffix}
+      '';
+    };
   components = { src }: {
-    jsongrpc = agent { inherit src; name = "jsongrpc"; };
-    core = agent { inherit src; name = "core"; };
-    rest = agent { inherit src; name = "rest"; suffix = "api"; };
-    msp-operator = agent { inherit src; name = "msp-operator"; };
-    csi-controller = agent { inherit src; name = "csi-controller"; };
+    jsongrpc = agent {
+      inherit src;
+      name = "jsongrpc";
+    };
+    core = agent {
+      inherit src;
+      name = "core";
+    };
+    rest = agent {
+      inherit src;
+      name = "rest";
+      suffix = "api";
+    };
+    msp-operator = agent {
+      inherit src;
+      name = "msp-operator";
+    };
+    csi-controller = agent {
+      inherit src;
+      name = "csi-controller";
+    };
   };
 in
 {

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -2,62 +2,66 @@
 # avoid dependency on docker tool chain. Though the maturity of OCI
 # builder in nixpkgs is questionable which is why we postpone this step.
 
-{ busybox
-, dockerTools
-, lib
-, utillinux
-, control-plane
-, tini
-}:
+{ busybox, dockerTools, lib, utillinux, control-plane, tini }:
 let
-  build-control-plane-image = { build, name, config ? { } }: dockerTools.buildImage {
-    tag = control-plane.version;
-    created = "now";
-    name = "mayadata/mcp-${name}";
-    contents = [ tini busybox control-plane.${build}.${name} ];
-    config = { Entrypoint = [ "tini" "--" control-plane.${build}.${name}.binary ]; } // config;
-  };
-  build-agent-image = { build, name, config ? { } }: build-control-plane-image {
-    inherit build name;
-  };
-  build-rest-image = { build }: build-control-plane-image {
-    inherit build;
-    name = "rest";
-    config = { ExposedPorts = { "8080/tcp" = { }; "8081/tcp" = { }; }; };
-  };
-  build-msp-operator-image = { build }: build-control-plane-image {
-    inherit build;
-    name = "msp-operator";
-  };
-  build-csi-controller-image = { build }: build-control-plane-image {
-    inherit build;
-    name = "csi-controller";
-  };
+  build-control-plane-image = { build, name, config ? { } }:
+    dockerTools.buildImage {
+      tag = control-plane.version;
+      created = "now";
+      name = "mayadata/mcp-${name}";
+      contents = [ tini busybox control-plane.${build}.${name} ];
+      config = {
+        Entrypoint = [ "tini" "--" control-plane.${build}.${name}.binary ];
+      } // config;
+    };
+  build-agent-image = { build, name, config ? { } }:
+    build-control-plane-image { inherit build name; };
+  build-rest-image = { build }:
+    build-control-plane-image {
+      inherit build;
+      name = "rest";
+      config = {
+        ExposedPorts = {
+          "8080/tcp" = { };
+          "8081/tcp" = { };
+        };
+      };
+    };
+  build-msp-operator-image = { build }:
+    build-control-plane-image {
+      inherit build;
+      name = "msp-operator";
+    };
+  build-csi-controller-image = { build }:
+    build-control-plane-image {
+      inherit build;
+      name = "csi-controller";
+    };
 
 in
 {
-  core = build-agent-image { build = "release"; name = "core"; };
-  core-dev = build-agent-image { build = "debug"; name = "core"; };
-  jsongrpc = build-agent-image { build = "release"; name = "jsongrpc"; };
-  jsongrpc-dev = build-agent-image { build = "debug"; name = "jsongrpc"; };
-  rest = build-rest-image {
+  core = build-agent-image {
     build = "release";
+    name = "core";
   };
-  rest-dev = build-rest-image {
+  core-dev = build-agent-image {
     build = "debug";
+    name = "core";
   };
+  jsongrpc = build-agent-image {
+    build = "release";
+    name = "jsongrpc";
+  };
+  jsongrpc-dev = build-agent-image {
+    build = "debug";
+    name = "jsongrpc";
+  };
+  rest = build-rest-image { build = "release"; };
+  rest-dev = build-rest-image { build = "debug"; };
 
-  msp-operator = build-msp-operator-image {
-    build = "release";
-  };
-  msp-operator-dev = build-msp-operator-image {
-    build = "debug";
-  };
+  msp-operator = build-msp-operator-image { build = "release"; };
+  msp-operator-dev = build-msp-operator-image { build = "debug"; };
 
-  csi-controller = build-csi-controller-image {
-    build = "release";
-  };
-  csi-controller-dev = build-csi-controller-image {
-    build = "debug";
-  };
+  csi-controller = build-csi-controller-image { build = "release"; };
+  csi-controller-dev = build-csi-controller-image { build = "debug"; };
 }

--- a/nix/pkgs/openapi-generator/default.nix
+++ b/nix/pkgs/openapi-generator/default.nix
@@ -20,13 +20,14 @@ let
       runHook postBuild
     '';
     # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
-    installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
+    installPhase =
+      "find $out/.m2 -type f -regex '.+\\(\\.lastUpdated\\|resolver-status\\.properties\\|_remote\\.repositories\\)' -delete";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
     outputHash = "0f30vfvqrwa4gdgid9c94kvv83yfrgpx6ii1npjxspdawqr3whrj";
   };
-in
 
+in
 stdenv.mkDerivation rec {
   inherit version;
   inherit src;
@@ -58,7 +59,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
+    description =
+      "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
     homepage = "https://github.com/openebs/openapi-generator";
     license = licenses.asl20;
     maintainers = [ maintainers.tiagolobocastro ];

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -8,7 +8,7 @@
         "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
         "sha256": "1jhagazh69w7jfbrchhdss54salxc66ap1a1yd7xasc92vr0qsx4",
         "type": "tarball",
-        "url": "https://github.com/nmattia/naersk/archive/2fc8ce9d3c025d59fee349c1f80be9785049d653.tar.gz",
+        "url": "https://github.com/nix-community/naersk/archive/2fc8ce9d3c025d59fee349c1f80be9785049d653.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6dcfb8f7b4532cdaa42164cd48129139378b9e7",
-        "sha256": "07wmkvx8y5c23mgk77yj4l8al9c29mlyzzjpf1l30v841rvksagi",
+        "rev": "6695286d1ddcabe71b9eeda1dc0701765fa3dbb6",
+        "sha256": "0y7lxr9rx73jy66bk5bcp47c3rzcfxnmq1qv1jgcpqk6i9jig8zx",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c6dcfb8f7b4532cdaa42164cd48129139378b9e7.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6695286d1ddcabe71b9eeda1dc0701765fa3dbb6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1efeb891b85c70ded412eb78a04bccb9badb14c6",
-        "sha256": "0wx7dg4p9gvjvmh9v208rd0wz6i7y6mqfkwqmzz232mb7rvg25sx",
+        "rev": "844ee700e1886b5826b809ecaef03cbd96b0b049",
+        "sha256": "1c4yk6j0qmbvsx6x5s2zcmbd247kxpfzjvq3ibw6pcjgif7w9a06",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/1efeb891b85c70ded412eb78a04bccb9badb14c6.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/844ee700e1886b5826b809ecaef03cbd96b0b049.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -17,29 +17,30 @@ let
       pkgs.fetchzip { inherit (spec) url sha256; };
 
   fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+    builtins.fetchGit {
+      url = spec.repo;
+      inherit (spec) rev ref;
+    };
 
   fetch_builtin-tarball = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-tarball" will soon be deprecated. You should
-          instead use `builtin = true`.
+    builtins.trace ''
+      WARNING:
+        The niv type "builtin-tarball" will soon be deprecated. You should
+        instead use `builtin = true`.
 
-          $ niv modify <package> -a type=tarball -a builtin=true
-      ''
+        $ niv modify <package> -a type=tarball -a builtin=true
+    ''
       builtins_fetchTarball
       { inherit (spec) url sha256; };
 
   fetch_builtin-url = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-url" will soon be deprecated. You should
-          instead use `builtin = true`.
+    builtins.trace ''
+      WARNING:
+        The niv type "builtin-url" will soon be deprecated. You should
+        instead use `builtin = true`.
 
-          $ niv modify <package> -a type=file -a builtin=true
-      ''
+        $ niv modify <package> -a type=file -a builtin=true
+    ''
       (builtins_fetchurl { inherit (spec) url sha256; });
 
   #
@@ -50,46 +51,55 @@ let
   mkPkgs = sources:
     let
       sourcesNixpkgs =
-        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) { };
+        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; })
+          { };
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
     in
-    if builtins.hasAttr "nixpkgs" sources
-    then sourcesNixpkgs
-    else if hasNixpkgsPath && ! hasThisAsNixpkgsPath then
+    if builtins.hasAttr "nixpkgs" sources then
+      sourcesNixpkgs
+    else if hasNixpkgsPath && !hasThisAsNixpkgsPath then
       import <nixpkgs> { }
     else
-      abort
-        ''
-          Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
-          add a package called "nixpkgs" to your sources.json.
-        '';
+      abort ''
+        Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
+        add a package called "nixpkgs" to your sources.json.
+      '';
 
   # The actual fetching function.
   fetch = pkgs: name: spec:
 
-    if ! builtins.hasAttr "type" spec then
+    if !builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
-    else if spec.type == "file" then fetch_file pkgs spec
-    else if spec.type == "tarball" then fetch_tarball pkgs spec
-    else if spec.type == "git" then fetch_git spec
-    else if spec.type == "builtin-tarball" then fetch_builtin-tarball spec
-    else if spec.type == "builtin-url" then fetch_builtin-url spec
+    else if spec.type == "file" then
+      fetch_file pkgs spec
+    else if spec.type == "tarball" then
+      fetch_tarball pkgs spec
+    else if spec.type == "git" then
+      fetch_git spec
+    else if spec.type == "builtin-tarball" then
+      fetch_builtin-tarball spec
+    else if spec.type == "builtin-url" then
+      fetch_builtin-url spec
     else
-      abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+      abort
+        "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
 
   # Ports of functions for older nix versions
 
   # a Nix version of mapAttrs if the built-in doesn't exist
-  mapAttrs = builtins.mapAttrs or (
-    f: set: with builtins;
-    listToAttrs (map (attr: { name = attr; value = f attr set.${attr}; }) (attrNames set))
-  );
+  mapAttrs = builtins.mapAttrs or (f: set:
+    with builtins;
+    listToAttrs (map
+      (attr: {
+        name = attr;
+        value = f attr set.${attr};
+      })
+      (attrNames set)));
 
   # fetchTarball version that is compatible between all the versions of Nix
   builtins_fetchTarball = { url, sha256 }@attrs:
-    let
-      inherit (builtins) lessThan nixVersion fetchTarball;
+    let inherit (builtins) lessThan nixVersion fetchTarball;
     in
     if lessThan nixVersion "1.12" then
       fetchTarball { inherit url; }
@@ -98,8 +108,7 @@ let
 
   # fetchurl version that is compatible between all the versions of Nix
   builtins_fetchurl = { url, sha256 }@attrs:
-    let
-      inherit (builtins) lessThan nixVersion fetchurl;
+    let inherit (builtins) lessThan nixVersion fetchurl;
     in
     if lessThan nixVersion "1.12" then
       fetchurl { inherit url; }
@@ -109,15 +118,12 @@ let
   # Create the final "sources" from the config
   mkSources = config:
     mapAttrs
-      (
-        name: spec:
-          if builtins.hasAttr "outPath" spec
-          then
-            abort
-              "The values in sources.json should not have an 'outPath' attribute"
-          else
-            spec // { outPath = fetch config.pkgs name spec; }
-      )
+      (name: spec:
+        if builtins.hasAttr "outPath" spec then
+          abort
+            "The values in sources.json should not have an 'outPath' attribute"
+        else
+          spec // { outPath = fetch config.pkgs name spec; })
       config.sources;
 
   # The "config" used by the fetchers
@@ -133,4 +139,6 @@ let
       inherit pkgs;
     };
 in
-mkSources (mkConfig { }) // { __functor = _: settings: mkSources (mkConfig settings); }
+mkSources (mkConfig { }) // {
+  __functor = _: settings: mkSources (mkConfig settings);
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -10,7 +10,6 @@ extern crate tonic;
 #[allow(clippy::unit_arg)]
 #[allow(clippy::redundant_closure)]
 #[allow(clippy::upper_case_acronyms)]
-#[allow(clippy::return_self_not_must_use)]
 pub mod mayastor {
     use std::str::FromStr;
 
@@ -40,7 +39,6 @@ pub mod mayastor {
     include!(concat!(env!("OUT_DIR"), "/mayastor.rs"));
 }
 
-#[allow(clippy::return_self_not_must_use)]
 pub mod csi {
     include!(concat!(env!("OUT_DIR"), "/csi.v1.rs"));
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,18 +1,14 @@
-{ norust ? false
-, mayastor ? ""
-}:
+{ norust ? false, mayastor ? "" }:
 let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
-    overlays = [
-      (_: _: { inherit sources; })
-      (import ./nix/overlay.nix)
-    ];
+    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix) ];
   };
 in
 with pkgs;
 let
-  norust_moth = "You have requested an environment without rust, you should provide it!";
+  norust_moth =
+    "You have requested an environment without rust, you should provide it!";
   mayastor_moth = "Using the following mayastor binary: ${mayastor}";
   channel = import ./nix/lib/rust.nix { inherit sources; };
   # python environment for tests/bdd

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {
-    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix) ];
+    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { }) ];
   };
 in
 with pkgs;

--- a/tests/bdd/features/garbage-collection/replicas/test_feature.py
+++ b/tests/bdd/features/garbage-collection/replicas/test_feature.py
@@ -28,9 +28,9 @@ NUM_VOLUME_REPLICAS = 2
 MAYASTOR_1 = "mayastor-1"
 MAYASTOR_2 = "mayastor-2"
 
-POOL_DISK1 = "disk1.img"
+POOL_DISK1 = "pdisk1.img"
 POOL1_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
-POOL_DISK2 = "disk2.img"
+POOL_DISK2 = "pdisk2.img"
 POOL2_UUID = "4cc6ee64-7232-497d-a26f-38284a444990"
 
 


### PR DESCRIPTION
chore(nix): format the existing nix files with nixpkgs-fmt

---------
refactor(images): tidy up building of images

There's a new build type at the root of the images which should simplify
adding new images (no need for -dev or -cov). Example, to build a debug
version of the core agent:
nix-build -A images.debug.agents.core

Add a build suffix to fix the debug builds which are broken. Example:
the core agent image will be named mcp-core and the debug mcp-core-dev

---------
chore(build): add allInOne and incremental arguments to the nix build

With allInOne set to true all components are built as part of the same "cargo build" derivation
this allows for a quicker build of all components but slower single components
with allInOne set to false each compoment gets its own "cargo build" derivation allowing for faster
individual builds but making the build of all components slower
EXPERIMENTAL incremental allows for faster incremental builds but as the build dependencies are
cached it might make the initial build sligtly slower as it's done in two steps
for this we use naersk which is not as fully fledged as the builtin rustPlatform so it should only
be used for development and not for CI.