### PR TITLE
feat(k8s): add proxy library for http and tcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,6 +1983,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-proxy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "k8s-openapi",
+ "kube",
+ "shutdown",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kube"
 version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,12 +2033,14 @@ dependencies = [
  "openssl",
  "pem",
  "pin-project",
+ "rand",
  "secrecy",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util 0.7.3",
  "tower",
  "tower-http",
@@ -3365,6 +3382,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,6 +3907,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4105,6 +4145,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tungstenite"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha-1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4187,6 +4246,12 @@ name = "urlencoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,8 +1988,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
+ "hyper",
  "k8s-openapi",
  "kube",
+ "serde_json",
  "shutdown",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "k8s/plugin",
     ## Supportability tool to create bundle
     "k8s/supportability",
+    "k8s/proxy",
     "deployer",
     "openapi",
     "rpc",

--- a/k8s/proxy/Cargo.toml
+++ b/k8s/proxy/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "k8s-proxy"
+description = "Kubernetes Proxy library"
+version = "0.1.0"
+edition = "2021"
+
+[[example]]
+name = "port-forward"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+kube = { version = "0.74.0", features = [ "ws" ] }
+k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_20"] }
+tokio = { version = "1.12.0", features = [ "full" ] }
+tokio-stream = { version = "0.1.9", features = ["net"] }
+futures = "0.3.21"
+anyhow = "1.0.44"
+tracing = "0.1.28"
+shutdown = { path = "../../utils/shutdown" }
+
+[dev-dependencies]
+tracing-subscriber = "0.3.15"

--- a/k8s/proxy/Cargo.toml
+++ b/k8s/proxy/Cargo.toml
@@ -18,6 +18,8 @@ futures = "0.3.21"
 anyhow = "1.0.44"
 tracing = "0.1.28"
 shutdown = { path = "../../utils/shutdown" }
+serde_json = "1.0.82"
+hyper = { version = "0.14.20", features = [ "client", "http1", "http2", "tcp", "stream" ] }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.15"

--- a/k8s/proxy/examples/http-forward.rs
+++ b/k8s/proxy/examples/http-forward.rs
@@ -1,0 +1,27 @@
+use hyper::service::Service;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let selector = k8s_proxy::TargetSelector::svc_label("app", "api-rest");
+    let target = k8s_proxy::Target::new(selector, "http", "mayastor");
+    let uri = k8s_proxy::HttpForward::new(target).await?.uri().await?;
+
+    let proxy = k8s_proxy::HttpProxy::try_default().await?;
+    let mut svc = hyper::service::service_fn(|request: hyper::Request<hyper::body::Body>| {
+        let mut proxy = proxy.clone();
+        async move { proxy.call(request).await }
+    });
+
+    let request = hyper::Request::builder()
+        .method("GET")
+        .uri(&format!("{}/v0/nodes", uri))
+        .body(hyper::Body::empty())
+        .unwrap();
+
+    let result = svc.call(request).await?;
+    tracing::info!(?result, "http request complete");
+
+    Ok(())
+}

--- a/k8s/proxy/examples/port-forward.rs
+++ b/k8s/proxy/examples/port-forward.rs
@@ -1,0 +1,13 @@
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let selector = k8s_proxy::TargetSelector::svc_label("app", "api-rest");
+    let target = k8s_proxy::Target::new(selector, "http", "mayastor");
+    let pf = k8s_proxy::PortForward::new(target, 30011).await?;
+
+    let handle = pf.port_forward().await?;
+    handle.await?;
+
+    Ok(())
+}

--- a/k8s/proxy/src/http_forward.rs
+++ b/k8s/proxy/src/http_forward.rs
@@ -1,0 +1,242 @@
+use crate::{
+    pod_selection::{AnyReady, PodSelection},
+    vx::{Pod, Service},
+};
+use hyper::{body, Response};
+use kube::{
+    api::{Api, ListParams},
+    ResourceExt,
+};
+use std::{future::Future, pin::Pin};
+
+/// Used to retrieve the `hyper::Uri` that can be used to proxy with the kubeapi server.
+/// This uri may then be used with `HttpProxy` which is a `tower::Service`.
+/// # Example
+/// ```ignore
+/// let selector = k8s_proxy::TargetSelector::svc_label("app", "api-rest");
+/// let target = k8s_proxy::Target::new(selector, "http", "mayastor");
+/// let hf = k8s_proxy::HttpForward::new(target).await?;
+///
+/// let uri = hf.uri().await?;
+/// tracing::info!(%uri, "generated kube-api");
+/// ```
+#[derive(Clone)]
+pub struct HttpForward {
+    target: crate::Target,
+    pod_api: Api<Pod>,
+    svc_api: Api<Service>,
+}
+
+impl HttpForward {
+    /// Return a new `Self`.
+    /// # Arguments
+    /// * `target` - the target we'll forward to
+    pub async fn new(target: crate::Target) -> anyhow::Result<Self> {
+        let client = kube::Client::try_default().await?;
+        let namespace = target.namespace.name_any();
+
+        Ok(Self {
+            target,
+            pod_api: Api::namespaced(client.clone(), &namespace),
+            svc_api: Api::namespaced(client, &namespace),
+        })
+    }
+
+    /// Returns the `hyper::Uri` that can be used to proxy with the kubeapi server.
+    pub async fn uri(self) -> anyhow::Result<hyper::Uri> {
+        let target = self.finder().find(&self.target).await?;
+        let uri = hyper::Uri::try_from(target)?;
+        tracing::info!(%uri, "generated kube-api");
+        Ok(uri)
+    }
+
+    fn finder(&self) -> TargetFinder {
+        TargetFinder {
+            pod_api: &self.pod_api,
+            svc_api: &self.svc_api,
+        }
+    }
+}
+
+/// A `tower::Service` that proxies requests to services/pods via the kubeapi server.
+/// The client must connect using the appropriate `hyper::Uri`, which can be easily
+/// generated using `HttpForward::uri`.
+/// # Example
+/// ```ignore
+/// let selector = k8s_proxy::TargetSelector::svc_label("app", "api-rest");
+/// let target = k8s_proxy::Target::new(selector, "http", "mayastor");
+/// let pf = k8s_proxy::HttpForward::new(target).await?;
+///
+/// let uri = pf.uri().await?;
+/// tracing::info!(%uri, "generated kube-api");
+///
+/// let proxy = k8s_proxy::HttpProxy::try_default().await?;
+/// let mut svc = hyper::service::service_fn(|request: hyper::Request<hyper::body::Body>| {
+///     let mut proxy = proxy.clone();
+///     async move { proxy.call(request).await }
+/// });
+///
+/// let request = hyper::Request::builder()
+///     .method("GET")
+///     .uri(&format!("{}/v0/nodes", uri))
+///     .body(hyper::Body::empty())
+///     .unwrap();
+///
+/// let result = svc.call(request).await?;
+/// tracing::info!(?result, "http request complete");
+/// ```
+#[derive(Clone)]
+pub struct HttpProxy {
+    client: kube::Client,
+}
+impl HttpProxy {
+    /// Returns a new `HttpProxy` using the provided `kube::Client`.
+    pub fn new(client: kube::Client) -> Self {
+        Self { client }
+    }
+    /// Tries to return a default `HttpProxy` with a default `kube::Client`.
+    pub async fn try_default() -> anyhow::Result<Self> {
+        Ok(Self {
+            client: kube::Client::try_default().await?,
+        })
+    }
+}
+
+impl hyper::service::Service<hyper::Request<body::Body>> for HttpProxy {
+    type Response = Response<body::Body>;
+    type Error = kube::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Response<body::Body>, kube::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: hyper::Request<body::Body>) -> Self::Future {
+        let client = self.client.clone();
+        Box::pin(async move {
+            let (parts, body) = request.into_parts();
+
+            let body_bytes = body::to_bytes(body).await.unwrap();
+            let bytes = body_bytes.to_vec();
+            let request = hyper::Request::from_parts(parts, bytes);
+            match client.request_text(request).await {
+                Ok(r) => Ok(Response::new(body::Body::from(r))),
+                Err(error) => match error {
+                    kube::Error::Api(response) => {
+                        // undo the debug print which created response.message
+                        let message = serde_json::from_str::<serde_json::Value>(&response.message)
+                            .map_err(kube::Error::SerdeError)?
+                            .as_str()
+                            .unwrap_or("")
+                            .to_string();
+
+                        Response::builder()
+                            .status(response.code)
+                            .body(body::Body::from(message))
+                            .map_err(kube::Error::HttpError)
+                    }
+                    _ => Err(error),
+                },
+            }
+        })
+    }
+}
+
+/// Finds an `HttpTarget` which is either a pod/service name and port.
+#[derive(Clone)]
+struct TargetFinder<'a> {
+    pod_api: &'a Api<Pod>,
+    svc_api: &'a Api<Service>,
+}
+impl<'a> TargetFinder<'a> {
+    /// Finds the `HttpTarget` according to the specified target.
+    /// # Arguments
+    /// * `target` - the target to be found
+    async fn find(&self, target: &crate::Target) -> anyhow::Result<HttpTarget> {
+        let pod_api = self.pod_api;
+        let svc_api = self.svc_api;
+
+        let target = target.clone();
+        let namespace = target.namespace;
+        match target.selector {
+            crate::TargetSelector::PodName(name) => Ok(HttpTarget::new(
+                TargetName::Pod(name),
+                target.port,
+                namespace,
+            )),
+            crate::TargetSelector::PodLabel(selector) => {
+                let pods = pod_api.list(&Self::pod_params(&selector)).await?;
+                let pod = AnyReady {}.select(&pods.items, &selector)?;
+                Ok(HttpTarget::new(
+                    TargetName::Pod(pod.name_any()),
+                    target.port,
+                    namespace,
+                ))
+            }
+            crate::TargetSelector::ServiceLabel(selector) => {
+                let services = svc_api.list(&Self::svc_params(&selector)).await?;
+                let service = match services.items.into_iter().next() {
+                    Some(service) => Ok(service),
+                    None => Err(anyhow::anyhow!("Service '{}' not found", selector)),
+                }?;
+
+                Ok(HttpTarget::new(
+                    TargetName::Service(service.name_any()),
+                    target.port,
+                    namespace,
+                ))
+            }
+        }
+    }
+    fn pod_params(selector: &str) -> ListParams {
+        ListParams::default()
+            .labels(selector)
+            .fields("status.phase=Running")
+    }
+    fn svc_params(selector: &str) -> ListParams {
+        ListParams::default().labels(selector)
+    }
+}
+
+enum TargetName {
+    Pod(String),
+    Service(String),
+}
+
+/// A target which is can either be a pod or a service.
+/// The port can be specified by name or number.
+struct HttpTarget {
+    name: TargetName,
+    port: crate::Port,
+    namespace: crate::NameSpace,
+}
+impl HttpTarget {
+    fn new(name: TargetName, port: crate::Port, namespace: crate::NameSpace) -> Self {
+        Self {
+            name,
+            port,
+            namespace,
+        }
+    }
+}
+
+impl TryFrom<HttpTarget> for hyper::Uri {
+    type Error = hyper::http::uri::InvalidUri;
+
+    fn try_from(value: HttpTarget) -> Result<Self, Self::Error> {
+        let (resource, name) = match value.name {
+            TargetName::Pod(name) => ("pods", name),
+            TargetName::Service(name) => ("services", name),
+        };
+        let port = value.port.any();
+        let namespace = value.namespace.name_any();
+
+        hyper::Uri::try_from(format!(
+            "/api/v1/namespaces/{}/{}/{}:{}/proxy",
+            namespace, resource, name, port
+        ))
+    }
+}

--- a/k8s/proxy/src/lib.rs
+++ b/k8s/proxy/src/lib.rs
@@ -4,9 +4,12 @@
 //! The different proxies can be used to communicate with in-cluster pods/services using the
 //! kubernetes api-server.
 
+mod http_forward;
 mod pod_selection;
 mod port_forward;
 
+/// Layer 7 proxies.
+pub use http_forward::{HttpForward, HttpProxy};
 /// Layer 4 proxies.
 pub use port_forward::PortForward;
 
@@ -78,6 +81,13 @@ impl Port {
         match self {
             Port::Number(number) => Some(*number),
             Port::Name(_) => None,
+        }
+    }
+    /// Returns the port as a string.
+    pub(crate) fn any(&self) -> String {
+        match self {
+            Port::Number(number) => number.to_string(),
+            Port::Name(name) => name.clone(),
         }
     }
 }

--- a/k8s/proxy/src/lib.rs
+++ b/k8s/proxy/src/lib.rs
@@ -1,0 +1,164 @@
+#![deny(missing_docs)]
+//! This library provides k8s proxy support.
+//!
+//! The different proxies can be used to communicate with in-cluster pods/services using the
+//! kubernetes api-server.
+
+mod pod_selection;
+mod port_forward;
+
+/// Layer 4 proxies.
+pub use port_forward::PortForward;
+
+/// The kubernetes api version used throughout the crate.
+pub(crate) use k8s_openapi::api::core::v1 as vx;
+
+use anyhow::Context;
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+use kube::ResourceExt;
+use vx::Pod;
+
+/// Different types of target selectors.
+#[derive(Clone)]
+pub enum TargetSelector {
+    /// By pod name.
+    PodName(String),
+    /// By pod label selector.
+    PodLabel(String),
+    /// By service label selector.
+    ServiceLabel(String),
+}
+impl TargetSelector {
+    /// New `Self` from the given pod label key value.
+    pub fn pod_label(key: &str, val: &str) -> Self {
+        Self::PodLabel(format!("{}={}", key, val))
+    }
+    /// New `Self` from the given service label key value.
+    pub fn svc_label(key: &str, val: &str) -> Self {
+        Self::ServiceLabel(format!("{}={}", key, val))
+    }
+}
+
+/// Identify a port explicitly by its number of by name.
+#[derive(Clone)]
+pub enum Port {
+    /// Specified using a number.
+    Number(i32),
+    /// Specified using a name.
+    Name(String),
+}
+impl From<i32> for Port {
+    fn from(port: i32) -> Self {
+        Self::Number(port)
+    }
+}
+impl From<&str> for Port {
+    fn from(port: &str) -> Self {
+        Self::Name(port.to_string())
+    }
+}
+impl From<IntOrString> for Port {
+    fn from(port: IntOrString) -> Self {
+        match port {
+            IntOrString::Int(port) => Self::Number(port),
+            IntOrString::String(port) => Self::Name(port),
+        }
+    }
+}
+impl Port {
+    /// Returns the port name, if set.
+    pub(crate) fn name(&self) -> Option<&String> {
+        match self {
+            Port::Number(_) => None,
+            Port::Name(name) => Some(name),
+        }
+    }
+    /// Returns the port number, if set.
+    pub(crate) fn number(&self) -> Option<i32> {
+        match self {
+            Port::Number(number) => Some(*number),
+            Port::Name(_) => None,
+        }
+    }
+}
+
+/// A kubernetes target.
+#[derive(Clone)]
+pub struct Target {
+    selector: TargetSelector,
+    port: Port,
+    namespace: NameSpace,
+}
+
+/// A kubernetes namespace.
+/// If None, the default is "default".
+#[derive(Clone)]
+pub(crate) struct NameSpace(Option<String>);
+impl NameSpace {
+    /// Returns the configured namespace or the default.
+    pub(crate) fn name_any(&self) -> String {
+        let default = "default".to_string();
+        self.0.clone().unwrap_or(default)
+    }
+}
+
+/// A pod target which is composed of its pod name and port number.
+#[derive(Clone)]
+pub(crate) struct TargetPod {
+    pod_name: String,
+    port_number: u16,
+}
+impl TargetPod {
+    fn new(pod_name: String, port_number: i32) -> anyhow::Result<Self> {
+        let port_number = u16::try_from(port_number).context("Port not valid")?;
+        Ok(Self {
+            pod_name,
+            port_number,
+        })
+    }
+    /// Convert `Self` into a tuple of `pod_name` and `port_number`.
+    pub(crate) fn into_parts(self) -> (String, u16) {
+        (self.pod_name, self.port_number)
+    }
+}
+
+impl Target {
+    /// Returns a new `Self` from the given parameters.
+    /// # Arguments
+    /// * `selector` - target selector
+    /// * `port` - target port
+    /// * `namespace` - target namespace
+    pub fn new<I: Into<Option<T>>, T: Into<String>, P: Into<Port>>(
+        selector: TargetSelector,
+        port: P,
+        namespace: I,
+    ) -> Self {
+        Self {
+            selector,
+            port: port.into(),
+            namespace: NameSpace(namespace.into().map(Into::into)),
+        }
+    }
+
+    /// Returns the `TargetPod` for the given pod/port or pod/self.port.
+    pub(crate) fn find(&self, pod: &Pod, port: Option<Port>) -> anyhow::Result<TargetPod> {
+        let port = match &port {
+            None => &self.port,
+            Some(port) => port,
+        };
+
+        TargetPod::new(
+            pod.name_any(),
+            match port {
+                Port::Number(port) => *port,
+                Port::Name(name) => {
+                    let spec = pod.spec.as_ref().context("Pod Spec is None")?;
+                    let containers = &spec.containers;
+                    let mut ports = containers.iter().filter_map(|c| c.ports.as_ref()).flatten();
+                    let port = ports.find(|p| p.name.as_ref() == Some(name));
+                    port.context("Port not found")?.container_port
+                }
+            },
+        )
+    }
+}

--- a/k8s/proxy/src/pod_selection.rs
+++ b/k8s/proxy/src/pod_selection.rs
@@ -1,0 +1,28 @@
+use crate::vx::Pod;
+use anyhow::Context;
+
+/// Pod selection according to impl specific criteria.
+pub(crate) trait PodSelection {
+    fn select<'p>(&self, pods: &'p [Pod], selector: &str) -> anyhow::Result<&'p Pod>;
+}
+
+/// Selects any pod so long as it's ready.
+pub(crate) struct AnyReady {}
+
+impl PodSelection for AnyReady {
+    fn select<'p>(&self, pods: &'p [Pod], selector: &str) -> anyhow::Result<&'p Pod> {
+        // todo: randomly select from the ready pods
+        let pod = pods
+            .iter()
+            .find(is_pod_ready)
+            .context(anyhow::anyhow!("No pod '{}' available", selector))?;
+        Ok(pod)
+    }
+}
+
+fn is_pod_ready(pod: &&Pod) -> bool {
+    let conditions = pod.status.as_ref().and_then(|s| s.conditions.as_ref());
+    conditions
+        .map(|c| c.iter().any(|c| c.type_ == "Ready" && c.status == "True"))
+        .unwrap_or(false)
+}

--- a/k8s/proxy/src/port_forward.rs
+++ b/k8s/proxy/src/port_forward.rs
@@ -1,0 +1,193 @@
+use anyhow::Context;
+use futures::{StreamExt, TryStreamExt};
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+
+use crate::{
+    pod_selection::{AnyReady, PodSelection},
+    vx::{Pod, Service},
+};
+use kube::{
+    api::{Api, ListParams},
+    Client,
+};
+
+/// Used to "proxy" connections to a pod by use of port forwarding.
+/// # Example
+/// ```ignore
+/// let selector = k8s_proxy::TargetSelector::pod_label("app", "etcd");
+/// let target = k8s_proxy::Target::new(selector, "client", "mayastor");
+/// let pf = k8s_proxy::PortForward::new(target, 35003).await?;
+///
+/// let handle = pf.port_forward().await?;
+/// handle.await?;
+/// ```
+#[derive(Clone)]
+pub struct PortForward {
+    target: crate::Target,
+    local_port: Option<u16>,
+    pod_api: Api<Pod>,
+    svc_api: Api<Service>,
+}
+
+impl PortForward {
+    /// Return a new `Self`.
+    /// # Arguments
+    /// * `target` - the target we'll forward to
+    /// * `local_port` - specific local port to use, if Some
+    pub async fn new(
+        target: crate::Target,
+        local_port: impl Into<Option<u16>>,
+    ) -> anyhow::Result<Self> {
+        let client = Client::try_default().await?;
+        let namespace = target.namespace.name_any();
+
+        Ok(Self {
+            target,
+            local_port: local_port.into(),
+            pod_api: Api::namespaced(client.clone(), &namespace),
+            svc_api: Api::namespaced(client, &namespace),
+        })
+    }
+
+    /// The specified local port, or 0.
+    /// Port 0 is special as it tells the kernel to give us the next free port.
+    fn local_port(&self) -> u16 {
+        self.local_port.unwrap_or(0)
+    }
+
+    /// Runs the port forwarding proxy until a SIGINT signal is received.
+    pub async fn port_forward(self) -> anyhow::Result<tokio::task::JoinHandle<()>> {
+        let addr = SocketAddr::from(([127, 0, 0, 1], self.local_port()));
+
+        let bind = TcpListener::bind(addr).await?;
+        let port = bind.local_addr()?.port();
+        tracing::trace!(port, "Bound to local port");
+
+        let server = TcpListenerStream::new(bind)
+            .take_until(shutdown::Shutdown::wait())
+            .try_for_each(move |client_conn| {
+                let pf = self.clone();
+
+                async {
+                    let client_conn = client_conn;
+                    if let Ok(peer_addr) = client_conn.peer_addr() {
+                        tracing::trace!(%peer_addr, "new connection");
+                    }
+
+                    tokio::spawn(async move {
+                        if let Err(e) = pf.forward_connection(client_conn).await {
+                            tracing::error!(
+                                error = e.as_ref() as &dyn std::error::Error,
+                                "failed to forward connection"
+                            );
+                        }
+                    });
+
+                    // keep the server running
+                    Ok(())
+                }
+            });
+
+        Ok(tokio::spawn(async {
+            if let Err(e) = server.await {
+                tracing::error!(error = &e as &dyn std::error::Error, "server error");
+            }
+        }))
+    }
+    async fn forward_connection(
+        self,
+        mut client_conn: tokio::net::TcpStream,
+    ) -> anyhow::Result<()> {
+        let target = self.finder().find(&self.target).await?;
+        let (pod_name, pod_port) = target.into_parts();
+
+        let mut forwarder = self.pod_api.portforward(&pod_name, &[pod_port]).await?;
+
+        let mut upstream_conn = forwarder
+            .take_stream(pod_port)
+            .context("port not found in forwarder")?;
+
+        let local_port = self.local_port();
+
+        tracing::debug!(local_port, pod_port, pod_name, "forwarding connections");
+
+        if let Err(error) =
+            tokio::io::copy_bidirectional(&mut client_conn, &mut upstream_conn).await
+        {
+            tracing::trace!(local_port, pod_port, pod_name, ?error, "connection error");
+        }
+
+        drop(upstream_conn);
+        forwarder.join().await?;
+        tracing::debug!(local_port, pod_port, pod_name, "connection closed");
+        Ok(())
+    }
+    fn finder(&self) -> TargetPodFinder {
+        TargetPodFinder {
+            pod_api: &self.pod_api,
+            svc_api: &self.svc_api,
+        }
+    }
+}
+
+/// Finds a `crate::TargetPod`, which is essentially a pod name and port.
+/// Note this finds the actual pod mapping and not the service.
+#[derive(Clone)]
+struct TargetPodFinder<'a> {
+    pod_api: &'a Api<Pod>,
+    svc_api: &'a Api<Service>,
+}
+impl<'a> TargetPodFinder<'a> {
+    /// Finds the name and port of the target pod specified by the selector.
+    /// # Arguments
+    /// * `target` - the target to be found
+    pub(crate) async fn find(&self, target: &crate::Target) -> anyhow::Result<crate::TargetPod> {
+        let pod_api = self.pod_api;
+        let svc_api = self.svc_api;
+        let ready_pod = AnyReady {};
+
+        match &target.selector {
+            crate::TargetSelector::PodName(name) => {
+                let pod = pod_api.get(name).await?;
+                target.find(&pod, None)
+            }
+            crate::TargetSelector::PodLabel(selector) => {
+                let pods = pod_api.list(&Self::pod_params(selector)).await?;
+                let pod = ready_pod.select(&pods.items, selector)?;
+                target.find(pod, None)
+            }
+            crate::TargetSelector::ServiceLabel(selector) => {
+                let pods = pod_api.list(&Self::pod_params(selector)).await?;
+                let pod = ready_pod.select(&pods.items, selector)?;
+
+                let services = svc_api.list(&Self::svc_params(selector)).await?;
+                let service = match services.items.into_iter().next() {
+                    Some(service) => Ok(service),
+                    None => Err(anyhow::anyhow!("Service '{}' not found", selector)),
+                }?;
+
+                let svc = service.spec.context("Spec is not defined")?;
+                let ports = svc.ports.unwrap_or_default();
+                let port = ports
+                    .into_iter()
+                    .find(|p| {
+                        p.name.as_ref() == target.port.name()
+                            || Some(p.port) == target.port.number()
+                    })
+                    .context("No port found in pod")?;
+
+                target.find(pod, port.target_port.map(|p| p.into()))
+            }
+        }
+    }
+    fn pod_params(selector: &str) -> ListParams {
+        ListParams::default()
+            .labels(selector)
+            .fields("status.phase=Running")
+    }
+    fn svc_params(selector: &str) -> ListParams {
+        ListParams::default().labels(selector)
+    }
+}


### PR DESCRIPTION
feat(k8s): add proxy library with portforward

Add new k8s proxy library which is capable of setting up port forwarding to a port.
A server is bound to a local port and each connection creates a new port forward to the
configured pod target.
Based on the kube-rs port bind example :+1

Found a few bugs with the port-forward and raised a PR to attempt fixing them: https://github.com/kube-rs/kube-rs/pull/973

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(k8s): add http forwarding to the proxy library

This consists of a layer7 proxy using the kube-rs text request.
Once https://github.com/kube-rs/kube-rs/pull/972 is released we'll tweak this commit
to make use of the raw request, thus avoid multiple data conversions.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
