### PR TITLE
fix(replica-openapi): revert back changes for poolid in Replica & ReplicaSpec openapi

### DIFF
--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2226,7 +2226,7 @@ components:
       properties:
         node:
           $ref: '#/components/schemas/NodeId'
-        poolId:
+        pool:
           $ref: '#/components/schemas/PoolId'
         poolUuid:
           $ref: '#/components/schemas/PoolUuid'
@@ -2254,7 +2254,7 @@ components:
           format: uuid
       required:
         - node
-        - poolId
+        - pool
         - share
         - size
         - state
@@ -2462,7 +2462,7 @@ components:
           nexuses:
             - 514ed1c8-7174-49ac-b9cd-ad44ef670a67
           volume: null
-        poolId: pooloop
+        pool: pooloop
         poolUuid: 22ca10d3-4f2b-4b95-9814-9181c025cc1a
         share: none
         size: 80241024
@@ -2513,8 +2513,9 @@ components:
               format: uuid
           required:
             - nexuses
-        poolId:
-          $ref: '#/components/schemas/PoolId'
+        pool:
+          description: The pool that the replica should live on.
+          type: string
         poolUuid:
           $ref: '#/components/schemas/PoolUuid'
         share:
@@ -2536,7 +2537,7 @@ components:
       required:
         - managed
         - owners
-        - poolId
+        - pool
         - share
         - size
         - status

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -173,7 +173,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
         replica,
         models::Replica {
             node: pool.spec.clone().unwrap().node,
-            pool_id: pool.id.clone(),
+            pool: pool.id.clone(),
             uuid: FromStr::from_str("e6e7d39d-e343-42f7-936a-1ab05f1839db").unwrap(),
             thin: false,
             size: 12582912,
@@ -189,7 +189,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
     );
     client
         .replicas_api()
-        .del_node_pool_replica(&replica.node, &replica.pool_id, &replica.uuid)
+        .del_node_pool_replica(&replica.node, &replica.pool, &replica.uuid)
         .await
         .unwrap();
 

--- a/k8s/supportability/src/collect/resources/replica.rs
+++ b/k8s/supportability/src/collect/resources/replica.rs
@@ -108,7 +108,7 @@ impl ReplicaClientWrapper {
         let replica = self.get_replica(id).await?;
         let topologer = self
             .pool_client
-            .get_topologer(Some(replica.pool_id.clone()))
+            .get_topologer(Some(replica.pool.clone()))
             .await?;
         let pool_topology = match topologer.downcast_ref::<PoolTopology>() {
             Some(val) => val.clone(),


### PR DESCRIPTION
This change is needed so that no breaking change is experienced in terms of system tests.

Signed-off-by: Abhishek Agarwal <abhiagarwal.agarwal2@gmail.com>