### PR TITLE
feat(ha): add apis for volume republish and targets destroy for switchover 

### DIFF
--- a/common/src/types/v0/store/volume.rs
+++ b/common/src/types/v0/store/volume.rs
@@ -184,6 +184,10 @@ impl SpecTransaction<VolumeOperation> for VolumeSpec {
                     self.target = Some(VolumeTarget::new(node, nexus.clone(), protocol));
                     self.last_nexus_id = Some(nexus);
                 }
+                VolumeOperation::Republish((node, nexus, protocol)) => {
+                    self.target = Some(VolumeTarget::new(node, nexus.clone(), Some(protocol)));
+                    self.last_nexus_id = Some(nexus);
+                }
                 VolumeOperation::Unpublish => {
                     self.target = None;
                 }
@@ -219,6 +223,7 @@ pub enum VolumeOperation {
     Unshare,
     SetReplica(u8),
     Publish((NodeId, NexusId, Option<VolumeShareProtocol>)),
+    Republish((NodeId, NexusId, VolumeShareProtocol)),
     Unpublish,
     RemoveUnusedReplica(ReplicaId),
 }
@@ -232,6 +237,7 @@ impl From<VolumeOperation> for models::volume_spec_operation::Operation {
             VolumeOperation::Unshare => models::volume_spec_operation::Operation::Unshare,
             VolumeOperation::SetReplica(_) => models::volume_spec_operation::Operation::SetReplica,
             VolumeOperation::Publish(_) => models::volume_spec_operation::Operation::Publish,
+            VolumeOperation::Republish(_) => models::volume_spec_operation::Operation::Republish,
             VolumeOperation::Unpublish => models::volume_spec_operation::Operation::Unpublish,
             VolumeOperation::RemoveUnusedReplica(_) => {
                 models::volume_spec_operation::Operation::RemoveUnusedReplica

--- a/common/src/types/v0/transport/mod.rs
+++ b/common/src/types/v0/transport/mod.rs
@@ -103,6 +103,8 @@ pub enum MessageIdVs {
     DestroyVolume,
     /// Publish Volume.
     PublishVolume,
+    /// Republish Volume.
+    RepublishVolume,
     /// Unpublish Volume.
     UnpublishVolume,
     /// Share Volume.

--- a/common/src/types/v0/transport/nexus.rs
+++ b/common/src/types/v0/transport/nexus.rs
@@ -70,14 +70,16 @@ rpc_impl_string_uuid!(NexusId, "UUID of a nexus");
 /// Nexus State information
 #[derive(Serialize, Deserialize, Debug, Clone, EnumString, ToString, Eq, PartialEq)]
 pub enum NexusStatus {
-    /// Default Unknown state
+    /// Default Unknown state.
     Unknown = 0,
-    /// healthy and working
+    /// Healthy and working.
     Online = 1,
-    /// not healthy but is able to serve IO (i.e. rebuild is in progress)
+    /// Not healthy but is able to serve IO (i.e. rebuild is in progress).
     Degraded = 2,
-    /// broken and unable to serve IO
+    /// Broken and unable to serve IO.
     Faulted = 3,
+    /// Shutdown state, i.e. blocked from serving IO.
+    Shutdown = 4,
 }
 impl Default for NexusStatus {
     fn default() -> Self {
@@ -90,6 +92,7 @@ impl From<i32> for NexusStatus {
             1 => Self::Online,
             2 => Self::Degraded,
             3 => Self::Faulted,
+            4 => Self::Shutdown,
             _ => Self::Unknown,
         }
     }
@@ -97,10 +100,11 @@ impl From<i32> for NexusStatus {
 impl From<NexusStatus> for models::NexusState {
     fn from(src: NexusStatus) -> Self {
         match src {
-            NexusStatus::Unknown => Self::Unknown,
             NexusStatus::Online => Self::Online,
             NexusStatus::Degraded => Self::Degraded,
             NexusStatus::Faulted => Self::Faulted,
+            NexusStatus::Unknown => Self::Unknown,
+            NexusStatus::Shutdown => Self::Shutdown,
         }
     }
 }
@@ -371,6 +375,25 @@ impl DestroyNexus {
     /// Return a reference to the disowners.
     pub fn disowners(&self) -> &NexusOwners {
         &self.disowners
+    }
+}
+
+/// Shutdown Nexus Request.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ShutdownNexus {
+    /// The uuid of the nexus.
+    uuid: NexusId,
+}
+
+impl ShutdownNexus {
+    /// Create a new `ShutdownNexus` using `uuid`.
+    pub fn new(uuid: NexusId) -> Self {
+        Self { uuid }
+    }
+    /// Get uuid of the nexus.
+    pub fn uuid(&self) -> NexusId {
+        self.uuid.clone()
     }
 }
 

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/garbage_collector.rs
@@ -33,7 +33,10 @@ impl TaskPoller for GarbageCollector {
                 Ok(guard) => guard,
                 Err(_) => continue,
             };
-            let _ = nexus.garbage_collect(context).await;
+            // if the nexus is in shutdown state don't let the reconcilers act on it.
+            if !nexus.lock().is_shutdown() {
+                let _ = nexus.garbage_collect(context).await;
+            }
         }
         PollResult::Ok(PollerState::Idle)
     }

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -101,12 +101,12 @@ async fn nexus_reconciler(
     nexus: &mut OperationGuardArc<NexusSpec>,
     context: &PollContext,
 ) -> PollResult {
-    let created = {
+    let reconcile = {
         let nexus_spec = nexus.lock();
-        nexus_spec.status().created()
+        nexus_spec.status().created() && !nexus_spec.is_shutdown()
     };
 
-    if created {
+    if reconcile {
         squash_results(vec![
             faulted_children_remover(nexus, context).await,
             unknown_children_remover(nexus, context).await,

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
@@ -64,6 +64,7 @@ async fn hot_spare_reconcile(
             hot_spare_nexus_reconcile(&mut volume, &volume_state, context).await
         }
         VolumeStatus::Faulted => PollResult::Ok(PollerState::Idle),
+        VolumeStatus::Shutdown => PollResult::Ok(PollerState::Idle),
     }
 }
 

--- a/control-plane/agents/src/bin/core/controller/resources/operations.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations.rs
@@ -48,6 +48,7 @@ pub(crate) trait ResourcePublishing {
     type Publish: Sync + Send;
     type PublishOutput: Sync + Send;
     type Unpublish: Sync + Send;
+    type Republish: Sync + Send;
 
     /// Publish the resource.
     async fn publish(
@@ -61,6 +62,12 @@ pub(crate) trait ResourcePublishing {
         registry: &Registry,
         request: &Self::Unpublish,
     ) -> Result<(), SvcError>;
+    /// Republish the resource by shutting down existing dependents.
+    async fn republish(
+        &mut self,
+        registry: &Registry,
+        request: &Self::Republish,
+    ) -> Result<Self::PublishOutput, SvcError>;
 }
 
 /// Resource Replica Operations.
@@ -110,5 +117,26 @@ pub(crate) trait ResourceOwnerUpdate {
         request: &Self::Update,
         // pre-update the actual spec anyway since this is a removal,
         update_on_commit: bool,
+    ) -> Result<(), SvcError>;
+}
+
+/// Resource shutdown related operations.
+#[async_trait::async_trait]
+pub(crate) trait ResourceShutdownOperations {
+    type RemoveShutdownTargets: Sync + Send;
+    type Shutdown: Sync + Send;
+
+    /// Shutdown the resource itself.
+    async fn shutdown(
+        &mut self,
+        registry: &Registry,
+        request: &Self::Shutdown,
+    ) -> Result<(), SvcError>;
+
+    /// Remove the shutdown targets.
+    async fn remove_shutdown_targets(
+        &mut self,
+        registry: &Registry,
+        request: &Self::RemoveShutdownTargets,
     ) -> Result<(), SvcError>;
 }

--- a/control-plane/agents/src/bin/core/controller/wrapper.rs
+++ b/control-plane/agents/src/bin/core/controller/wrapper.rs
@@ -41,6 +41,7 @@ use common_lib::{
 };
 
 use async_trait::async_trait;
+use common_lib::types::v0::transport::ShutdownNexus;
 use parking_lot::RwLock;
 use snafu::ResultExt;
 use std::{
@@ -750,6 +751,8 @@ pub(crate) trait ClientOps {
     async fn remove_child(&self, request: &RemoveNexusChild) -> Result<(), SvcError>;
     /// Fault a child from its parent nexus via gRPC.
     async fn fault_child(&self, request: &FaultNexusChild) -> Result<(), SvcError>;
+    /// Shutdown an existing nexus.
+    async fn shutdown_nexus(&self, _: &ShutdownNexus) -> Result<(), SvcError>;
 }
 
 /// Internal Operations on a io-engine locked `NodeWrapper` for the implementor
@@ -1144,6 +1147,11 @@ impl ClientOps for Arc<tokio::sync::RwLock<NodeWrapper>> {
                 Err(error)
             }
         }
+    }
+
+    async fn shutdown_nexus(&self, _: &ShutdownNexus) -> Result<(), SvcError> {
+        // todo: add implementation
+        Ok(())
     }
 }
 
@@ -1549,6 +1557,11 @@ impl ClientOps for GrpcClientLocked {
                 Ok(())
             }
         }
+    }
+
+    async fn shutdown_nexus(&self, _: &ShutdownNexus) -> Result<(), SvcError> {
+        // todo: add implementation
+        Ok(())
     }
 }
 

--- a/control-plane/agents/src/bin/core/nexus/specs.rs
+++ b/control-plane/agents/src/bin/core/nexus/specs.rs
@@ -84,6 +84,7 @@ impl SpecOperationsHelper for NexusSpec {
                 })
             }
             NexusOperation::RemoveChild(_) => Ok(()),
+            NexusOperation::Shutdown => Ok(()),
             _ => unreachable!(),
         }?;
         self.start_op(op);

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -780,6 +780,7 @@ async fn disown_unused_replicas() {
             &volume.spec.uuid,
             models::VolumeShareProtocol::Nvmf,
             Some(&node),
+            Some(false),
         )
         .await
         .unwrap();

--- a/control-plane/agents/src/bin/core/tests/volume/capacity.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/capacity.rs
@@ -37,6 +37,7 @@ async fn fault_enospc_child() {
             &volume_1.spec.uuid,
             models::VolumeShareProtocol::Nvmf,
             Some(cluster.node(0).as_str()),
+            Some(false),
         )
         .await
         .unwrap();

--- a/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
@@ -154,6 +154,7 @@ async fn offline_replicas_reconcile(cluster: &Cluster, reconcile_period: Duratio
             &volume.spec.uuid,
             models::VolumeShareProtocol::Nvmf,
             Some(&free_node),
+            Some(false),
         )
         .await
         .unwrap();
@@ -216,6 +217,7 @@ async fn unused_nexus_reconcile(cluster: &Cluster) {
             &volume.spec.uuid,
             models::VolumeShareProtocol::Nvmf,
             Some(cluster.node(0).as_str()),
+            Some(false),
         )
         .await
         .unwrap();
@@ -297,6 +299,7 @@ async fn unused_reconcile(cluster: &Cluster) {
             &volume.spec.uuid,
             models::VolumeShareProtocol::Nvmf,
             Some(nexus_node.id.as_str()),
+            Some(false),
         )
         .await
         .unwrap();
@@ -315,6 +318,7 @@ async fn unused_reconcile(cluster: &Cluster) {
             &volume.spec.uuid,
             models::VolumeShareProtocol::Nvmf,
             Some(unused_node.id.as_str()),
+            Some(false),
         )
         .await
         .unwrap();
@@ -400,6 +404,7 @@ async fn missing_nexus_reconcile(cluster: &Cluster) {
             &volume.spec().uuid,
             models::VolumeShareProtocol::Nvmf,
             Some(cluster.node(0).as_str()),
+            Some(false),
         )
         .await
         .unwrap();

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -283,11 +283,12 @@ impl IoEngineApiClient {
         volume_id: &uuid::Uuid,
         node: Option<&str>,
         protocol: VolumeShareProtocol,
+        republish: bool,
     ) -> Result<Volume, ApiClientError> {
         let volume = self
             .rest_client
             .volumes_api()
-            .put_volume_target(volume_id, protocol, node)
+            .put_volume_target(volume_id, protocol, node, Some(republish))
             .await?;
         Ok(volume.into_body())
     }

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -396,7 +396,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
                 // Volume is not published.
                 let v = IoEngineApiClient::get_client()
-                    .publish_volume(&volume_id, target_node, protocol)
+                    .publish_volume(&volume_id, target_node, protocol, false)
                     .await?;
 
                 if let Some((node, uri)) = get_volume_share_location(&v) {

--- a/control-plane/grpc/proto/v1/nexus/nexus.proto
+++ b/control-plane/grpc/proto/v1/nexus/nexus.proto
@@ -41,6 +41,8 @@ enum NexusStatus {
   Degraded = 2;
   // broken and unable to serve IO
   Faulted = 3;
+  // shutdown i.e. blocked from serving IO
+  Shutdown = 4;
 }
 
 message Child {

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -171,6 +171,16 @@ message PublishVolumeRequest {
   optional VolumeShareProtocol share = 3;
 }
 
+// Republish a volume on a node by shutting down existing target
+message RepublishVolumeRequest {
+  // uuid of the volume
+  google.protobuf.StringValue uuid = 1;
+  // the node where front-end IO will be sent to
+  optional string target_node = 2;
+  // share protocol
+  VolumeShareProtocol share = 3;
+}
+
 // Unpublish a volume from any node where it may be published
 // Unshares the children nexuses from the volume and destroys them.
 message UnpublishVolumeRequest {
@@ -252,6 +262,14 @@ message PublishVolumeReply {
   }
 }
 
+// Reply type for a RepublishVolume request
+message RepublishVolumeReply {
+  oneof reply {
+    Volume volume = 1;
+    common.ReplyError error = 2;
+  }
+}
+
 // Reply type for a UnpublishVolume request
 message UnpublishVolumeReply {
   oneof reply {
@@ -276,11 +294,24 @@ message ProbeResponse {
   bool ready = 1;
 }
 
+// Destroy Shutdown orphaned Nexus Request
+message DestroyShutdownTargetRequest {
+  // uuid of the volume
+  google.protobuf.StringValue volume_id = 1;
+}
+
+// Reply type for a DestroyShutdownTargetRequest request
+message DestroyShutdownTargetReply {
+  optional common.ReplyError error = 1;
+}
+
 service VolumeGrpc {
   rpc CreateVolume (CreateVolumeRequest) returns (CreateVolumeReply) {}
   rpc DestroyVolume (DestroyVolumeRequest) returns (DestroyVolumeReply) {}
+  rpc DestroyShutdownTarget (DestroyShutdownTargetRequest) returns (DestroyShutdownTargetReply) {}
   rpc GetVolumes (GetVolumesRequest) returns (GetVolumesReply) {}
   rpc PublishVolume (PublishVolumeRequest) returns (PublishVolumeReply) {}
+  rpc RepublishVolume (RepublishVolumeRequest) returns (RepublishVolumeReply) {}
   rpc UnpublishVolume (UnpublishVolumeRequest) returns (UnpublishVolumeReply) {}
   rpc ShareVolume (ShareVolumeRequest) returns (ShareVolumeReply) {}
   rpc UnshareVolume (UnshareVolumeRequest) returns (UnshareVolumeReply) {}

--- a/control-plane/grpc/src/operations/nexus/traits.rs
+++ b/control-plane/grpc/src/operations/nexus/traits.rs
@@ -170,16 +170,18 @@ impl From<nexus::NexusStatus> for NexusStatus {
             nexus::NexusStatus::Online => Self::Online,
             nexus::NexusStatus::Degraded => Self::Degraded,
             nexus::NexusStatus::Faulted => Self::Faulted,
+            nexus::NexusStatus::Shutdown => Self::Shutdown,
         }
     }
 }
 impl From<NexusStatus> for nexus::NexusStatus {
     fn from(src: NexusStatus) -> Self {
         match src {
-            NexusStatus::Unknown => Self::Unknown,
             NexusStatus::Online => Self::Online,
             NexusStatus::Degraded => Self::Degraded,
             NexusStatus::Faulted => Self::Faulted,
+            NexusStatus::Shutdown => Self::Shutdown,
+            NexusStatus::Unknown => Self::Unknown,
         }
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1437,6 +1437,14 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/VolumeShareProtocol'
+        - in: query
+          name: republish
+          x-api-scope: internal
+          description: |-
+            Allows republishing the volume on the node by shutting down the existing target first.
+          required: false
+          schema:
+            type: boolean
       responses:
         '200':
           description: OK
@@ -2038,6 +2046,7 @@ components:
         - Online
         - Degraded
         - Faulted
+        - Shutdown
     Nexus:
       example:
         children:
@@ -2583,6 +2592,7 @@ components:
                 - SetReplica
                 - RemoveUnusedReplica
                 - Publish
+                - Republish
                 - Unpublish
             result:
               description: Result of the operation
@@ -2648,6 +2658,7 @@ components:
         - Online
         - Degraded
         - Faulted
+        - Shutdown
     VolumeShareProtocol:
       description: Volume Share Protocol
       type: string

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -286,6 +286,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
             &volume.state.uuid,
             models::VolumeShareProtocol::Nvmf,
             Some(io_engine1.as_str()),
+            Some(false),
         )
         .await
         .unwrap();

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -57,7 +57,9 @@ impl ComponentAction for CoreAgent {
         if let Some(max_rebuilds) = &options.max_rebuilds {
             binary = binary.with_args(vec!["--max-rebuilds", &max_rebuilds.to_string()]);
         }
-        Ok(cfg.add_container_bin(name, binary))
+        Ok(cfg.add_container_spec(
+            ContainerSpec::from_binary(name, binary).with_portmap("50051", "50051"),
+        ))
     }
     async fn start(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
         cfg.start("core").await?;

--- a/tests/io-engine/tests/rebuild.rs
+++ b/tests/io-engine/tests/rebuild.rs
@@ -49,6 +49,7 @@ async fn concurrent_rebuilds() {
                 &volume.spec.uuid,
                 models::VolumeShareProtocol::Nvmf,
                 Some(cluster.node(i).as_str()),
+                Some(false),
             )
             .await
             .unwrap();

--- a/utils/pstor-usage/src/volumes.rs
+++ b/utils/pstor-usage/src/volumes.rs
@@ -85,6 +85,7 @@ impl ResourceUpdates for Vec<models::Volume> {
                     &volume.spec.uuid,
                     models::VolumeShareProtocol::Nvmf,
                     Some(node_id.as_str()),
+                    Some(false),
                 )
                 .await?;
             node_index = (node_index + 1) % node_ids.len();


### PR DESCRIPTION
1. Add volume republish api.
2. Add volume destroy shutdown targets api.
3. Add changes to the reconcilers to not act on shutdown states.