### PR TITLE
chore: update example deployment definition files

### DIFF
--- a/deploy/core-agents-deployment.yaml
+++ b/deploy/core-agents-deployment.yaml
@@ -23,15 +23,13 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep
-            1; done;
+          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep 1; done;
           image: busybox:latest
           name: nats-probe
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd...";
-            sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd..."; sleep 1; done;
           image: busybox:latest
           name: etcd-probe
       containers:
@@ -43,8 +41,8 @@ spec:
             requests:
               cpu: 500m
               memory: 16Mi
-          image: mayadata/mcp-core:e2e-nightly
-          imagePullPolicy: Always
+          image: mayadata/mcp-core:v1.0.0
+          imagePullPolicy: IfNotPresent
           args:
             - "-smayastor-etcd"
             - "-nnats"

--- a/deploy/csi-deployment.yaml
+++ b/deploy/csi-deployment.yaml
@@ -26,8 +26,7 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz rest 8081; do echo "Waiting for REST API endpoint
-            to become available"; sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz rest 8081; do echo "Waiting for REST API endpoint to become available"; sleep 1; done;
           image: busybox:latest
           name: rest-probe
       containers:
@@ -66,8 +65,8 @@ spec:
             requests:
               cpu: 16m
               memory: 64Mi
-          image: mayadata/mcp-csi-controller:e2e-nightly
-          imagePullPolicy: Always
+          image: mayadata/mcp-csi-controller:v1.0.0
+          imagePullPolicy: IfNotPresent
           args:
             - "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock"
             - "--rest-endpoint=http://$(REST_SERVICE_HOST):8081"

--- a/deploy/msp-deployment.yaml
+++ b/deploy/msp-deployment.yaml
@@ -24,15 +24,13 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep
-            1; done;
+          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep 1; done;
           image: busybox:latest
           name: nats-probe
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd...";
-            sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd..."; sleep 1; done;
           image: busybox:latest
           name: etcd-probe
       containers:
@@ -44,8 +42,8 @@ spec:
             requests:
               cpu: 50m
               memory: 16Mi
-          image: mayadata/mcp-msp-operator:e2e-nightly
-          imagePullPolicy: Always
+          image: mayadata/mcp-msp-operator:v1.0.0
+          imagePullPolicy: IfNotPresent
           args:
             - "-e http://$(REST_SERVICE_HOST):8081"
             - "--interval=30s"

--- a/deploy/rest-deployment.yaml
+++ b/deploy/rest-deployment.yaml
@@ -23,15 +23,13 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep
-            1; done;
+          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep 1; done;
           image: busybox:latest
           name: nats-probe
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd...";
-            sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd..."; sleep 1; done;
           image: busybox:latest
           name: etcd-probe
       containers:
@@ -43,8 +41,8 @@ spec:
             requests:
               cpu: 50m
               memory: 32Mi
-          image: mayadata/mcp-rest:e2e-nightly
-          imagePullPolicy: Always
+          image: mayadata/mcp-rest:v1.0.0
+          imagePullPolicy: IfNotPresent
           args:
             - "--dummy-certificates"
             - "--no-auth"


### PR DESCRIPTION
Update k8s definition files referenced in the user
docs as an example deployment

- Container image tags should reflect 1.0.0 release version
- Template used should be the 'Release' profile