### PR TITLE
refactor: cleaning up spec operations api

### DIFF
--- a/common/src/types/v0/store/mod.rs
+++ b/common/src/types/v0/store/mod.rs
@@ -115,41 +115,70 @@ impl Default for OperationSequenceState {
 }
 
 /// Operations are locked
-pub trait OperationSequencer {
+pub trait AsOperationSequencer {
     fn as_ref(&self) -> &OperationSequence;
     fn as_mut(&mut self) -> &mut OperationSequence;
 }
 
-/// Guard for Spec Operations
-/// It unlock the sequence lock on drop
+pub trait OperationSequencer: std::fmt::Debug + Clone {
+    /// Check if the transition is valid.
+    fn valid(&self, next: OperationSequenceState) -> bool;
+    /// Try to transition from current to next state.
+    fn transition(&self, next: OperationSequenceState) -> Option<OperationSequenceState>;
+    /// Sequence an operation using the provided `OperationMode`.
+    /// It returns the state which must be used to revert this operation.
+    fn sequence(&self, mode: OperationMode) -> Option<OperationSequenceState>;
+    /// Complete the operation sequenced using the provided `OperationMode`.
+    fn complete(&self, revert: OperationSequenceState);
+}
+
+impl<T: AsOperationSequencer + std::fmt::Debug> OperationSequencer for Arc<Mutex<T>> {
+    fn valid(&self, next: OperationSequenceState) -> bool {
+        self.lock().as_mut().valid(next)
+    }
+    fn transition(&self, next: OperationSequenceState) -> Option<OperationSequenceState> {
+        self.lock().as_mut().transition(next)
+    }
+    fn sequence(&self, mode: OperationMode) -> Option<OperationSequenceState> {
+        self.lock().as_mut().sequence(mode)
+    }
+    fn complete(&self, revert: OperationSequenceState) {
+        self.lock().as_mut().complete(revert);
+    }
+}
+
+/// Operation Guard for a Arc<Mutex<T>> type.
+pub type OperationGuardArc<T> = OperationGuard<Arc<Mutex<T>>>;
+
+/// Guard for Spec Operations.
+/// It unlocks the sequence lock on drop.
 #[derive(Debug)]
 pub struct OperationGuard<T: OperationSequencer> {
-    locked: Option<(OperationSequenceState, Arc<Mutex<T>>)>,
+    locked: Option<(OperationSequenceState, T)>,
 }
-impl<T: OperationSequencer> OperationGuard<T> {
+impl<T: OperationSequencer + Sized> OperationGuard<T> {
     fn unlock(&mut self) {
         if let Some((revert, resource)) = self.locked.take() {
-            resource.lock().as_mut().complete(revert);
+            resource.complete(revert);
         }
     }
     /// Create operation Guard for the resource with the operation mode
-    pub fn try_sequence(resource: &Arc<Mutex<T>>, mode: OperationMode) -> Result<Self, String> {
+    pub fn try_sequence(resource: &T, mode: OperationMode) -> Result<Self, String> {
         // use result variable to make sure the mutex's temporary guard is dropped
-        let result = resource.lock().as_mut().sequence(mode);
-        match result {
+        match resource.sequence(mode) {
             Some(revert) => Ok(Self {
                 locked: Some((revert, resource.clone())),
             }),
             None => Err(format!(
                 "Cannot transition from '{:?}' to '{:?}'",
-                resource.lock().as_ref(),
+                resource,
                 mode.apply()
             )),
         }
     }
 }
 
-impl<T: OperationSequencer> Drop for OperationGuard<T> {
+impl<T: OperationSequencer + Sized> Drop for OperationGuard<T> {
     fn drop(&mut self) {
         self.unlock();
     }
@@ -181,7 +210,7 @@ impl OperationMode {
 
 impl OperationSequence {
     /// Check if the transition is valid
-    fn valid(&mut self, next: OperationSequenceState) -> bool {
+    fn valid(&self, next: OperationSequenceState) -> bool {
         match self.state {
             OperationSequenceState::Idle => {
                 matches!(

--- a/common/src/types/v0/store/nexus.rs
+++ b/common/src/types/v0/store/nexus.rs
@@ -13,7 +13,7 @@ use crate::types::v0::{
     },
 };
 
-use crate::types::v0::store::{OperationSequence, OperationSequencer};
+use crate::types::v0::store::{AsOperationSequencer, OperationSequence};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
@@ -175,7 +175,7 @@ impl From<&NexusSpec> for CreateNexus {
     }
 }
 
-impl OperationSequencer for NexusSpec {
+impl AsOperationSequencer for NexusSpec {
     fn as_ref(&self) -> &OperationSequence {
         &self.sequencer
     }

--- a/common/src/types/v0/store/pool.rs
+++ b/common/src/types/v0/store/pool.rs
@@ -4,7 +4,7 @@ use crate::types::v0::{
     openapi::models,
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
-        OperationSequence, OperationSequencer, ResourceUuid, SpecStatus, SpecTransaction,
+        AsOperationSequencer, OperationSequence, ResourceUuid, SpecStatus, SpecTransaction,
     },
     transport::{self, CreatePool, NodeId, PoolDeviceUri, PoolId},
 };
@@ -14,6 +14,7 @@ pub type PoolLabel = ::std::collections::HashMap<String, String>;
 
 use serde::{Deserialize, Serialize};
 use std::{convert::From, fmt::Debug};
+
 /// Pool data structure used by the persistent store.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Pool {
@@ -104,7 +105,7 @@ macro_rules! pool_span {
 }
 crate::impl_trace_span!(pool_span, PoolSpec);
 
-impl OperationSequencer for PoolSpec {
+impl AsOperationSequencer for PoolSpec {
     fn as_ref(&self) -> &OperationSequence {
         &self.sequencer
     }

--- a/common/src/types/v0/store/replica.rs
+++ b/common/src/types/v0/store/replica.rs
@@ -4,7 +4,7 @@ use crate::types::v0::{
     openapi::models,
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
-        OperationSequence, OperationSequencer, ResourceUuid, SpecStatus, SpecTransaction,
+        AsOperationSequencer, OperationSequence, ResourceUuid, SpecStatus, SpecTransaction,
     },
     transport::{
         self, CreateReplica, NodeId, PoolId, Protocol, Replica as MbusReplica, ReplicaId,
@@ -92,7 +92,7 @@ pub struct ReplicaSpec {
     pub operation: Option<ReplicaOperationState>,
 }
 
-impl OperationSequencer for ReplicaSpec {
+impl AsOperationSequencer for ReplicaSpec {
     fn as_ref(&self) -> &OperationSequence {
         &self.sequencer
     }

--- a/common/src/types/v0/store/volume.rs
+++ b/common/src/types/v0/store/volume.rs
@@ -11,7 +11,7 @@ use crate::types::v0::{
 use crate::{
     types::v0::{
         openapi::models,
-        store::{OperationSequence, OperationSequencer, ResourceUuid},
+        store::{AsOperationSequencer, OperationSequence, ResourceUuid},
         transport::{ReplicaId, Topology, VolumeLabels, VolumePolicy, VolumeStatus},
     },
     IntoOption,
@@ -137,7 +137,7 @@ macro_rules! volume_span {
 }
 crate::impl_trace_span!(volume_span, VolumeSpec);
 
-impl OperationSequencer for VolumeSpec {
+impl AsOperationSequencer for VolumeSpec {
     fn as_ref(&self) -> &OperationSequence {
         &self.sequencer
     }

--- a/control-plane/agents/core/src/core/reconciler/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/mod.rs
@@ -6,10 +6,12 @@ mod replica;
 mod volume;
 
 pub(crate) use crate::core::task_poller::PollTriggerEvent;
-use crate::core::task_poller::{PollContext, PollEvent, TaskPoller};
+use crate::core::task_poller::{squash_results, PollContext, PollEvent, PollResult, TaskPoller};
 use poller::ReconcilerWorker;
+use std::fmt::Debug;
 
 use crate::core::registry::Registry;
+
 use parking_lot::Mutex;
 
 /// Used to start and stop the reconcile pollers
@@ -54,4 +56,50 @@ impl ReconcilerControl {
             tracing::warn!(error=?error, "Failed to send event to reconcile worker");
         }
     }
+}
+
+#[async_trait::async_trait]
+trait Reconciler {
+    /// Run the reconcile logic for this resource.
+    async fn reconcile(&self, context: &PollContext) -> PollResult;
+}
+
+#[async_trait::async_trait]
+trait GarbageCollect {
+    /// Run the `GarbageCollect` reconciler.
+    /// The default implementation calls all garbage collection methods.
+    async fn garbage_collect(&self, context: &PollContext) -> PollResult {
+        squash_results(vec![
+            self.disown_orphaned(context).await,
+            self.disown_unused(context).await,
+            self.destroy_deleting(context).await,
+            self.destroy_orphaned(context).await,
+        ])
+    }
+
+    /// Destroy resources which are in the deleting phase.
+    /// A resource goes into the deleting phase when we start to delete it and stay in this
+    /// state until we successfully delete it.
+    async fn destroy_deleting(&self, context: &PollContext) -> PollResult;
+
+    /// Destroy resources which have been orphaned.
+    /// A resource becomes orphaned when all its owners have disowned it and at that point
+    /// it is no longer needed and may be destroyed.
+    async fn destroy_orphaned(&self, context: &PollContext) -> PollResult;
+
+    /// Disown resources which are no longer needed by their owners.
+    async fn disown_unused(&self, context: &PollContext) -> PollResult;
+    /// Disown resources whose owners are no longer in existence.
+    /// This may happen as a result of a bug or manual edit of the persistent store (etcd).
+    async fn disown_orphaned(&self, context: &PollContext) -> PollResult;
+}
+
+#[async_trait::async_trait]
+trait ReCreate {
+    /// Recreate the state according to the specification.
+    /// This is required when an io-engine instance crashes/restarts as it always starts with no
+    /// state.
+    /// This is because it's the control-plane's job to recreate the state since it has the
+    /// overview of the whole system.
+    async fn recreate_state(&self, context: &PollContext) -> PollResult;
 }

--- a/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
@@ -178,7 +178,7 @@ async fn destroy_nexus(
         let request = DestroyNexus::from(&nexus_clone);
         match context
             .specs()
-            .destroy_nexus(context.registry(), &request, true, mode)
+            .destroy_nexus(Some(nexus_spec), context.registry(), &request, true, mode)
             .await
         {
             Ok(_) => {

--- a/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
@@ -402,7 +402,12 @@ pub(super) async fn fixup_nexus_protocol(
             if (nexus_state.share.shared() && nexus.share.shared()) || !nexus.share.shared() {
                 context
                     .specs()
-                    .unshare_nexus(context.registry(), &UnshareNexus::from(&nexus_state), mode)
+                    .unshare_nexus(
+                        Some(nexus_spec),
+                        context.registry(),
+                        &UnshareNexus::from(&nexus_state),
+                        mode,
+                    )
                     .await?;
             }
             if nexus.share.shared() {
@@ -411,6 +416,7 @@ pub(super) async fn fixup_nexus_protocol(
                         context
                             .specs()
                             .share_nexus(
+                                Some(nexus_spec),
                                 context.registry(),
                                 &ShareNexus::from((&nexus_state, None, protocol)),
                                 mode,

--- a/control-plane/agents/core/src/core/reconciler/pool/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/pool/mod.rs
@@ -187,7 +187,7 @@ async fn deleting_pool_spec_reconciler(
         };
         match context
             .specs()
-            .destroy_pool(context.registry(), &request, OperationMode::ReconcileStep)
+            .destroy_pool(Some(pool_spec), context.registry(), &request, OperationMode::ReconcileStep)
             .await
         {
             Ok(_) => {

--- a/control-plane/agents/core/src/core/reconciler/pool/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/pool/mod.rs
@@ -1,4 +1,5 @@
 use crate::core::{
+    reconciler::{GarbageCollect, ReCreate},
     specs::{OperationSequenceGuard, SpecOperations},
     task_poller::{PollContext, PollPeriods, PollResult, PollTimer, PollerState, TaskPoller},
     wrapper::ClientOps,
@@ -34,21 +35,53 @@ impl PoolReconciler {
 impl TaskPoller for PoolReconciler {
     async fn poll(&mut self, context: &PollContext) -> PollResult {
         let pools = context.specs().get_locked_pools();
-        let mut results = Vec::with_capacity(pools.len() * 2);
+        let mut results = Vec::with_capacity(pools.len());
         for pool in pools {
             let _guard = match pool.operation_guard(OperationMode::ReconcileStart) {
                 Ok(guard) => guard,
                 Err(_) => continue,
             };
 
-            results.push(missing_pool_state_reconciler(&pool, context).await);
-            results.push(deleting_pool_spec_reconciler(&pool, context).await);
+            results.push(Self::squash_results(vec![
+                pool.garbage_collect(context).await,
+                pool.recreate_state(context).await,
+            ]))
         }
         Self::squash_results(results)
     }
 
     async fn poll_timer(&mut self, _context: &PollContext) -> bool {
         self.counter.poll()
+    }
+}
+
+#[async_trait::async_trait]
+impl GarbageCollect for Arc<Mutex<PoolSpec>> {
+    async fn garbage_collect(&self, context: &PollContext) -> PollResult {
+        self.destroy_deleting(context).await
+    }
+
+    async fn destroy_deleting(&self, context: &PollContext) -> PollResult {
+        deleting_pool_spec_reconciler(self, context).await
+    }
+
+    async fn destroy_orphaned(&self, _context: &PollContext) -> PollResult {
+        unimplemented!()
+    }
+
+    async fn disown_unused(&self, _context: &PollContext) -> PollResult {
+        unimplemented!()
+    }
+
+    async fn disown_orphaned(&self, _context: &PollContext) -> PollResult {
+        unimplemented!()
+    }
+}
+
+#[async_trait::async_trait]
+impl ReCreate for Arc<Mutex<PoolSpec>> {
+    async fn recreate_state(&self, context: &PollContext) -> PollResult {
+        missing_pool_state_reconciler(self, context).await
     }
 }
 

--- a/control-plane/agents/core/src/core/reconciler/replica/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/replica/mod.rs
@@ -195,6 +195,7 @@ async fn destroy_replica(
         match context
             .specs()
             .destroy_replica(
+                Some(replica_spec),
                 context.registry(),
                 &ResourceSpecsLocked::destroy_replica_request(
                     replica_clone,

--- a/control-plane/agents/core/src/core/reconciler/replica/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/replica/mod.rs
@@ -2,6 +2,7 @@
 mod tests;
 
 use crate::core::{
+    reconciler::{GarbageCollect, ReCreate},
     specs::{OperationSequenceGuard, ResourceSpecsLocked, SpecOperations},
     task_poller::{
         PollContext, PollEvent, PollResult, PollTimer, PollTriggerEvent, PollerState, TaskPoller,
@@ -30,12 +31,10 @@ impl ReplicaReconciler {
 impl TaskPoller for ReplicaReconciler {
     async fn poll(&mut self, context: &PollContext) -> PollResult {
         let replicas = context.specs().get_replicas();
-        let mut results = Vec::with_capacity(replicas.len() * 3);
+        let mut results = Vec::with_capacity(replicas.len());
 
         for replica in replicas {
-            results.push(remove_missing_owners(&replica, context).await);
-            results.push(destroy_orphaned_replica(&replica, context).await);
-            results.push(destroy_deleting_replica(&replica, context).await);
+            results.push(replica.garbage_collect(context).await);
         }
 
         Self::squash_results(results)
@@ -50,6 +49,41 @@ impl TaskPoller for ReplicaReconciler {
             PollEvent::TimedRun | PollEvent::Triggered(PollTriggerEvent::Start) => true,
             PollEvent::Shutdown | PollEvent::Triggered(_) => false,
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl ReCreate for Arc<Mutex<ReplicaSpec>> {
+    async fn recreate_state(&self, _context: &PollContext) -> PollResult {
+        // We get this automatically when recreating pools
+        PollResult::Ok(PollerState::Idle)
+    }
+}
+
+#[async_trait::async_trait]
+impl GarbageCollect for Arc<Mutex<ReplicaSpec>> {
+    async fn garbage_collect(&self, context: &PollContext) -> PollResult {
+        ReplicaReconciler::squash_results(vec![
+            self.disown_orphaned(context).await,
+            self.destroy_deleting(context).await,
+            self.destroy_orphaned(context).await,
+        ])
+    }
+
+    async fn destroy_deleting(&self, context: &PollContext) -> PollResult {
+        destroy_deleting_replica(self, context).await
+    }
+
+    async fn destroy_orphaned(&self, context: &PollContext) -> PollResult {
+        destroy_orphaned_replica(self, context).await
+    }
+
+    async fn disown_unused(&self, _context: &PollContext) -> PollResult {
+        unimplemented!()
+    }
+
+    async fn disown_orphaned(&self, context: &PollContext) -> PollResult {
+        remove_missing_owners(self, context).await
     }
 }
 

--- a/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
@@ -106,7 +106,12 @@ async fn destroy_volume(
     let uuid = volume_spec.lock().uuid.clone();
     match context
         .specs()
-        .destroy_volume(context.registry(), &DestroyVolume::new(&uuid), mode)
+        .destroy_volume(
+            volume_spec,
+            context.registry(),
+            &DestroyVolume::new(&uuid),
+            mode,
+        )
         .await
     {
         Ok(_) => {

--- a/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
@@ -280,7 +280,7 @@ async fn is_replica_healthy(
     };
     if info.no_healthy_replicas() {
         Err(SvcError::NoHealthyReplicas {
-            id: volume_spec.uuid(),
+            id: volume_spec.uuid_str(),
         })
     } else {
         Ok(info.is_replica_healthy(&replica_spec.uuid))

--- a/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
@@ -6,7 +6,7 @@ use crate::core::{
 
 use common_lib::types::v0::store::{volume::VolumeSpec, OperationMode, TraceSpan, TraceStrLog};
 
-use crate::core::specs::SpecOperations;
+use crate::core::{reconciler::GarbageCollect, specs::SpecOperations};
 use common::errors::SvcError;
 use common_lib::types::v0::{
     store::{nexus_persistence::NexusInfo, replica::ReplicaSpec},
@@ -35,9 +35,7 @@ impl TaskPoller for GarbageCollector {
     async fn poll(&mut self, context: &PollContext) -> PollResult {
         let mut results = vec![];
         for volume in context.specs().get_locked_volumes() {
-            results.push(destroy_deleting_volume(&volume, context).await);
-            results.push(disown_unused_nexuses(&volume, context).await);
-            results.push(disown_unused_replicas(&volume, context).await);
+            results.push(volume.garbage_collect(context).await);
         }
         Self::squash_results(results)
     }
@@ -56,16 +54,40 @@ impl TaskPoller for GarbageCollector {
     }
 }
 
+#[async_trait::async_trait]
+impl GarbageCollect for Arc<Mutex<VolumeSpec>> {
+    async fn garbage_collect(&self, context: &PollContext) -> PollResult {
+        GarbageCollector::squash_results(vec![
+            self.destroy_deleting(context).await,
+            self.disown_unused(context).await,
+        ])
+    }
+
+    async fn destroy_deleting(&self, context: &PollContext) -> PollResult {
+        destroy_deleting_volume(self, context).await
+    }
+
+    async fn destroy_orphaned(&self, _context: &PollContext) -> PollResult {
+        unimplemented!()
+    }
+
+    async fn disown_unused(&self, context: &PollContext) -> PollResult {
+        GarbageCollector::squash_results(vec![
+            disown_unused_nexuses(self, context).await,
+            disown_unused_replicas(self, context).await,
+        ])
+    }
+
+    async fn disown_orphaned(&self, _context: &PollContext) -> PollResult {
+        unimplemented!()
+    }
+}
+
 #[tracing::instrument(level = "trace", skip(volume_spec, context), fields(volume.uuid = %volume_spec.lock().uuid, request.reconcile = true))]
 async fn destroy_deleting_volume(
     volume_spec: &Arc<Mutex<VolumeSpec>>,
     context: &PollContext,
 ) -> PollResult {
-    let _guard = match volume_spec.operation_guard(OperationMode::ReconcileStart) {
-        Ok(guard) => guard,
-        Err(_) => return PollResult::Ok(PollerState::Busy),
-    };
-
     let deleting = volume_spec.lock().status().deleting();
     if deleting {
         destroy_volume(volume_spec, context, OperationMode::ReconcileStep)

--- a/control-plane/agents/core/src/nexus/service.rs
+++ b/control-plane/agents/core/src/nexus/service.rs
@@ -138,32 +138,57 @@ impl Service {
     /// Destroy nexus
     #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn destroy_nexus(&self, request: &DestroyNexus) -> Result<(), SvcError> {
+        let nexus = self.specs().get_nexus(&request.uuid);
         self.specs()
-            .destroy_nexus(&self.registry, request, true, OperationMode::Exclusive)
+            .destroy_nexus(
+                nexus.as_ref(),
+                &self.registry,
+                request,
+                true,
+                OperationMode::Exclusive,
+            )
             .await
     }
 
     /// Share nexus
     #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn share_nexus(&self, request: &ShareNexus) -> Result<String, SvcError> {
+        let nexus = self.specs().get_nexus(&request.uuid);
         self.specs()
-            .share_nexus(&self.registry, request, OperationMode::Exclusive)
+            .share_nexus(
+                nexus.as_ref(),
+                &self.registry,
+                request,
+                OperationMode::Exclusive,
+            )
             .await
     }
 
     /// Unshare nexus
     #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn unshare_nexus(&self, request: &UnshareNexus) -> Result<(), SvcError> {
+        let nexus = self.specs().get_nexus(&request.uuid);
         self.specs()
-            .unshare_nexus(&self.registry, request, OperationMode::Exclusive)
+            .unshare_nexus(
+                nexus.as_ref(),
+                &self.registry,
+                request,
+                OperationMode::Exclusive,
+            )
             .await
     }
 
     /// Add nexus child
     #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.nexus))]
     pub(super) async fn add_nexus_child(&self, request: &AddNexusChild) -> Result<Child, SvcError> {
+        let nexus = self.specs().get_nexus(&request.nexus);
         self.specs()
-            .add_nexus_child(&self.registry, request, OperationMode::Exclusive)
+            .add_nexus_child(
+                nexus.as_ref(),
+                &self.registry,
+                request,
+                OperationMode::Exclusive,
+            )
             .await
     }
 
@@ -173,8 +198,14 @@ impl Service {
         &self,
         request: &RemoveNexusChild,
     ) -> Result<(), SvcError> {
+        let nexus = self.specs().get_nexus(&request.nexus);
         self.specs()
-            .remove_nexus_child(&self.registry, request, OperationMode::Exclusive)
+            .remove_nexus_child(
+                nexus.as_ref(),
+                &self.registry,
+                request,
+                OperationMode::Exclusive,
+            )
             .await
     }
 }

--- a/control-plane/agents/core/src/pool/service.rs
+++ b/control-plane/agents/core/src/pool/service.rs
@@ -6,10 +6,10 @@ use common_lib::{
         ReplyError,
     },
     types::v0::{
-        store::OperationMode,
+        store::{pool::PoolSpec, replica::ReplicaSpec, OperationMode},
         transport::{
             CreatePool, CreateReplica, DestroyPool, DestroyReplica, Filter, GetPools, GetReplicas,
-            NodeId, Pool, PoolId, Replica, ShareReplica, UnshareReplica,
+            NodeId, Pool, PoolId, Replica, ReplicaId, ShareReplica, UnshareReplica,
         },
     },
 };
@@ -23,7 +23,9 @@ use grpc::{
         },
     },
 };
+use parking_lot::Mutex;
 use snafu::OptionExt;
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub(super) struct Service {
@@ -235,6 +237,15 @@ impl Service {
         .map(Replicas)
     }
 
+    /// Get the protected VolumeSpec for the given volume `id`, if any exists
+    pub(crate) fn locked_pool(&self, pool: &PoolId) -> Option<Arc<Mutex<PoolSpec>>> {
+        self.specs().get_locked_pool(pool)
+    }
+    /// Get the protected VolumeSpec for the given volume `id`, if any exists
+    pub(crate) fn locked_replica(&self, replica: &ReplicaId) -> Option<Arc<Mutex<ReplicaSpec>>> {
+        self.specs().get_replica(replica)
+    }
+
     /// Create pool
     #[tracing::instrument(level = "debug", skip(self), err, fields(pool.uuid = %request.id))]
     pub(super) async fn create_pool(&self, request: &CreatePool) -> Result<Pool, SvcError> {
@@ -246,8 +257,10 @@ impl Service {
     /// Destroy pool
     #[tracing::instrument(level = "info", skip(self), err, fields(pool.uuid = %request.id))]
     pub(super) async fn destroy_pool(&self, request: &DestroyPool) -> Result<(), SvcError> {
+        let pool_spec = self.locked_pool(&request.id);
+        let pool_spec = pool_spec.as_ref();
         self.specs()
-            .destroy_pool(&self.registry, request, OperationMode::Exclusive)
+            .destroy_pool(pool_spec, &self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -265,24 +278,43 @@ impl Service {
     /// Destroy replica
     #[tracing::instrument(level = "info", skip(self), err, fields(replica.uuid = %request.uuid))]
     pub(super) async fn destroy_replica(&self, request: &DestroyReplica) -> Result<(), SvcError> {
+        let replica = self.locked_replica(&request.uuid);
         self.specs()
-            .destroy_replica(&self.registry, request, false, OperationMode::Exclusive)
+            .destroy_replica(
+                replica.as_ref(),
+                &self.registry,
+                request,
+                false,
+                OperationMode::Exclusive,
+            )
             .await
     }
 
     /// Share replica
     #[tracing::instrument(level = "info", skip(self), err, fields(replica.uuid = %request.uuid))]
     pub(super) async fn share_replica(&self, request: &ShareReplica) -> Result<String, SvcError> {
+        let replica = self.locked_replica(&request.uuid);
         self.specs()
-            .share_replica(&self.registry, request, OperationMode::Exclusive)
+            .share_replica(
+                replica.as_ref(),
+                &self.registry,
+                request,
+                OperationMode::Exclusive,
+            )
             .await
     }
 
     /// Unshare replica
     #[tracing::instrument(level = "info", skip(self), err, fields(replica.uuid = %request.uuid))]
     pub(super) async fn unshare_replica(&self, request: &UnshareReplica) -> Result<(), SvcError> {
+        let replica = self.locked_replica(&request.uuid);
         self.specs()
-            .unshare_replica(&self.registry, request, OperationMode::Exclusive)
+            .unshare_replica(
+                replica.as_ref(),
+                &self.registry,
+                request,
+                OperationMode::Exclusive,
+            )
             .await?;
         Ok(())
     }


### PR DESCRIPTION
refactor: add reconciling traits to the poller worker tasks

Some reconciler operations are common amond various resources types, so it makes sense to create
a common interface for them.

todo: make the operation guard part of the SpecOperations api using the type system, this will
make it clearer, and less error-prone.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

refactor: make operation guard usage explicit

Enforce use of the operation guard for SpecOperations.
Previously it would have been possible to drop the guard before
continuing or completing an operation.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

refactor: use resource spec as argument to operations

This is in preparation of the next commit where we'll change the SpecOps trait impl from
Spec to Arc<Mutex<Spec>> and thus make the operation mode implicit, by passing a
ResourceGuard which is either Exclusive or Reconcile and from which we can retrieve
the Arc<Mutex<Spec>> thus simplifying the calls and reducing errors.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

refactor: split SpecOps into separate traits

GuardedSpecOperations now is implemented only for the Guards.
A reduced SpecOperations is implemented only for the inner Specs.

todo: change all operations to receive the Guard as part of the call - this should
make the api more obvious and also make sure there are no modifications in case
someone forgets to setup the guard at the top level.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>