### PR TITLE
feat: drain alternative implementation

### DIFF
--- a/control-plane/agents/core/src/node/mod.rs
+++ b/control-plane/agents/core/src/node/mod.rs
@@ -53,6 +53,8 @@ mod tests {
                 endpoint.clone(),
                 NodeLabels::new(),
                 None,
+                None,
+                None,
             )),
             Some(NodeState::new(id, endpoint, status)),
         )

--- a/control-plane/agents/core/src/node/specs.rs
+++ b/control-plane/agents/core/src/node/specs.rs
@@ -31,6 +31,8 @@ impl ResourceSpecsLocked {
                         node.grpc_endpoint.clone(),
                         NodeLabels::new(),
                         None,
+                        None,
+                        None,
                     );
                     specs.nodes.insert(node.clone());
                     (true, node)
@@ -87,7 +89,7 @@ impl ResourceSpecsLocked {
         let cordoned_node_spec = {
             let mut locked_node = node.lock();
             // Do not allow the same label to be applied more than once.
-            if locked_node.cordon_labels().contains(&label) {
+            if locked_node.has_cordon_label(label.clone()) {
                 return Err(SvcError::CordonLabel {
                     node_id: node_id.to_string(),
                     label,
@@ -110,7 +112,7 @@ impl ResourceSpecsLocked {
     ) -> Result<NodeSpec, SvcError> {
         let node = self.get_locked_node(node_id)?;
         // Return an error if the uncordon label doesn't exist.
-        if !node.lock().cordon_labels().contains(&label) {
+        if !node.lock().has_cordon_label(label.clone()) {
             return Err(SvcError::UncordonLabel {
                 node_id: node_id.to_string(),
                 label,
@@ -139,5 +141,30 @@ impl ResourceSpecsLocked {
                 }
             })
             .collect()
+    }
+
+    /// Drain the node with the given ID.
+    /// Return the NodeSpec after draining.
+    pub(crate) async fn drain_node(
+        &self,
+        registry: &Registry,
+        node_id: &NodeId,
+        label: String,
+    ) -> Result<NodeSpec, SvcError> {
+        let node = self.get_locked_node(node_id)?;
+        let drained_node_spec = {
+            let mut locked_node = node.lock();
+            // Do not allow the same label to be applied more than once.
+            if locked_node.has_cordon_label(label.clone()) {
+                return Err(SvcError::CordonLabel {
+                    node_id: node_id.to_string(),
+                    label,
+                });
+            }
+            locked_node.drain(label);
+            locked_node.clone()
+        };
+        registry.store_obj(&drained_node_spec).await?;
+        Ok(drained_node_spec.clone())
     }
 }

--- a/control-plane/grpc/proto/v1/node/node.proto
+++ b/control-plane/grpc/proto/v1/node/node.proto
@@ -17,12 +17,6 @@ message Node {
   optional NodeState state = 3;
 }
 
-// Node cordon information
-message NodeCordon {
-  // Node cordon label.
-  repeated string label = 2;
-}
-
 message NodeSpec {
   // Node identification
   string node_id = 1;
@@ -31,8 +25,11 @@ message NodeSpec {
   // Node labels.
   common.StringMapValue labels = 3;
   // Cordon information.
-  NodeCordon cordon = 4;
-
+  repeated string cordon_labels = 4;
+  // Drain information.
+  repeated string drain_labels = 5;
+  // Is the node draining
+  bool is_draining = 6;
 }
 
 message NodeState {
@@ -113,10 +110,25 @@ message UncordonNodeReply {
   }
 }
 
+message DrainNodeRequest {
+  // Node identification
+  string node_id = 1;
+  // Node cordon label
+  string label = 2;
+}
+
+message DrainNodeReply {
+  oneof reply {
+    Node node = 1;
+    common.ReplyError error = 2;
+  }
+}
+
 service NodeGrpc {
   rpc GetNodes (GetNodesRequest) returns (GetNodesReply) {}
   rpc GetBlockDevices (blockdevice.GetBlockDevicesRequest) returns (blockdevice.GetBlockDevicesReply) {}
   rpc Probe (ProbeRequest) returns (ProbeResponse) {}
   rpc CordonNode (CordonNodeRequest) returns (CordonNodeReply) {}
   rpc UncordonNode (UncordonNodeRequest) returns (UncordonNodeReply) {}
+  rpc DrainNode (DrainNodeRequest) returns (DrainNodeReply) {}
 }

--- a/control-plane/grpc/src/operations/node/server.rs
+++ b/control-plane/grpc/src/operations/node/server.rs
@@ -2,10 +2,11 @@ use crate::{
     blockdevice::{get_block_devices_reply, GetBlockDevicesReply, GetBlockDevicesRequest},
     node,
     node::{
-        cordon_node_reply, get_nodes_reply,
+        cordon_node_reply, drain_node_reply, get_nodes_reply,
         node_grpc_server::{NodeGrpc, NodeGrpcServer},
-        uncordon_node_reply, CordonNodeReply, CordonNodeRequest, GetNodesReply, GetNodesRequest,
-        ProbeRequest, ProbeResponse, UncordonNodeReply, UncordonNodeRequest,
+        uncordon_node_reply, CordonNodeReply, CordonNodeRequest, DrainNodeReply, DrainNodeRequest,
+        GetNodesReply, GetNodesRequest, ProbeRequest, ProbeResponse, UncordonNodeReply,
+        UncordonNodeRequest,
     },
     operations::node::traits::NodeOperations,
 };
@@ -98,6 +99,21 @@ impl NodeGrpc for NodeServer {
             })),
             Err(err) => Ok(Response::new(UncordonNodeReply {
                 reply: Some(uncordon_node_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn drain_node(
+        &self,
+        request: tonic::Request<DrainNodeRequest>,
+    ) -> Result<tonic::Response<DrainNodeReply>, tonic::Status> {
+        let req: DrainNodeRequest = request.into_inner();
+        match self.service.drain(req.node_id.into(), req.label).await {
+            Ok(node) => Ok(Response::new(DrainNodeReply {
+                reply: Some(drain_node_reply::Reply::Node(node.into())),
+            })),
+            Err(err) => Ok(Response::new(DrainNodeReply {
+                reply: Some(drain_node_reply::Reply::Error(err.into())),
             })),
         }
     }

--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -2,8 +2,13 @@ use clap::Parser;
 use openapi::tower::client::Url;
 use opentelemetry::global;
 use plugin::{
-    operations::{Cordoning, Get, GetBlockDevices, List, Operations, ReplicaTopology, Scale},
-    resources::{blockdevice, node, pool, volume, CordonResources, GetResources, ScaleResources},
+    operations::{
+        Cordoning, Drain, Get, GetBlockDevices, List, Operations, ReplicaTopology, Scale,
+    },
+    resources::{
+        blockdevice, cordon, drain, node, pool, volume, CordonResources, DrainResources,
+        GetCordonArgs, GetDrainArgs, GetResources, ScaleResources,
+    },
     rest_wrapper::RestClient,
 };
 use std::env;
@@ -54,7 +59,30 @@ async fn execute(cli_args: CliArgs) {
 
     // Perform the operations based on the subcommand, with proper output format.
     match &cli_args.operations {
+        Operations::Drain(resource) => match resource {
+            DrainResources::Node(drain_node_args) => {
+                node::Node::drain(
+                    &drain_node_args.node_id(),
+                    drain_node_args.label(),
+                    drain_node_args.drain_timeout(),
+                    &cli_args.output,
+                )
+                .await
+            }
+        },
         Operations::Get(resource) => match resource {
+            GetResources::Cordon(get_cordon_resource) => match get_cordon_resource {
+                GetCordonArgs::Node { id: node_id } => {
+                    cordon::NodeCordon::get(node_id, &cli_args.output).await
+                }
+                GetCordonArgs::Nodes => cordon::NodeCordons::list(&cli_args.output).await,
+            },
+            GetResources::Drain(get_drain_resource) => match get_drain_resource {
+                GetDrainArgs::Node { id: node_id } => {
+                    drain::NodeDrain::get(node_id, &cli_args.output).await
+                }
+                GetDrainArgs::Nodes => drain::NodeDrains::list(&cli_args.output).await,
+            },
             GetResources::Volumes => volume::Volumes::list(&cli_args.output).await,
             GetResources::Volume { id } => volume::Volume::get(id, &cli_args.output).await,
             GetResources::VolumeReplicaTopology { id } => {
@@ -63,13 +91,7 @@ async fn execute(cli_args: CliArgs) {
             GetResources::Pools => pool::Pools::list(&cli_args.output).await,
             GetResources::Pool { id } => pool::Pool::get(id, &cli_args.output).await,
             GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
-            GetResources::Node(args) => {
-                if args.show_cordon_labels() {
-                    node::Node::get_labels(&args.node_id(), &cli_args.output).await
-                } else {
-                    node::Node::get(&args.node_id(), &cli_args.output).await
-                }
-            }
+            GetResources::Node(args) => node::Node::get(&args.node_id(), &cli_args.output).await,
             GetResources::BlockDevices(bdargs) => {
                 blockdevice::BlockDevice::get_blockdevices(
                     &bdargs.node_id(),

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -1,9 +1,12 @@
-use crate::resources::{utils, CordonResources, GetResources, ScaleResources};
+use crate::resources::{utils, CordonResources, DrainResources, GetResources, ScaleResources};
 use async_trait::async_trait;
 
 /// The types of operations that are supported.
 #[derive(clap::Subcommand, Debug)]
 pub enum Operations {
+    /// 'Drain' resources.
+    #[clap(subcommand)]
+    Drain(DrainResources),
     /// 'Get' resources.
     #[clap(subcommand)]
     Get(GetResources),
@@ -16,6 +19,19 @@ pub enum Operations {
     /// 'Uncordon' resources.
     #[clap(subcommand)]
     Uncordon(CordonResources),
+}
+
+/// Drain trait.
+/// To be implemented by resources which support the 'drain' operation.
+#[async_trait(?Send)]
+pub trait Drain {
+    type ID;
+    async fn drain(
+        id: &Self::ID,
+        label: String,
+        drain_timeout: Option<humantime::Duration>,
+        output: &utils::OutputFormat,
+    );
 }
 
 /// List trait.
@@ -64,5 +80,4 @@ pub trait Cordoning {
     type ID;
     async fn cordon(id: &Self::ID, label: &str, output: &utils::OutputFormat);
     async fn uncordon(id: &Self::ID, label: &str, output: &utils::OutputFormat);
-    async fn get_labels(id: &Self::ID, output: &utils::OutputFormat);
 }

--- a/control-plane/plugin/src/resources/cordon.rs
+++ b/control-plane/plugin/src/resources/cordon.rs
@@ -1,0 +1,53 @@
+pub struct NodeCordon {}
+pub struct NodeCordons {}
+
+use async_trait::async_trait;
+
+use crate::{
+    operations::{Get, List},
+    resources::{
+        node::{node_display_print, node_display_print_one, NodeDisplayFormat},
+        utils::OutputFormat,
+        NodeId,
+    },
+    rest_wrapper::RestClient,
+};
+
+#[async_trait(?Send)]
+impl Get for NodeCordon {
+    type ID = NodeId;
+    async fn get(id: &Self::ID, output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_node(id).await {
+            Ok(node) => {
+                node_display_print_one(node.into_body(), output, NodeDisplayFormat::CordonLabels)
+            }
+            Err(e) => {
+                println!("Failed to get node {}. Error {}", id, e)
+            }
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl List for NodeCordons {
+    async fn list(output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_nodes().await {
+            Ok(nodes) => {
+                // iterate through the nodes and filter for only those that have cordon or drain
+                // labels
+                let nodelist = nodes.into_body();
+                let mut filteredlist = nodelist;
+                // remove nodes with no cordon or drain labels
+                filteredlist.retain(|i| {
+                    i.spec.is_some()
+                        && !(i.spec.as_ref().unwrap().cordon_labels.is_empty()
+                            && i.spec.as_ref().unwrap().drain_labels.is_empty())
+                });
+                node_display_print(filteredlist, output, NodeDisplayFormat::CordonLabels)
+            }
+            Err(e) => {
+                println!("Failed to list nodes. Error {}", e)
+            }
+        }
+    }
+}

--- a/control-plane/plugin/src/resources/drain.rs
+++ b/control-plane/plugin/src/resources/drain.rs
@@ -1,0 +1,49 @@
+pub struct NodeDrain {}
+pub struct NodeDrains {}
+
+use async_trait::async_trait;
+
+use crate::{
+    operations::{Get, List},
+    resources::{
+        node::{node_display_print, node_display_print_one, NodeDisplayFormat},
+        utils::OutputFormat,
+        NodeId,
+    },
+    rest_wrapper::RestClient,
+};
+
+#[async_trait(?Send)]
+impl Get for NodeDrain {
+    type ID = NodeId;
+    async fn get(id: &Self::ID, output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_node(id).await {
+            Ok(node) => node_display_print_one(node.into_body(), output, NodeDisplayFormat::Drain),
+            Err(e) => {
+                println!("Failed to get node {}. Error {}", id, e)
+            }
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl List for NodeDrains {
+    async fn list(output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_nodes().await {
+            Ok(nodes) => {
+                // iterate through the nodes and filter for only those that have drain labels
+                // then print with the format NodeDisplayFormat::Drain
+                let nodelist = nodes.into_body();
+                let mut filteredlist = nodelist;
+                // remove nodes with no drain labels
+                filteredlist.retain(|i| {
+                    i.spec.is_some() && !i.spec.as_ref().unwrap().drain_labels.is_empty()
+                });
+                node_display_print(filteredlist, output, NodeDisplayFormat::Drain);
+            }
+            Err(e) => {
+                println!("Failed to list nodes. Error {}", e)
+            }
+        }
+    }
+}

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -1,6 +1,11 @@
-use crate::resources::{blockdevice::BlockDeviceArgs, node::GetNodeArgs};
+use crate::resources::{
+    blockdevice::BlockDeviceArgs,
+    node::{DrainNodeArgs, GetNodeArgs},
+};
 
 pub mod blockdevice;
+pub mod cordon;
+pub mod drain;
 pub mod node;
 pub mod pool;
 pub mod utils;
@@ -14,6 +19,12 @@ pub type NodeId = String;
 /// The types of resources that support the 'get' operation.
 #[derive(clap::Subcommand, Debug)]
 pub enum GetResources {
+    /// get cordon
+    #[clap(subcommand)]
+    Cordon(GetCordonArgs),
+    /// get drain
+    #[clap(subcommand)]
+    Drain(GetDrainArgs),
     /// Get all volumes.
     Volumes,
     /// Get volume with the given ID.
@@ -51,6 +62,32 @@ pub enum ScaleResources {
 pub enum CordonResources {
     /// Cordon the node with the given ID by applying the cordon label to that node.
     Node { id: NodeId, label: String },
+}
+
+/// The types of resources that support the 'get cordon' operation.
+#[derive(clap::Subcommand, Debug)]
+pub enum GetCordonArgs {
+    /// Get the cordon for the node with the given ID.
+    Node {
+        id: NodeId,
+    },
+    Nodes,
+}
+
+/// The types of resources that support the 'drain' operation.
+#[derive(clap::Subcommand, Debug)]
+pub enum DrainResources {
+    /// Drain node with the given ID.
+    Node(DrainNodeArgs),
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum GetDrainArgs {
+    /// Get the drain for the node with the given ID.
+    Node {
+        id: NodeId,
+    },
+    Nodes,
 }
 
 /// Tabular Output Tests

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -1,5 +1,5 @@
 use crate::{
-    operations::{Cordoning, Get, List},
+    operations::{Cordoning, Drain, Get, List},
     resources::{
         utils,
         utils::{print_table, CreateRows, GetHeaderRow, OutputFormat},
@@ -11,26 +11,20 @@ use async_trait::async_trait;
 use openapi::models::NodeSpec;
 use prettytable::{Cell, Row};
 use serde::Serialize;
+use std::time;
+use tokio::time::Duration;
 
 #[derive(Debug, Clone, clap::Args)]
 /// Arguments used when getting a node.
 pub struct GetNodeArgs {
     /// Id of the node
     node_id: NodeId,
-    #[clap(long)]
-    /// Shows the cordon labels associated with the node
-    show_cordon_labels: bool,
 }
 
 impl GetNodeArgs {
     /// Return the node ID.
     pub fn node_id(&self) -> NodeId {
         self.node_id.clone()
-    }
-
-    /// Return whether or not we should show the cordon labels.
-    pub fn show_cordon_labels(&self) -> bool {
-        self.show_cordon_labels
     }
 }
 
@@ -54,7 +48,7 @@ impl CreateRows for openapi::models::Node {
             self.id,
             state.grpc_endpoint,
             state.status,
-            !spec.cordon_labels.is_empty(),
+            !(spec.cordon_labels.is_empty() && spec.drain_labels.is_empty()),
         ]];
         rows
     }
@@ -94,8 +88,7 @@ impl Get for Node {
         match RestClient::client().nodes_api().get_node(id).await {
             Ok(node) => {
                 // Print table, json or yaml based on output format.
-                let node_display = NodeDisplay::new(node.into_body(), NodeDisplayFormat::Default);
-                print_table(output, node_display);
+                utils::print_table(output, node.into_body());
             }
             Err(e) => {
                 println!("Failed to get node {}. Error {}", id, e)
@@ -143,16 +136,24 @@ impl Cordoning for Node {
                 OutputFormat::None => {
                     // In case the output format is not specified, show a success message.
                     let cordon_labels = node
+                        .clone()
                         .into_body()
                         .spec
                         .map(|node_spec| node_spec.cordon_labels)
                         .unwrap_or_default();
-                    if cordon_labels.is_empty() {
+
+                    let drain_labels = node
+                        .into_body()
+                        .spec
+                        .map(|node_spec| node_spec.drain_labels)
+                        .unwrap_or_default();
+                    let labels = [cordon_labels, drain_labels].concat();
+                    if labels.is_empty() {
                         println!("Node {} successfully uncordoned", id);
                     } else {
                         println!(
                             "Cordon label successfully removed. Remaining cordon labels {:?}",
-                            cordon_labels
+                            labels,
                         );
                     }
                 }
@@ -162,35 +163,23 @@ impl Cordoning for Node {
             }
         }
     }
-
-    async fn get_labels(id: &Self::ID, output: &OutputFormat) {
-        match RestClient::client().nodes_api().get_node(id).await {
-            Ok(node) => {
-                let node_display =
-                    NodeDisplay::new(node.into_body(), NodeDisplayFormat::CordonLabels);
-                print_table(output, node_display);
-            }
-            Err(e) => {
-                println!("Failed to get node {}. Error {}", id, e)
-            }
-        }
-    }
 }
 
 /// Display format options for a `Node` object.
 #[derive(Debug)]
-enum NodeDisplayFormat {
+pub enum NodeDisplayFormat {
     Default,
     CordonLabels,
+    Drain,
 }
 
 /// The NodeDisply structure is responsible for controlling the display formatting of Node objects.
 /// `#[serde(flatten)]` and `#[serde(skip)]` attributes are used to ensure that when the object is
 /// serialised, only the `inner` object is represented.
 #[derive(Serialize, Debug)]
-struct NodeDisplay {
+pub struct NodeDisplay {
     #[serde(flatten)]
-    inner: openapi::models::Node,
+    pub inner: Vec<openapi::models::Node>,
     #[serde(skip)]
     format: NodeDisplayFormat,
 }
@@ -198,8 +187,12 @@ struct NodeDisplay {
 impl NodeDisplay {
     /// Create a new `NodeDisplay` instance.
     pub(crate) fn new(node: openapi::models::Node, format: NodeDisplayFormat) -> Self {
+        let vec: Vec<openapi::models::Node> = vec![node];
+        Self { inner: vec, format }
+    }
+    pub(crate) fn new_nodes(nodes: Vec<openapi::models::Node>, format: NodeDisplayFormat) -> Self {
         Self {
-            inner: node,
+            inner: nodes,
             format,
         }
     }
@@ -211,20 +204,92 @@ impl CreateRows for NodeDisplay {
         match self.format {
             NodeDisplayFormat::Default => self.inner.create_rows(),
             NodeDisplayFormat::CordonLabels => {
-                let mut rows = self.inner.create_rows();
-                let cordon_labels_string = self
-                    .inner
-                    .spec
-                    .as_ref()
-                    .unwrap_or(&NodeSpec::default())
-                    .cordon_labels
-                    .join(", ");
-
-                // Add the cordon labels to each row.
-                rows.iter_mut()
-                    .for_each(|row| row.add_cell(Cell::new(&cordon_labels_string)));
+                let mut rows = vec![];
+                for node in self.inner.iter() {
+                    let mut row = node.create_rows();
+                    let mut cordon_labels_string = node
+                        .spec
+                        .as_ref()
+                        .unwrap_or(&NodeSpec::default())
+                        .cordon_labels
+                        .join(", ");
+                    let drain_labels_string = node
+                        .spec
+                        .as_ref()
+                        .unwrap_or(&NodeSpec::default())
+                        .drain_labels
+                        .join(", ");
+                    if !cordon_labels_string.is_empty() && !drain_labels_string.is_empty() {
+                        cordon_labels_string += ", ";
+                    }
+                    cordon_labels_string += &drain_labels_string;
+                    // Add the cordon labels to each row.
+                    row[0].add_cell(Cell::new(&cordon_labels_string));
+                    rows.push(row[0].clone());
+                }
                 rows
             }
+            NodeDisplayFormat::Drain => {
+                let mut rows = vec![];
+                for node in self.inner.iter() {
+                    let mut row = node.create_rows();
+
+                    let ns = node.spec.as_ref().unwrap_or(&NodeSpec::default()).clone();
+
+                    let drain_status_string: String;
+                    if ns.drain_labels.is_empty() {
+                        drain_status_string = "Not Draining".to_string();
+                    } else if ns.is_draining {
+                        drain_status_string = "Draining".to_string();
+                    } else {
+                        drain_status_string = "Drained".to_string();
+                    }
+
+                    let drain_labels_string = node
+                        .spec
+                        .as_ref()
+                        .unwrap_or(&NodeSpec::default())
+                        .drain_labels
+                        .join(", ");
+                    // Add the drain labels to each row.
+                    row[0].add_cell(Cell::new(&drain_status_string));
+                    row[0].add_cell(Cell::new(&drain_labels_string));
+                    rows.push(row[0].clone());
+                }
+                rows
+            }
+        }
+    }
+}
+
+pub fn node_display_print(
+    nodes: Vec<openapi::models::Node>,
+    output: &OutputFormat,
+    format: NodeDisplayFormat,
+) {
+    let node_display = NodeDisplay::new_nodes(nodes, format);
+    match output {
+        OutputFormat::Yaml | OutputFormat::Json => {
+            print_table(output, node_display.inner);
+        }
+        OutputFormat::None => {
+            print_table(output, node_display);
+        }
+    }
+}
+
+pub fn node_display_print_one(
+    nodes: openapi::models::Node,
+    output: &OutputFormat,
+    format: NodeDisplayFormat,
+) {
+    let node_display = NodeDisplay::new(nodes, format);
+    match output {
+        OutputFormat::Yaml | OutputFormat::Json => {
+            print_table(output, node_display.inner);
+        }
+        OutputFormat::None => {
+            print_table(output, node_display);
         }
     }
 }
@@ -238,6 +303,104 @@ impl GetHeaderRow for NodeDisplay {
             NodeDisplayFormat::CordonLabels => {
                 header.extend(vec!["CORDON LABELS"]);
                 header
+            }
+            NodeDisplayFormat::Drain => {
+                header.extend(vec!["DRAIN STATE"]);
+                header.extend(vec!["DRAIN LABELS"]);
+                header
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct DrainNodeArgs {
+    /// Id of the node
+    node_id: NodeId,
+    /// Label of the drain
+    label: String,
+    #[clap(long)]
+    /// Timeout for the drain operation
+    drain_timeout: Option<humantime::Duration>,
+}
+
+impl DrainNodeArgs {
+    /// Return the node ID.
+    pub fn node_id(&self) -> NodeId {
+        self.node_id.clone()
+    }
+    /// Return the drain label.
+    pub fn label(&self) -> String {
+        self.label.clone()
+    }
+    /// Return whether or not we should show the drain labels.
+    pub fn drain_timeout(&self) -> Option<humantime::Duration> {
+        self.drain_timeout
+    }
+}
+
+#[async_trait(?Send)]
+impl Drain for Node {
+    type ID = NodeId;
+    async fn drain(
+        id: &Self::ID,
+        label: String,
+        drain_timeout: Option<humantime::Duration>,
+        output: &utils::OutputFormat,
+    ) {
+        let mut timeout_instant: Option<time::Instant> = None;
+        if let Some(dt) = drain_timeout {
+            //let duration: std::time::Duration = drain_timeout.unwrap().into();
+            timeout_instant = time::Instant::now().checked_add(dt.into());
+        }
+        match RestClient::client()
+            .nodes_api()
+            .put_node_drain(id, &label)
+            .await
+        {
+            Ok(_node) => {
+                // loop this call until no longer draining
+                loop {
+                    match RestClient::client().nodes_api().get_node(id).await {
+                        Ok(node) => {
+                            let node_body = &node.clone().into_body();
+                            let is_draining = node_body.spec.as_ref().unwrap().is_draining;
+                            let has_labels =
+                                !node_body.spec.as_ref().unwrap().drain_labels.is_empty();
+
+                            if !is_draining {
+                                match output {
+                                    OutputFormat::None => {
+                                        if has_labels {
+                                            println!("Drain completed");
+                                        } else {
+                                            println!("Drain has been cancelled");
+                                        }
+                                    }
+                                    _ => {
+                                        // json or yaml
+                                        print_table(output, node.into_body());
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            println!("Failed to get node {}. Error {}", id, e);
+                            break;
+                        }
+                    }
+                    if timeout_instant.is_some() && time::Instant::now() > timeout_instant.unwrap()
+                    {
+                        println!("Drain command timed out");
+                        break;
+                    }
+                    let sleep = Duration::from_secs(1);
+                    tokio::time::sleep(sleep).await;
+                }
+            }
+            Err(e) => {
+                println!("Failed to get node {}. Error {}", id, e)
             }
         }
     }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -285,6 +285,35 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: [ ]
+  '/nodes/{id}/drain/{label}':
+    put:
+      tags:
+        - Nodes
+      operationId: put_node_drain
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: label
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
   '/nodes/{id}/nexuses':
     get:
       tags:
@@ -2073,6 +2102,8 @@ components:
         grpcEndpoint: '10.1.0.5:10124'
         id: io-engine-1
         cordonLabels: [label-1]
+        drainLabels: [label-1]
+        isDraining: false
       description: io-engine storage node information
       type: object
       properties:
@@ -2085,10 +2116,18 @@ components:
           type: array
           items:
             type: string
+        drainLabels:
+          type: array
+          items:
+            type: string
+        isDraining:
+          type: bool
       required:
         - grpcEndpoint
         - id
         - cordonLabels
+        - drainLabels
+        - isDraining
     NodeState:
       example:
         grpcEndpoint: '10.1.0.5:10124'
@@ -2108,6 +2147,7 @@ components:
         - grpcEndpoint
         - id
         - status
+        - drainStatus
     Node:
       description: io-engine storage node information
       type: object

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -37,6 +37,13 @@ impl apis::actix_server::Nodes for RestApi {
         let node = client().uncordon(id.into(), label).await?;
         Ok(node.into())
     }
+
+    async fn put_node_drain(
+        Path((id, label)): Path<(String, String)>,
+    ) -> Result<models::Node, RestError<RestJsonError>> {
+        let node = client().drain(id.into(), label).await?;
+        Ok(node.into())
+    }
 }
 
 /// returns node from node option and returns an error on non existence

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -95,6 +95,8 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
                 cluster.composer().container_ip(cluster.node(0).as_str())
             ),
             cordon_labels: vec![],
+            drain_labels: vec![],
+            is_draining: false,
         }),
         state: Some(models::NodeState {
             id: io_engine1.to_string(),

--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -3,8 +3,11 @@ use clap::Parser;
 use openapi::tower::client::Url;
 use opentelemetry::global;
 use plugin::{
-    operations::{Cordoning, Get, GetBlockDevices, List, ReplicaTopology, Scale},
-    resources::{blockdevice, node, pool, volume, CordonResources, GetResources, ScaleResources},
+    operations::{Cordoning, Drain, Get, GetBlockDevices, List, ReplicaTopology, Scale},
+    resources::{
+        blockdevice, cordon, drain, node, pool, volume, CordonResources, DrainResources,
+        GetCordonArgs, GetDrainArgs, GetResources, ScaleResources,
+    },
     rest_wrapper::RestClient,
 };
 use std::{
@@ -73,6 +76,18 @@ async fn execute(cli_args: CliArgs) {
     // Perform the operations based on the subcommand, with proper output format.
     match cli_args.operations {
         Operations::Get(resource) => match resource {
+            GetResources::Cordon(get_cordon_resource) => match get_cordon_resource {
+                GetCordonArgs::Node { id: node_id } => {
+                    cordon::NodeCordon::get(&node_id, &cli_args.output).await
+                }
+                GetCordonArgs::Nodes => cordon::NodeCordons::list(&cli_args.output).await,
+            },
+            GetResources::Drain(get_drain_resource) => match get_drain_resource {
+                GetDrainArgs::Node { id: node_id } => {
+                    drain::NodeDrain::get(&node_id, &cli_args.output).await
+                }
+                GetDrainArgs::Nodes => drain::NodeDrains::list(&cli_args.output).await,
+            },
             GetResources::Volumes => volume::Volumes::list(&cli_args.output).await,
             GetResources::Volume { id } => volume::Volume::get(&id, &cli_args.output).await,
             GetResources::VolumeReplicaTopology { id } => {
@@ -81,17 +96,22 @@ async fn execute(cli_args: CliArgs) {
             GetResources::Pools => pool::Pools::list(&cli_args.output).await,
             GetResources::Pool { id } => pool::Pool::get(&id, &cli_args.output).await,
             GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
-            GetResources::Node(args) => {
-                if args.show_cordon_labels() {
-                    node::Node::get_labels(&args.node_id(), &cli_args.output).await
-                } else {
-                    node::Node::get(&args.node_id(), &cli_args.output).await
-                }
-            }
+            GetResources::Node(args) => node::Node::get(&args.node_id(), &cli_args.output).await,
             GetResources::BlockDevices(bdargs) => {
                 blockdevice::BlockDevice::get_blockdevices(
                     &bdargs.node_id(),
                     &bdargs.all(),
+                    &cli_args.output,
+                )
+                .await
+            }
+        },
+        Operations::Drain(resource) => match resource {
+            DrainResources::Node(drain_node_args) => {
+                node::Node::drain(
+                    &drain_node_args.node_id(),
+                    drain_node_args.label(),
+                    drain_node_args.drain_timeout(),
                     &cli_args.output,
                 )
                 .await

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -1,10 +1,13 @@
 use clap::Parser;
-use plugin::resources::{CordonResources, GetResources, ScaleResources};
+use plugin::resources::{CordonResources, DrainResources, GetResources, ScaleResources};
 use supportability::DumpArgs;
 
 /// The types of operations that are supported.
 #[derive(Parser, Debug)]
 pub enum Operations {
+    /// 'Drain' resources.
+    #[clap(subcommand)]
+    Drain(DrainResources),
     /// 'Get' resources.
     #[clap(subcommand)]
     Get(GetResources),


### PR DESCRIPTION
Signed-off-by: chriswldenyer <christopher.denyer@datacore.com>
Signed-off-by: chriswldenyer <christopher.denyer@mayadata.io>

Add APIs to drain a node.
Drain is not yet fully implemented - what is missing is the reconciler
that moves nexuses to another node, which is dependent on HA being
implemented.
With this PR, drain labels are now stored in the core agent and perform
the same cordoning function as cordon labels but also flag that a drain
is to be undertaken.
The Node object returned from the core-agent now includes a boolean
is_draining field.
This is set via the drain api command but will be cleared by the
reconciler, when implemented.

The kubectl plugin initiates a drain via:
    kubectl-plugin drain node
and cancels it via:
    kubectl-plugin uncordon node

Two new get objects cordon and drain are implemented for the plugin.

    get cordon <node id> # lists cordon information concerning the node
    get cordons          # lists cordon information for all cordoned nodes
    get drain <node id>  # lists drain information concerning the node
    get drains           # as above but for all nodes with drain labels

Note: the get node <node id> --show-cordon-labels option has been removed.