### PR TITLE
feat(csi): decouple volume target from application

### DIFF
--- a/control-plane/agents/core/tests/pool/mod.rs
+++ b/control-plane/agents/core/tests/pool/mod.rs
@@ -770,7 +770,11 @@ async fn disown_unused_replicas() {
         .unwrap();
 
     let volume = volumes_api
-        .put_volume_target(&volume.spec.uuid, &node, models::VolumeShareProtocol::Nvmf)
+        .put_volume_target(
+            &volume.spec.uuid,
+            models::VolumeShareProtocol::Nvmf,
+            Some(&node),
+        )
         .await
         .unwrap();
 

--- a/control-plane/agents/core/tests/volume/garbage_collection.rs
+++ b/control-plane/agents/core/tests/volume/garbage_collection.rs
@@ -60,8 +60,8 @@ async fn deleting_volume_reconcile(cluster: &Cluster) {
         .publish(
             &PublishVolume {
                 uuid: volume.uuid().clone(),
-                target_node: None,
                 share: None,
+                target_node: None,
             },
             None,
         )
@@ -152,8 +152,8 @@ async fn offline_replicas_reconcile(cluster: &Cluster, reconcile_period: Duratio
     let volume = volumes_api
         .put_volume_target(
             &volume.spec.uuid,
-            &free_node,
             models::VolumeShareProtocol::Nvmf,
+            Some(&free_node),
         )
         .await
         .unwrap();
@@ -214,8 +214,8 @@ async fn unused_nexus_reconcile(cluster: &Cluster) {
     let volume = volumes_api
         .put_volume_target(
             &volume.spec.uuid,
-            cluster.node(0).as_str(),
             models::VolumeShareProtocol::Nvmf,
+            Some(cluster.node(0).as_str()),
         )
         .await
         .unwrap();
@@ -295,8 +295,8 @@ async fn unused_reconcile(cluster: &Cluster) {
     let volume = volumes_api
         .put_volume_target(
             &volume.spec.uuid,
-            nexus_node.id.as_str(),
             models::VolumeShareProtocol::Nvmf,
+            Some(nexus_node.id.as_str()),
         )
         .await
         .unwrap();
@@ -313,8 +313,8 @@ async fn unused_reconcile(cluster: &Cluster) {
     let volume = volumes_api
         .put_volume_target(
             &volume.spec.uuid,
-            unused_node.id.as_str(),
             models::VolumeShareProtocol::Nvmf,
+            Some(unused_node.id.as_str()),
         )
         .await
         .unwrap();
@@ -398,8 +398,8 @@ async fn missing_nexus_reconcile(cluster: &Cluster) {
     let volume = volumes_api
         .put_volume_target(
             &volume.spec().uuid,
-            cluster.node(0).as_str(),
             models::VolumeShareProtocol::Nvmf,
+            Some(cluster.node(0).as_str()),
         )
         .await
         .unwrap();

--- a/control-plane/csi-driver/controller/src/client.rs
+++ b/control-plane/csi-driver/controller/src/client.rs
@@ -134,6 +134,12 @@ impl IoEngineApiClient {
         Ok(response.into_body())
     }
 
+    /// Get a particular node available in IoEngine cluster.
+    pub(crate) async fn get_node(&self, node_id: &str) -> Result<Node, ApiClientError> {
+        let response = self.rest_client.nodes_api().get_node(node_id).await?;
+        Ok(response.into_body())
+    }
+
     /// List all pools available in IoEngine cluster.
     pub(crate) async fn list_pools(&self) -> Result<Vec<Pool>, ApiClientError> {
         let response = self.rest_client.pools_api().get_pools().await?;
@@ -181,7 +187,6 @@ impl IoEngineApiClient {
         replicas: u8,
         size: u64,
         volume_topology: CreateVolumeTopology,
-        _pinned_volume: bool,
         thin: bool,
     ) -> Result<Volume, ApiClientError> {
         let topology =
@@ -276,13 +281,13 @@ impl IoEngineApiClient {
     pub(crate) async fn publish_volume(
         &self,
         volume_id: &uuid::Uuid,
-        node: &str,
+        node: Option<&str>,
         protocol: VolumeShareProtocol,
     ) -> Result<Volume, ApiClientError> {
         let volume = self
             .rest_client
             .volumes_api()
-            .put_volume_target(volume_id, node, protocol)
+            .put_volume_target(volume_id, protocol, node)
             .await?;
         Ok(volume.into_body())
     }

--- a/control-plane/csi-driver/controller/src/config.rs
+++ b/control-plane/csi-driver/controller/src/config.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use clap::ArgMatches;
 use once_cell::sync::OnceCell;
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 static CONFIG: OnceCell<CsiControllerConfig> = OnceCell::new();
 
@@ -11,8 +11,6 @@ pub(crate) struct CsiControllerConfig {
     rest_endpoint: String,
     /// I/O timeout for REST API operations.
     io_timeout: Duration,
-    /// IO-Engine DaemonSet selector labels.
-    io_engine_selector: HashMap<String, String>,
 }
 
 impl CsiControllerConfig {
@@ -32,43 +30,11 @@ impl CsiControllerConfig {
             .context("I/O timeout must be specified")?
             .parse::<humantime::Duration>()?;
 
-        let io_engine_selector = {
-            let values = match args.values_of("io-engine-selector") {
-                Some(values) => values.map(ToString::to_string).collect::<Vec<_>>(),
-                None => vec![Self::default_io_selector()],
-            };
-            let values = values.iter().map(|source| match source.split_once(':') {
-                None => Err(anyhow::anyhow!(
-                    "Each io-engine-selector label must be in the format: 'Key=Value'"
-                )),
-                Some((key, value)) => Ok((key.to_string(), value.to_string())),
-            });
-            if let Some(error) = values.clone().find_map(|f| match f {
-                Ok(_) => None,
-                Err(error) => Some(error),
-            }) {
-                return Err(error);
-            }
-            values
-                .filter_map(|source| source.ok())
-                .collect::<HashMap<_, _>>()
-        };
-
         CONFIG.get_or_init(|| Self {
             rest_endpoint: rest_endpoint.into(),
             io_timeout: io_timeout.into(),
-            io_engine_selector,
         });
         Ok(())
-    }
-
-    /// Default IO-Engine DaemonSet selector label.
-    pub(crate) fn default_io_selector() -> String {
-        format!(
-            "{}:{}",
-            utils::IO_ENGINE_SELECTOR_KEY,
-            utils::IO_ENGINE_SELECTOR_VALUE
-        )
     }
 
     /// Get global instance of CSI controller config.
@@ -86,10 +52,5 @@ impl CsiControllerConfig {
     /// Get I/O timeout for REST API operations.
     pub(crate) fn io_timeout(&self) -> Duration {
         self.io_timeout
-    }
-
-    /// IO-Engine DaemonSet selector labels.
-    pub(crate) fn io_engine_selector(&self) -> HashMap<String, String> {
-        self.io_engine_selector.clone()
     }
 }

--- a/control-plane/csi-driver/controller/src/controller.rs
+++ b/control-plane/csi-driver/controller/src/controller.rs
@@ -382,9 +382,10 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                 // if the csi-node happens to be a data-plane node, use that for nexus creation, otherwise
                 // let the control-plane select the target node.
                 let target_node = match IoEngineApiClient::get_client().get_node(&node_id).await {
-                    Err(ApiClientError::ResourceNotExists(_)) => None,
-                    _ => Some(node_id.as_str()),
-                };
+                    Err(ApiClientError::ResourceNotExists(_)) => Ok(None),
+                    Err(error) => Err(error),
+                    Ok(_) => Ok(Some(node_id.as_str())),
+                }?;
 
                 // Volume is not published.
                 let v = IoEngineApiClient::get_client()

--- a/control-plane/csi-driver/controller/src/main.rs
+++ b/control-plane/csi-driver/controller/src/main.rs
@@ -24,7 +24,6 @@ fn initialize_controller(args: &ArgMatches) -> anyhow::Result<()> {
 
 #[tokio::main(worker_threads = 2)]
 async fn main() -> anyhow::Result<()> {
-    let default_io_selector = CsiControllerConfig::default_io_selector();
     let args = App::new(utils::package_description!())
         .author(clap::crate_authors!())
         .version(utils::version_info_str!())
@@ -61,18 +60,6 @@ async fn main() -> anyhow::Result<()> {
                 .long("rest-timeout")
                 .env("REST_TIMEOUT")
                 .default_value("5s"),
-        )
-        .arg(
-            Arg::with_name("io-engine-selector")
-                .long("io-engine-selector")
-                .multiple(true)
-                .number_of_values(1)
-                .allow_hyphen_values(true)
-                .default_value(&default_io_selector)
-                .help(
-                    "Adds io-engine selector labels (supports multiple values).\n\
-                Example:\n --io-engine-selector key:value --io-engine-selector key2:value2",
-                ),
         )
         .get_matches();
 

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1400,7 +1400,6 @@ paths:
             The node where the front-end workload resides.
             If the workload moves then the volume must be republished.
           name: node
-          required: true
           schema:
             $ref: '#/components/schemas/NodeId'
         - in: query

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -128,13 +128,13 @@ impl apis::actix_server::Volumes for RestApi {
 
     async fn put_volume_target(
         Path(volume_id): Path<Uuid>,
-        Query((node, protocol)): Query<(String, VolumeShareProtocol)>,
+        Query((node, protocol)): Query<(Option<String>, VolumeShareProtocol)>,
     ) -> Result<models::Volume, RestError<RestJsonError>> {
         let volume = client()
             .publish(
                 &PublishVolume {
                     uuid: volume_id.into(),
-                    target_node: Some(node.into()),
+                    target_node: node.map(|id| id.into()),
                     share: Some(protocol.into()),
                 },
                 None,

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -283,8 +283,8 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
         .volumes_api()
         .put_volume_target(
             &volume.state.uuid,
-            io_engine1.as_str(),
             models::VolumeShareProtocol::Nvmf,
+            Some(io_engine1.as_str()),
         )
         .await
         .unwrap();

--- a/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
+++ b/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
@@ -117,7 +117,7 @@ def background():
         VOLUME_UUID, CreateVolumeBody(VolumePolicy(False), 1, VOLUME_SIZE, False)
     )
     volume = ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, TARGET_NODE_1, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=TARGET_NODE_1
     )
     yield volume
     Deployer.stop()
@@ -167,7 +167,7 @@ def publish_to_node_2(background):
 
     ApiClient.volumes_api().del_volume_target(VOLUME_UUID, force="true")
     volume_updated = ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, TARGET_NODE_2, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=TARGET_NODE_2
     )
     device_uri_2 = volume_updated.state["target"]["deviceUri"]
     assert device_uri != device_uri_2

--- a/tests/bdd/features/csi/controller/controller.feature
+++ b/tests/bdd/features/csi/controller/controller.feature
@@ -102,21 +102,12 @@ Scenario: create 1 replica local nvmf volume
     Then a new local volume of requested size should be successfully created
     And local volume must be accessible only from all existing Io-Engine nodes
 
-Scenario: unpinned volume creation
-    Given 2 Io-Engine nodes with one pool on each node
-    When a CreateVolume request is sent to create a 1 replica nvmf volume (local=false)
-    Then volume creation should fail with invalid argument
-
-    Given 2 Io-Engine nodes with one pool on each node
-    When a CreateVolume request is sent to create a 1 replica nvmf volume (local unset)
-    Then volume creation should fail with invalid argument
-
 Scenario: list local volume
     Given 2 existing volumes
     Given an existing unpublished local volume
     When a ListVolumesRequest is sent to CSI controller
     Then listed local volume must be accessible only from all existing Io-Engine nodes
-    And no topology restrictions should be imposed to non-local volumes
+    And no topology restrictions should be imposed to volumes
 
 Scenario: unpublish volume when nexus node is offline
     Given a volume published on a node

--- a/tests/bdd/features/csi/node/test_csi.py
+++ b/tests/bdd/features/csi/node/test_csi.py
@@ -145,7 +145,9 @@ def volume_id(fs_type):
 @pytest.fixture
 def published_nexus(volumes, share_type, volume_id):
     uuid = volume_id
-    volume = ApiClient.volumes_api().put_volume_target(uuid, NODE1, Protocol("nvmf"))
+    volume = ApiClient.volumes_api().put_volume_target(
+        uuid, Protocol("nvmf"), node=NODE1
+    )
     yield volume.state["target"]
     ApiClient.volumes_api().del_volume_target(volume.spec.uuid)
 

--- a/tests/bdd/features/csi/node/test_node.py
+++ b/tests/bdd/features/csi/node/test_node.py
@@ -284,7 +284,7 @@ def published_nexuses(setup, volumes):
 def publish_nexus(setup, volumes, published_nexuses):
     def publish(uuid, protocol):
         volume = ApiClient.volumes_api().put_volume_target(
-            uuid, NODE1, Protocol("nvmf")
+            uuid, Protocol("nvmf"), node=NODE1
         )
         nexus = Nexus(uuid, protocol, volume.state["target"]["deviceUri"])
         published_nexuses[uuid] = nexus

--- a/tests/bdd/features/csi/node/test_parameters.py
+++ b/tests/bdd/features/csi/node/test_parameters.py
@@ -78,7 +78,7 @@ def staging_a_volume(staging_target_path, csi_instance, block_volume_capability)
         VOLUME_UUID, CreateVolumeBody(VolumePolicy(False), 1, 10241024, False)
     )
     volume = ApiClient.volumes_api().put_volume_target(
-        volume.spec.uuid, NODE1, Protocol("nvmf")
+        volume.spec.uuid, Protocol("nvmf"), node=NODE1
     )
     device_uri = volume.state["target"]["deviceUri"]
     print(device_uri)

--- a/tests/bdd/features/garbage-collection/replicas/test_feature.py
+++ b/tests/bdd/features/garbage-collection/replicas/test_feature.py
@@ -76,7 +76,7 @@ def init(create_pool_disk_images):
     )
     ApiClient.volumes_api().put_volume(VOLUME_UUID, request)
     ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, IO_ENGINE_1, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=IO_ENGINE_1
     )
 
     yield

--- a/tests/bdd/features/rebuild/test_rebuild.py
+++ b/tests/bdd/features/rebuild/test_rebuild.py
@@ -87,7 +87,7 @@ def an_existing_published_volume():
     )
     ApiClient.volumes_api().put_volume(VOLUME_UUID, request)
     ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_1_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE_1_NAME
     )
 
     # Now the volume has been created, create the additional pool.

--- a/tests/bdd/features/volume/delete/test_feature.py
+++ b/tests/bdd/features/volume/delete/test_feature.py
@@ -92,7 +92,7 @@ def a_volume_that_is_not_sharedpublished(volume_ctx):
 def a_volume_that_is_sharedpublished():
     """a volume that is shared/published."""
     volume = ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE1_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE1_NAME
     )
     assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))
 

--- a/tests/bdd/features/volume/nexus-info/test_feature.py
+++ b/tests/bdd/features/volume/nexus-info/test_feature.py
@@ -156,7 +156,7 @@ def an_existing_volume():
 # Publish the volume
 def publish_volume():
     volume = ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE_NAME
     )
     assert hasattr(volume.state, "target")
     return volume

--- a/tests/bdd/features/volume/nexus/test_feature.py
+++ b/tests/bdd/features/volume/nexus/test_feature.py
@@ -47,7 +47,7 @@ def a_published_selfhealing_volume():
     )
     ApiClient.volumes_api().put_volume(VOLUME_UUID, request)
     ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, IO_ENGINE_1, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=IO_ENGINE_1
     )
 
 

--- a/tests/bdd/features/volume/publish/test_feature.py
+++ b/tests/bdd/features/volume/publish/test_feature.py
@@ -54,7 +54,7 @@ def test_sharepublish_an_already_sharedpublished_volume():
 def a_published_volume():
     """a published volume."""
     volume = ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE_NAME
     )
     assert hasattr(volume.spec, "target")
     assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))
@@ -77,7 +77,7 @@ def publishing_the_volume_should_return_an_already_published_error():
     """publishing the volume should return an already published error."""
     try:
         ApiClient.volumes_api().put_volume_target(
-            VOLUME_UUID, NODE_NAME, Protocol("nvmf")
+            VOLUME_UUID, Protocol("nvmf"), node=NODE_NAME
         )
     except Exception as e:
         exception_info = e.__dict__
@@ -91,7 +91,7 @@ def publishing_the_volume_should_return_an_already_published_error():
 def publishing_the_volume_should_succeed_with_a_returned_volume_object_containing_the_share_uri():
     """publishing the volume should succeed with a returned volume object containing the share URI."""
     volume = ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE_NAME
     )
     assert hasattr(volume.spec, "target")
     assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))

--- a/tests/bdd/features/volume/replicas/test_feature.py
+++ b/tests/bdd/features/volume/replicas/test_feature.py
@@ -71,7 +71,7 @@ def init_resources():
     )
     # Publish volume so that there is a nexus to add a replica to.
     volume = ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_1_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE_1_NAME
     )
     assert hasattr(volume.spec, "target")
     assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))

--- a/tests/bdd/features/volume/topology/test_feature.py
+++ b/tests/bdd/features/volume/topology/test_feature.py
@@ -218,7 +218,7 @@ def an_existing_published_volume_without_pool_topology():
     )
     # Publish volume so that there is a nexus to add a replica to.
     ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_1_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE_1_NAME
     )
 
 
@@ -252,7 +252,7 @@ def an_existing_published_volume_with_a_topology_matching_pool_labels():
     )
     # Publish volume so that there is a nexus to add a replica to.
     ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_1_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE_1_NAME
     )
 
 
@@ -278,7 +278,7 @@ def an_existing_published_volume_with_a_topology_not_matching_pool_labels():
     )
     # Publish volume so that there is a nexus to add a replica to.
     ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_1_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE_1_NAME
     )
 
 

--- a/tests/bdd/features/volume/unpublish/test_feature.py
+++ b/tests/bdd/features/volume/unpublish/test_feature.py
@@ -54,7 +54,7 @@ def test_unpublish_an_already_unpublished_volume():
 def a_published_volume():
     """a published volume."""
     volume = ApiClient.volumes_api().put_volume_target(
-        VOLUME_UUID, NODE_NAME, Protocol("nvmf")
+        VOLUME_UUID, Protocol("nvmf"), node=NODE_NAME
     )
     assert hasattr(volume.spec, "target")
     assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))

--- a/tests/io-engine/tests/rebuild.rs
+++ b/tests/io-engine/tests/rebuild.rs
@@ -47,8 +47,8 @@ async fn concurrent_rebuilds() {
         let volume = vol_cli
             .put_volume_target(
                 &volume.spec.uuid,
-                cluster.node(i).as_str(),
                 models::VolumeShareProtocol::Nvmf,
+                Some(cluster.node(i).as_str()),
             )
             .await
             .unwrap();

--- a/utils/pstor-usage/src/volumes.rs
+++ b/utils/pstor-usage/src/volumes.rs
@@ -83,8 +83,8 @@ impl ResourceUpdates for Vec<models::Volume> {
                 .volumes_api()
                 .put_volume_target(
                     &volume.spec.uuid,
-                    node_id,
                     models::VolumeShareProtocol::Nvmf,
+                    Some(node_id.as_str()),
                 )
                 .await?;
             node_index = (node_index + 1) % node_ids.len();

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -17,11 +17,6 @@ pub const STORE_LEASE_LOCK_TTL: &str = "30s";
 /// Io-Engine container image used for testing
 pub const IO_ENGINE_IMAGE: &str = "mayadata/mayastor-io-engine:develop";
 
-/// IO-Engine node selector label key.
-pub const IO_ENGINE_SELECTOR_KEY: &str = "openebs.io/engine";
-/// IO-Engine node selector label value.
-pub const IO_ENGINE_SELECTOR_VALUE: &str = "io-engine";
-
 /// Environment variable that points to an io-engine binary
 /// This must be in sync with shell.nix
 pub const DATA_PLANE_BINARY: &str = "IO_ENGINE_BIN";


### PR DESCRIPTION
As of now volume targets are always created on the same node where the application lives.
With the addition of HA w’ll be able to switch the nvmf target at the application node level, so we can now allow the target to live on any io-engine node in the cluster. This PR enables that change.

Signed-off-by: Abhinandan Purkait <abhinandan.purkait@mayadata.io>