### PR TITLE
chore: update conversion from v1 replica grpc to transport replica struct

### DIFF
--- a/control-plane/agents/src/bin/core/controller/wrapper.rs
+++ b/control-plane/agents/src/bin/core/controller/wrapper.rs
@@ -1136,11 +1136,7 @@ impl ClientOps for GrpcClientLocked {
                         resource: ResourceKind::Replica,
                         request: "create_replica",
                     })?;
-                let mut replica =
-                    v1_rpc_replica_to_agent(&rpc_replica.into_inner(), &request.node)?;
-                // Replica doesn't have the pool name.
-                // Fill this with the requested pool name.
-                replica.pool_id = request.pool_id.clone();
+                let replica = v1_rpc_replica_to_agent(&rpc_replica.into_inner(), &request.node)?;
                 Ok(replica)
             }
         }

--- a/control-plane/agents/src/common/msg_translation/v1.rs
+++ b/control-plane/agents/src/common/msg_translation/v1.rs
@@ -89,9 +89,7 @@ impl TryIoEngineToAgent for v1_rpc::replica::Replica {
                 uuid: self.uuid.to_owned(),
                 kind: ResourceKind::Replica,
             })?,
-            // Replica only contains pooluuid.
-            // Patch the pool name after this call.
-            pool_id: Default::default(),
+            pool_id: self.poolname.clone().into(),
             pool_uuid: Some(PoolUuid::try_from(self.pooluuid.clone()).map_err(|_| {
                 SvcError::InvalidUuid {
                     uuid: self.pooluuid.to_owned(),


### PR DESCRIPTION
Some REST replica operations like `get_node_pool_replicas`, `del_pool_replica` were failing because these apply some filters based on poolid(or poolname). But since in v1 replica we only get pooluuid in response from mayastor, the filters failed to recognise the replicas on respective pools.

Hence, this PR updates the rpc submodule dependency to have the poolname also embedded in the response and the corresponding type conversions needed for it so that the above operations pass successfully.

Signed-off-by: Abhishek Agarwal <abhiagarwal.agarwal2@gmail.com>