### PR TITLE
feat(restart-detection): use instance uuid to detect io-engine restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "utils",
+ "uuid",
 ]
 
 [[package]]

--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -130,12 +130,12 @@ pub struct NodeState {
 }
 
 /// Node spec data, including the cordon/drain state.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct NodeSpec {
     /// Node identification.
     id: NodeId,
     /// Endpoint of the io-engine instance (gRPC).
-    endpoint: String,
+    endpoint: std::net::SocketAddr,
     /// Node labels.
     labels: NodeLabels,
     /// Cordon/drain state.
@@ -148,7 +148,7 @@ impl NodeSpec {
     /// Return a new `Self`.
     pub fn new(
         id: NodeId,
-        endpoint: String,
+        endpoint: std::net::SocketAddr,
         labels: NodeLabels,
         cordon_drain_state: Option<CordonDrainState>,
     ) -> Self {
@@ -164,8 +164,8 @@ impl NodeSpec {
         &self.id
     }
     /// Node gRPC endpoint.
-    pub fn endpoint(&self) -> &str {
-        &self.endpoint
+    pub fn endpoint(&self) -> std::net::SocketAddr {
+        self.endpoint
     }
     /// Node labels.
     pub fn labels(&self) -> &NodeLabels {
@@ -177,7 +177,7 @@ impl NodeSpec {
     }
 
     /// Node gRPC endpoint.
-    pub fn set_endpoint(&mut self, endpoint: String) {
+    pub fn set_endpoint(&mut self, endpoint: std::net::SocketAddr) {
         self.endpoint = endpoint
     }
 
@@ -291,7 +291,11 @@ impl NodeSpec {
 
 impl From<NodeSpec> for models::NodeSpec {
     fn from(src: NodeSpec) -> Self {
-        Self::new_all(src.endpoint, src.id, src.cordon_drain_state.into_opt())
+        Self::new_all(
+            src.endpoint.to_string(),
+            src.id,
+            src.cordon_drain_state.into_opt(),
+        )
     }
 }
 

--- a/common/src/types/v0/transport/node.rs
+++ b/common/src/types/v0/transport/node.rs
@@ -18,6 +18,8 @@ pub struct Register {
     pub grpc_endpoint: std::net::SocketAddr,
     /// Api versions registered by the dataplane.
     pub api_versions: Option<Vec<ApiVersion>>,
+    /// Used to identify dataplane process restarts.
+    pub instance_uuid: Option<uuid::Uuid>,
 }
 
 /// Deregister message payload
@@ -121,10 +123,12 @@ pub struct NodeState {
     pub status: NodeStatus,
     /// Api versions supported by the dataplane.
     pub api_versions: Option<Vec<ApiVersion>>,
+    /// Used to identify dataplane process restarts.
+    instance_uuid: Option<uuid::Uuid>,
 }
 
 impl NodeState {
-    /// Return a new `Self`
+    /// Return a new `Self`.
     pub fn new(
         id: NodeId,
         grpc_endpoint: std::net::SocketAddr,
@@ -136,15 +140,20 @@ impl NodeState {
             grpc_endpoint,
             status,
             api_versions,
+            instance_uuid: None,
         }
     }
-    /// Get the node identification
+    /// Get the node identification.
     pub fn id(&self) -> &NodeId {
         &self.id
     }
-    /// Get the node status
+    /// Get the node status.
     pub fn status(&self) -> &NodeStatus {
         &self.status
+    }
+    /// Get the instance uuid.
+    pub fn instance_uuid(&self) -> &Option<uuid::Uuid> {
+        &self.instance_uuid
     }
 }
 impl From<&Register> for NodeState {
@@ -159,6 +168,7 @@ impl From<Register> for NodeState {
             grpc_endpoint: src.grpc_endpoint,
             status: NodeStatus::Online,
             api_versions: src.api_versions,
+            instance_uuid: src.instance_uuid,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/resources/resource_map.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/resource_map.rs
@@ -3,9 +3,21 @@ use common_lib::IntoVec;
 use indexmap::{map::Values, IndexMap};
 use std::{fmt::Debug, hash::Hash};
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub(crate) struct ResourceMap<I, S: Clone> {
     map: IndexMap<I, ResourceMutex<S>>,
+}
+
+impl<I, S> Default for ResourceMap<I, S>
+where
+    I: Eq + Hash + Clone,
+    S: Clone + ResourceUid<Uid = I> + Debug,
+{
+    fn default() -> Self {
+        Self {
+            map: IndexMap::new(),
+        }
+    }
 }
 
 impl<I, S> ResourceMap<I, S>

--- a/control-plane/agents/src/bin/core/controller/states.rs
+++ b/control-plane/agents/src/bin/core/controller/states.rs
@@ -9,13 +9,13 @@ use parking_lot::RwLock;
 use std::{ops::Deref, sync::Arc};
 
 /// Locked Resource States.
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Default, Debug)]
 pub(crate) struct ResourceStatesLocked(Arc<RwLock<ResourceStates>>);
 
 impl ResourceStatesLocked {
     /// Return a new empty `Self`.
     pub(crate) fn new() -> Self {
-        ResourceStatesLocked::default()
+        Default::default()
     }
 }
 

--- a/control-plane/agents/src/bin/core/controller/wrapper.rs
+++ b/control-plane/agents/src/bin/core/controller/wrapper.rs
@@ -111,9 +111,8 @@ impl NodeWrapper {
         // don't modify the status through the state.
         node_state.status = self.status();
         if self.node_state() != &node_state {
-            // during startup don't flag state changes as the first state is inferred so it may be
-            // incorrect.
-            // Example: we don't what api versions we've got yet.
+            // don't flag state changes as the first state is inferred so it may be incorrect.
+            // Example: we don't know what api versions the node supports yet.
             if !creation {
                 trace!(
                     node.id=%node_state.id,
@@ -124,9 +123,20 @@ impl NodeWrapper {
                 if self.node_state().api_versions != node_state.api_versions {
                     warn!(
                         node.id=%node_state.id,
-                        "API Versions changed from {:?} to {:?}",
+                        "Node grpc api versions changed from {:?} to {:?}",
                         self.node_state().api_versions,
                         node_state.api_versions
+                    );
+                }
+
+                if self.node_state().instance_uuid().is_some()
+                    && self.node_state().instance_uuid() != node_state.instance_uuid()
+                {
+                    warn!(
+                        node.id=%node_state.id,
+                        "Node restart detected: {:?} to {:?}",
+                        self.node_state().instance_uuid(),
+                        node_state.instance_uuid()
                     );
                 }
             }

--- a/control-plane/agents/src/bin/core/controller/wrapper.rs
+++ b/control-plane/agents/src/bin/core/controller/wrapper.rs
@@ -31,7 +31,7 @@ use common_lib::{
         store,
         store::{nexus::NexusState, replica::ReplicaState},
         transport::{
-            APIVersion, AddNexusChild, Child, CreateNexus, CreatePool, CreateReplica, DestroyNexus,
+            AddNexusChild, ApiVersion, Child, CreateNexus, CreatePool, CreateReplica, DestroyNexus,
             DestroyPool, DestroyReplica, FaultNexusChild, MessageIdVs, Nexus, NexusId, NodeId,
             NodeState, NodeStatus, PoolId, PoolState, PoolStatus, Protocol, Register,
             RemoveNexusChild, Replica, ReplicaId, ReplicaName, ShareNexus, ShareReplica,
@@ -48,7 +48,7 @@ use std::{
     ops::{Deref, DerefMut},
     sync::Arc,
 };
-use tracing::debug;
+use tracing::{debug, trace, warn};
 
 type NodeResourceStates = (Vec<Replica>, Vec<PoolState>, Vec<Nexus>);
 
@@ -106,34 +106,57 @@ impl NodeWrapper {
         }
     }
 
-    /// set the node state to the passed argument
-    pub(crate) fn set_state(&mut self, node_state: NodeState) {
-        self.node_state = node_state;
+    /// Set the node state to the passed argument.
+    fn set_state_inner(&mut self, mut node_state: NodeState, creation: bool) -> bool {
+        // don't modify the status through the state.
+        node_state.status = self.status();
+        if self.node_state() != &node_state {
+            // during startup don't flag state changes as the first state is inferred so it may be
+            // incorrect.
+            // Example: we don't what api versions we've got yet.
+            if !creation {
+                trace!(
+                    node.id=%node_state.id,
+                    "Node state changed from {:?} to {:?}",
+                    self.node_state(),
+                    node_state
+                );
+                if self.node_state().api_versions != node_state.api_versions {
+                    warn!(
+                        node.id=%node_state.id,
+                        "API Versions changed from {:?} to {:?}",
+                        self.node_state().api_versions,
+                        node_state.api_versions
+                    );
+                }
+            }
+            self.node_state = node_state;
+            true
+        } else {
+            false
+        }
     }
 
-    /// set the node state on apiversion change to the passed argument
-    pub(crate) fn set_state_on_version_change(&mut self, node_state: NodeState) {
-        if self.node_state().api_versions != node_state.api_versions {
-            debug!(
-                node.id=%node_state.id,
-                "API Versions changed from {:?} to {:?}",
-                self.node_state().api_versions,
-                node_state.api_versions
-            );
-            self.set_state(node_state)
-        }
+    /// Set the node state to the passed argument.
+    /// No state changes are not logged during creation since we're still constructing the node.
+    pub(crate) fn set_startup_creation(&mut self, node_state: NodeState) -> bool {
+        self.set_state_inner(node_state, true)
+    }
+    /// Set the node state to the passed argument.
+    pub(crate) fn set_state(&mut self, node_state: NodeState) -> bool {
+        self.set_state_inner(node_state, false)
     }
 
     /// get the latest api version from the list of supported api
     /// versions by the dataplane
-    pub(crate) fn latest_api_version(&self) -> Option<APIVersion> {
+    pub(crate) fn latest_api_version(&self) -> Option<ApiVersion> {
         match self.node_state.api_versions.clone() {
             None => None,
             Some(mut api_version) => {
                 api_version.sort();
                 // get the last element after sort, if it was an empty vec, then
                 // return the latest version as V0
-                Some(api_version.last().unwrap_or(&APIVersion::V0).clone())
+                Some(api_version.last().unwrap_or(&ApiVersion::V0).clone())
             }
         }
     }
@@ -155,7 +178,7 @@ impl NodeWrapper {
             Ok(GrpcContext::new(
                 self.lock.clone(),
                 self.id(),
-                &self.endpoint_str(),
+                self.node_state().grpc_endpoint,
                 &self.comms_timeouts,
                 Some(request),
                 api_version,
@@ -174,7 +197,7 @@ impl NodeWrapper {
             Ok(GrpcContext::new(
                 self.lock.clone(),
                 self.id(),
-                &self.endpoint_str(),
+                self.node_state().grpc_endpoint,
                 &timeout,
                 None,
                 api_version,
@@ -190,7 +213,7 @@ impl NodeWrapper {
             Ok(GrpcContext::new(
                 self.lock.clone(),
                 self.id(),
-                &self.endpoint_str(),
+                self.node_state().grpc_endpoint,
                 &self.comms_timeouts,
                 None,
                 api_version,
@@ -281,7 +304,7 @@ impl NodeWrapper {
         );
 
         // Set the api version to latest and make a call
-        self.node_state.api_versions = Some(vec![APIVersion::V1]);
+        self.node_state.api_versions = Some(vec![ApiVersion::V1]);
         let client = self.grpc_client_timeout(timeouts.clone()).await?;
         match client.liveness_probe().await {
             Ok(data) => return Ok(data),
@@ -306,14 +329,14 @@ impl NodeWrapper {
         }
 
         // Set the api version to second latest and make a call
-        self.node_state.api_versions = Some(vec![APIVersion::V0]);
+        self.node_state.api_versions = Some(vec![ApiVersion::V0]);
         let client = self.grpc_client_timeout(timeouts).await?;
-        client
-            .liveness_probe()
-            .await
-            .map_err(|_| SvcError::NodeNotOnline {
+        client.liveness_probe().await.map_err(|error| {
+            tracing::error!(?error, "V0 liveness probe failed");
+            SvcError::NodeNotOnline {
                 node: self.id().clone(),
-            })
+            }
+        })
     }
 
     /// Set the node status and return the previous status
@@ -384,7 +407,7 @@ impl NodeWrapper {
 
     /// Get the node grpc endpoint as string.
     pub(crate) fn endpoint_str(&self) -> String {
-        self.node_state().grpc_endpoint.clone()
+        self.node_state().grpc_endpoint.to_string()
     }
     /// Get all pools
     pub(crate) fn pools(&self) -> Vec<PoolState> {
@@ -826,15 +849,17 @@ impl InternalOps for Arc<tokio::sync::RwLock<NodeWrapper>> {
     }
 
     async fn on_register(&self, node_state: NodeState) -> Result<bool, SvcError> {
-        let setting_online = {
+        let (not_online, state_changed) = {
             let mut node = self.write().await;
-            node.set_state_on_version_change(node_state);
+            // if the state changed we should update the node to fetch latest information
+            let state_changed = node.set_state(node_state);
             node.pet().await;
-            !node.is_online()
+            (!node.is_online(), state_changed)
         };
-        // if the node was not previously online then let's update all states right away
-        if setting_online {
-            self.update_all(setting_online).await.map(|_| true)
+        // if the node was not previously online or the state has changed then let's update all
+        // states right away
+        if not_online || state_changed {
+            self.update_all(not_online).await.map(|_| true)
         } else {
             Ok(false)
         }
@@ -1120,7 +1145,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn create_pool(&self, request: &CreatePool) -> Result<PoolState, SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let rpc_pool = self
                     .client_v0()?
                     .create_pool(v0_conversion::to_rpc(request))
@@ -1132,7 +1157,7 @@ impl ClientOps for GrpcClientLocked {
                 let pool = v0_rpc_pool_to_agent(&rpc_pool.into_inner(), &request.node);
                 Ok(pool)
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let rpc_pool = self
                     .client_v1()?
                     .pool()
@@ -1150,7 +1175,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn destroy_pool(&self, request: &DestroyPool) -> Result<(), SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let _ = self
                     .client_v0()?
                     .destroy_pool(v0_conversion::to_rpc(request))
@@ -1161,7 +1186,7 @@ impl ClientOps for GrpcClientLocked {
                     })?;
                 Ok(())
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let _ = self
                     .client_v1()?
                     .pool()
@@ -1178,7 +1203,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn create_replica(&self, request: &CreateReplica) -> Result<Replica, SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let rpc_replica = self
                     .client_v0()?
                     .create_replica_v2(v0_conversion::to_rpc(request))
@@ -1190,7 +1215,7 @@ impl ClientOps for GrpcClientLocked {
                 let replica = v0_rpc_replica_to_agent(&rpc_replica.into_inner(), &request.node)?;
                 Ok(replica)
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let rpc_replica = self
                     .client_v1()?
                     .replica()
@@ -1208,7 +1233,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn share_replica(&self, request: &ShareReplica) -> Result<String, SvcError> {
         match self.api_version() {
-            APIVersion::V0 => Ok(self
+            ApiVersion::V0 => Ok(self
                 .client_v0()?
                 .share_replica(v0_conversion::to_rpc(request))
                 .await
@@ -1218,7 +1243,7 @@ impl ClientOps for GrpcClientLocked {
                 })?
                 .into_inner()
                 .uri),
-            APIVersion::V1 => Ok(self
+            ApiVersion::V1 => Ok(self
                 .client_v1()?
                 .replica()
                 .share_replica(v1_conversion::to_rpc(request))
@@ -1234,7 +1259,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn unshare_replica(&self, request: &UnshareReplica) -> Result<String, SvcError> {
         match self.api_version() {
-            APIVersion::V0 => Ok(self
+            ApiVersion::V0 => Ok(self
                 .client_v0()?
                 .share_replica(v0_conversion::to_rpc(request))
                 .await
@@ -1244,7 +1269,7 @@ impl ClientOps for GrpcClientLocked {
                 })?
                 .into_inner()
                 .uri),
-            APIVersion::V1 => Ok(self
+            ApiVersion::V1 => Ok(self
                 .client_v1()?
                 .replica()
                 .unshare_replica(v1_conversion::to_rpc(request))
@@ -1260,7 +1285,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn destroy_replica(&self, request: &DestroyReplica) -> Result<(), SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let _ = self
                     .client_v0()?
                     .destroy_replica(v0_conversion::to_rpc(request))
@@ -1271,7 +1296,7 @@ impl ClientOps for GrpcClientLocked {
                     })?;
                 Ok(())
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let _ = self
                     .client_v1()?
                     .replica()
@@ -1288,7 +1313,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn create_nexus(&self, request: &CreateNexus) -> Result<Nexus, SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let rpc_nexus = self
                     .client_v0()?
                     .create_nexus_v2(v0_conversion::to_rpc(request))
@@ -1303,7 +1328,7 @@ impl ClientOps for GrpcClientLocked {
                 nexus.uuid = request.uuid.clone();
                 Ok(nexus)
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let rpc_nexus = self
                     .client_v1()?
                     .nexus()
@@ -1330,7 +1355,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn destroy_nexus(&self, request: &DestroyNexus) -> Result<(), SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let _ = self
                     .client_v0()?
                     .destroy_nexus(v0_conversion::to_rpc(request))
@@ -1341,7 +1366,7 @@ impl ClientOps for GrpcClientLocked {
                     })?;
                 Ok(())
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let _ = self
                     .client_v1()?
                     .nexus()
@@ -1358,7 +1383,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn share_nexus(&self, request: &ShareNexus) -> Result<String, SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let share = self
                     .client_v0()?
                     .publish_nexus(v0_conversion::to_rpc(request))
@@ -1370,7 +1395,7 @@ impl ClientOps for GrpcClientLocked {
                 let share = share.into_inner().device_uri;
                 Ok(share)
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let rpc_nexus = self
                     .client_v1()?
                     .nexus()
@@ -1396,7 +1421,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn unshare_nexus(&self, request: &UnshareNexus) -> Result<(), SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let _ = self
                     .client_v0()?
                     .unpublish_nexus(v0_conversion::to_rpc(request))
@@ -1407,7 +1432,7 @@ impl ClientOps for GrpcClientLocked {
                     })?;
                 Ok(())
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let _ = self
                     .client_v1()?
                     .nexus()
@@ -1424,7 +1449,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn add_child(&self, request: &AddNexusChild) -> Result<Child, SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let rpc_child = self
                     .client_v0()?
                     .add_child_nexus(v0_conversion::to_rpc(request))
@@ -1435,7 +1460,7 @@ impl ClientOps for GrpcClientLocked {
                     })?;
                 Ok(rpc_child.into_inner().to_agent())
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let rpc_nexus = self
                     .client_v1()?
                     .nexus()
@@ -1462,7 +1487,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn remove_child(&self, request: &RemoveNexusChild) -> Result<(), SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let _ = self
                     .client_v0()?
                     .remove_child_nexus(v0_conversion::to_rpc(request))
@@ -1473,7 +1498,7 @@ impl ClientOps for GrpcClientLocked {
                     })?;
                 Ok(())
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 let _ = self
                     .client_v1()?
                     .nexus()
@@ -1490,7 +1515,7 @@ impl ClientOps for GrpcClientLocked {
 
     async fn fault_child(&self, request: &FaultNexusChild) -> Result<(), SvcError> {
         match self.api_version() {
-            APIVersion::V0 => {
+            ApiVersion::V0 => {
                 let _ = self
                     .client_v0()?
                     .fault_nexus_child(request.to_rpc())
@@ -1501,7 +1526,7 @@ impl ClientOps for GrpcClientLocked {
                     })?;
                 Ok(())
             }
-            APIVersion::V1 => {
+            ApiVersion::V1 => {
                 unimplemented!()
             }
         }

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -145,6 +145,7 @@ impl Service {
                         id: node.id().clone(),
                         grpc_endpoint: node.endpoint(),
                         api_versions: None,
+                        instance_uuid: None,
                     },
                     true,
                 )

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -23,16 +23,12 @@ impl ResourceSpecsLocked {
                     let mut node_spec = node_spec.lock();
                     let changed = node_spec.endpoint() != node.grpc_endpoint;
 
-                    node_spec.set_endpoint(node.grpc_endpoint.clone());
+                    node_spec.set_endpoint(node.grpc_endpoint);
                     (changed, node_spec.clone())
                 }
                 None => {
-                    let node = NodeSpec::new(
-                        node.id.clone(),
-                        node.grpc_endpoint.clone(),
-                        NodeLabels::new(),
-                        None,
-                    );
+                    let node =
+                        NodeSpec::new(node.id.clone(), node.grpc_endpoint, NodeLabels::new(), None);
                     specs.nodes.insert(node.clone());
                     (true, node)
                 }

--- a/control-plane/agents/src/bin/core/tests/node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/node/mod.rs
@@ -1,6 +1,6 @@
 use common_lib::types::v0::{
     store::node::{NodeLabels, NodeSpec},
-    transport::{APIVersion, Filter, Node, NodeId, NodeState, NodeStatus},
+    transport::{ApiVersion, Filter, Node, NodeId, NodeState, NodeStatus},
 };
 use deployer_cluster::ClusterBuilder;
 use grpc::operations::node::traits::NodeOperations;
@@ -11,16 +11,12 @@ fn new_node(
     id: NodeId,
     endpoint: String,
     status: NodeStatus,
-    api_versions: Option<Vec<APIVersion>>,
+    api_versions: Option<Vec<ApiVersion>>,
 ) -> Node {
+    let endpoint = std::str::FromStr::from_str(&endpoint).unwrap();
     Node::new(
         id.clone(),
-        Some(NodeSpec::new(
-            id.clone(),
-            endpoint.clone(),
-            NodeLabels::new(),
-            None,
-        )),
+        Some(NodeSpec::new(id.clone(), endpoint, NodeLabels::new(), None)),
         Some(NodeState::new(id, endpoint, status, api_versions)),
     )
 }

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -20,6 +20,8 @@ common-lib = { path = "../../common" }
 humantime = "2.1.0"
 utils = { path = "../../utils/utils-lib" }
 rpc = { path = "../../rpc"}
+uuid = { version = "0.8.2", features = ["v4"] }
+
 # Tracing
 tracing-subscriber = { version = "0.3.15", features = [ "env-filter" ] }
 tracing-opentelemetry = "0.17.4"

--- a/control-plane/grpc/src/operations/registration/traits.rs
+++ b/control-plane/grpc/src/operations/registration/traits.rs
@@ -1,6 +1,6 @@
 use common_lib::{
-    transport_api::ReplyError,
-    types::v0::transport::{APIVersion, Deregister, NodeId, Register},
+    transport_api::{ReplyError, ResourceKind},
+    types::v0::transport::{node, Deregister, NodeId, Register},
 };
 use rpc::{
     v1::registration::{DeregisterRequest, RegisterRequest},
@@ -8,32 +8,33 @@ use rpc::{
         DeregisterRequest as V1AlphaDeregisterRequest, RegisterRequest as V1AlphaRegisterRequest,
     },
 };
+use std::str::FromStr;
 
-/// new type to wrap grpc ApiVersion type
+/// New type to wrap grpc ApiVersion type.
 pub struct ApiVersion(pub rpc::v1::registration::ApiVersion);
 
-/// Operations to be supportes by the Registration Service
+/// Operations to be supportes by the Registration Service.
 #[tonic::async_trait]
 pub trait RegistrationOperations: Send + Sync {
-    /// Register a dataplane node to controlplane
+    /// Register a dataplane node to controlplane.
     async fn register(&self, req: &dyn RegisterInfo) -> Result<(), ReplyError>;
-    /// Deregister a dataplane node to controlplane
+    /// Deregister a dataplane node to controlplane.
     async fn deregister(&self, req: &dyn DeregisterInfo) -> Result<(), ReplyError>;
 }
 
-/// Trait to be implemented for Register operation
+/// Trait to be implemented for Register operation.
 pub trait RegisterInfo: Send + Sync {
-    /// Id of the IoEngine instance
+    /// Node Id of the IoEngine instance.
     fn node_id(&self) -> NodeId;
-    /// Grpc endpoint of the IoEngine instance
+    /// Grpc endpoint of the IoEngine instance.
     fn grpc_endpoint(&self) -> String;
-    /// api-version supported by the dataplane
-    fn api_version(&self) -> Option<Vec<APIVersion>>;
+    /// Api-version supported by the dataplane.
+    fn api_version(&self) -> Option<Vec<node::ApiVersion>>;
 }
 
-/// Trait to be implemented for Register operation
+/// Trait to be implemented for Register operation.
 pub trait DeregisterInfo: Send + Sync {
-    /// Id of the IoEngine instance
+    /// Node Id of the IoEngine instance.
     fn node_id(&self) -> NodeId;
 }
 
@@ -43,10 +44,10 @@ impl RegisterInfo for Register {
     }
 
     fn grpc_endpoint(&self) -> String {
-        self.grpc_endpoint.clone()
+        self.grpc_endpoint.to_string()
     }
 
-    fn api_version(&self) -> Option<Vec<APIVersion>> {
+    fn api_version(&self) -> Option<Vec<node::ApiVersion>> {
         self.api_versions.clone()
     }
 }
@@ -60,7 +61,7 @@ impl RegisterInfo for RegisterRequest {
         self.grpc_endpoint.clone()
     }
 
-    fn api_version(&self) -> Option<Vec<APIVersion>> {
+    fn api_version(&self) -> Option<Vec<node::ApiVersion>> {
         Some(
             self.api_version
                 .clone()
@@ -83,9 +84,9 @@ impl RegisterInfo for V1AlphaRegisterRequest {
         self.grpc_endpoint.clone()
     }
 
-    fn api_version(&self) -> Option<Vec<APIVersion>> {
+    fn api_version(&self) -> Option<Vec<node::ApiVersion>> {
         // Older versions support only V0
-        Some(vec![APIVersion::V0])
+        Some(vec![node::ApiVersion::V0])
     }
 }
 
@@ -107,13 +108,22 @@ impl DeregisterInfo for V1AlphaDeregisterRequest {
     }
 }
 
-impl From<&dyn RegisterInfo> for Register {
-    fn from(register: &dyn RegisterInfo) -> Self {
-        Self {
+impl TryFrom<&dyn RegisterInfo> for Register {
+    type Error = ReplyError;
+    fn try_from(register: &dyn RegisterInfo) -> Result<Self, Self::Error> {
+        Ok(Self {
             id: register.node_id(),
-            grpc_endpoint: register.grpc_endpoint(),
+            grpc_endpoint: std::net::SocketAddr::from_str(&register.grpc_endpoint()).map_err(
+                |error| {
+                    Self::Error::invalid_argument(
+                        ResourceKind::Node,
+                        "register.grpc_endpoint",
+                        error.to_string(),
+                    )
+                },
+            )?,
             api_versions: register.api_version(),
-        }
+        })
     }
 }
 
@@ -125,16 +135,16 @@ impl From<&dyn DeregisterInfo> for Deregister {
     }
 }
 
-impl From<APIVersion> for ApiVersion {
-    fn from(v: APIVersion) -> Self {
+impl From<node::ApiVersion> for ApiVersion {
+    fn from(v: node::ApiVersion) -> Self {
         match v {
-            APIVersion::V0 => ApiVersion(rpc::v1::registration::ApiVersion::V0),
-            APIVersion::V1 => ApiVersion(rpc::v1::registration::ApiVersion::V1),
+            node::ApiVersion::V0 => Self(rpc::v1::registration::ApiVersion::V0),
+            node::ApiVersion::V1 => Self(rpc::v1::registration::ApiVersion::V1),
         }
     }
 }
 
-impl From<ApiVersion> for APIVersion {
+impl From<ApiVersion> for node::ApiVersion {
     fn from(v: ApiVersion) -> Self {
         match v {
             ApiVersion(rpc::v1::registration::ApiVersion::V0) => Self::V0,


### PR DESCRIPTION
fix(node-endpoint): use socketaddr type to ensure endpoint correctness

In some cases a node endpoint was being added the scheme twice.
Leverage the typesystem with the socketaddr type to make things clearer.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(restart-detection): use instance uuid to detect io-engine restarts

The registration instance uuid is used to detect io-engine restarts, allowing the control-plane
to run reconcilers etc as soon as possible.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
