### PR TITLE
test: thin provisioning check now succeeds

### DIFF
--- a/control-plane/agents/core/src/pool/tests.rs
+++ b/control-plane/agents/core/src/pool/tests.rs
@@ -91,7 +91,7 @@ async fn pool() {
             name: ReplicaName::from("cf36a440-74c6-4042-b16c-4f7eddfc24da"),
             uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
             pool: "pooloop".into(),
-            thin: false,
+            thin: true,
             size: 12582912,
             share: Protocol::None,
             uri,

--- a/tests/io-engine/tests/replicas.rs
+++ b/tests/io-engine/tests/replicas.rs
@@ -3,9 +3,7 @@ use grpc::operations::replica::traits::ReplicaOperations;
 
 use deployer_cluster::{result_either, test_result_grpc, ClusterBuilder};
 
-// FIXME: CAS-721
 #[tokio::test]
-#[should_panic]
 async fn create_replica() {
     let cluster = ClusterBuilder::builder()
         .with_pools(1)
@@ -31,8 +29,8 @@ async fn create_replica() {
     assert_eq!(created_replica.pool, replica.pool);
 
     // todo: why is this not the same?
+    // because replica size is multiple of pool chunks, maybe we should expose the chunk size..
     // assert_eq!(created_replica.size, replica.size);
-    // fixme: replicas are always created without thin provisioning
     assert_eq!(created_replica.thin, replica.thin);
     assert_eq!(created_replica.share, replica.share);
 }

--- a/tests/io-engine/tests/replicas.rs
+++ b/tests/io-engine/tests/replicas.rs
@@ -16,7 +16,7 @@ async fn create_replica() {
 
     let replica = v0::CreateReplica {
         node: cluster.node(0),
-        uuid: Default::default(),
+        uuid: v0::ReplicaId::new(),
         pool: cluster.pool(0, 0),
         size: 5 * 1024 * 1024,
         thin: true,


### PR DESCRIPTION
The bug has been fixed here:
https://github.com/openebs/mayastor/pull/1167

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>