### PR TITLE
feat(Nexus HA): determination of nexus destination node on failover

### DIFF
--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -386,6 +386,7 @@ impl From<SvcError> for ReplyError {
                     NotEnough::OfPools { .. } => ResourceKind::Pool,
                     NotEnough::OfReplicas { .. } => ResourceKind::Replica,
                     NotEnough::OfNexuses { .. } => ResourceKind::Nexus,
+                    NotEnough::OfNodes { .. } => ResourceKind::Node,
                 },
                 source: desc.to_string(),
                 extra: error.full_string(),
@@ -634,4 +635,6 @@ pub enum NotEnough {
     OfReplicas { have: u64, need: u64 },
     #[snafu(display("Not enough nexuses available, {}/{}", have, need))]
     OfNexuses { have: u64, need: u64 },
+    #[snafu(display("Not enough nodes available, {}/{}", have, need))]
+    OfNodes { have: u64, need: u64 },
 }

--- a/control-plane/agents/core/src/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/core/src/controller/scheduling/resources/mod.rs
@@ -194,3 +194,20 @@ impl ChildItem {
         &self.pool_state
     }
 }
+
+/// Individual Node candidate which is a wrapper over nodewrapper used for filtering.
+#[derive(Clone)]
+pub(crate) struct NodeItem {
+    node_wrapper: NodeWrapper,
+}
+
+impl NodeItem {
+    /// Create a new node item with given `node_wrapper`.
+    pub(crate) fn new(node_wrapper: NodeWrapper) -> Self {
+        Self { node_wrapper }
+    }
+    /// Get the internal `node_wrapper` from `NodeItem`.
+    pub(crate) fn node_wrapper(&self) -> NodeWrapper {
+        self.node_wrapper.clone()
+    }
+}

--- a/control-plane/agents/core/src/controller/scheduling/volume.rs
+++ b/control-plane/agents/core/src/controller/scheduling/volume.rs
@@ -97,7 +97,7 @@ impl AddVolumeReplica {
             // fallback
             // 5. only one replica per node
             .filter(NodeFilters::cordoned)
-            .filter(NodeFilters::online)
+            .filter(NodeFilters::online_for_pool)
             .filter(NodeFilters::allowed)
             .filter(NodeFilters::unused)
             .filter(PoolFilters::usable)


### PR DESCRIPTION
This adds the node determination module in case of implicit failover, scheduling decision is made based on the following information:
- topology restrictions for volume.
- distribution of volumes across nodes (to provide equal volume distribution across nodes).

Signed-off-by: Abhinandan Purkait <abhinandan.purkait@mayadata.io>