### PR TITLE
feat(PV Garbage Collector) Adding implementation

### DIFF
--- a/common/src/platform/mod.rs
+++ b/common/src/platform/mod.rs
@@ -17,8 +17,9 @@ pub trait PlatformInfo: Send + Sync {
     fn uid(&self) -> PlatformUid;
 }
 
-/// The various types of platforms.
-enum PlatformType {
+#[derive(Eq, PartialEq)]
+/// The various types of platforms.  
+pub enum PlatformType {
     /// As it says in the tin.
     K8s,
     /// We don't have others, other than running the binary directly or on deployer "clusters".
@@ -26,7 +27,7 @@ enum PlatformType {
 }
 
 /// Get the current `PlatformType`.
-fn current_plaform_type() -> PlatformType {
+pub fn current_plaform_type() -> PlatformType {
     if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
         PlatformType::K8s
     } else {

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -14,6 +14,7 @@ path = "controller/src/main.rs"
 name = "csi-node"
 path = "node/src/main.rs"
 
+
 [build-dependencies]
 tonic-build = "0.5.2"
 prost-build = "0.8.0"
@@ -54,7 +55,7 @@ url = "2.2.2"
 uuid = { version = "0.8.2", features = ["v4"] }
 which = "4.2.2"
 k8s-openapi = { version = "0.15.0", features = ["v1_20"] }
-kube = { version = "0.74.0", features = ["derive"] }
+kube = { version = "0.74.0", features = ["runtime", "derive"] }
 devinfo = { path = "../../utils/dependencies/devinfo" }
 nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
 sysfs = { path = "../../utils/dependencies/sysfs" }

--- a/control-plane/csi-driver/controller/src/controller.rs
+++ b/control-plane/csi-driver/controller/src/controller.rs
@@ -304,11 +304,9 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
     ) -> Result<tonic::Response<DeleteVolumeResponse>, tonic::Status> {
         let args = request.into_inner();
         tracing::trace!(volume.uuid = %args.volume_id, request = ?args);
-
         let volume_uuid = Uuid::parse_str(&args.volume_id).map_err(|_e| {
             Status::invalid_argument(format!("Malformed volume UUID: {}", args.volume_id))
         })?;
-
         IoEngineApiClient::get_client()
             .delete_volume(&volume_uuid)
             .await

--- a/control-plane/csi-driver/controller/src/identity.rs
+++ b/control-plane/csi-driver/controller/src/identity.rs
@@ -1,4 +1,5 @@
 use crate::{ApiClientError, IoEngineApiClient};
+use csi_driver::CSI_PLUGIN_NAME;
 use rpc::csi::*;
 use std::collections::HashMap;
 use tonic::{Request, Response, Status};
@@ -7,7 +8,6 @@ use tracing::{debug, error, instrument};
 #[derive(Debug, Default)]
 pub(crate) struct CsiIdentitySvc {}
 
-const CSI_PLUGIN_NAME: &str = "io.openebs.csi-mayastor";
 const CSI_PLUGIN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[tonic::async_trait]

--- a/control-plane/csi-driver/controller/src/pvwatcher.rs
+++ b/control-plane/csi-driver/controller/src/pvwatcher.rs
@@ -1,0 +1,121 @@
+use futures::TryStreamExt;
+use k8s_openapi::api::core::v1::PersistentVolume;
+
+use kube::{
+    api::{Api, ListParams},
+    runtime::{watcher, WatchStreamExt},
+    Client, ResourceExt,
+};
+use tracing::{debug, error, info};
+use uuid::Uuid;
+
+use csi_driver::CSI_PLUGIN_NAME;
+
+use crate::IoEngineApiClient;
+
+/// Struct for PV Garbage collector
+#[derive(Clone)]
+pub(crate) struct PvGarbageCollector {
+    pub(crate) pv_handle: Api<PersistentVolume>,
+}
+
+/// Methods implemented by PV Garbage Collector
+impl PvGarbageCollector {
+    /// Returns an instance of PV Garbage collector
+    pub(crate) async fn new() -> anyhow::Result<Self> {
+        let client = Client::try_default().await?;
+        Ok(Self {
+            pv_handle: Api::<PersistentVolume>::all(client),
+        })
+    }
+    /// Starts watching PV events
+    pub(crate) async fn run_watcher(&self) {
+        info!("Starting PV Garbage Collector");
+        let cloned_self = self.clone();
+        tokio::spawn(async move {
+            cloned_self.handle_missed_events().await;
+        });
+        watcher(self.pv_handle.clone(), ListParams::default())
+            .touched_objects()
+            .try_for_each(|pvol| async {
+                self.process_object(pvol).await;
+                Ok(())
+            })
+            .await
+            .expect("Watcher unexpectedly terminated");
+    }
+
+    async fn process_object(&self, pv: PersistentVolume) {
+        if pv.metadata.clone().deletion_timestamp.is_none() {
+            return;
+        }
+        if let Some(provisioner) = &pv.spec.as_ref().unwrap().csi {
+            if provisioner.driver != CSI_PLUGIN_NAME {
+                return;
+            }
+        }
+
+        if let Some(reclaim_policy) = &pv.spec.as_ref().unwrap().persistent_volume_reclaim_policy {
+            if let Some(phase) = &pv.status.as_ref().unwrap().phase {
+                if reclaim_policy == "Retain" && phase == "Released" {
+                    debug!(pv.name = pv.name_any(), "PV is a deletion candidate");
+                    if let Some(provisioner) = &pv.spec.as_ref().unwrap().csi {
+                        delete_volume(&provisioner.volume_handle.to_string()).await;
+                    }
+                }
+                if phase == "Bound" {
+                    match self.pv_handle.get_opt(&pv.name_any()).await {
+                        Ok(pvol) => match pvol {
+                            Some(_) => debug!(pv.name = pv.name_any(), "PV present on API server"),
+                            None => {
+                                debug!(pv.name = pv.name_any(), "PV is a deletion candidate");
+                                if let Some(provisioner) = &pv.spec.as_ref().unwrap().csi {
+                                    delete_volume(&provisioner.volume_handle.to_string()).await;
+                                }
+                            }
+                        },
+                        Err(error) => error!(%error, "Error while verifying if PV is present"),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handle if there is any missed events at startup.
+    async fn handle_missed_events(&self) {
+        debug!("Handling if any missed events");
+        match IoEngineApiClient::get_client()
+            .list_volumes(0, "".to_string())
+            .await
+        {
+            Ok(volume_list) => {
+                for vol in volume_list.entries {
+                    let pv = "pvc-".to_string() + &vol.spec.uuid.to_string();
+                    if let Ok(pvol) = self.pv_handle.get_opt(&pv).await {
+                        match pvol {
+                            Some(_) => {}
+                            None => {
+                                debug!(pv.name = pv, "PV is a deletion candidate");
+                                let vol_handle = &vol.spec.uuid.to_string();
+                                delete_volume(vol_handle).await;
+                            }
+                        }
+                    }
+                }
+            }
+            Err(error) => error!(?error, "Unable to list volumes"),
+        }
+    }
+}
+
+/// Accepts volume id and calls Control plane api to delete the Volume
+async fn delete_volume(vol_handle: &str) {
+    let volume_uuid = Uuid::parse_str(vol_handle).unwrap();
+    match IoEngineApiClient::get_client()
+        .delete_volume(&volume_uuid)
+        .await
+    {
+        Ok(_) => info!(volume.uuid = %volume_uuid, "Successfully deleted volume"),
+        Err(error) => error!(?error, volume.uuid = %volume_uuid, "Failed to delete volume"),
+    }
+}

--- a/control-plane/csi-driver/controller/src/server.rs
+++ b/control-plane/csi-driver/controller/src/server.rs
@@ -126,6 +126,7 @@ impl CsiServer {
         };
 
         // Try to detect REST API endpoint to debug the accessibility status.
+
         ping_rest_api().await;
 
         Server::builder()
@@ -136,7 +137,6 @@ impl CsiServer {
             })
             .await
             .map_err(|_| "Failed to start gRPC server")?;
-
         Ok(())
     }
 }

--- a/control-plane/csi-driver/src/lib.rs
+++ b/control-plane/csi-driver/src/lib.rs
@@ -1,0 +1,1 @@
+pub const CSI_PLUGIN_NAME: &str = "io.openebs.csi-mayastor";


### PR DESCRIPTION
Signed-off-by: Abhilash Shetty <abhilash.shetty@datacore.com>

PV Garbage collector is a UX improvement. There is no user facing changes in this. This is implemented in CSI controller plugin. 

Post updating Cluster's CSI controller images. PV garbage collector will start running, Will cleanup if there are any existing Orphened Mayastor volumes and will start watching for events which can lead to orphaning volume in storage layer, PV Garbage collector mitigate this by taking necessary action.





