### PR TITLE
feat(ha-agent): dynamic path failure detection for nvme paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio",
+ "mio 0.8.4",
  "num_cpus",
  "socket2",
  "tokio",
@@ -242,9 +242,11 @@ dependencies = [
  "async-trait",
  "chrono",
  "common-lib",
+ "crossbeam-queue",
  "deployer-cluster",
  "dyn-clonable",
  "futures",
+ "futures-util",
  "grpc",
  "http",
  "humantime",
@@ -253,6 +255,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "lazy_static",
+ "nvmeadm",
  "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -267,6 +270,8 @@ dependencies = [
  "state",
  "structopt",
  "tokio",
+ "tokio-stream",
+ "tokio-udev",
  "tonic",
  "tracing",
  "tracing-opentelemetry",
@@ -862,6 +867,16 @@ name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2387,6 +2402,19 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
@@ -2395,6 +2423,15 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2442,6 +2479,15 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3924,7 +3970,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.4",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -4021,6 +4067,18 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-udev"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246ffebae60acd93eb0056bac967cad807c7aa09916fabceac50479ad1f53e64"
+dependencies = [
+ "futures-core",
+ "mio 0.7.14",
+ "tokio",
+ "udev",
 ]
 
 [[package]]
@@ -4285,6 +4343,7 @@ checksum = "1c960764f7e816eed851a96c364745d37f9fe71a2e7dba79fbd40104530b5dd0"
 dependencies = [
  "libc",
  "libudev-sys",
+ "mio 0.8.4",
  "pkg-config",
 ]
 

--- a/common/src/transport_api/mod.rs
+++ b/common/src/transport_api/mod.rs
@@ -264,6 +264,15 @@ impl ReplyError {
             extra: "".to_string(),
         }
     }
+    /// for errors that represent unimplemented functionality.
+    pub fn unimplemented(msg: String) -> Self {
+        Self {
+            kind: ReplyErrorKind::Unimplemented,
+            resource: ResourceKind::Unknown,
+            source: "Test Library".to_string(),
+            extra: msg,
+        }
+    }
 }
 
 impl std::fmt::Display for ReplyError {

--- a/common/src/types/v0/transport/cluster_agent.rs
+++ b/common/src/types/v0/transport/cluster_agent.rs
@@ -26,3 +26,42 @@ impl NodeAgentInfo {
         self.endpoint
     }
 }
+
+/// Failed NVMe path.
+#[derive(Debug, Clone)]
+pub struct FailedPath {
+    target_nqn: String,
+}
+
+impl FailedPath {
+    /// Create a new instance of FailedPath for a given NVMe target NQN.
+    pub fn new(target_nqn: String) -> Self {
+        Self { target_nqn }
+    }
+
+    /// Get target NQN.
+    pub fn target_nqn(&self) -> &str {
+        &self.target_nqn
+    }
+}
+
+/// Report failed NVMe paths.
+#[derive(Debug)]
+pub struct ReportFailedPaths {
+    node: String,
+    failed_paths: Vec<FailedPath>,
+}
+
+impl ReportFailedPaths {
+    pub fn new(node: String, failed_paths: Vec<FailedPath>) -> Self {
+        Self { node, failed_paths }
+    }
+
+    pub fn node_name(&self) -> &str {
+        &self.node
+    }
+
+    pub fn failed_paths(&self) -> &Vec<FailedPath> {
+        &self.failed_paths
+    }
+}

--- a/common/src/types/v0/transport/mod.rs
+++ b/common/src/types/v0/transport/mod.rs
@@ -14,6 +14,7 @@ pub mod watch;
 
 pub use blockdevice::*;
 pub use child::*;
+pub use cluster_agent::*;
 pub use jsongrpc::*;
 pub use misc::*;
 pub use nexus::*;
@@ -126,6 +127,8 @@ pub enum MessageIdVs {
     GetSpecs,
     /// Get States
     GetStates,
+    /// Report failed NVMe paths
+    ReportFailedPaths,
 }
 
 impl From<MessageIdVs> for MessageId {

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -26,6 +26,7 @@ path = "common/src/lib.rs"
  path = "cluster/src/main.rs"
 
 [dependencies]
+anyhow = "1.0.44"
 rpc =  { path = "../../rpc"}
 common-lib = { path = "../../common" }
 utils = { path = "../../utils/utils-lib" }
@@ -52,7 +53,11 @@ once_cell = "1.9.0"
 indexmap = "1.8.0"
 k8s-openapi = { version = "0.15.0", features = ["v1_20"] }
 kube = { version = "0.74.0", features = ["derive"] }
-anyhow = "1.0.44"
+tokio-udev = { version = "0.8.0" }
+nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
+futures-util = { version = "0.3.21" }
+tokio-stream = { version = "0.1.9" }
+crossbeam-queue = "0.3.6"
 
 # Tracing
 opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio-current-thread"] }

--- a/control-plane/agents/cluster/src/server.rs
+++ b/control-plane/agents/cluster/src/server.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use common_lib::transport_api::{ReplyError, ResourceKind};
 use grpc::operations::ha_node::{
     server::ClusterAgentServer,
-    traits::{ClusterAgentOperations, NodeInfo},
+    traits::{ClusterAgentOperations, NodeInfo, ReportFailedPathsInfo},
 };
 use std::{net::SocketAddr, sync::Arc};
 use tonic::transport::Server;
@@ -47,5 +47,14 @@ impl ClusterAgentOperations for ClusterAgentSvc {
 
         tracing::trace!(agent = request.node(), "node successfully registered");
         Ok(())
+    }
+
+    async fn report_failed_nvme_paths(
+        &self,
+        _request: &dyn ReportFailedPathsInfo,
+    ) -> Result<(), ReplyError> {
+        Err(ReplyError::unimplemented(
+            "NVMe path reporting is not yet implemented".to_string(),
+        ))
     }
 }

--- a/control-plane/agents/ha-node/src/detector.rs
+++ b/control-plane/agents/ha-node/src/detector.rs
@@ -1,0 +1,208 @@
+use crate::{
+    path_provider::{CachedNvmePathProvider, NvmePathNameCollection},
+    reporter::PathReporter,
+    Cli,
+};
+use nvmeadm::nvmf_subsystem::Subsystem;
+use std::{collections::HashMap, rc::Rc};
+use tokio::time::{sleep, Duration};
+
+/// Possible states of every path record.
+#[derive(Debug, Clone)]
+enum PathState {
+    Good,
+    Suspected,
+    Failed,
+}
+
+impl std::fmt::Display for PathState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", *self)
+    }
+}
+
+/// Object that represents a broken/suspected NVMe path.
+#[derive(Debug, Clone)]
+struct PathRecord {
+    /// Used to allow detection of outdated records.
+    epoch: u64,
+    nqn: String,
+    state: PathState,
+    reporter: Rc<PathReporter>,
+}
+
+impl PathRecord {
+    fn new(nqn: String, epoch: u64, reporter: Rc<PathReporter>) -> Self {
+        Self {
+            nqn,
+            epoch,
+            state: PathState::Good,
+            reporter,
+        }
+    }
+
+    fn get_nqn(&self) -> &str {
+        &self.nqn
+    }
+
+    #[inline]
+    fn get_epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    #[inline]
+    fn set_epoch(&mut self, epoch: u64) {
+        self.epoch = epoch;
+    }
+
+    // Trigger state transition based on 'connecting' state of the underlying NVMe controller.
+    fn report_connecting(&mut self) {
+        match self.state {
+            PathState::Good => {
+                self.state = PathState::Suspected;
+                tracing::info!(
+                    state=%PathState::Suspected,
+                    target=self.nqn,
+                    "Target state transition"
+                );
+            }
+            PathState::Suspected => {
+                self.state = PathState::Failed;
+                tracing::error!(
+                    state=%PathState::Failed,
+                    target=self.nqn,
+                    "Target state transition",
+                );
+                self.reporter.report_failed_path(self.nqn.clone());
+            }
+            PathState::Failed => {} // Multiple failures don't cause any state transitions.
+        }
+    }
+
+    fn report_live(&mut self) {
+        self.state = PathState::Good;
+    }
+}
+
+/// Path failure detector for NVMe paths.
+/// All known NVMe paths on system are periodically checked for liveness and get classified
+/// as:
+///  Good  - path is fully functional.
+///  Suspected - path experiences connectivity problems for the first time.
+///  Failed - path has experienced connectivity problems two times in a row.
+/// Once a path is classified as Failed, it's reported to PathReporter and gets sent to
+/// HA Cluster agent.
+#[derive(Debug)]
+pub struct PathFailureDetector {
+    epoch: u64,
+    detection_period: Duration,
+    suspected_paths: HashMap<String, PathRecord>,
+    reporter: Rc<PathReporter>,
+}
+
+impl PathFailureDetector {
+    pub(crate) fn new(args: &Cli) -> anyhow::Result<Self> {
+        let reporter = PathReporter::new(
+            args.node_name.clone(),
+            *args.retransmission_period,
+            *args.aggregation_period,
+        );
+
+        Ok(Self {
+            epoch: 0,
+            detection_period: *args.detection_period,
+            suspected_paths: HashMap::new(),
+            reporter: Rc::new(reporter),
+        })
+    }
+
+    fn rescan_paths(&mut self, path_collection: &mut NvmePathNameCollection) {
+        // Update epoch before scanning controllers.
+        self.epoch += 1;
+
+        // Scan all reported NVMe paths on system and check for connectivity.
+        for ctrlr in path_collection.get_entries() {
+            match Subsystem::new(ctrlr.path()) {
+                Ok(subsystem) => {
+                    let existing_record = match subsystem.state.as_str() {
+                        "connecting" => {
+                            // Add a new record in case no record exists for target NQN.
+                            if !self.suspected_paths.contains_key(&subsystem.nqn) {
+                                self.suspected_paths.insert(
+                                    subsystem.nqn.clone(),
+                                    PathRecord::new(
+                                        subsystem.nqn.clone(),
+                                        self.epoch,
+                                        self.reporter.clone(),
+                                    ),
+                                );
+                            }
+
+                            let rec = self.suspected_paths.get_mut(&subsystem.nqn).unwrap();
+                            rec.report_connecting();
+                            Some(rec)
+                        }
+                        "live" => self.suspected_paths.get_mut(&subsystem.nqn).map(|rec| {
+                            rec.report_live();
+                            rec
+                        }),
+                        _ => None,
+                    };
+
+                    // Update epoch for the existing record.
+                    if let Some(rec) = existing_record {
+                        rec.set_epoch(self.epoch);
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to get status for NVMe path: {}", e);
+                }
+            }
+        }
+
+        // Remove all existing records that don't have underlying NVMe controllers:
+        // can happen in case controller was removed after it had been identified as
+        // broken/suspected. Stalled/outdated records have a different (old) epoch number
+        // since they have not been touched during the current iteration.
+        let mut to_remove = vec![];
+
+        for v in self.suspected_paths.values() {
+            if v.get_epoch() != self.epoch {
+                to_remove.push(v.get_nqn().to_owned());
+            }
+        }
+
+        if !to_remove.is_empty() {
+            for k in to_remove {
+                self.suspected_paths.remove(&k);
+                tracing::debug!("Removing stalled path record for NQN {}", k);
+            }
+        }
+    }
+
+    /// Start NVMe path error detection loop.
+    pub async fn start(mut self) -> anyhow::Result<()> {
+        let mut path_provider = CachedNvmePathProvider::new();
+        let mut path_collection = path_provider.get_path_collection().unwrap();
+        let start = path_provider.start()?;
+        tokio::pin!(start);
+
+        tracing::info!(
+            "Starting NVMe path error detection loop, path detection interval: {:?}",
+            self.detection_period,
+        );
+
+        loop {
+            tokio::select! {
+                _ = &mut start => {
+                    tracing::warn!("NVMe path provider completed, stopping error detection");
+                    break;
+                },
+                _ = sleep(self.detection_period) => self.rescan_paths(&mut path_collection),
+            }
+        }
+
+        tracing::info!("Stopping NVMe path error detection loop");
+        Ok(())
+    }
+}

--- a/control-plane/agents/ha-node/src/main.rs
+++ b/control-plane/agents/ha-node/src/main.rs
@@ -2,15 +2,24 @@ use common_lib::types::v0::transport::cluster_agent::NodeAgentInfo;
 use grpc::operations::ha_node::{client::ClusterAgentClient, traits::ClusterAgentOperations};
 use http::Uri;
 use once_cell::sync::OnceCell;
+use opentelemetry::KeyValue;
 use structopt::StructOpt;
 use utils::{
     package_description, version_info_str, DEFAULT_CLUSTER_AGENT_CLIENT_ADDR,
-    DEFAULT_NODE_AGENT_SERVER_ADDR,
+    DEFAULT_NODE_AGENT_SERVER_ADDR, NVME_PATH_AGGREGATION_PERIOD, NVME_PATH_CHECK_PERIOD,
+    NVME_PATH_RETRANSMISSION_PERIOD,
 };
 
+mod detector;
+mod path_provider;
+mod reporter;
+
+use detector::PathFailureDetector;
+
+/// TODO
 #[derive(Debug, StructOpt)]
 #[structopt(name = package_description!(), version = version_info_str!())]
-struct Cli {
+pub(crate) struct Cli {
     /// HA Cluster Agent URL or address to connect to the services.
     #[structopt(long, short, default_value = DEFAULT_CLUSTER_AGENT_CLIENT_ADDR)]
     cluster_agent: Uri,
@@ -22,11 +31,31 @@ struct Cli {
     /// IP address and port for the ha node-agent to listen on
     #[structopt(short, long, default_value = DEFAULT_NODE_AGENT_SERVER_ADDR)]
     grpc_endpoint: Uri,
+
+    /// Add process service tags to the traces
+    #[structopt(short, long, env = "TRACING_TAGS", value_delimiter=",", parse(try_from_str = utils::tracing_telemetry::parse_key_value))]
+    tracing_tags: Vec<KeyValue>,
+
+    /// Path failure detection period.
+    #[structopt(short, long, env = "DETECTION_PERIOD", default_value = NVME_PATH_CHECK_PERIOD)]
+    detection_period: humantime::Duration,
+
+    /// Retransmission period for reporting failed paths in case of network issues.
+    #[structopt(short, long, env = "RETRANSMISSION_PERIOD", default_value = NVME_PATH_RETRANSMISSION_PERIOD)]
+    retransmission_period: humantime::Duration,
+
+    /// Period for aggregating multiple failed paths before reporting them.
+    #[structopt(short, long, env = "AGGREGATION_PERIOD", default_value = NVME_PATH_AGGREGATION_PERIOD)]
+    aggregation_period: humantime::Duration,
+
+    /// Trace rest requests to the Jaeger endpoint agent
+    #[structopt(long, short)]
+    jaeger: Option<String>,
 }
 
 static CLUSTER_AGENT_CLIENT: OnceCell<ClusterAgentClient> = OnceCell::new();
 
-fn cluster_agent_client() -> &'static ClusterAgentClient {
+pub fn cluster_agent_client() -> &'static ClusterAgentClient {
     CLUSTER_AGENT_CLIENT
         .get()
         .expect("HA Cluster-Agent client should have been initialized")
@@ -40,17 +69,26 @@ impl Cli {
 
 #[tokio::main]
 async fn main() {
-    let cli = Cli::args();
+    let cli_args = Cli::args();
+
+    utils::print_package_info!();
+
+    utils::tracing_telemetry::init_tracing(
+        "agent-ha-node",
+        cli_args.tracing_tags.clone(),
+        cli_args.jaeger.clone(),
+    );
 
     CLUSTER_AGENT_CLIENT
-        .set(ClusterAgentClient::new(cli.cluster_agent, None).await)
+        .set(ClusterAgentClient::new(cli_args.cluster_agent.clone(), None).await)
         .ok()
         .expect("Expect to be initialized only once");
 
-    cluster_agent_client()
+    if let Err(e) = cluster_agent_client()
         .register(&NodeAgentInfo::new(
-            cli.node_name.clone(),
-            cli.grpc_endpoint
+            cli_args.node_name.clone(),
+            cli_args
+                .grpc_endpoint
                 .authority()
                 .unwrap()
                 .to_string()
@@ -58,5 +96,19 @@ async fn main() {
                 .unwrap(),
         ))
         .await
-        .unwrap();
+    {
+        tracing::error!(
+            "Failed to register HA Node agent in Cluster HA agent: {:?}",
+            e
+        );
+    }
+
+    // Instantinate path failure detector.
+    let detector =
+        PathFailureDetector::new(&cli_args).expect("Failed to initialize path failure detector");
+
+    detector
+        .start()
+        .await
+        .expect("Failed to start NVMe path failure detector");
 }

--- a/control-plane/agents/ha-node/src/path_provider.rs
+++ b/control-plane/agents/ha-node/src/path_provider.rs
@@ -1,0 +1,222 @@
+use crossbeam_queue::SegQueue;
+use futures_util::{future::ready, stream::StreamExt};
+use nvmeadm::nvmf_subsystem::{NvmeSubsystems, Subsystem};
+use std::{
+    collections::HashMap,
+    convert::TryInto,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use tokio_udev::{AsyncMonitorSocket, EventType, MonitorBuilder};
+use utils::NVME_TARGET_NQN_PREFIX;
+
+const SYSFS_PREFIX: &str = "/sys/devices/virtual/nvme-fabrics/ctl/";
+/// Maximum number of events to process upon cache update (to prevent event flooding).
+const CACHE_EVENTS_BATCH_SIZE: usize = 128;
+
+/// Object that represents a path to sysfs NVMe object.
+#[derive(Debug, Clone)]
+pub struct NvmePath {
+    path_buffer: PathBuf,
+}
+
+impl NvmePath {
+    fn new(path_buffer: PathBuf) -> Self {
+        Self { path_buffer }
+    }
+
+    #[inline]
+    pub fn path(&self) -> &Path {
+        self.path_buffer.as_path()
+    }
+}
+
+/// Check that NVMe path represents a target created by our product and
+/// obtain a Path object that represents a system path for this NVMe device.
+fn get_nvme_path_buf(path: &String) -> Option<PathBuf> {
+    Path::new(path).canonicalize().ok().and_then(|pb| {
+        Subsystem::new(pb.as_path()).ok().and_then(|s| {
+            // Check NQN of the subsystem to make sure it belongs to the product.
+            if s.nqn.starts_with(NVME_TARGET_NQN_PREFIX) {
+                Some(pb)
+            } else {
+                None
+            }
+        })
+    })
+}
+
+/// UDEV-driven cache synchronization messages.
+#[derive(Debug, Clone)]
+enum CacheOp {
+    Add(String),
+    Remove(String),
+    InvalidateCache,
+}
+
+/// UDEV-based NVMe path provider that uses cache to keep all known NVMe targets
+/// in memory and avoid wildcard Sysfs enumeration when there is a need to get
+/// a list of all existing NVMe path in the system.
+/// This name provider consists of 2 parts: backend and frontend.
+/// Backend: (CachedNvmePathProvider itself) is responsible for monitoring UDEV events
+/// and signalling cache modification in case there are suitable UDEV events related
+/// to NVMe subsystem.
+/// Frontend: (NvmePathNameCollection), which represents a cache for all known NVMe
+/// paths in the system. Note: we only cache paths that represent NVMe targets with product's
+/// NQN, so cache acts as a filter for 'unknown' NQNs.
+/// In order to eliminate cache inconsistency, there must be only one front-end path collection.
+/// To eliminate locking/contention, backend communicates with frontend via a lockless queue.
+#[derive(Debug)]
+pub struct CachedNvmePathProvider {
+    udev_queue: Arc<SegQueue<CacheOp>>,
+    frontend: Option<NvmePathNameCollection>,
+}
+
+impl CachedNvmePathProvider {
+    /// Start UDEV monitoring loop.
+    pub fn start(&mut self) -> anyhow::Result<impl std::future::Future<Output = ()> + '_> {
+        let builder = MonitorBuilder::new()?.match_subsystem("nvme")?;
+
+        let monitor: AsyncMonitorSocket = builder.listen()?.try_into()?;
+
+        tracing::info!("Starting UDEV event monitor for NVMe subsystem");
+
+        // Once UDEV event monitor is successfully created, we will be notified
+        // about all changes in device tree, hence from this point the cache will
+        // always be in sync, so it's time to trigger the cache invalidation
+        // for the front-end.
+        self.udev_queue.push(CacheOp::InvalidateCache);
+
+        let f = monitor.for_each(move |event| {
+            if let Ok(event) = event {
+                tracing::debug!(
+                    "Received UDEV hotplug event: {}: {} = {}",
+                    event.event_type(),
+                    event.device().syspath().display(),
+                    event
+                        .subsystem()
+                        .map_or("", |s| { s.to_str().unwrap_or("") })
+                );
+
+                // Make sure we have a valid UNICODE path.
+                match event.device().syspath().to_str() {
+                    Some(p) => {
+                        // Handle UDEV path addition/removal events.
+                        let e = match event.event_type() {
+                            EventType::Add => {
+                                tracing::info!("New NVMe path added: {}", p);
+                                Some(CacheOp::Add(p.to_owned()))
+                            }
+                            EventType::Remove => {
+                                tracing::info!("NVMe path removed: {}", p);
+                                Some(CacheOp::Remove(p.to_owned()))
+                            }
+                            _ => None,
+                        };
+
+                        if let Some(m) = e {
+                            self.udev_queue.push(m);
+                        }
+                    }
+                    None => {
+                        tracing::error!(
+                            "Device path is not a valid UNICODE path: {}",
+                            event.device().syspath().display()
+                        );
+                    }
+                }
+            }
+            ready(())
+        });
+        Ok(f)
+    }
+
+    /// Get a front-end path collection for this name provider.
+    pub fn get_path_collection(&mut self) -> Option<NvmePathNameCollection> {
+        self.frontend.take()
+    }
+
+    /// Create a new cached name provider.
+    pub fn new() -> Self {
+        let q = Arc::new(SegQueue::new());
+
+        Self {
+            frontend: Some(NvmePathNameCollection::new(Arc::clone(&q))),
+            udev_queue: q,
+        }
+    }
+}
+
+/// Front-end part of the cached name provider.
+#[derive(Debug)]
+pub struct NvmePathNameCollection {
+    udev_queue: Arc<SegQueue<CacheOp>>,
+    entries: HashMap<String, NvmePath>,
+}
+
+impl NvmePathNameCollection {
+    fn new(udev_queue: Arc<SegQueue<CacheOp>>) -> Self {
+        Self {
+            udev_queue,
+            entries: HashMap::new(),
+        }
+    }
+
+    fn add_cache_entry(&mut self, path: String) {
+        if let Some(pb) = get_nvme_path_buf(&path) {
+            tracing::debug!("Adding new NVMe path to cache: {}", path);
+            self.entries.insert(path, NvmePath::new(pb));
+        }
+    }
+
+    /// Fully rebuild the NVMe path cache.
+    fn invalidate_cache(&mut self) {
+        self.entries.clear();
+
+        let subsystems = NvmeSubsystems::new().expect("Failed to intialize NVMe subsystems");
+
+        for e in subsystems {
+            match e {
+                Ok(s) => self.add_cache_entry(format!("{SYSFS_PREFIX}{}", s.name)),
+                Err(e) => tracing::error!("Failed to read NVMe subsystem: {:?}", e),
+            };
+        }
+
+        tracing::info!(
+            "NVMe path cache invalidated, records added: {}",
+            self.entries.len()
+        );
+    }
+
+    /// Update cache based on UDEV events detected by the path provider.
+    fn update_cache(&mut self) {
+        let mut to_process = CACHE_EVENTS_BATCH_SIZE;
+
+        while to_process > 0 && !self.udev_queue.is_empty() {
+            if let Some(e) = self.udev_queue.pop() {
+                match e {
+                    CacheOp::Add(p) => {
+                        self.add_cache_entry(p);
+                    }
+                    CacheOp::Remove(p) => match self.entries.remove(&p) {
+                        Some(_) => tracing::info!("NVMe path removed from the cache: {}", p),
+                        None => tracing::warn!("NVMe path not in cache, skipping removal: {}", p),
+                    },
+                    CacheOp::InvalidateCache => {
+                        self.invalidate_cache();
+                    }
+                }
+            } else {
+                break;
+            }
+            to_process -= 1;
+        }
+    }
+
+    /// Get all cached path entries.
+    pub fn get_entries(&mut self) -> impl Iterator<Item = &NvmePath> {
+        // Check if we have any pending UDEV events and synchronize the cache.
+        self.update_cache();
+        self.entries.values()
+    }
+}

--- a/control-plane/agents/ha-node/src/reporter.rs
+++ b/control-plane/agents/ha-node/src/reporter.rs
@@ -1,0 +1,183 @@
+use crate::cluster_agent_client;
+use common_lib::types::v0::transport::{FailedPath, ReportFailedPaths};
+use grpc::operations::ha_node::traits::ClusterAgentOperations;
+use tokio::{
+    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    time::{sleep, Duration},
+};
+
+/// Initial size of a batch.
+const DEFAULT_BATCH_SIZE: usize = 16;
+
+/// Entity that reports failed NVMe paths to HA Cluster agent via gRPC.
+/// Failed NVMe paths are always aggregated before sending, which avoids
+/// many gRPC invocations for ebery individual failed path and fully utilizes
+/// the ability to report multiple failed paths in one call.
+#[derive(Debug)]
+pub struct PathReporter {
+    node_name: String,
+    channel: UnboundedSender<String>,
+    retransmission_period: Duration,
+    aggregation_period: Duration,
+}
+
+impl PathReporter {
+    pub fn new(
+        node_name: String,
+        retransmission_period: Duration,
+        aggregation_period: Duration,
+    ) -> Self {
+        let (tx, rx) = unbounded_channel();
+
+        let reporter = Self {
+            channel: tx,
+            node_name,
+            retransmission_period,
+            aggregation_period,
+        };
+
+        reporter.start(rx);
+        reporter
+    }
+
+    /// Start main loop for reporter.
+    fn start(&self, path_receiver: UnboundedReceiver<String>) {
+        let node_name = self.node_name.clone();
+        let retransmission_period = self.retransmission_period;
+        let aggregation_period = self.aggregation_period;
+
+        tracing::info!(
+            "Starting path reporter (retransmission period: {:?}, aggregation period: {:?})",
+            retransmission_period,
+            aggregation_period,
+        );
+
+        tokio::spawn(async move {
+            let mut aggregator = RequestAggregator::new(path_receiver, aggregation_period);
+
+            loop {
+                // Phase 1: wait till a path batch is available.
+                let batch = aggregator
+                    .receive_batch()
+                    .await
+                    .expect("Failed to receive aggregated paths");
+
+                // Phase 2: send all aggregated paths in one shot.
+                let failed_paths = batch
+                    .paths()
+                    .iter()
+                    .map(|p| FailedPath::new(p.to_string()))
+                    .collect::<Vec<FailedPath>>();
+
+                let req = ReportFailedPaths::new(node_name.clone(), failed_paths);
+
+                // Report all paths in a separate task, continue till transmission succeeds.
+                tokio::spawn(async move {
+                    let client = cluster_agent_client();
+
+                    loop {
+                        match client.report_failed_nvme_paths(&req).await {
+                            Ok(_) => break,
+                            Err(e) => {
+                                tracing::error!("Failed to report failed NVMe paths: {}", e);
+                                sleep(retransmission_period).await;
+                            }
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    pub fn report_failed_path(&self, nqn: String) {
+        self.channel
+            .send(nqn)
+            .expect("Reporter channel disappeared");
+    }
+}
+
+#[derive(Debug)]
+struct PathBatch {
+    pub paths: Vec<String>,
+}
+
+impl PathBatch {
+    pub fn new() -> Self {
+        Self {
+            paths: Vec::with_capacity(DEFAULT_BATCH_SIZE),
+        }
+    }
+
+    pub fn paths(&self) -> &Vec<String> {
+        &self.paths
+    }
+
+    pub fn add_path(&mut self, path: String) {
+        self.paths.push(path)
+    }
+}
+
+/// Batched aggregator which aggregates reported paths over
+/// time window and produces one batch for all paths reported
+/// within this time window.
+struct RequestAggregator {
+    batch_receiver: UnboundedReceiver<PathBatch>,
+    aggregation_period: Duration,
+}
+
+impl RequestAggregator {
+    pub fn new(path_receiver: UnboundedReceiver<String>, aggregation_period: Duration) -> Self {
+        let (tx, rx) = unbounded_channel();
+
+        let receiver = Self {
+            batch_receiver: rx,
+            aggregation_period,
+        };
+
+        receiver.start(path_receiver, tx);
+        receiver
+    }
+
+    fn start(
+        &self,
+        mut path_receiver: UnboundedReceiver<String>,
+        batch_sender: UnboundedSender<PathBatch>,
+    ) {
+        let aggregation_period = self.aggregation_period;
+
+        tokio::spawn(async move {
+            loop {
+                // Phase 1: wait for the first path to trigger batch aggregation.
+                let p = path_receiver.recv().await.expect("Path sender disappeared");
+
+                // Phase 2: add all subsequent reported paths to the batch.
+                let mut batch = PathBatch::new();
+                batch.add_path(p);
+
+                loop {
+                    tokio::select! {
+                        r = path_receiver.recv() => {
+                            let p = r.expect("Path sender disappeared");
+                            batch.add_path(p);
+                        },
+                        _ = sleep(aggregation_period) => {
+                            break;
+                        }
+                    }
+                }
+
+                batch_sender
+                    .send(batch)
+                    .expect("Batch receiver disappeared");
+            }
+        });
+    }
+
+    /// Wait till a batch of reported paths is available.
+    pub async fn receive_batch(&mut self) -> anyhow::Result<PathBatch> {
+        self.batch_receiver
+            .recv()
+            .await
+            .ok_or_else(|| anyhow::Error::msg("Batch producer's channel disappeared"))
+    }
+}

--- a/control-plane/grpc/proto/v1/ha/cluster_agent.proto
+++ b/control-plane/grpc/proto/v1/ha/cluster_agent.proto
@@ -7,6 +7,7 @@ package v1.ha_cluster_agent;
 // Service for managing cluster-agent rpc calls
 service HaRpc {
   rpc RegisterNodeAgent (HaNodeInfo) returns (google.protobuf.Empty) {}
+  rpc ReportFailedNvmePaths (ReportFailedNvmePathsRequest) returns (google.protobuf.Empty) {}
 }
 
 // Node information
@@ -15,3 +16,17 @@ message HaNodeInfo {
     string endpoint = 2;
 }
 
+// Failed NVMe path.
+message FailedNvmePath {
+  // NQN of the NVMe target to which this path is connected.
+  string target_nqn = 1;
+}
+
+// Failed paths message.
+message ReportFailedNvmePathsRequest {
+  // Node which reports failed paths.
+  string nodename = 1;
+
+  // List of failed
+  repeated FailedNvmePath failed_paths = 4;
+}

--- a/control-plane/grpc/src/operations/ha_node/server.rs
+++ b/control-plane/grpc/src/operations/ha_node/server.rs
@@ -3,7 +3,7 @@ use tonic::{Response, Status};
 use crate::{
     ha_cluster_agent::{
         ha_rpc_server::{HaRpc, HaRpcServer},
-        HaNodeInfo,
+        HaNodeInfo, ReportFailedNvmePathsRequest,
     },
     operations::ha_node::traits::ClusterAgentOperations,
 };
@@ -40,5 +40,13 @@ impl HaRpc for ClusterAgentServer {
                 err
             ))),
         }
+    }
+    async fn report_failed_nvme_paths(
+        &self,
+        _request: tonic::Request<ReportFailedNvmePathsRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        Err(Status::unimplemented(
+            "NVMe path reporting is not yet implemented",
+        ))
     }
 }

--- a/control-plane/grpc/src/operations/ha_node/traits.rs
+++ b/control-plane/grpc/src/operations/ha_node/traits.rs
@@ -1,11 +1,21 @@
-use crate::ha_cluster_agent::HaNodeInfo;
-use common_lib::{transport_api::ReplyError, types::v0::transport::cluster_agent::NodeAgentInfo};
+use crate::ha_cluster_agent::{FailedNvmePath, HaNodeInfo, ReportFailedNvmePathsRequest};
+use common_lib::{
+    transport_api::ReplyError,
+    types::v0::transport::{cluster_agent::NodeAgentInfo, FailedPath, ReportFailedPaths},
+    IntoVec,
+};
 
 /// ClusterAgentOperations trait implemented by client which supports cluster-agent operations
 #[tonic::async_trait]
 pub trait ClusterAgentOperations: Send + Sync {
     /// Register node with cluster-agent
     async fn register(&self, request: &dyn NodeInfo) -> Result<(), ReplyError>;
+
+    /// Report failed NVMe paths.
+    async fn report_failed_nvme_paths(
+        &self,
+        request: &dyn ReportFailedPathsInfo,
+    ) -> Result<(), ReplyError>;
 }
 
 /// NodeInfo trait for the node-agent registration to be implemented by entities which want to
@@ -34,5 +44,41 @@ impl NodeInfo for HaNodeInfo {
 
     fn endpoint(&self) -> String {
         self.endpoint.clone()
+    }
+}
+
+/// Trait to be implemented for ReportFailedNvmePaths operation.
+pub trait ReportFailedPathsInfo: Send + Sync + std::fmt::Debug {
+    /// Id of the application node.
+    fn node(&self) -> String;
+
+    /// List of failed NVMe paths.
+    fn failed_paths(&self) -> Vec<FailedPath>;
+}
+
+impl ReportFailedPathsInfo for ReportFailedPaths {
+    fn node(&self) -> String {
+        self.node_name().to_string()
+    }
+
+    fn failed_paths(&self) -> Vec<FailedPath> {
+        self.failed_paths().clone()
+    }
+}
+
+impl From<&dyn ReportFailedPathsInfo> for ReportFailedNvmePathsRequest {
+    fn from(info: &dyn ReportFailedPathsInfo) -> Self {
+        Self {
+            nodename: info.node(),
+            failed_paths: info.failed_paths().into_vec(),
+        }
+    }
+}
+
+impl From<FailedPath> for FailedNvmePath {
+    fn from(path: FailedPath) -> Self {
+        Self {
+            target_nqn: path.target_nqn().to_string(),
+        }
     }
 }

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -83,3 +83,14 @@ pub const DEFAULT_REST_MAX_WORKER_THREADS: &str = "8";
 
 /// The default kubernetes namespace for this project.
 pub const DEFAULT_NAMESPACE: &str = "mayastor";
+/// NQN prefix for NVMe targets created by the product.
+pub const NVME_TARGET_NQN_PREFIX: &str = "nqn.2019-05.io.openebs:";
+
+/// NVMe path check period.
+pub const NVME_PATH_CHECK_PERIOD: &str = "3s";
+
+/// The default retransmission interval for reporting failed paths in case of network issues.
+pub const NVME_PATH_RETRANSMISSION_PERIOD: &str = "10s";
+
+/// Period for aggregating multiple failed paths before reporting them.
+pub const NVME_PATH_AGGREGATION_PERIOD: &str = "1s";


### PR DESCRIPTION
Implemented NVMe path detector which detects failed path and reports
them to HA Cluster agent.
UDEV-based cache keeps in sync cached NVMe paths with system device tree
and updates locally cached device paths in response to device
addition/removal events.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>