### PR TITLE
feat(ha-agent): path replacement grpc api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "rpc",
  "serde",
  "serde_json",
+ "shutdown",
  "snafu",
  "state",
  "structopt",

--- a/common/src/transport_api/mod.rs
+++ b/common/src/transport_api/mod.rs
@@ -273,6 +273,15 @@ impl ReplyError {
             extra: msg,
         }
     }
+    /// for internal errors.
+    pub fn internal_error(resource: ResourceKind, source: String, extra: String) -> Self {
+        Self {
+            kind: ReplyErrorKind::Internal,
+            resource,
+            source,
+            extra,
+        }
+    }
 }
 
 impl std::fmt::Display for ReplyError {

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -62,6 +62,7 @@ nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
 futures-util = { version = "0.3.21" }
 tokio-stream = { version = "0.1.9" }
 crossbeam-queue = "0.3.6"
+shutdown = { path = "../../utils/shutdown" }
 
 # Tracing
 opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio-current-thread"] }

--- a/control-plane/agents/ha-node/src/detector.rs
+++ b/control-plane/agents/ha-node/src/detector.rs
@@ -4,8 +4,11 @@ use crate::{
     Cli,
 };
 use nvmeadm::nvmf_subsystem::Subsystem;
-use std::{collections::HashMap, rc::Rc};
-use tokio::time::{sleep, Duration};
+use std::{collections::HashMap, convert::From, rc::Rc, sync::Arc};
+use tokio::{
+    sync::mpsc::{channel, Receiver, Sender},
+    time::{sleep, Duration},
+};
 
 /// Possible states of every path record.
 #[derive(Debug, Clone)]
@@ -28,14 +31,16 @@ struct PathRecord {
     epoch: u64,
     nqn: String,
     state: PathState,
+    path: String,
     reporter: Rc<PathReporter>,
 }
 
 impl PathRecord {
-    fn new(nqn: String, epoch: u64, reporter: Rc<PathReporter>) -> Self {
+    fn new(nqn: String, epoch: u64, path: String, reporter: Rc<PathReporter>) -> Self {
         Self {
             nqn,
             epoch,
+            path,
             state: PathState::Good,
             reporter,
         }
@@ -84,6 +89,57 @@ impl PathRecord {
     }
 }
 
+/// Front-end API client for NVMe cache.
+/// Clients use this API client to query cached NVMe controllers.
+#[derive(Clone)]
+pub struct NvmePathCache {
+    channel: Arc<Sender<NvmeCacheMessage>>,
+}
+
+impl NvmePathCache {
+    fn new(channel: Arc<Sender<NvmeCacheMessage>>) -> Self {
+        Self { channel }
+    }
+}
+
+/// Cached NVMe controller object.
+#[derive(Debug)]
+pub(crate) struct NvmeController {
+    pub _nqn: String,
+    pub path: String,
+}
+
+impl NvmeController {
+    /// Instantiate Nvme controller for given NQN and system path.
+    fn new(nqn: String, path: String) -> Self {
+        Self { _nqn: nqn, path }
+    }
+}
+
+impl From<&PathRecord> for NvmeController {
+    fn from(v: &PathRecord) -> Self {
+        Self::new(v.nqn.clone(), v.path.clone())
+    }
+}
+
+/// Command for querying NVMe path cache.
+#[derive(Debug)]
+enum NvmePathCacheCommand {
+    LookupNvmeController(String),
+}
+
+/// Response objects for NVMe cache commands.
+enum NvmePathCacheCommandResponse {
+    /// Negative response, contains extended information about failure.
+    Nack(String),
+    /// Cached instance of an NVMe controller available in the system.
+    CachedNvmeController(NvmeController),
+}
+
+/// Messsage sent to NVMe cache from a cache client: client passes a channel
+/// to receive a response from the cache.
+type NvmeCacheMessage = (NvmePathCacheCommand, Sender<NvmePathCacheCommandResponse>);
+
 /// Path failure detector for NVMe paths.
 /// All known NVMe paths on system are periodically checked for liveness and get classified
 /// as:
@@ -98,6 +154,8 @@ pub struct PathFailureDetector {
     detection_period: Duration,
     suspected_paths: HashMap<String, PathRecord>,
     reporter: Rc<PathReporter>,
+    cache_channel_rx: Receiver<NvmeCacheMessage>,
+    cache_channel_tx: Arc<Sender<NvmeCacheMessage>>,
 }
 
 impl PathFailureDetector {
@@ -108,11 +166,15 @@ impl PathFailureDetector {
             *args.aggregation_period,
         );
 
+        let (tx, rx) = channel(64);
+
         Ok(Self {
             epoch: 0,
             detection_period: *args.detection_period,
             suspected_paths: HashMap::new(),
             reporter: Rc::new(reporter),
+            cache_channel_tx: Arc::new(tx),
+            cache_channel_rx: rx,
         })
     }
 
@@ -122,40 +184,41 @@ impl PathFailureDetector {
 
         // Scan all reported NVMe paths on system and check for connectivity.
         for ctrlr in path_collection.get_entries() {
-            match Subsystem::new(ctrlr.path()) {
-                Ok(subsystem) => {
-                    let existing_record = match subsystem.state.as_str() {
-                        "connecting" => {
-                            // Add a new record in case no record exists for target NQN.
-                            if !self.suspected_paths.contains_key(&subsystem.nqn) {
-                                self.suspected_paths.insert(
+            // Silently ignore errors when we can't get a subsystem for target path,
+            // as we might see lots of false-positive errors when removing a failed path
+            // from a multi-pathed NVMe subsystem.
+            if let Ok(subsystem) = Subsystem::new(ctrlr.path()) {
+                let existing_record = match subsystem.state.as_str() {
+                    "connecting" => {
+                        // Add a new record in case no record exists for target NQN.
+                        if !self.suspected_paths.contains_key(&subsystem.nqn) {
+                            let path = ctrlr.path().to_string_lossy().to_string();
+
+                            self.suspected_paths.insert(
+                                subsystem.nqn.clone(),
+                                PathRecord::new(
                                     subsystem.nqn.clone(),
-                                    PathRecord::new(
-                                        subsystem.nqn.clone(),
-                                        self.epoch,
-                                        self.reporter.clone(),
-                                    ),
-                                );
-                            }
-
-                            let rec = self.suspected_paths.get_mut(&subsystem.nqn).unwrap();
-                            rec.report_connecting();
-                            Some(rec)
+                                    self.epoch,
+                                    path,
+                                    self.reporter.clone(),
+                                ),
+                            );
                         }
-                        "live" => self.suspected_paths.get_mut(&subsystem.nqn).map(|rec| {
-                            rec.report_live();
-                            rec
-                        }),
-                        _ => None,
-                    };
 
-                    // Update epoch for the existing record.
-                    if let Some(rec) = existing_record {
-                        rec.set_epoch(self.epoch);
+                        let rec = self.suspected_paths.get_mut(&subsystem.nqn).unwrap();
+                        rec.report_connecting();
+                        Some(rec)
                     }
-                }
-                Err(e) => {
-                    tracing::error!("Failed to get status for NVMe path: {}", e);
+                    "live" => self.suspected_paths.get_mut(&subsystem.nqn).map(|rec| {
+                        rec.report_live();
+                        rec
+                    }),
+                    _ => None,
+                };
+
+                // Update epoch for the existing record.
+                if let Some(rec) = existing_record {
+                    rec.set_epoch(self.epoch);
                 }
             }
         }
@@ -173,9 +236,26 @@ impl PathFailureDetector {
         }
 
         if !to_remove.is_empty() {
-            for k in to_remove {
-                self.suspected_paths.remove(&k);
-                tracing::debug!("Removing stalled path record for NQN {}", k);
+            for nqn in to_remove {
+                self.suspected_paths.remove(&nqn);
+                tracing::debug!(nqn, "Removing stalled NQN path");
+            }
+        }
+    }
+
+    /// Handle command for NVMe cache.
+    fn handle_cache_command(&self, cmd: NvmePathCacheCommand) -> NvmePathCacheCommandResponse {
+        match cmd {
+            NvmePathCacheCommand::LookupNvmeController(nqn) => {
+                match self.suspected_paths.get(&nqn) {
+                    Some(c) => {
+                        NvmePathCacheCommandResponse::CachedNvmeController(NvmeController::from(c))
+                    }
+                    None => NvmePathCacheCommandResponse::Nack(format!(
+                        "No NVMe cache record for NQN {}",
+                        nqn
+                    )),
+                }
             }
         }
     }
@@ -194,15 +274,58 @@ impl PathFailureDetector {
 
         loop {
             tokio::select! {
+                // Path-provider loop, should not complete.
                 _ = &mut start => {
                     tracing::warn!("NVMe path provider completed, stopping error detection");
                     break;
                 },
+
+                // Path rescan loop.
                 _ = sleep(self.detection_period) => self.rescan_paths(&mut path_collection),
+
+                // Cache command loop.
+                msg = self.cache_channel_rx.recv() => {
+                    match msg {
+                        Some((cmd, sender)) => {
+                            if let Err(error) = sender
+                                .send(self.handle_cache_command(cmd))
+                                .await {
+                                    tracing::error!(%error,"Failed to send response to cache client");
+                                }
+                        },
+                        None => {
+                            tracing::error!("Empty command for NVMe path cache, ignoring");
+                        }
+                    }
+                }
             }
         }
 
         tracing::info!("Stopping NVMe path error detection loop");
         Ok(())
+    }
+
+    /// Instantiate Nvme cache front-end.
+    pub fn get_cache(&self) -> NvmePathCache {
+        NvmePathCache::new(self.cache_channel_tx.clone())
+    }
+}
+
+impl NvmePathCache {
+    pub(crate) async fn lookup_controller(&self, nqn: String) -> anyhow::Result<NvmeController> {
+        let (tx, mut rx) = channel(1);
+
+        self.channel
+            .send((NvmePathCacheCommand::LookupNvmeController(nqn.clone()), tx))
+            .await
+            .map_err(|_| anyhow::Error::msg("No Nvme cache available"))?;
+
+        match rx.recv().await {
+            Some(NvmePathCacheCommandResponse::CachedNvmeController(ctrlr)) => Ok(ctrlr),
+            _ => Err(anyhow::Error::msg(format!(
+                "Can't find Nvme controller for NQN: {}",
+                nqn
+            ))),
+        }
     }
 }

--- a/control-plane/agents/ha-node/src/path_provider.rs
+++ b/control-plane/agents/ha-node/src/path_provider.rs
@@ -33,7 +33,7 @@ impl NvmePath {
 
 /// Check that NVMe path represents a target created by our product and
 /// obtain a Path object that represents a system path for this NVMe device.
-fn get_nvme_path_buf(path: &String) -> Option<PathBuf> {
+pub fn get_nvme_path_buf(path: &String) -> Option<PathBuf> {
     Path::new(path).canonicalize().ok().and_then(|pb| {
         Subsystem::new(pb.as_path()).ok().and_then(|s| {
             // Check NQN of the subsystem to make sure it belongs to the product.

--- a/control-plane/agents/ha-node/src/server.rs
+++ b/control-plane/agents/ha-node/src/server.rs
@@ -1,0 +1,244 @@
+use crate::{
+    detector::{NvmeController, NvmePathCache},
+    path_provider::get_nvme_path_buf,
+};
+use anyhow::anyhow;
+use common::errors::SvcError;
+use common_lib::transport_api::{ReplyError, ResourceKind};
+use grpc::operations::ha_node::{
+    server::NodeAgentServer,
+    traits::{NodeAgentOperations, ReplacePathInfo},
+};
+use http::Uri;
+use nvmeadm::{
+    nvmf_discovery::{ConnectArgs, ConnectArgsBuilder},
+    nvmf_subsystem::Subsystem,
+};
+use std::{net::SocketAddr, sync::Arc};
+use tokio::time::{sleep, Duration};
+use tonic::transport::Server;
+use utils::NVME_TARGET_NQN_PREFIX;
+
+/// Common error source name for all gRPC errors in HA Node agent.
+const HA_AGENT_ERR_SOURCE: &str = "HA Node agent gRPC server";
+
+/// NVMe subsystem refresh interval when monitoring its state, in milliseconds.
+const SUBSYSTEM_STATE_REFRESH_INTERVAL_MS: u64 = 500;
+
+/// High-level object that represents HA Node agent gRPC server.
+pub struct NodeAgentApiServer {
+    endpoint: SocketAddr,
+    path_cache: NvmePathCache,
+}
+
+impl NodeAgentApiServer {
+    pub fn new(uri: Uri, path_cache: NvmePathCache) -> Self {
+        let endpoint = uri.authority().unwrap().to_string().parse().unwrap();
+
+        Self {
+            endpoint,
+            path_cache,
+        }
+    }
+
+    pub async fn serve(&self) -> anyhow::Result<()> {
+        let r = NodeAgentServer::new(Arc::new(NodeAgentSvc::new(self.path_cache.clone())));
+        tracing::info!("Starting gRPC server at {:?}", self.endpoint);
+        Server::builder()
+            .add_service(r.into_grpc_server())
+            .serve_with_shutdown(self.endpoint, async move {
+                let _ = shutdown::Shutdown::wait().await;
+            })
+            .await
+            .map_err(|err| anyhow!("Failed to start gRPC server: {err}"))
+    }
+}
+
+/// gRPC server implementation for HA Node agent.
+struct NodeAgentSvc {
+    path_cache: NvmePathCache,
+}
+
+impl NodeAgentSvc {
+    pub fn new(path_cache: NvmePathCache) -> Self {
+        Self { path_cache }
+    }
+}
+
+/// Disconnect cached NVMe controller.
+fn disconnect_controller(ctrlr: &NvmeController) -> Result<(), SvcError> {
+    match get_nvme_path_buf(&ctrlr.path) {
+        Some(pbuf) => {
+            let subsystem = Subsystem::new(pbuf.as_path()).map_err(|_| SvcError::Internal {
+                details: "Failed to get NVMe subsystem for controller".to_string(),
+            })?;
+
+            tracing::info!(
+                path=%ctrlr.path,
+                "Disconnecting NVMe controller"
+            );
+
+            subsystem.disconnect().map_err(|e| SvcError::Internal {
+                details: format!(
+                    "Failed to disconnect NVMe controller {}: {:?}",
+                    ctrlr.path, e,
+                ),
+            })
+        }
+        None => {
+            tracing::error!(
+                path=%ctrlr.path,
+                "Failed to get system path for controller"
+            );
+
+            Err(SvcError::Internal {
+                details: "Failed to get system path for controller".to_string(),
+            })
+        }
+    }
+}
+
+impl NodeAgentSvc {
+    /// Translate new path URI into connection arguments for Subsystem connect API.
+    fn get_nvmf_connection_args(&self, new_path: &str) -> Option<ConnectArgs> {
+        let uri = new_path.parse::<Uri>().ok()?;
+
+        let host = uri.host()?;
+        let port = uri.port()?.to_string();
+        let nqn = &uri.path()[1 ..];
+
+        // Check NQN of the subsystem to make sure it belongs to the product.
+        if !nqn.starts_with(NVME_TARGET_NQN_PREFIX) {
+            return None;
+        }
+
+        ConnectArgsBuilder::default()
+            .traddr(host)
+            .trsvcid(port)
+            .nqn(nqn)
+            .ctrl_loss_tmo(Some(5))
+            .reconnect_delay(Some(10))
+            .build()
+            .ok()
+    }
+
+    /// Connect NVMe controller. Wait till the controller is fully connected.
+    async fn connect_controller(&self, new_path: String) -> Result<(), SvcError> {
+        let connect_args = match self.get_nvmf_connection_args(&new_path) {
+            Some(ca) => ca,
+            None => return Err(SvcError::InvalidArguments {}),
+        };
+
+        tracing::info!(new_path, "Connecting to NVMe target");
+
+        // Open connection to the new nexus: ANA will automatically create
+        // the second path and add it as an alternative for the first broken one,
+        // which immediately resumes all stalled I/O.
+        let mut subsystem = match connect_args.connect() {
+            Ok(c) => {
+                tracing::info!(new_path, "Successfully connected to NVMe target");
+                c
+            }
+            Err(error) => {
+                tracing::error!(
+                    new_path,
+                    error=%error,
+                    "Failed to connect to NVMe target"
+                );
+                return Err(SvcError::Internal {
+                    details: "Failed to connect to NVMe target".to_string(),
+                });
+            }
+        };
+
+        // Wait till new controller is fully connected before completing the call.
+        // Straight after connection subsystem transitions into 'new' state, then
+        // proceeds to 'connecting' till the connection is fully established,
+        // so wait a bit before checking the state.
+        loop {
+            sleep(Duration::from_millis(SUBSYSTEM_STATE_REFRESH_INTERVAL_MS)).await;
+
+            // Refresh subsystem to get the latest state.
+            if let Err(error) = subsystem.sync() {
+                tracing::error!(
+                    new_path,
+                    error=%error,
+                    "Failed to synchronize NVMe subsystem state"
+                );
+                // Just log error and exit, since such a situation can take
+                // place when the path is explicitly removed by user.
+                break;
+            }
+
+            // TODO: consider max retries to prevent controller from
+            // not reaching 'live' state.
+            match subsystem.state.as_str() {
+                "connecting" | "new" => {
+                    tracing::info!(
+                        new_path,
+                        state = "connecting",
+                        "New NVMe path is not ready to serve I/O, waiting."
+                    );
+                }
+                "live" => {
+                    tracing::info!(new_path, "New NVMe path is ready to serve I/O");
+                    break;
+                }
+                _ => {
+                    tracing::error!(
+                        new_path,
+                        state = subsystem.state.as_str(),
+                        "New NVMe path is in incorrect state"
+                    );
+                    return Err(SvcError::Internal {
+                        details: format!(
+                            "New NVMe path is in incorrect state: {}",
+                            subsystem.state.as_str()
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[tonic::async_trait]
+impl NodeAgentOperations for NodeAgentSvc {
+    async fn replace_path(&self, request: &dyn ReplacePathInfo) -> Result<(), ReplyError> {
+        tracing::info!("Replacing failed NVMe path: {:?}", request);
+
+        // Lookup NVMe controller whose path has failed.
+        let ctrlr = self
+            .path_cache
+            .lookup_controller(request.target_nqn())
+            .await
+            .map_err(|_| {
+                ReplyError::internal_error(
+                    ResourceKind::Nexus,
+                    HA_AGENT_ERR_SOURCE.to_string(),
+                    "Failed to lookup controller".to_string(),
+                )
+            })?;
+
+        // Step 1: populate an aditional healthy path to target NQN in addition to
+        // existing failed path. Once this additional path is created, client I/O
+        // automatically resumes.
+        self.connect_controller(request.new_path()).await?;
+
+        // Step 2: disconnect broken path to leave the only new healthy path.
+        // Note that errors under disconnection are not critical, since the second I/O
+        // path has been successfully created, so having the first failed path in addition
+        // to the second healthy one is OK: just display a warning and proceed as if
+        // the call has completed successfully.
+        disconnect_controller(&ctrlr).or_else(|e| {
+            tracing::warn!(
+                uri=%request.new_path(),
+                error=%e,
+                "Failed to disconnect failed path"
+            );
+            Ok(())
+        })
+    }
+}

--- a/control-plane/grpc/proto/v1/ha/cluster_agent.proto
+++ b/control-plane/grpc/proto/v1/ha/cluster_agent.proto
@@ -30,3 +30,17 @@ message ReportFailedNvmePathsRequest {
   // List of failed
   repeated FailedNvmePath failed_paths = 4;
 }
+
+// Service for managing node-agent rpc calls
+service HaNodeRpc {
+  rpc ReplacePath (ReplacePathRequest) returns (google.protobuf.Empty) {}
+}
+
+// Path replacement message.
+message ReplacePathRequest {
+  // NQN of the target
+  string target_nqn = 1;
+
+  // URI of the new path
+  string new_path = 2;
+}

--- a/control-plane/grpc/src/operations/ha_node/server.rs
+++ b/control-plane/grpc/src/operations/ha_node/server.rs
@@ -2,12 +2,48 @@ use tonic::{Response, Status};
 
 use crate::{
     ha_cluster_agent::{
+        ha_node_rpc_server::{HaNodeRpc, HaNodeRpcServer},
         ha_rpc_server::{HaRpc, HaRpcServer},
-        HaNodeInfo, ReportFailedNvmePathsRequest,
+        HaNodeInfo, ReplacePathRequest, ReportFailedNvmePathsRequest,
     },
-    operations::ha_node::traits::ClusterAgentOperations,
+    operations::ha_node::traits::{ClusterAgentOperations, NodeAgentOperations},
 };
 use std::sync::Arc;
+
+/// RPC cluster-node server
+pub struct NodeAgentServer {
+    service: Arc<dyn NodeAgentOperations>,
+}
+
+impl NodeAgentServer {
+    /// returns a new cluster-agent server with the service implementing cluster-agent operations
+    pub fn new(svc: Arc<dyn NodeAgentOperations>) -> Self {
+        Self { service: svc }
+    }
+
+    /// converts the node-agent server to corresponding grpc server type
+    pub fn into_grpc_server(self) -> HaNodeRpcServer<Self> {
+        HaNodeRpcServer::new(self)
+    }
+}
+
+#[tonic::async_trait]
+impl HaNodeRpc for NodeAgentServer {
+    async fn replace_path(
+        &self,
+        request: tonic::Request<ReplacePathRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        let msg = request.into_inner();
+
+        match self.service.replace_path(&msg).await {
+            Ok(_) => Ok(Response::new(())),
+            Err(err) => Err(Status::internal(format!(
+                "Failed to replace failed NVMe path: {:?}",
+                err
+            ))),
+        }
+    }
+}
 
 /// RPC cluster-agent server
 pub struct ClusterAgentServer {

--- a/control-plane/grpc/src/operations/ha_node/traits.rs
+++ b/control-plane/grpc/src/operations/ha_node/traits.rs
@@ -1,9 +1,37 @@
-use crate::ha_cluster_agent::{FailedNvmePath, HaNodeInfo, ReportFailedNvmePathsRequest};
+use crate::ha_cluster_agent::{
+    FailedNvmePath, HaNodeInfo, ReplacePathRequest, ReportFailedNvmePathsRequest,
+};
 use common_lib::{
     transport_api::ReplyError,
     types::v0::transport::{cluster_agent::NodeAgentInfo, FailedPath, ReportFailedPaths},
     IntoVec,
 };
+
+/// NodeAgentOperations trait implemented by client which supports cluster-agent operations
+#[tonic::async_trait]
+pub trait NodeAgentOperations: Send + Sync {
+    /// Replace failed NVMe path for target NQN.
+    async fn replace_path(&self, request: &dyn ReplacePathInfo) -> Result<(), ReplyError>;
+}
+
+/// ReplacePathInfo trait for the failed path replacement to be implemented by entities
+/// which want to use this operation.
+pub trait ReplacePathInfo: Send + Sync + std::fmt::Debug {
+    /// NQN of the target
+    fn target_nqn(&self) -> String;
+    /// URI of the new path
+    fn new_path(&self) -> String;
+}
+
+impl ReplacePathInfo for ReplacePathRequest {
+    fn target_nqn(&self) -> String {
+        self.target_nqn.clone()
+    }
+
+    fn new_path(&self) -> String {
+        self.new_path.clone()
+    }
+}
 
 /// ClusterAgentOperations trait implemented by client which supports cluster-agent operations
 #[tonic::async_trait]

--- a/deployer/src/infra/hanodeagent.rs
+++ b/deployer/src/infra/hanodeagent.rs
@@ -1,15 +1,45 @@
 use super::*;
 
+use tokio::time::{sleep, Duration};
+use tonic::transport::Endpoint;
+
 #[async_trait]
 impl ComponentAction for HANodeAgent {
     fn configure(&self, _options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
-        let spec = ContainerSpec::from_binary("agent-ha-node", Binary::from_dbg("agent-ha-node"));
+        let mut spec = ContainerSpec::from_binary(
+            "agent-ha-node",
+            Binary::from_dbg("agent-ha-node").with_args(vec!["-n=localhost"]),
+        )
+        .with_portmap("11600", "11600")
+        .with_bind("/run/udev", "/run/udev:ro")
+        .with_bind("/dev", "/dev:ro")
+        .with_privileged(Some(true));
+
+        if cfg.container_exists("jaeger") {
+            let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());
+            spec = spec.with_args(vec!["--jaeger", &jaeger_config])
+        };
 
         Ok(cfg.add_container_spec(spec))
     }
 
     async fn start(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
         cfg.start("agent-ha-node").await?;
+        Ok(())
+    }
+
+    async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+        // Wait till node-agent's gRPC server is ready to server the request
+        loop {
+            match Endpoint::try_from("https://[::]:11600")?
+                .connect_timeout(Duration::from_millis(100))
+                .connect()
+                .await
+            {
+                Ok(_) => break,
+                Err(_) => sleep(Duration::from_millis(1000)).await,
+            }
+        }
         Ok(())
     }
 }

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -58,7 +58,7 @@ class StartOptions:
 
         agent_arg = "--agents=Core"
         if self.ha_node_agent:
-            agent_arg += ",HaNodeAgent"
+            agent_arg += ",HANodeAgent"
         if self.ha_cluster_agent:
             agent_arg += ",ClusterAgent"
         args.append(agent_arg)

--- a/tests/bdd/common/ha.py
+++ b/tests/bdd/common/ha.py
@@ -1,0 +1,18 @@
+"""
+Wrapper around gRPC handle to communicate with HA agents (both node and cluster).
+"""
+
+import grpc
+import cluster_agent_pb2_grpc as rpc
+
+
+class HaNodeHandle(object):
+    def __init__(self, csi_socket):
+        self.channel = grpc.insecure_channel(csi_socket)
+        self.api = rpc.HaNodeRpcStub(self.channel)
+
+    def __del__(self):
+        del self.channel
+
+    def close(self):
+        self.__del__()

--- a/tests/bdd/features/ha/node-agent/node_agent.feature
+++ b/tests/bdd/features/ha/node-agent/node_agent.feature
@@ -1,0 +1,12 @@
+Feature: Swap ANA enabled Nexus on ANA enabled host
+
+  Background:
+    Given a control plane, 2 ANA-enabled Io-Engine instances, 1 ANA-enabled host and a published volume
+    Given a running ha node agent
+
+  Scenario: replace failed I/O path on demand for NVMe controller
+    Given a client connected to one nexus via single I/O path
+    And fio client is running against target nexus
+    When the only I/O path degrades
+    Then it should be possible to create a second nexus and replace failed path with it
+    And fio client should successfully complete with the replaced I/O path

--- a/tests/bdd/features/ha/node-agent/test_path_replacement.py
+++ b/tests/bdd/features/ha/node-agent/test_path_replacement.py
@@ -1,0 +1,210 @@
+"""Swap ANA enabled Nexus on ANA enabled host feature tests."""
+import http
+
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+)
+import pytest
+import subprocess
+from time import sleep
+
+from common.deployer import Deployer
+from common.apiclient import ApiClient
+from common.docker import Docker
+from common.ha import HaNodeHandle
+from common.fio import Fio
+from common.nvme import (
+    nvme_connect,
+    nvme_disconnect,
+    nvme_list_subsystems,
+    nvme_disconnect_controller,
+)
+
+from openapi.model.create_pool_body import CreatePoolBody
+from openapi.model.create_volume_body import CreateVolumeBody
+from openapi.model.volume_policy import VolumePolicy
+from openapi.model.protocol import Protocol
+from openapi.exceptions import ApiException
+
+import cluster_agent_pb2 as pb
+
+VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
+VOLUME_SIZE = 10485761
+POOL_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
+POOL_NODE = "io-engine-3"
+TARGET_NODE_1 = "io-engine-1"
+TARGET_NODE_2 = "io-engine-2"
+NEXUS_NQN = "nqn.2019-05.io.openebs:%s" % VOLUME_UUID
+# Interval to wait before HA Node agent classifies broken path as failed
+PATH_DETECTION_TIME = 6
+# FIO should be active long enough to outlive the detection interval.
+FIO_RUNTIME = PATH_DETECTION_TIME * 2
+
+
+@scenario(
+    "node_agent.feature",
+    "replace failed I/O path on demand for NVMe controller",
+)
+def test_replace_failed_io_path_on_demand_for_nvme_controller():
+    """replace failed I/O path on demand for NVMe controller."""
+
+
+@given("a client connected to one nexus via single I/O path")
+def a_client_connected_to_one_nexus_via_single_io_path(connect_to_first_path):
+    """a client connected to one nexus via single I/O path."""
+    pass
+
+
+@given(
+    "a control plane, 2 ANA-enabled Io-Engine instances, 1 ANA-enabled host and a published volume"
+)
+def a_control_plane_2_anaenabled_io_engine_instances_1_anaenabled_host_and_a_published_volume(
+    background,
+):
+    """a control plane, 2 ANA-enabled Io-Engine instances, 1 ANA-enabled host and a published volume."""
+    volume = background
+    assert hasattr(volume.state, "target")
+    pass
+
+
+@given("fio client is running against target nexus")
+def fio_client_is_running_against_target_nexus(run_fio_to_first_path):
+    """fio client is running against target nexus."""
+    pass
+
+
+@given("a running ha node agent", target_fixture="ha_node_instance")
+def a_running_ha_node_agent():
+    return HaNodeHandle("127.0.0.1:11600")
+
+
+@when("the only I/O path degrades")
+def the_only_io_path_degrades(degrade_first_path):
+    """the only I/O path degrades."""
+    pass
+
+
+@then("fio client should successfully complete with the replaced I/O path")
+def fio_client_should_successfully_complete_with_the_replaced_io_path(
+    fio_completes_successfully,
+):
+    """fio client should successfully complete with the replaced I/O path."""
+    pass
+
+
+@then("it should be possible to create a second nexus and replace failed path with it")
+def it_should_be_possible_to_create_a_second_nexus_and_replace_failed_path_with_it(
+    publish_to_node_2, replace_failed_path_with_node2
+):
+    """it should be possible to create a second nexus and connect it as the second path."""
+    pass
+
+
+"""" FixTure Implementations """
+
+
+@pytest.fixture
+def background():
+    Deployer.start(
+        3,
+        node_agent=True,
+        cluster_agent=True,
+        cache_period="1s",
+        io_engine_env="NEXUS_NVMF_ANA_ENABLE=1,NEXUS_NVMF_RESV_ENABLE=1",
+        agents_env="TEST_NEXUS_NVMF_ANA_ENABLE=1",
+    )
+
+    ApiClient.pools_api().put_node_pool(
+        POOL_NODE, POOL_UUID, CreatePoolBody(["malloc:///disk?size_mb=100"])
+    )
+    ApiClient.volumes_api().put_volume(
+        VOLUME_UUID, CreateVolumeBody(VolumePolicy(False), 1, VOLUME_SIZE, False)
+    )
+    volume = ApiClient.volumes_api().put_volume_target(
+        VOLUME_UUID, Protocol("nvmf"), node=TARGET_NODE_1
+    )
+    yield volume
+    Deployer.stop()
+
+
+@pytest.fixture
+def connect_to_first_path(background):
+    volume = background
+    device_uri = volume.state["target"]["deviceUri"]
+    yield nvme_connect(device_uri)
+    nvme_disconnect(device_uri)
+
+
+@pytest.fixture
+def run_fio_to_first_path(connect_to_first_path):
+    device = connect_to_first_path
+    desc = nvme_list_subsystems(device)
+    assert (
+        len(desc["Subsystems"]) == 1
+    ), "Must be exactly one NVMe subsystem for target nexus"
+    subsystem = desc["Subsystems"][0]
+    assert len(subsystem["Paths"]) == 1, "Must be exactly one I/O path to target nexus"
+    assert subsystem["Paths"][0]["State"] == "live", "I/O path is not healthy"
+    # Launch fio in background and let it always run along with the test.
+    fio = Fio("job", "randread", device, runtime=FIO_RUNTIME).build()
+    return subprocess.Popen(fio, shell=True)
+
+
+@pytest.fixture
+def degrade_first_path():
+    Docker.kill_container(TARGET_NODE_1)
+    # Sleep some time to allow HA node agent detect failed path.
+    # Add one extra second to make sure detection 100% happens.
+    sleep(PATH_DETECTION_TIME + 1)
+
+
+@pytest.fixture
+def publish_to_node_2(background):
+    volume = background
+    device_uri = volume.state["target"]["deviceUri"]
+
+    try:
+        ApiClient.volumes_api().del_volume_target(VOLUME_UUID)
+    except ApiException as e:
+        # Timeout or node not online
+        assert (
+            e.status == http.HTTPStatus.REQUEST_TIMEOUT
+            or e.status == http.HTTPStatus.PRECONDITION_FAILED
+        )
+
+    ApiClient.volumes_api().del_volume_target(VOLUME_UUID, force="true")
+    volume_updated = ApiClient.volumes_api().put_volume_target(
+        VOLUME_UUID, Protocol("nvmf"), node=TARGET_NODE_2
+    )
+    device_uri_2 = volume_updated.state["target"]["deviceUri"]
+    assert device_uri != device_uri_2
+    return device_uri_2
+
+
+@pytest.fixture
+def replace_failed_path_with_node2(
+    connect_to_first_path, publish_to_node_2, ha_node_instance
+):
+    ha_node_instance.api.ReplacePath(
+        pb.ReplacePathRequest(target_nqn=NEXUS_NQN, new_path=publish_to_node_2)
+    )
+
+    device = connect_to_first_path
+    desc = nvme_list_subsystems(device)
+    subsystem = desc["Subsystems"][0]
+    assert len(subsystem["Paths"]) == 1, "Second nexus must be added to I/O path"
+    assert (
+        subsystem["Paths"][0]["State"] == "live"
+    ), "Healthy I/O path has incorrect state"
+
+
+@pytest.fixture
+def fio_completes_successfully(run_fio_to_first_path):
+    try:
+        code = run_fio_to_first_path.wait(timeout=FIO_RUNTIME * 2)
+    except subprocess.TimeoutExpired:
+        assert False, "FIO timed out"
+    assert code == 0, "FIO failed, exit code: %d" % code


### PR DESCRIPTION
Ha node agent now exposes a dedicated gRPC method to replace a failed
NVMe path with a healthy one.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>