### PR TITLE
feature: drain

### DIFF
--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -37,7 +37,11 @@ pub struct NodeSpec {
     /// Cordon labels.
     #[serde(default)] // Ensure backwards compatibility in etcd when upgrading.
     cordon_labels: Vec<String>,
+    /// Drain labels.
+    #[serde(default)] // Ensure backwards compatibility in etcd when upgrading.
+    drain_labels: Vec<String>,
 }
+
 impl NodeSpec {
     /// Return a new `Self`
     pub fn new(
@@ -45,12 +49,14 @@ impl NodeSpec {
         endpoint: String,
         labels: NodeLabels,
         cordon_label: Option<Vec<String>>,
+        drain_label: Option<Vec<String>>,
     ) -> Self {
         Self {
             id,
             endpoint,
             labels,
             cordon_labels: cordon_label.unwrap_or_default(),
+            drain_labels: drain_label.unwrap_or_default(),
         }
     }
     /// Node identification
@@ -73,25 +79,49 @@ impl NodeSpec {
     pub fn cordon(&mut self, label: String) {
         self.cordon_labels.push(label);
     }
+    /// Drain node by applying the drain label.
+    pub fn drain(&mut self, label: String) {
+        self.drain_labels.push(label);
+    }
     /// Uncordon node by removing the corresponding label.
     pub fn uncordon(&mut self, label: String) {
         if let Some(index) = self.cordon_labels.iter().position(|l| l == &label) {
             self.cordon_labels.remove(index);
         }
+        if let Some(index) = self.drain_labels.iter().position(|l| l == &label) {
+            self.drain_labels.remove(index);
+        }
     }
     /// Returns whether or not the node is cordoned.
     pub fn cordoned(&self) -> bool {
-        !self.cordon_labels.is_empty()
+        !self.cordon_labels.is_empty() || !self.drain_labels.is_empty()
+    }
+    /// Returns whether or not the node is cordoned for drain.
+    pub fn cordoned_for_drain(&self) -> bool {
+        !self.drain_labels.is_empty()
     }
     /// Returns the cordon labels
     pub fn cordon_labels(&self) -> Vec<String> {
         self.cordon_labels.clone()
     }
+    /// Returns the drain labels
+    pub fn drain_labels(&self) -> Vec<String> {
+        self.drain_labels.clone()
+    }
+    pub fn has_cordon_label(&self, label: String) -> bool {
+        if self.cordon_labels.contains(&label) {
+            return true;
+        }
+        if self.drain_labels.contains(&label) {
+            return true;
+        }
+        false
+    }
 }
 
 impl From<NodeSpec> for models::NodeSpec {
     fn from(src: NodeSpec) -> Self {
-        Self::new(src.endpoint, src.id, src.cordon_labels)
+        Self::new(src.endpoint, src.id, src.cordon_labels, src.drain_labels)
     }
 }
 

--- a/control-plane/agents/core/src/node/mod.rs
+++ b/control-plane/agents/core/src/node/mod.rs
@@ -38,7 +38,7 @@ mod tests {
     use super::*;
     use common_lib::types::v0::{
         store::node::{NodeLabels, NodeSpec},
-        transport::{Filter, Node, NodeId, NodeState, NodeStatus},
+        transport::{DrainStatus, Filter, Node, NodeId, NodeState, NodeStatus},
     };
     use deployer_cluster::ClusterBuilder;
     use grpc::operations::node::traits::NodeOperations;
@@ -53,8 +53,14 @@ mod tests {
                 endpoint.clone(),
                 NodeLabels::new(),
                 None,
+                None,
             )),
-            Some(NodeState::new(id, endpoint, status)),
+            Some(NodeState::new(
+                id,
+                endpoint,
+                status,
+                DrainStatus::NotDraining,
+            )),
         )
     }
 

--- a/control-plane/agents/core/src/node/registry.rs
+++ b/control-plane/agents/core/src/node/registry.rs
@@ -1,6 +1,6 @@
 use crate::core::{registry::Registry, wrapper::NodeWrapper};
 use common::errors::SvcError;
-use common_lib::types::v0::transport::{NodeId, NodeState, Register};
+use common_lib::types::v0::transport::{DrainStatus, NodeId, NodeState, Register};
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -13,13 +13,21 @@ impl Registry {
     }
 
     /// Get all node states
-    pub(crate) async fn get_node_states(&self) -> Vec<NodeState> {
+    pub(crate) async fn get_node_states(&self) -> Result<Vec<NodeState>, SvcError> {
         let nodes = self.nodes().read().await;
         let mut nodes_vec = vec![];
         for node in nodes.values() {
-            nodes_vec.push(node.read().await.node_state().clone());
+            let mut copy_node_state = node.read().await.node_state().clone();
+            copy_node_state.drain_status =
+                match self.get_node_drain_status(copy_node_state.id()).await {
+                    Ok(ds) => ds,
+                    Err(e) => {
+                        return Err(e);
+                    }
+                };
+            nodes_vec.push(copy_node_state);
         }
-        nodes_vec
+        Ok(nodes_vec)
     }
 
     /// Get node wrapper by its `NodeId`
@@ -57,8 +65,36 @@ impl Registry {
                     })
                 }
             }
-            Some(node) => Ok(node.read().await.node_state().clone()),
+            Some(node) => {
+                let mut copy_node_state = node.read().await.node_state().clone();
+                copy_node_state.drain_status = match self.get_node_drain_status(node_id).await {
+                    Ok(ds) => ds,
+                    Err(e) => {
+                        return Err(e);
+                    }
+                };
+                Ok(copy_node_state)
+            }
         }
+    }
+
+    // deduce the drain state from the presence of drain labels and nexus instances
+    async fn get_node_drain_status(&self, node_id: &NodeId) -> Result<DrainStatus, SvcError> {
+        let spec = match self.specs().get_node(node_id) {
+            Ok(sp) => sp,
+            Err(e) => return Err(e),
+        };
+        let cordoned_for_drain = spec.cordoned_for_drain();
+        let mut drain_status = DrainStatus::NotDraining;
+        if cordoned_for_drain {
+            let nexuses = self.get_node_nexuses(node_id).await;
+            if nexuses.unwrap().is_empty() {
+                drain_status = DrainStatus::Drained;
+            } else {
+                drain_status = DrainStatus::Draining;
+            }
+        }
+        Ok(drain_status)
     }
 
     /// Register new NodeSpec for the given `Register` Request

--- a/control-plane/grpc/proto/v1/node/node.proto
+++ b/control-plane/grpc/proto/v1/node/node.proto
@@ -17,18 +17,6 @@ message Node {
   optional NodeState state = 3;
 }
 
-// Node cordon information
-message NodeCordon {
-  // Node cordon label.
-  repeated string label = 2;
-}
-
-// Node drain information
-message NodeDrain {
-  // Node drain label.
-  repeated string label = 2;
-}
-
 message NodeSpec {
   // Node identification
   string node_id = 1;
@@ -37,9 +25,9 @@ message NodeSpec {
   // Node labels.
   common.StringMapValue labels = 3;
   // Cordon information.
-  NodeCordon cordon = 4;
+  repeated string cordon_labels = 4;
   // Drain information.
-  NodeDrain drain = 5;
+  repeated string drain_labels = 5;
 }
 
 message NodeState {

--- a/control-plane/grpc/proto/v1/node/node.proto
+++ b/control-plane/grpc/proto/v1/node/node.proto
@@ -23,6 +23,12 @@ message NodeCordon {
   repeated string label = 2;
 }
 
+// Node drain information
+message NodeDrain {
+  // Node drain label.
+  repeated string label = 2;
+}
+
 message NodeSpec {
   // Node identification
   string node_id = 1;
@@ -32,7 +38,8 @@ message NodeSpec {
   common.StringMapValue labels = 3;
   // Cordon information.
   NodeCordon cordon = 4;
-
+  // Drain information.
+  NodeDrain drain = 5;
 }
 
 message NodeState {
@@ -42,6 +49,8 @@ message NodeState {
   string endpoint = 2;
   // deemed status of the node
   NodeStatus status = 3;
+  // drain state
+  DrainStatus drain_status = 4;
 }
 
 // Multiple nodes
@@ -59,6 +68,16 @@ enum NodeStatus {
   // Node is deemed offline if has missed the
   // registration keep alive deadline
   Offline = 2;
+}
+
+// Status of the Node
+enum DrainStatus {
+    // Node has no drain labels
+    NotDraining = 0;
+    // Node has at least 1 drain label and at least 1 nexus
+    Draining = 1;
+    // Node has at least 1 drain label and no nexuses
+    Drained = 2;
 }
 
 // Get storage nodes by filter
@@ -113,10 +132,25 @@ message UncordonNodeReply {
   }
 }
 
+message DrainNodeRequest {
+  // Node identification
+  string node_id = 1;
+  // Node cordon label
+  string label = 2;
+}
+
+message DrainNodeReply {
+  oneof reply {
+    Node node = 1;
+    common.ReplyError error = 2;
+  }
+}
+
 service NodeGrpc {
   rpc GetNodes (GetNodesRequest) returns (GetNodesReply) {}
   rpc GetBlockDevices (blockdevice.GetBlockDevicesRequest) returns (blockdevice.GetBlockDevicesReply) {}
   rpc Probe (ProbeRequest) returns (ProbeResponse) {}
   rpc CordonNode (CordonNodeRequest) returns (CordonNodeReply) {}
   rpc UncordonNode (UncordonNodeRequest) returns (UncordonNodeReply) {}
+  rpc DrainNode (DrainNodeRequest) returns (DrainNodeReply) {}
 }

--- a/control-plane/grpc/src/operations/node/server.rs
+++ b/control-plane/grpc/src/operations/node/server.rs
@@ -2,10 +2,11 @@ use crate::{
     blockdevice::{get_block_devices_reply, GetBlockDevicesReply, GetBlockDevicesRequest},
     node,
     node::{
-        cordon_node_reply, get_nodes_reply,
+        cordon_node_reply, drain_node_reply, get_nodes_reply,
         node_grpc_server::{NodeGrpc, NodeGrpcServer},
-        uncordon_node_reply, CordonNodeReply, CordonNodeRequest, GetNodesReply, GetNodesRequest,
-        ProbeRequest, ProbeResponse, UncordonNodeReply, UncordonNodeRequest,
+        uncordon_node_reply, CordonNodeReply, CordonNodeRequest, DrainNodeReply, DrainNodeRequest,
+        GetNodesReply, GetNodesRequest, ProbeRequest, ProbeResponse, UncordonNodeReply,
+        UncordonNodeRequest,
     },
     operations::node::traits::NodeOperations,
 };
@@ -98,6 +99,21 @@ impl NodeGrpc for NodeServer {
             })),
             Err(err) => Ok(Response::new(UncordonNodeReply {
                 reply: Some(uncordon_node_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn drain_node(
+        &self,
+        request: tonic::Request<DrainNodeRequest>,
+    ) -> Result<tonic::Response<DrainNodeReply>, tonic::Status> {
+        let req: DrainNodeRequest = request.into_inner();
+        match self.service.drain(req.node_id.into(), req.label).await {
+            Ok(node) => Ok(Response::new(DrainNodeReply {
+                reply: Some(drain_node_reply::Reply::Node(node.into())),
+            })),
+            Err(err) => Ok(Response::new(DrainNodeReply {
+                reply: Some(drain_node_reply::Reply::Error(err.into())),
             })),
         }
     }

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -1,9 +1,6 @@
 use crate::{
-    blockdevice,
-    blockdevice::GetBlockDevicesRequest,
-    context::Context,
-    node,
-    node::{get_nodes_request, NodeCordon, NodeDrain},
+    blockdevice, blockdevice::GetBlockDevicesRequest, context::Context, node,
+    node::get_nodes_request,
 };
 use common_lib::{
     transport_api::{
@@ -49,8 +46,8 @@ impl TryFrom<node::Node> for Node {
                 spec.node_id.into(),
                 spec.endpoint,
                 spec.labels.unwrap_or_default().value,
-                spec.cordon.map(|cordon| cordon.label),
-                spec.drain.map(|drain| drain.label),
+                Some(spec.cordon_labels),
+                Some(spec.drain_labels),
             )
         });
         let node_state = match node_grpc_type.state {
@@ -101,12 +98,8 @@ impl From<Node> for node::Node {
             labels: Some(crate::common::StringMapValue {
                 value: spec.labels().clone(),
             }),
-            cordon: Some(NodeCordon {
-                label: spec.cordon_labels(),
-            }),
-            drain: Some(NodeDrain {
-                label: spec.drain_labels(),
-            }),
+            cordon_labels: spec.cordon_labels(),
+            drain_labels: spec.drain_labels(),
         });
         let node_state = match node.state() {
             None => None,

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -1,9 +1,12 @@
-use crate::resources::{utils, CordonResources, GetResources, ScaleResources};
+use crate::resources::{utils, CordonResources, DrainResources, GetResources, ScaleResources};
 use async_trait::async_trait;
 
 /// The types of operations that are supported.
 #[derive(clap::Subcommand, Debug)]
 pub enum Operations {
+    /// 'Drain' resources.
+    #[clap(subcommand)]
+    Drain(DrainResources),
     /// 'Get' resources.
     #[clap(subcommand)]
     Get(GetResources),
@@ -16,6 +19,27 @@ pub enum Operations {
     /// 'Uncordon' resources.
     #[clap(subcommand)]
     Uncordon(CordonResources),
+}
+
+/// Drain trait.
+/// To be implemented by resources which support the 'drain' operation.
+#[async_trait(?Send)]
+pub trait Drain {
+    type ID;
+    async fn drain(
+        id: &Self::ID,
+        label: String,
+        drain_timeout: Option<humantime::Duration>,
+        output: &utils::OutputFormat,
+    );
+    async fn get_node_with_drain_info(id: &Self::ID, output: &utils::OutputFormat);
+}
+
+// Drain trait.
+/// To be implemented by resources which support the 'drain list' operation.
+#[async_trait(?Send)]
+pub trait DrainList {
+    async fn list_nodes_with_drain_info(output: &utils::OutputFormat);
 }
 
 /// List trait.
@@ -64,5 +88,5 @@ pub trait Cordoning {
     type ID;
     async fn cordon(id: &Self::ID, label: &str, output: &utils::OutputFormat);
     async fn uncordon(id: &Self::ID, label: &str, output: &utils::OutputFormat);
-    async fn get_labels(id: &Self::ID, output: &utils::OutputFormat);
+    async fn get_node_with_cordon_labels(id: &Self::ID, output: &utils::OutputFormat);
 }

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -1,4 +1,7 @@
-use crate::resources::{blockdevice::BlockDeviceArgs, node::GetNodeArgs};
+use crate::resources::{
+    blockdevice::BlockDeviceArgs,
+    node::{DrainNodeArgs, GetNodeArgs, GetNodesArgs},
+};
 
 pub mod blockdevice;
 pub mod node;
@@ -25,13 +28,20 @@ pub enum GetResources {
     /// Get pool with the given ID.
     Pool { id: PoolId },
     /// Get all nodes.
-    Nodes,
+    Nodes(GetNodesArgs),
     /// Get node with the given ID.
     Node(GetNodeArgs),
     /// Get BlockDevices present on the Node. Lists usable devices by default.
     /// Currently disks having blobstore pools not created by control-plane are also shown as
     /// usable.
     BlockDevices(BlockDeviceArgs),
+}
+
+/// The types of resources that support the 'drain' operation.
+#[derive(clap::Subcommand, Debug)]
+pub enum DrainResources {
+    /// Drain node with the given ID.
+    Node(DrainNodeArgs),
 }
 
 /// The types of resources that support the 'scale' operation.

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -1,5 +1,5 @@
 use crate::{
-    operations::{Cordoning, Get, List},
+    operations::{Cordoning, Drain, DrainList, Get, List},
     resources::{
         utils,
         utils::{print_table, CreateRows, GetHeaderRow, OutputFormat},
@@ -11,6 +11,8 @@ use async_trait::async_trait;
 use openapi::models::NodeSpec;
 use prettytable::{Cell, Row};
 use serde::Serialize;
+use std::time;
+use tokio::time::Duration;
 
 #[derive(Debug, Clone, clap::Args)]
 /// Arguments used when getting a node.
@@ -20,6 +22,9 @@ pub struct GetNodeArgs {
     #[clap(long)]
     /// Shows the cordon labels associated with the node
     show_cordon_labels: bool,
+    #[clap(long)]
+    /// Shows the drain information and filter for draining / drained nodes
+    show_drain: bool,
 }
 
 impl GetNodeArgs {
@@ -31,6 +36,26 @@ impl GetNodeArgs {
     /// Return whether or not we should show the cordon labels.
     pub fn show_cordon_labels(&self) -> bool {
         self.show_cordon_labels
+    }
+
+    /// Return whether or not we should show the drain labels.
+    pub fn show_drain(&self) -> bool {
+        self.show_drain
+    }
+}
+
+#[derive(Debug, Clone, clap::Args)]
+/// Arguments used when getting a node.
+pub struct GetNodesArgs {
+    #[clap(long)]
+    /// Shows the drain information and filter for draining / drained nodes
+    show_drain: bool,
+}
+
+impl GetNodesArgs {
+    /// Return whether or not we should show the drain labels and filter based on drain labels
+    pub fn show_drain(&self) -> bool {
+        self.show_drain
     }
 }
 
@@ -49,12 +74,13 @@ impl CreateRows for openapi::models::Node {
             id: spec.id,
             grpc_endpoint: spec.grpc_endpoint,
             status: openapi::models::NodeStatus::Unknown,
+            drain_status: openapi::models::DrainStatus::NotDraining,
         });
         let rows = vec![row![
             self.id,
             state.grpc_endpoint,
             state.status,
-            !spec.cordon_labels.is_empty(),
+            !(spec.cordon_labels.is_empty() && spec.drain_labels.is_empty()),
         ]];
         rows
     }
@@ -143,16 +169,24 @@ impl Cordoning for Node {
                 OutputFormat::None => {
                     // In case the output format is not specified, show a success message.
                     let cordon_labels = node
+                        .clone()
                         .into_body()
                         .spec
                         .map(|node_spec| node_spec.cordon_labels)
                         .unwrap_or_default();
-                    if cordon_labels.is_empty() {
+
+                    let drain_labels = node
+                        .into_body()
+                        .spec
+                        .map(|node_spec| node_spec.drain_labels)
+                        .unwrap_or_default();
+                    let labels = [cordon_labels, drain_labels].concat();
+                    if labels.is_empty() {
                         println!("Node {} successfully uncordoned", id);
                     } else {
                         println!(
                             "Cordon label successfully removed. Remaining cordon labels {:?}",
-                            cordon_labels
+                            labels,
                         );
                     }
                 }
@@ -163,7 +197,7 @@ impl Cordoning for Node {
         }
     }
 
-    async fn get_labels(id: &Self::ID, output: &OutputFormat) {
+    async fn get_node_with_cordon_labels(id: &Self::ID, output: &OutputFormat) {
         match RestClient::client().nodes_api().get_node(id).await {
             Ok(node) => {
                 let node_display =
@@ -182,6 +216,7 @@ impl Cordoning for Node {
 enum NodeDisplayFormat {
     Default,
     CordonLabels,
+    Drain,
 }
 
 /// The NodeDisply structure is responsible for controlling the display formatting of Node objects.
@@ -190,7 +225,7 @@ enum NodeDisplayFormat {
 #[derive(Serialize, Debug)]
 struct NodeDisplay {
     #[serde(flatten)]
-    inner: openapi::models::Node,
+    inner: Vec<openapi::models::Node>,
     #[serde(skip)]
     format: NodeDisplayFormat,
 }
@@ -198,8 +233,12 @@ struct NodeDisplay {
 impl NodeDisplay {
     /// Create a new `NodeDisplay` instance.
     pub(crate) fn new(node: openapi::models::Node, format: NodeDisplayFormat) -> Self {
+        let vec: Vec<openapi::models::Node> = vec![node];
+        Self { inner: vec, format }
+    }
+    pub(crate) fn new_nodes(nodes: Vec<openapi::models::Node>, format: NodeDisplayFormat) -> Self {
         Self {
-            inner: node,
+            inner: nodes,
             format,
         }
     }
@@ -211,18 +250,52 @@ impl CreateRows for NodeDisplay {
         match self.format {
             NodeDisplayFormat::Default => self.inner.create_rows(),
             NodeDisplayFormat::CordonLabels => {
-                let mut rows = self.inner.create_rows();
-                let cordon_labels_string = self
-                    .inner
-                    .spec
-                    .as_ref()
-                    .unwrap_or(&NodeSpec::default())
-                    .cordon_labels
-                    .join(", ");
+                let mut rows = vec![];
+                for node in self.inner.iter() {
+                    let mut row = node.create_rows();
+                    let mut cordon_labels_string = node
+                        .spec
+                        .as_ref()
+                        .unwrap_or(&NodeSpec::default())
+                        .cordon_labels
+                        .join(", ");
+                    let drain_labels_string = node
+                        .spec
+                        .as_ref()
+                        .unwrap_or(&NodeSpec::default())
+                        .drain_labels
+                        .join(", ");
+                    if !cordon_labels_string.is_empty() && !drain_labels_string.is_empty() {
+                        cordon_labels_string += ", ";
+                    }
+                    cordon_labels_string += &drain_labels_string;
+                    // Add the cordon labels to each row.
+                    row[0].add_cell(Cell::new(&cordon_labels_string));
+                    rows.push(row[0].clone());
+                }
+                rows
+            }
+            NodeDisplayFormat::Drain => {
+                let mut rows = vec![];
+                for node in self.inner.iter() {
+                    let mut row = node.create_rows();
+                    let drain_status_string = match node.state.as_ref().unwrap().drain_status {
+                        openapi::models::DrainStatus::NotDraining => "Not Draining",
+                        openapi::models::DrainStatus::Draining => "Draining",
+                        openapi::models::DrainStatus::Drained => "Drained",
+                    };
 
-                // Add the cordon labels to each row.
-                rows.iter_mut()
-                    .for_each(|row| row.add_cell(Cell::new(&cordon_labels_string)));
+                    let drain_labels_string = node
+                        .spec
+                        .as_ref()
+                        .unwrap_or(&NodeSpec::default())
+                        .drain_labels
+                        .join(", ");
+                    // Add the drain labels to each row.
+                    row[0].add_cell(Cell::new(drain_status_string));
+                    row[0].add_cell(Cell::new(&drain_labels_string));
+                    rows.push(row[0].clone());
+                }
                 rows
             }
         }
@@ -238,6 +311,142 @@ impl GetHeaderRow for NodeDisplay {
             NodeDisplayFormat::CordonLabels => {
                 header.extend(vec!["CORDON LABELS"]);
                 header
+            }
+            NodeDisplayFormat::Drain => {
+                header.extend(vec!["DRAIN STATE"]);
+                header.extend(vec!["DRAIN LABELS"]);
+                header
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct DrainNodeArgs {
+    /// Id of the node
+    node_id: NodeId,
+    /// Label of the drain
+    label: String,
+    #[clap(long)]
+    /// Timeout for the drain operation
+    drain_timeout: Option<humantime::Duration>,
+}
+
+impl DrainNodeArgs {
+    /// Return the node ID.
+    pub fn node_id(&self) -> NodeId {
+        self.node_id.clone()
+    }
+    /// Return the drain label.
+    pub fn label(&self) -> String {
+        self.label.clone()
+    }
+    /// Return whether or not we should show the drain labels.
+    pub fn drain_timeout(&self) -> Option<humantime::Duration> {
+        self.drain_timeout
+    }
+}
+
+#[async_trait(?Send)]
+impl Drain for Node {
+    type ID = NodeId;
+    async fn drain(
+        id: &Self::ID,
+        label: String,
+        drain_timeout: Option<humantime::Duration>,
+        output: &utils::OutputFormat,
+    ) {
+        let mut timeout_instant: Option<time::Instant> = None;
+        if let Some(dt) = drain_timeout {
+            //let duration: std::time::Duration = drain_timeout.unwrap().into();
+            timeout_instant = time::Instant::now().checked_add(dt.into());
+        }
+        match RestClient::client()
+            .nodes_api()
+            .put_node_drain(id, &label)
+            .await
+        {
+            Ok(_node) => {
+                // loop this call until no longer draining
+                loop {
+                    match RestClient::client().nodes_api().get_node(id).await {
+                        Ok(node) => {
+                            let node_body = &node.clone().into_body();
+                            let state = node_body.state.as_ref().unwrap().drain_status;
+                            match state {
+                                openapi::models::DrainStatus::NotDraining
+                                | openapi::models::DrainStatus::Drained => {
+                                    match output {
+                                        OutputFormat::None => match state {
+                                            openapi::models::DrainStatus::NotDraining => {
+                                                println!("Drain has been cancelled");
+                                            }
+                                            openapi::models::DrainStatus::Drained => {
+                                                println!("Drain completed");
+                                            }
+                                            _ => {} // not possible
+                                        },
+                                        _ => {
+                                            // json or yaml
+                                            print_table(output, node.into_body());
+                                        }
+                                    }
+                                    break;
+                                }
+                                openapi::models::DrainStatus::Draining => {}
+                            }
+                        }
+                        Err(e) => {
+                            println!("Failed to get node {}. Error {}", id, e);
+                            break;
+                        }
+                    }
+                    if timeout_instant.is_some() && time::Instant::now() > timeout_instant.unwrap()
+                    {
+                        println!("Drain command timed out");
+                        break;
+                    }
+                    let sleep = Duration::from_secs(1);
+                    tokio::time::sleep(sleep).await;
+                }
+            }
+            Err(e) => {
+                println!("Failed to get node {}. Error {}", id, e)
+            }
+        }
+    }
+
+    async fn get_node_with_drain_info(id: &Self::ID, output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_node(id).await {
+            Ok(node) => {
+                let node_display = NodeDisplay::new(node.into_body(), NodeDisplayFormat::Drain);
+                print_table(output, node_display);
+            }
+            Err(e) => {
+                println!("Failed to get node {}. Error {}", id, e)
+            }
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl DrainList for Nodes {
+    async fn list_nodes_with_drain_info(output: &utils::OutputFormat) {
+        match RestClient::client().nodes_api().get_nodes().await {
+            Ok(nodes) => {
+                // iterate through the nodes and filter for only those that have drain labels
+                // then print with the format NodeDisplayFormat::Drain
+                let nodelist = nodes.into_body();
+                let mut filteredlist = nodelist;
+                // remove nodes with no drain labels
+                filteredlist.retain(|i| {
+                    i.spec.is_some() && !i.spec.as_ref().unwrap().drain_labels.is_empty()
+                });
+                let node_display = NodeDisplay::new_nodes(filteredlist, NodeDisplayFormat::Drain);
+                utils::print_table(output, node_display);
+            }
+            Err(e) => {
+                println!("Failed to list nodes. Error {}", e)
             }
         }
     }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -285,6 +285,35 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: [ ]
+  '/nodes/{id}/drain/{label}':
+    put:
+      tags:
+        - Nodes
+      operationId: put_node_drain
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: label
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
   '/nodes/{id}/nexuses':
     get:
       tags:
@@ -1836,6 +1865,13 @@ components:
       required:
         - size
         - thin
+    DrainStatus:
+      description: current drain state
+      type: string
+      enum:
+        - NotDraining
+        - Draining
+        - Drained
     PoolTopology:
       example:
         explicit: null
@@ -2073,6 +2109,7 @@ components:
         grpcEndpoint: '10.1.0.5:10124'
         id: io-engine-1
         cordonLabels: [label-1]
+        drainLabels: [label-1]
       description: io-engine storage node information
       type: object
       properties:
@@ -2085,10 +2122,15 @@ components:
           type: array
           items:
             type: string
+        drainLabels:
+          type: array
+          items:
+            type: string
       required:
         - grpcEndpoint
         - id
         - cordonLabels
+        - drainLabels
     NodeState:
       example:
         grpcEndpoint: '10.1.0.5:10124'
@@ -2104,10 +2146,13 @@ components:
           $ref: '#/components/schemas/NodeId'
         status:
           $ref: '#/components/schemas/NodeStatus'
+        drainStatus:
+            $ref: '#/components/schemas/DrainStatus'
       required:
         - grpcEndpoint
         - id
         - status
+        - drainStatus
     Node:
       description: io-engine storage node information
       type: object

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -37,6 +37,13 @@ impl apis::actix_server::Nodes for RestApi {
         let node = client().uncordon(id.into(), label).await?;
         Ok(node.into())
     }
+
+    async fn put_node_drain(
+        Path((id, label)): Path<(String, String)>,
+    ) -> Result<models::Node, RestError<RestJsonError>> {
+        let node = client().drain(id.into(), label).await?;
+        Ok(node.into())
+    }
 }
 
 /// returns node from node option and returns an error on non existence

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -95,6 +95,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
                 cluster.composer().container_ip(cluster.node(0).as_str())
             ),
             cordon_labels: vec![],
+            drain_labels: vec![],
         }),
         state: Some(models::NodeState {
             id: io_engine1.to_string(),
@@ -103,6 +104,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
                 cluster.composer().container_ip(cluster.node(0).as_str())
             ),
             status: models::NodeStatus::Online,
+            drain_status: models::DrainStatus::NotDraining,
         }),
     };
     assert_eq!(listed_node.unwrap(), node);

--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -3,8 +3,11 @@ use clap::Parser;
 use openapi::tower::client::Url;
 use opentelemetry::global;
 use plugin::{
-    operations::{Cordoning, Get, GetBlockDevices, List, ReplicaTopology, Scale},
-    resources::{blockdevice, node, pool, volume, CordonResources, GetResources, ScaleResources},
+    operations::{Cordoning, Drain, DrainList, Get, GetBlockDevices, List, ReplicaTopology, Scale},
+    resources::{
+        blockdevice, node, pool, volume, CordonResources, DrainResources, GetResources,
+        ScaleResources,
+    },
     rest_wrapper::RestClient,
 };
 use std::{
@@ -80,10 +83,18 @@ async fn execute(cli_args: CliArgs) {
             }
             GetResources::Pools => pool::Pools::list(&cli_args.output).await,
             GetResources::Pool { id } => pool::Pool::get(&id, &cli_args.output).await,
-            GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
+            GetResources::Nodes(args) => {
+                if args.show_drain() {
+                    node::Nodes::list_nodes_with_drain_info(&cli_args.output).await
+                } else {
+                    node::Nodes::list(&cli_args.output).await
+                }
+            }
             GetResources::Node(args) => {
                 if args.show_cordon_labels() {
-                    node::Node::get_labels(&args.node_id(), &cli_args.output).await
+                    node::Node::get_node_with_cordon_labels(&args.node_id(), &cli_args.output).await
+                } else if args.show_drain() {
+                    node::Node::get_node_with_drain_info(&args.node_id(), &cli_args.output).await
                 } else {
                     node::Node::get(&args.node_id(), &cli_args.output).await
                 }
@@ -92,6 +103,17 @@ async fn execute(cli_args: CliArgs) {
                 blockdevice::BlockDevice::get_blockdevices(
                     &bdargs.node_id(),
                     &bdargs.all(),
+                    &cli_args.output,
+                )
+                .await
+            }
+        },
+        Operations::Drain(resource) => match resource {
+            DrainResources::Node(drain_node_args) => {
+                node::Node::drain(
+                    &drain_node_args.node_id(),
+                    drain_node_args.label(),
+                    drain_node_args.drain_timeout(),
                     &cli_args.output,
                 )
                 .await

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -1,10 +1,13 @@
 use clap::Parser;
-use plugin::resources::{CordonResources, GetResources, ScaleResources};
+use plugin::resources::{CordonResources, DrainResources, GetResources, ScaleResources};
 use supportability::DumpArgs;
 
 /// The types of operations that are supported.
 #[derive(Parser, Debug)]
 pub enum Operations {
+    /// 'Drain' resources.
+    #[clap(subcommand)]
+    Drain(DrainResources),
     /// 'Get' resources.
     #[clap(subcommand)]
     Get(GetResources),


### PR DESCRIPTION
Add APIs to drain a node.
Drain is not yet fully implemented - what is missing is the reconciler that moves nexuses to another node, which is dependent on HA being implemented.
With this PR, drain labels are now stored in the core agent and perform the same cordoning function as cordon labels but also flag that a drain is to be undertaken.
The Node object returned from the core-agent now includes a DrainStatus field which is one of:
NotDraining
Draining
Drained
dependent on the presence of nexuses and drain labels on the node.
The kubectl plugin initiates a drain via:
    kubectl-plugin drain node <node id> <drain label>
and cancels it via:
    kubectl-plugin uncordon node <node id> <drain label>

A new option --show-drain when used with "get node" or "get nodes" will display the drain labels and the state.
When used with "get nodes" only nodes that are in Draining or Drained state are listed.
