### PR TITLE
chore: add worker thread knobs to the api-rest service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,6 +2988,7 @@ dependencies = [
  "http",
  "humantime",
  "jsonwebtoken",
+ "num_cpus",
  "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -44,6 +44,7 @@ utils = { path = "../../utils/utils-lib" }
 humantime = "2.1.0"
 git-version = "0.3.5"
 grpc = { path = "../grpc" }
+num_cpus = "1.13.1"
 
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["full"] }

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -46,7 +46,7 @@ pub struct ListOptions {
     pub no_docker: bool,
 
     /// Format the docker output
-    #[structopt(short, long, conflicts_with = "no_docker")]
+    #[structopt(short, long, conflicts_with = "no-docker")]
     pub format: Option<String>,
 
     /// Label for the cluster

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -59,3 +59,6 @@ pub const DEFAULT_CLUSTER_AGENT_SERVER_ADDR: &str = "https://ha-cluster-agent:11
 
 /// The default value to be assigned as node-agent GRPC server addr if not overridden
 pub const DEFAULT_NODE_AGENT_SERVER_ADDR: &str = "https://0.0.0.0:11600";
+
+/// The default worker threads cap for the api-rest service.
+pub const DEFAULT_REST_MAX_WORKER_THREADS: &str = "8";


### PR DESCRIPTION
By default set the max number of worker threads is set to 8.
This will unblock running on servers with large numbers of cpus and using more memory
than what our defaults in the helm charts are prepared to dish out.

Adds 2 new args to the api-rest, workers and max workers.
By default workers is the number of physical cpus and the default max is 8.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>