### PR TITLE
feat: drain initial implementation

### DIFF
--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -1,95 +1,324 @@
 //! Definition of node types that can be saved to the persistent store.
-
-use crate::types::v0::{
-    openapi::models,
-    store::definitions::{ObjectKey, StorableObject, StorableObjectType},
-    transport::{self, NodeId},
+use crate::{
+    types::v0::{
+        openapi::models,
+        store::definitions::{ObjectKey, StorableObject, StorableObjectType},
+        transport::{self, NodeId},
+    },
+    IntoOption,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Generic labels associated with the node.
 pub type NodeLabels = HashMap<String, String>;
 
+/// Data relating to the cordoning of a node.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CordonedState {
+    /// Labels used to enforce a node cordon.
+    pub cordonlabels: Vec<String>,
+}
+
+impl CordonedState {
+    /// Create a new CordonedState object.
+    pub fn new(cordonlabels: Vec<String>) -> Self {
+        Self { cordonlabels }
+    }
+    /// Create a DrainState from a CordonedState.
+    pub fn into_drain(&self, drainlabel: &str) -> DrainState {
+        DrainState::new(self.cordonlabels.clone(), vec![String::from(drainlabel)])
+    }
+    /// Remove a cordon label from a CordonedState object.
+    pub fn remove_label(&mut self, label: &str) {
+        self.cordonlabels.retain(|l| l != label)
+    }
+}
+
+/// Data relating to a draining or drained node, including non-drain cordon labels.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct DrainState {
+    /// Labels used to enforce a node cordon.
+    pub cordonlabels: Vec<String>,
+    /// Labels used to cordon a node specifically for a drain.
+    pub drainlabels: Vec<String>,
+}
+
+impl DrainState {
+    /// Create a new DrainState object.
+    pub fn new(cordonlabels: Vec<String>, drainlabels: Vec<String>) -> Self {
+        Self {
+            cordonlabels,
+            drainlabels,
+        }
+    }
+    /// Remove a label from a DrainState object.
+    pub fn remove_label(&mut self, label: &str) {
+        self.cordonlabels.retain(|l| l != label);
+        self.drainlabels.retain(|l| l != label);
+    }
+    /// Add a drain label to a DrainState object.
+    pub fn add_drain_label(&mut self, label: &str) {
+        self.drainlabels.push(label.to_string());
+    }
+}
+
+/// Enum variant encompassing data related to a cordoned or draining node.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub enum CordonDrainState {
+    /// The node is being cordoned.
+    Cordoned(CordonedState),
+    /// The node is being drained.
+    Draining(DrainState),
+    /// The drain has completed.
+    Drained(DrainState),
+}
+
+impl CordonDrainState {
+    /// Add the given label to the cordon labels.
+    pub fn add_cordon_label(&mut self, label: &str) {
+        match self {
+            CordonDrainState::Draining(state) => state.cordonlabels.push(label.to_string()),
+            CordonDrainState::Drained(state) => state.cordonlabels.push(label.to_string()),
+            CordonDrainState::Cordoned(state) => state.cordonlabels.push(label.to_string()),
+        }
+    }
+    /// Returns a new Cordoned enum with the given cordon label.
+    pub fn cordon(label: &str) -> Self {
+        CordonDrainState::Cordoned(CordonedState::new(vec![String::from(label)]))
+    }
+
+    /// Returns whether the state has the specified cordon label.
+    pub fn has_cordon_only_label(&self, label: &str) -> bool {
+        match self {
+            CordonDrainState::Draining(state) => state.cordonlabels.iter().any(|i| i == label),
+            CordonDrainState::Drained(state) => state.cordonlabels.iter().any(|i| i == label),
+            CordonDrainState::Cordoned(state) => state.cordonlabels.iter().any(|i| i == label),
+        }
+    }
+    /// Returns whether the state has the specified drain label.
+    pub fn has_drain_label(&self, label: &str) -> bool {
+        match self {
+            CordonDrainState::Draining(state) => state.drainlabels.iter().any(|i| i == label),
+            CordonDrainState::Drained(state) => state.drainlabels.iter().any(|i| i == label),
+            CordonDrainState::Cordoned(_) => false,
+        }
+    }
+    /// Returns whether the state corresponds to draining.
+    pub fn is_draining(&self) -> bool {
+        match self {
+            CordonDrainState::Cordoned(_) => false,
+            CordonDrainState::Draining(_) => true,
+            CordonDrainState::Drained(_) => false,
+        }
+    }
+}
+
+/// Node information.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Node {
-    /// Node information.
+    /// Node state information.
     node: transport::NodeState,
     /// Node labels.
     labels: NodeLabels,
 }
 
+/// Node state information.
 pub struct NodeState {
-    /// Node information
+    /// Node information.
     pub node: transport::NodeState,
 }
 
+/// Node spec data, including the cordon/drain state.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct NodeSpec {
     /// Node identification.
     id: NodeId,
-    /// Endpoint of the io-engine instance (gRPC)
+    /// Endpoint of the io-engine instance (gRPC).
     endpoint: String,
     /// Node labels.
     labels: NodeLabels,
-    /// Cordon labels.
+    /// Cordon/drain state.
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)] // Ensure backwards compatibility in etcd when upgrading.
-    cordon_labels: Vec<String>,
+    cordon_drain_state: Option<CordonDrainState>,
 }
 
 impl NodeSpec {
-    /// Return a new `Self`
+    /// Return a new `Self`.
     pub fn new(
         id: NodeId,
         endpoint: String,
         labels: NodeLabels,
-        cordon_label: Option<Vec<String>>,
+        cordon_drain_state: Option<CordonDrainState>,
     ) -> Self {
         Self {
             id,
             endpoint,
             labels,
-            cordon_labels: cordon_label.unwrap_or_default(),
+            cordon_drain_state,
         }
     }
-    /// Node identification
+    /// Node identification.
     pub fn id(&self) -> &NodeId {
         &self.id
     }
-    /// Node gRPC endpoint
+    /// Node gRPC endpoint.
     pub fn endpoint(&self) -> &str {
         &self.endpoint
     }
-    /// Node labels
+    /// Node labels.
     pub fn labels(&self) -> &NodeLabels {
         &self.labels
     }
-    /// Node gRPC endpoint
+    /// Node labels.
+    pub fn cordon_drain_state(&self) -> &Option<CordonDrainState> {
+        &self.cordon_drain_state
+    }
+
+    /// Node gRPC endpoint.
     pub fn set_endpoint(&mut self, endpoint: String) {
         self.endpoint = endpoint
     }
+
     /// Cordon node by applying the label.
     pub fn cordon(&mut self, label: String) {
-        self.cordon_labels.push(label);
+        match &mut self.cordon_drain_state {
+            Some(ds) => ds.add_cordon_label(&label),
+            None => {
+                //add the label and set the state to cordoned
+                self.cordon_drain_state = Some(CordonDrainState::cordon(&label));
+            }
+        }
+    }
+
+    /// Drain node by applying the drain label.
+    pub fn set_drain(&mut self, label: String) {
+        // the the node has the label, return with an error
+        match &mut self.cordon_drain_state {
+            Some(ds) => match ds {
+                CordonDrainState::Cordoned(state) => {
+                    // set state to draining and add label
+                    self.cordon_drain_state =
+                        Some(CordonDrainState::Draining(state.into_drain(&label)))
+                }
+                CordonDrainState::Draining(state) => {
+                    // add the label
+                    state.add_drain_label(&label);
+                }
+                CordonDrainState::Drained(state) => {
+                    // add the label
+                    state.add_drain_label(&label);
+                }
+            },
+            None => {
+                //add the label and set the state to draining
+                let cordonlabels = Vec::<String>::new();
+                let drainlabels = vec![label];
+                self.cordon_drain_state = Some(CordonDrainState::Draining(DrainState::new(
+                    cordonlabels,
+                    drainlabels,
+                )));
+            }
+        }
     }
     /// Uncordon node by removing the corresponding label.
     pub fn uncordon(&mut self, label: String) {
-        if let Some(index) = self.cordon_labels.iter().position(|l| l == &label) {
-            self.cordon_labels.remove(index);
+        match &mut self.cordon_drain_state {
+            Some(ds) => match ds {
+                CordonDrainState::Cordoned(state) => {
+                    // remove the cordon label
+                    // if none left set ds to none
+                    state.remove_label(&label);
+                    if state.cordonlabels.is_empty() {
+                        self.cordon_drain_state = None;
+                    }
+                }
+                CordonDrainState::Draining(state) | CordonDrainState::Drained(state) => {
+                    // if no drain labels left, set to cordoned or none
+                    state.remove_label(&label);
+                    if state.drainlabels.is_empty() {
+                        if state.cordonlabels.is_empty() {
+                            self.cordon_drain_state = None;
+                        } else {
+                            self.cordon_drain_state = Some(CordonDrainState::Cordoned(
+                                CordonedState::new(state.cordonlabels.clone()),
+                            ));
+                        }
+                    }
+                }
+            },
+            None => {
+                // should not be possible
+            }
         }
     }
+
     /// Returns whether or not the node is cordoned.
     pub fn cordoned(&self) -> bool {
-        !self.cordon_labels.is_empty()
+        self.cordon_drain_state.is_some()
     }
-    /// Returns the cordon labels
-    pub fn cordon_labels(&self) -> Vec<String> {
-        self.cordon_labels.clone()
+
+    /// Returns true if it has the label in either of the lists.
+    pub fn has_cordon_label(&self, label: &str) -> bool {
+        self.has_cordon_only_label(label) || self.has_drain_label(label)
+    }
+
+    /// Returns true if it has the label in the cordon list.
+    pub fn has_cordon_only_label(&self, label: &str) -> bool {
+        match &self.cordon_drain_state {
+            Some(ds) => ds.has_cordon_only_label(label),
+            None => false,
+        }
+    }
+
+    /// Returns true if it has the label in the drain list.
+    pub fn has_drain_label(&self, label: &str) -> bool {
+        match &self.cordon_drain_state {
+            Some(ds) => ds.has_drain_label(label),
+            None => false,
+        }
+    }
+
+    /// Returns true if the node is in the draining state.
+    pub fn is_draining(&self) -> bool {
+        match &self.cordon_drain_state {
+            Some(ds) => ds.is_draining(),
+            None => false,
+        }
     }
 }
 
 impl From<NodeSpec> for models::NodeSpec {
     fn from(src: NodeSpec) -> Self {
-        Self::new(src.endpoint, src.id, src.cordon_labels)
+        Self::new_all(src.endpoint, src.id, src.cordon_drain_state.into_opt())
+    }
+}
+
+impl From<CordonDrainState> for models::CordonDrainState {
+    fn from(node_ds: CordonDrainState) -> Self {
+        match node_ds {
+            CordonDrainState::Cordoned(state) => {
+                let cs = models::CordonedState {
+                    cordonlabels: state.cordonlabels,
+                };
+                models::CordonDrainState::cordonedstate(cs)
+            }
+            CordonDrainState::Draining(state) => {
+                let ds = models::DrainState {
+                    cordonlabels: state.cordonlabels,
+                    drainlabels: state.drainlabels,
+                };
+                models::CordonDrainState::drainingstate(ds)
+            }
+            CordonDrainState::Drained(state) => {
+                let ds = models::DrainState {
+                    cordonlabels: state.cordonlabels,
+                    drainlabels: state.drainlabels,
+                };
+                models::CordonDrainState::drainedstate(ds)
+            }
+        }
     }
 }
 

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -88,7 +88,7 @@ impl ResourceSpecsLocked {
         let cordoned_node_spec = {
             let mut locked_node = node.lock();
             // Do not allow the same label to be applied more than once.
-            if locked_node.cordon_labels().contains(&label) {
+            if locked_node.has_cordon_label(&label) {
                 return Err(SvcError::CordonLabel {
                     node_id: node_id.to_string(),
                     label,
@@ -111,7 +111,7 @@ impl ResourceSpecsLocked {
     ) -> Result<NodeSpec, SvcError> {
         let node = self.get_locked_node(node_id)?;
         // Return an error if the uncordon label doesn't exist.
-        if !node.lock().cordon_labels().contains(&label) {
+        if !node.lock().has_cordon_label(&label) {
             return Err(SvcError::UncordonLabel {
                 node_id: node_id.to_string(),
                 label,
@@ -140,5 +140,30 @@ impl ResourceSpecsLocked {
                 }
             })
             .collect()
+    }
+
+    /// Apply the drain label to trigger draining.
+    /// Return the NodeSpec.
+    pub(crate) async fn drain_node(
+        &self,
+        registry: &Registry,
+        node_id: &NodeId,
+        label: String,
+    ) -> Result<NodeSpec, SvcError> {
+        let node = self.get_locked_node(node_id)?;
+        let drained_node_spec = {
+            let mut locked_node = node.lock();
+            // Do not allow the same label to be applied more than once.
+            if locked_node.has_cordon_label(&label) {
+                return Err(SvcError::CordonLabel {
+                    node_id: node_id.to_string(),
+                    label,
+                });
+            }
+            locked_node.set_drain(label);
+            locked_node.clone()
+        };
+        registry.store_obj(&drained_node_spec).await?;
+        Ok(drained_node_spec)
     }
 }

--- a/control-plane/grpc/proto/v1/node/node.proto
+++ b/control-plane/grpc/proto/v1/node/node.proto
@@ -17,12 +17,6 @@ message Node {
   optional NodeState state = 3;
 }
 
-// Node cordon information
-message NodeCordon {
-  // Node cordon label.
-  repeated string label = 2;
-}
-
 message NodeSpec {
   // Node identification
   string node_id = 1;
@@ -30,8 +24,8 @@ message NodeSpec {
   string endpoint = 2;
   // Node labels.
   common.StringMapValue labels = 3;
-  // Cordon information.
-  NodeCordon cordon = 4;
+  // Drain state
+  optional CordonDrainState cordon_drain_state = 4;
 }
 
 message NodeState {
@@ -112,10 +106,45 @@ message UncordonNodeReply {
   }
 }
 
+message DrainNodeRequest {
+  // Node identification
+  string node_id = 1;
+  // Node cordon label
+  string label = 2;
+}
+
+message DrainNodeReply {
+  oneof reply {
+    Node node = 1;
+    common.ReplyError error = 2;
+  }
+}
+
+message CordonDrainState {
+    oneof cordondrainstate {
+        CordonedState cordoned = 1;
+        DrainState draining = 2;
+        DrainState drained = 3;
+      }
+}
+
+message CordonedState {
+  // Cordon information.
+  repeated string cordon_labels = 1;
+}
+
+message DrainState {
+  // Cordon information.
+  repeated string cordon_labels = 1;
+  // Drain information.
+  repeated string drain_labels = 2;
+}
+
 service NodeGrpc {
   rpc GetNodes (GetNodesRequest) returns (GetNodesReply) {}
   rpc GetBlockDevices (blockdevice.GetBlockDevicesRequest) returns (blockdevice.GetBlockDevicesReply) {}
   rpc Probe (ProbeRequest) returns (ProbeResponse) {}
   rpc CordonNode (CordonNodeRequest) returns (CordonNodeReply) {}
   rpc UncordonNode (UncordonNodeRequest) returns (UncordonNodeReply) {}
+  rpc DrainNode (DrainNodeRequest) returns (DrainNodeReply) {}
 }

--- a/control-plane/grpc/src/operations/node/server.rs
+++ b/control-plane/grpc/src/operations/node/server.rs
@@ -2,10 +2,11 @@ use crate::{
     blockdevice::{get_block_devices_reply, GetBlockDevicesReply, GetBlockDevicesRequest},
     node,
     node::{
-        cordon_node_reply, get_nodes_reply,
+        cordon_node_reply, drain_node_reply, get_nodes_reply,
         node_grpc_server::{NodeGrpc, NodeGrpcServer},
-        uncordon_node_reply, CordonNodeReply, CordonNodeRequest, GetNodesReply, GetNodesRequest,
-        ProbeRequest, ProbeResponse, UncordonNodeReply, UncordonNodeRequest,
+        uncordon_node_reply, CordonNodeReply, CordonNodeRequest, DrainNodeReply, DrainNodeRequest,
+        GetNodesReply, GetNodesRequest, ProbeRequest, ProbeResponse, UncordonNodeReply,
+        UncordonNodeRequest,
     },
     operations::node::traits::NodeOperations,
 };
@@ -98,6 +99,21 @@ impl NodeGrpc for NodeServer {
             })),
             Err(err) => Ok(Response::new(UncordonNodeReply {
                 reply: Some(uncordon_node_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn drain_node(
+        &self,
+        request: tonic::Request<DrainNodeRequest>,
+    ) -> Result<tonic::Response<DrainNodeReply>, tonic::Status> {
+        let req: DrainNodeRequest = request.into_inner();
+        match self.service.drain(req.node_id.into(), req.label).await {
+            Ok(node) => Ok(Response::new(DrainNodeReply {
+                reply: Some(drain_node_reply::Reply::Node(node.into())),
+            })),
+            Err(err) => Ok(Response::new(DrainNodeReply {
+                reply: Some(drain_node_reply::Reply::Error(err.into())),
             })),
         }
     }

--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -2,8 +2,13 @@ use clap::Parser;
 use openapi::tower::client::Url;
 use opentelemetry::global;
 use plugin::{
-    operations::{Cordoning, Get, GetBlockDevices, List, Operations, ReplicaTopology, Scale},
-    resources::{blockdevice, node, pool, volume, CordonResources, GetResources, ScaleResources},
+    operations::{
+        Cordoning, Drain, Get, GetBlockDevices, List, Operations, ReplicaTopology, Scale,
+    },
+    resources::{
+        blockdevice, cordon, drain, node, pool, volume, CordonResources, DrainResources,
+        GetCordonArgs, GetDrainArgs, GetResources, ScaleResources,
+    },
     rest_wrapper::RestClient,
 };
 use std::env;
@@ -54,7 +59,30 @@ async fn execute(cli_args: CliArgs) {
 
     // Perform the operations based on the subcommand, with proper output format.
     match &cli_args.operations {
+        Operations::Drain(resource) => match resource {
+            DrainResources::Node(drain_node_args) => {
+                node::Node::drain(
+                    &drain_node_args.node_id(),
+                    drain_node_args.label(),
+                    drain_node_args.drain_timeout(),
+                    &cli_args.output,
+                )
+                .await
+            }
+        },
         Operations::Get(resource) => match resource {
+            GetResources::Cordon(get_cordon_resource) => match get_cordon_resource {
+                GetCordonArgs::Node { id: node_id } => {
+                    cordon::NodeCordon::get(node_id, &cli_args.output).await
+                }
+                GetCordonArgs::Nodes => cordon::NodeCordons::list(&cli_args.output).await,
+            },
+            GetResources::Drain(get_drain_resource) => match get_drain_resource {
+                GetDrainArgs::Node { id: node_id } => {
+                    drain::NodeDrain::get(node_id, &cli_args.output).await
+                }
+                GetDrainArgs::Nodes => drain::NodeDrains::list(&cli_args.output).await,
+            },
             GetResources::Volumes => volume::Volumes::list(&cli_args.output).await,
             GetResources::Volume { id } => volume::Volume::get(id, &cli_args.output).await,
             GetResources::VolumeReplicaTopology { id } => {
@@ -63,13 +91,7 @@ async fn execute(cli_args: CliArgs) {
             GetResources::Pools => pool::Pools::list(&cli_args.output).await,
             GetResources::Pool { id } => pool::Pool::get(id, &cli_args.output).await,
             GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
-            GetResources::Node(args) => {
-                if args.show_cordon_labels() {
-                    node::Node::get_labels(&args.node_id(), &cli_args.output).await
-                } else {
-                    node::Node::get(&args.node_id(), &cli_args.output).await
-                }
-            }
+            GetResources::Node(args) => node::Node::get(&args.node_id(), &cli_args.output).await,
             GetResources::BlockDevices(bdargs) => {
                 blockdevice::BlockDevice::get_blockdevices(
                     &bdargs.node_id(),

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -1,9 +1,12 @@
-use crate::resources::{utils, CordonResources, GetResources, ScaleResources};
+use crate::resources::{utils, CordonResources, DrainResources, GetResources, ScaleResources};
 use async_trait::async_trait;
 
 /// The types of operations that are supported.
 #[derive(clap::Subcommand, Debug)]
 pub enum Operations {
+    /// 'Drain' resources.
+    #[clap(subcommand)]
+    Drain(DrainResources),
     /// 'Get' resources.
     #[clap(subcommand)]
     Get(GetResources),
@@ -16,6 +19,19 @@ pub enum Operations {
     /// 'Uncordon' resources.
     #[clap(subcommand)]
     Uncordon(CordonResources),
+}
+
+/// Drain trait.
+/// To be implemented by resources which support the 'drain' operation.
+#[async_trait(?Send)]
+pub trait Drain {
+    type ID;
+    async fn drain(
+        id: &Self::ID,
+        label: String,
+        drain_timeout: Option<humantime::Duration>,
+        output: &utils::OutputFormat,
+    );
 }
 
 /// List trait.
@@ -64,5 +80,4 @@ pub trait Cordoning {
     type ID;
     async fn cordon(id: &Self::ID, label: &str, output: &utils::OutputFormat);
     async fn uncordon(id: &Self::ID, label: &str, output: &utils::OutputFormat);
-    async fn get_labels(id: &Self::ID, output: &utils::OutputFormat);
 }

--- a/control-plane/plugin/src/resources/cordon.rs
+++ b/control-plane/plugin/src/resources/cordon.rs
@@ -1,0 +1,60 @@
+pub struct NodeCordon {}
+pub struct NodeCordons {}
+
+use async_trait::async_trait;
+use openapi::models::CordonDrainState;
+
+use crate::{
+    operations::{Get, List},
+    resources::{
+        node::{node_display_print, node_display_print_one, NodeDisplayFormat},
+        utils::OutputFormat,
+        NodeId,
+    },
+    rest_wrapper::RestClient,
+};
+
+#[async_trait(?Send)]
+impl Get for NodeCordon {
+    type ID = NodeId;
+    async fn get(id: &Self::ID, output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_node(id).await {
+            Ok(node) => {
+                node_display_print_one(node.into_body(), output, NodeDisplayFormat::CordonLabels)
+            }
+            Err(e) => {
+                println!("Failed to get node {}. Error {}", id, e)
+            }
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl List for NodeCordons {
+    async fn list(output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_nodes().await {
+            Ok(nodes) => {
+                // iterate through the nodes and filter for only those that have cordon or drain
+                // labels
+                let nodelist = nodes.into_body();
+                let mut filteredlist = nodelist;
+                // remove nodes with no cordon or drain labels
+                filteredlist.retain(|i| {
+                    i.spec.is_some()
+                        && match &i.spec.as_ref().unwrap().cordondrainstate {
+                            Some(ds) => match ds {
+                                CordonDrainState::cordonedstate(_) => true,
+                                CordonDrainState::drainingstate(_) => true,
+                                CordonDrainState::drainedstate(_) => true,
+                            },
+                            None => false,
+                        }
+                });
+                node_display_print(filteredlist, output, NodeDisplayFormat::CordonLabels)
+            }
+            Err(e) => {
+                println!("Failed to list nodes. Error {}", e)
+            }
+        }
+    }
+}

--- a/control-plane/plugin/src/resources/drain.rs
+++ b/control-plane/plugin/src/resources/drain.rs
@@ -1,0 +1,58 @@
+pub struct NodeDrain {}
+pub struct NodeDrains {}
+
+use async_trait::async_trait;
+use openapi::models::CordonDrainState;
+
+use crate::{
+    operations::{Get, List},
+    resources::{
+        node::{node_display_print, node_display_print_one, NodeDisplayFormat},
+        utils::OutputFormat,
+        NodeId,
+    },
+    rest_wrapper::RestClient,
+};
+
+#[async_trait(?Send)]
+impl Get for NodeDrain {
+    type ID = NodeId;
+    async fn get(id: &Self::ID, output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_node(id).await {
+            Ok(node) => node_display_print_one(node.into_body(), output, NodeDisplayFormat::Drain),
+            Err(e) => {
+                println!("Failed to get node {}. Error {}", id, e)
+            }
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl List for NodeDrains {
+    async fn list(output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_nodes().await {
+            Ok(nodes) => {
+                // iterate through the nodes and filter for only those that have drain labels
+                // then print with the format NodeDisplayFormat::Drain
+                let nodelist = nodes.into_body();
+                let mut filteredlist = nodelist;
+                // remove nodes with no drain labels
+                filteredlist.retain(|i| {
+                    i.spec.is_some()
+                        && match &i.spec.as_ref().unwrap().cordondrainstate {
+                            Some(ds) => match ds {
+                                CordonDrainState::cordonedstate(_) => false,
+                                CordonDrainState::drainingstate(_) => true,
+                                CordonDrainState::drainedstate(_) => true,
+                            },
+                            None => false,
+                        }
+                });
+                node_display_print(filteredlist, output, NodeDisplayFormat::Drain);
+            }
+            Err(e) => {
+                println!("Failed to list nodes. Error {}", e)
+            }
+        }
+    }
+}

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -1,6 +1,11 @@
-use crate::resources::{blockdevice::BlockDeviceArgs, node::GetNodeArgs};
+use crate::resources::{
+    blockdevice::BlockDeviceArgs,
+    node::{DrainNodeArgs, GetNodeArgs},
+};
 
 pub mod blockdevice;
+pub mod cordon;
+pub mod drain;
 pub mod node;
 pub mod pool;
 pub mod utils;
@@ -14,6 +19,12 @@ pub type NodeId = String;
 /// The types of resources that support the 'get' operation.
 #[derive(clap::Subcommand, Debug)]
 pub enum GetResources {
+    /// get cordon
+    #[clap(subcommand)]
+    Cordon(GetCordonArgs),
+    /// get drain
+    #[clap(subcommand)]
+    Drain(GetDrainArgs),
     /// Get all volumes.
     Volumes,
     /// Get volume with the given ID.
@@ -51,6 +62,32 @@ pub enum ScaleResources {
 pub enum CordonResources {
     /// Cordon the node with the given ID by applying the cordon label to that node.
     Node { id: NodeId, label: String },
+}
+
+/// The types of resources that support the 'get cordon' operation.
+#[derive(clap::Subcommand, Debug)]
+pub enum GetCordonArgs {
+    /// Get the cordon for the node with the given ID.
+    Node {
+        id: NodeId,
+    },
+    Nodes,
+}
+
+/// The types of resources that support the 'drain' operation.
+#[derive(clap::Subcommand, Debug)]
+pub enum DrainResources {
+    /// Drain node with the given ID.
+    Node(DrainNodeArgs),
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum GetDrainArgs {
+    /// Get the drain for the node with the given ID.
+    Node {
+        id: NodeId,
+    },
+    Nodes,
 }
 
 /// Tabular Output Tests

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -285,6 +285,35 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: [ ]
+  '/nodes/{id}/drain/{label}':
+    put:
+      tags:
+        - Nodes
+      operationId: put_node_drain
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: label
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
   '/nodes/{id}/nexuses':
     get:
       tags:
@@ -2076,23 +2105,23 @@ components:
       example:
         grpcEndpoint: '10.1.0.5:10124'
         id: io-engine-1
-        cordonLabels: [label-1]
-      description: io-engine storage node information
+      description: Node spec
       type: object
       properties:
         grpcEndpoint:
           description: gRPC endpoint of the io-engine instance
           type: string
         id:
+          description: node ID
           $ref: '#/components/schemas/NodeId'
-        cordonLabels:
-          type: array
-          items:
-            type: string
+        cordondrainstate:
+          description: the drain state
+          allOf:
+            - $ref: '#/components/schemas/CordonDrainState'
+      additionalProperties: false
       required:
         - grpcEndpoint
         - id
-        - cordonLabels
     NodeState:
       example:
         grpcEndpoint: '10.1.0.5:10124'
@@ -2742,6 +2771,50 @@ components:
           $ref: '#/components/schemas/ReplicaState'
       required:
         - state
+    CordonDrainState:
+      description: The drain state
+      type: object
+      properties:
+        cordonedstate:
+          $ref: '#/components/schemas/CordonedState'
+        drainingstate:
+          $ref: '#/components/schemas/DrainState'
+        drainedstate:
+          $ref: '#/components/schemas/DrainState'
+      oneOf:
+        - required:
+            - cordonedstate
+        - required:
+            - drainingstate
+        - required:
+            - drainedstate
+    CordonLabels:
+      type: array
+      items:
+        type: string
+    DrainLabels:
+      type: array
+      items:
+        type: string
+    CordonedState:
+      description: The item is cordoned
+      type: object
+      properties:
+        cordonlabels:
+          $ref: '#/components/schemas/CordonLabels'
+      required:
+        - cordonlabels
+    DrainState:
+      description: The item is draining
+      type: object
+      properties:
+        cordonlabels:
+          $ref: '#/components/schemas/CordonLabels'
+        drainlabels:
+          $ref: '#/components/schemas/DrainLabels'
+      required:
+        - cordonlabels
+        - drainlabels
   responses:
     ClientError:
       description: Client side error

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -37,6 +37,13 @@ impl apis::actix_server::Nodes for RestApi {
         let node = client().uncordon(id.into(), label).await?;
         Ok(node.into())
     }
+
+    async fn put_node_drain(
+        Path((id, label)): Path<(String, String)>,
+    ) -> Result<models::Node, RestError<RestJsonError>> {
+        let node = client().drain(id.into(), label).await?;
+        Ok(node.into())
+    }
 }
 
 /// returns node from node option and returns an error on non existence

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -94,7 +94,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
                 "{}:10124",
                 cluster.composer().container_ip(cluster.node(0).as_str())
             ),
-            cordon_labels: vec![],
+            cordondrainstate: None,
         }),
         state: Some(models::NodeState {
             id: io_engine1.to_string(),

--- a/k8s/plugin/README.md
+++ b/k8s/plugin/README.md
@@ -130,25 +130,61 @@ The plugin needs to be able to connect to the REST server in order to make the a
 ```
 **NOTE: The above command lists usable blockdevices if `--all` flag is not used, but currently since there isn't a way to identify whether the `disk` has a blobstore pool, `disks` not used by `pools` created by `control-plane` are shown as usable if they lack any filesystem uuid.**
 
-10. Node Cordoning
-```
-❯ kubectl mayastor cordon node io-engine-1 my-label
-Node io-engine-1 cordoned successfully
-```
+</details>
 
-11. Node Uncordoning
+<details>
+<summary> Node Cordon And Drain Operations </summary>
+
+1. Node Cordoning
 ```
-❯ kubectl mayastor uncordon node io-engine-1 my-label
+❯ kubectl mayastor cordon node node-1-14048 my_cordon_1
+Node node-1-14048 cordoned successfully
+```
+2. Node Uncordoning
+```
+❯ kubectl mayastor uncordon node node-1-14048 my_cordon_1
+Node node-1-14048 successfully uncordoned
+```
+3. Get Cordon
+```
+❯ kubectl mayastor get cordon node node-1-14048
+ ID            GRPC ENDPOINT        STATUS  CORDONED  CORDON LABELS
+ node-1-14048  95.217.158.66:10124  Online  true      my_cordon_1
+
+❯ kubectl mayastor get cordon nodes
+ ID            GRPC ENDPOINT        STATUS  CORDONED  CORDON LABELS
+ node-2-14048  95.217.152.7:10124   Online  true      my_cordon_2
+ node-1-14048  95.217.158.66:10124  Online  true      my_cordon_1
+```
+4. Node Draining
+```
+❯ kubectl mayastor drain node io-engine-1 my-drain-label
+Node node-1-14048 successfully drained
+
+❯ kubectl mayastor drain node node-1-14048 my-drain-label --drain-timeout 10s
+Node node-1-14048 drain command timed out
+```
+5. Cancel Node Drain (via uncordon)
+```
+❯ kubectl mayastor uncordon node io-engine-1 my-drain-label
 Node io-engine-1 successfully uncordoned
 ```
-
-12. Listing Cordon Labels
+6. Get Drain
 ```
-❯ kubectl mayastor get node io-engine-1 --show-cordon-labels
- ID           GRPC ENDPOINT   STATUS  CORDONED  CORDON LABELS
- io-engine-1  10.1.0.5:10124  Online  true      my-label
-```
+❯ kubectl mayastor get drain node node-2-14048
+ ID            GRPC ENDPOINT       STATUS  CORDONED  DRAIN STATE  DRAIN LABELS
+ node-2-14048  95.217.152.7:10124  Online  true      Draining     my_drain_2
 
+❯ kubectl-plugin/bin/kubectl-mayastor get drain node node-0-14048
+ ID            GRPC ENDPOINT          STATUS  CORDONED  DRAIN STATE   DRAIN LABELS
+ node-0-14048  135.181.206.173:10124  Online  false     Not draining
+
+❯ kubectl mayastor get drain nodes
+ ID            GRPC ENDPOINT        STATUS  CORDONED  DRAIN STATE  DRAIN LABELS
+ node-2-14048  95.217.152.7:10124   Online  true      Draining     my_drain_2
+ node-1-14048  95.217.158.66:10124  Online  true      Drained      my_drain_1
+
+```
 </details>
 
 <details>

--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -3,8 +3,11 @@ use clap::Parser;
 use openapi::tower::client::Url;
 use opentelemetry::global;
 use plugin::{
-    operations::{Cordoning, Get, GetBlockDevices, List, ReplicaTopology, Scale},
-    resources::{blockdevice, node, pool, volume, CordonResources, GetResources, ScaleResources},
+    operations::{Cordoning, Drain, Get, GetBlockDevices, List, ReplicaTopology, Scale},
+    resources::{
+        blockdevice, cordon, drain, node, pool, volume, CordonResources, DrainResources,
+        GetCordonArgs, GetDrainArgs, GetResources, ScaleResources,
+    },
     rest_wrapper::RestClient,
 };
 use std::{env, path::PathBuf};
@@ -69,6 +72,18 @@ async fn execute(cli_args: CliArgs) {
     let fut = async move {
         match cli_args.operations {
             Operations::Get(resource) => match resource {
+                GetResources::Cordon(get_cordon_resource) => match get_cordon_resource {
+                    GetCordonArgs::Node { id: node_id } => {
+                        cordon::NodeCordon::get(&node_id, &cli_args.output).await
+                    }
+                    GetCordonArgs::Nodes => cordon::NodeCordons::list(&cli_args.output).await,
+                },
+                GetResources::Drain(get_drain_resource) => match get_drain_resource {
+                    GetDrainArgs::Node { id: node_id } => {
+                        drain::NodeDrain::get(&node_id, &cli_args.output).await
+                    }
+                    GetDrainArgs::Nodes => drain::NodeDrains::list(&cli_args.output).await,
+                },
                 GetResources::Volumes => volume::Volumes::list(&cli_args.output).await,
                 GetResources::Volume { id } => volume::Volume::get(&id, &cli_args.output).await,
                 GetResources::VolumeReplicaTopology { id } => {
@@ -78,16 +93,23 @@ async fn execute(cli_args: CliArgs) {
                 GetResources::Pool { id } => pool::Pool::get(&id, &cli_args.output).await,
                 GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
                 GetResources::Node(args) => {
-                    if args.show_cordon_labels() {
-                        node::Node::get_labels(&args.node_id(), &cli_args.output).await
-                    } else {
-                        node::Node::get(&args.node_id(), &cli_args.output).await
-                    }
+                    node::Node::get(&args.node_id(), &cli_args.output).await
                 }
                 GetResources::BlockDevices(bdargs) => {
                     blockdevice::BlockDevice::get_blockdevices(
                         &bdargs.node_id(),
                         &bdargs.all(),
+                        &cli_args.output,
+                    )
+                    .await
+                }
+            },
+            Operations::Drain(resource) => match resource {
+                DrainResources::Node(drain_node_args) => {
+                    node::Node::drain(
+                        &drain_node_args.node_id(),
+                        drain_node_args.label(),
+                        drain_node_args.drain_timeout(),
                         &cli_args.output,
                     )
                     .await

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -1,10 +1,13 @@
 use clap::Parser;
-use plugin::resources::{CordonResources, GetResources, ScaleResources};
+use plugin::resources::{CordonResources, DrainResources, GetResources, ScaleResources};
 use supportability::DumpArgs;
 
 /// The types of operations that are supported.
 #[derive(Parser, Debug)]
 pub enum Operations {
+    /// 'Drain' resources.
+    #[clap(subcommand)]
+    Drain(DrainResources),
     /// 'Get' resources.
     #[clap(subcommand)]
     Get(GetResources),


### PR DESCRIPTION
Signed-off-by: chriswldenyer <christopher.denyer@datacore.com>
Signed-off-by: chriswldenyer <christopher.denyer@mayadata.io>

Add APIs to drain a node.
Drain is not yet fully implemented - what is missing is the reconciler
that moves nexuses to another node, which is dependent on HA being
implemented.
With this PR, drain labels are now stored in the core agent and perform
the same cordoning function as cordon labels but also flag that a drain
is to be undertaken.
The Node object within the core-agent now includes a DrainState
enum variant which contains both cordon labels and drain labels.
This is controlled via the REST API but also by the reconciler,
when implemented.

The kubectl plugin initiates a drain via:
    kubectl-plugin drain node <node name> <drain label>
and cancels it via:
    kubectl-plugin uncordon node <node name> <drain label>

Two new get objects cordon and drain are implemented for the plugin.

    get cordon node <node id> # lists cordon information concerning the node
    get cordon nodes          # lists cordon information for all cordoned nodes
    get drain node <node id>  # lists drain information concerning the node
    get drain nodes           # as above but for all nodes with drain labels

Note: the "get node <node id> --show-cordon-labels" variant has been removed.