### PR TITLE
feat(cluster-agent): implementing persistence layer and switchover engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ name = "common-lib"
 version = "1.0.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "dyn-clonable",
  "etcd-client",
  "k8s-openapi",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8.4"
 tonic = "0.8.0"
 k8s-openapi = { version = "0.15.0", features = ["v1_20"] }
 kube = { version = "0.74.0", features = ["derive"] }
+chrono = { version = "0.4.19", features = ["serde"] }
 
 # Tracing
 tracing-subscriber = { version = "0.3.15", features = [ "env-filter" ] }

--- a/common/src/types/v0/store/definitions.rs
+++ b/common/src/types/v0/store/definitions.rs
@@ -166,6 +166,7 @@ pub enum StorableObjectType {
     CoreRegistryConfig,
     StoreLeaseLock,
     StoreLeaseOwner,
+    SwitchOver,
 }
 
 /// Returns the key prefix that should is used for the keys, when running from within the cluster.

--- a/common/src/types/v0/store/mod.rs
+++ b/common/src/types/v0/store/mod.rs
@@ -7,6 +7,7 @@ pub mod node;
 pub mod pool;
 pub mod registry;
 pub mod replica;
+pub mod switchover;
 pub mod volume;
 pub mod watch;
 

--- a/common/src/types/v0/store/switchover.rs
+++ b/common/src/types/v0/store/switchover.rs
@@ -1,0 +1,166 @@
+use crate::types::v0::{
+    store::{
+        definitions::{ObjectKey, StorableObject, StorableObjectType},
+        SpecTransaction,
+    },
+    transport::VolumeId,
+};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Defines operation for SwitchOverSpec.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum Operation {
+    /// Initialize SwitchOverSpec.
+    Init,
+    /// Shutdown original/old volume target of SwitchOverSpec.
+    ShutdownOriginal,
+    /// Create new volume target for SwitchOverSpec.
+    ReconstructTarget,
+    /// Switch volume target to newly created target.
+    SwitchOverTarget,
+    /// Delete old volume target.
+    DeleteTarget,
+    /// Publish updated path of volume.
+    PublishPath,
+    /// Represent failed SwitchOverSpec.
+    Errored(String),
+}
+
+/// Represent the state for the operation.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct OperationState {
+    operation: Operation,
+    result: Option<bool>,
+}
+
+impl OperationState {
+    /// Create a new OperationState.
+    pub fn new(operation: Operation, result: Option<bool>) -> Self {
+        Self { operation, result }
+    }
+}
+
+/// Defines timestamp for switchoverspec.
+pub type SwitchOverTime = DateTime<Utc>;
+
+/// Represent switchover spec.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SwitchOverSpec {
+    /// Uri of node-agent to report new path.
+    pub callback_uri: String,
+    /// Volume for which switchover needs to be executed.
+    pub volume: VolumeId,
+    /// Operation represent current running operation on SwitchOverSpec.
+    pub operation: Option<OperationState>,
+    /// Timestamp when switchover request was generated.
+    pub timestamp: SwitchOverTime,
+}
+
+impl SwitchOverSpec {
+    /// Update spec with error message.
+    pub fn set_error_msg(&mut self, msg: String) {
+        self.operation = Some(OperationState {
+            operation: Operation::Errored(msg),
+            result: Some(false),
+        })
+    }
+
+    /// If switchoverspec is marked as completed or not.
+    pub fn is_completed(&self) -> bool {
+        if let Some(op) = &self.operation {
+            match op.operation {
+                Operation::Errored(_) => true,
+                Operation::PublishPath => matches!(op.result.unwrap_or(false), true),
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
+
+    /// If relevant request was errored or not.
+    pub fn is_errored(&self) -> bool {
+        if let Some(op) = &self.operation {
+            matches!(op.operation, Operation::Errored(_))
+        } else {
+            false
+        }
+    }
+
+    /// Returns current Operation for SwitchOverSpec.
+    pub fn operation(&self) -> Option<Operation> {
+        self.operation.as_ref().map(|op| op.operation.clone())
+    }
+}
+
+pub struct SwitchOverSpecKey(VolumeId);
+
+impl StorableObject for SwitchOverSpec {
+    type Key = SwitchOverSpecKey;
+
+    fn key(&self) -> Self::Key {
+        SwitchOverSpecKey(self.volume.clone())
+    }
+}
+
+impl SwitchOverSpecKey {
+    pub fn new(id: VolumeId) -> Self {
+        SwitchOverSpecKey(id)
+    }
+}
+
+impl ObjectKey for SwitchOverSpecKey {
+    fn key_type(&self) -> StorableObjectType {
+        StorableObjectType::SwitchOver
+    }
+
+    fn key_uuid(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl SpecTransaction<Operation> for SwitchOverSpec {
+    fn pending_op(&self) -> bool {
+        self.operation.is_some()
+    }
+
+    fn commit_op(&mut self) {
+        let next_op = if let Some(op) = self.operation.clone() {
+            match op.operation {
+                Operation::Init => Some(Operation::ShutdownOriginal),
+                Operation::ShutdownOriginal => Some(Operation::ReconstructTarget),
+                Operation::ReconstructTarget => Some(Operation::SwitchOverTarget),
+                Operation::SwitchOverTarget => Some(Operation::DeleteTarget),
+                Operation::DeleteTarget => Some(Operation::PublishPath),
+                Operation::PublishPath => None,
+                Operation::Errored(_) => None,
+            }
+        } else {
+            None
+        };
+
+        if let Some(op) = next_op {
+            self.start_op(op);
+        }
+    }
+
+    fn clear_op(&mut self) {
+        println!("TODO clear_op");
+        self.operation = None;
+    }
+
+    fn start_op(&mut self, operation: Operation) {
+        self.operation = Some(OperationState {
+            operation,
+            result: None,
+        })
+    }
+
+    fn set_op_result(&mut self, result: bool) {
+        if let Some(op) = &mut self.operation {
+            op.result = Some(result);
+        }
+    }
+}

--- a/control-plane/agents/src/bin/ha/cluster/etcd.rs
+++ b/control-plane/agents/src/bin/ha/cluster/etcd.rs
@@ -1,0 +1,97 @@
+use crate::switchover::SwitchOverRequest;
+use common_lib::{
+    store::etcd::Etcd,
+    types::v0::store::{
+        definitions::{
+            key_prefix_obj, ObjectKey, StorableObject, StorableObjectType, Store, StoreError,
+        },
+        switchover::SwitchOverSpec,
+    },
+};
+use futures::lock::Mutex;
+use http::Uri;
+use std::{convert::TryFrom, sync::Arc, time::Duration};
+use tracing::debug;
+
+/// Represent object to access Etcd.
+#[derive(Debug, Clone)]
+pub struct EtcdStore {
+    store: Arc<Mutex<Etcd>>,
+    timeout: Duration,
+}
+
+impl EtcdStore {
+    /// Create a new Etcd client.
+    pub async fn new(endpoint: Uri, timeout: Duration) -> Result<Self, StoreError> {
+        match tokio::time::timeout(timeout, async { Etcd::new(&endpoint.to_string()).await }).await
+        {
+            Ok(v) => {
+                let store = v?;
+                Ok(Self {
+                    store: Arc::new(Mutex::new(store)),
+                    timeout,
+                })
+            }
+            Err(_) => Err(StoreError::Timeout {
+                operation: "connect".to_string(),
+                timeout,
+            }),
+        }
+    }
+
+    /// Serialized write to the persistent store.
+    pub async fn store_obj<O: StorableObject>(&self, object: &O) -> Result<(), anyhow::Error> {
+        let mut store = self.store.lock().await;
+        match tokio::time::timeout(self.timeout, async move { store.put_obj(object).await }).await {
+            Ok(result) => result.map_err(Into::into),
+            Err(_) => Err(StoreError::Timeout {
+                operation: "Put".to_string(),
+                timeout: self.timeout,
+            }
+            .into()),
+        }
+    }
+
+    /// Delete the object from the persistent store.
+    pub async fn delete_obj<O: StorableObject>(&self, object: &O) -> Result<(), anyhow::Error> {
+        let mut store = self.store.lock().await;
+        match tokio::time::timeout(self.timeout, async move {
+            store.delete_kv(&object.key().key()).await
+        })
+        .await
+        {
+            Ok(_) => Ok(()),
+            Err(_) => Err(StoreError::Timeout {
+                operation: "Delete".to_string(),
+                timeout: self.timeout,
+            }
+            .into()),
+        }
+    }
+
+    /// Get incomplete requests stored in Etcd.
+    /// Request with error or path published is considered a complete request.
+    pub async fn fetch_incomplete_requests(&self) -> Result<Vec<SwitchOverRequest>, anyhow::Error> {
+        let mut store = self.store.lock().await;
+        let key = key_prefix_obj(StorableObjectType::SwitchOver);
+        let store_entries = store.get_values_prefix(&key).await?;
+
+        debug!("fetched entries from etcd");
+
+        let entries = store_entries
+            .into_iter()
+            .map(|v| v.1)
+            .map(serde_json::from_value)
+            .collect::<Result<Vec<SwitchOverSpec>, serde_json::Error>>()?;
+
+        let mut partial_entries = vec![];
+        for spec in entries {
+            if !spec.is_completed() {
+                let req = SwitchOverRequest::try_from(&spec)?;
+                partial_entries.push(req)
+            }
+        }
+
+        Ok(partial_entries)
+    }
+}

--- a/control-plane/agents/src/bin/ha/cluster/nodes.rs
+++ b/control-plane/agents/src/bin/ha/cluster/nodes.rs
@@ -1,0 +1,65 @@
+use crate::volume::VolumeMover;
+use common_lib::types::v0::transport::NodeId;
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use tokio::sync::Mutex;
+use tracing::info;
+
+/// Store node information and reported failed path.
+#[derive(Debug, Clone)]
+pub struct NodeList {
+    list: Arc<Mutex<HashMap<NodeId, SocketAddr>>>,
+    failed_path: Arc<Mutex<HashMap<String, SocketAddr>>>,
+}
+
+impl NodeList {
+    pub fn new() -> Self {
+        NodeList {
+            list: Arc::new(Mutex::new(HashMap::new())),
+            failed_path: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Register node and its endpoint.
+    /// If node is already registered then update it details.
+    pub async fn register_node(&self, name: NodeId, endpoint: SocketAddr) {
+        let mut list = self.list.lock().await;
+        list.insert(name, endpoint);
+    }
+
+    pub async fn remove_failed_path(&self, path: String) {
+        let mut failed_path = self.failed_path.lock().await;
+        failed_path.remove(&path);
+    }
+
+    /// Send switchover request to switchover engine for the
+    /// reported node and path.
+    pub async fn report_failed_path(
+        self,
+        node: NodeId,
+        path: String,
+        mover: VolumeMover,
+    ) -> Result<(), anyhow::Error> {
+        let uri = {
+            let list = self.list.lock().await;
+            list.get(&node).copied()
+        };
+
+        let mut failed_path = self.failed_path.lock().await;
+
+        if failed_path.get(&path).is_some() {
+            anyhow::bail!("Path {} is already reported for switchover", path);
+        };
+
+        info!(node.id=%node, %path, "Sending switchover for path");
+
+        if let Some(uri) = uri {
+            info!(node.id=%node, %path, "Sending switchover for path");
+
+            mover.switchover(uri.to_string(), path.clone()).await?;
+            failed_path.insert(path, uri);
+            Ok(())
+        } else {
+            Err(anyhow::format_err!("Node {} is not registered", node))
+        }
+    }
+}

--- a/control-plane/agents/src/bin/ha/cluster/server.rs
+++ b/control-plane/agents/src/bin/ha/cluster/server.rs
@@ -1,4 +1,5 @@
-use common_lib::transport_api::{ReplyError, ResourceKind};
+use crate::{nodes::NodeList, volume::VolumeMover};
+use common_lib::transport_api::{ReplyError, ReplyErrorKind, ResourceKind};
 use grpc::{
     context::Context,
     operations::ha_node::{
@@ -6,21 +7,33 @@ use grpc::{
         traits::{ClusterAgentOperations, NodeInfo, ReportFailedPathsInfo},
     },
 };
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::{AddrParseError, SocketAddr},
+    sync::Arc,
+};
 
 /// High-level object that represents HA Cluster agent gRPC server.
 pub(crate) struct ClusterAgent {
     endpoint: SocketAddr,
+    nodes: NodeList,
+    mover: VolumeMover,
 }
 
 impl ClusterAgent {
     /// Returns a new `Self` with the given parameters.
-    pub(crate) fn new(endpoint: SocketAddr) -> Self {
-        ClusterAgent { endpoint }
+    pub(crate) fn new(endpoint: SocketAddr, nodes: NodeList, mover: VolumeMover) -> Self {
+        ClusterAgent {
+            endpoint,
+            nodes,
+            mover,
+        }
     }
     /// Runs this server as a future until a shutdown signal is received.
     pub(crate) async fn run(&self) -> Result<(), agents::ServiceError> {
-        let r = ClusterAgentServer::new(Arc::new(ClusterAgentSvc {}));
+        let r = ClusterAgentServer::new(Arc::new(ClusterAgentSvc {
+            nodes: self.nodes.clone(),
+            mover: self.mover.clone(),
+        }));
         agents::Service::builder()
             .with_service(r.into_grpc_server())
             .run_err(self.endpoint)
@@ -28,10 +41,14 @@ impl ClusterAgent {
     }
 }
 
-struct ClusterAgentSvc {}
+struct ClusterAgentSvc {
+    nodes: NodeList,
+    mover: VolumeMover,
+}
 
 #[tonic::async_trait]
 impl ClusterAgentOperations for ClusterAgentSvc {
+    #[tracing::instrument(level = "info", skip(self), err, fields(node.id = %request.node(), node.endpoint = %request.endpoint()))]
     async fn register(
         &self,
         request: &dyn NodeInfo,
@@ -51,17 +68,49 @@ impl ClusterAgentOperations for ClusterAgentSvc {
             ));
         }
 
+        let ep: SocketAddr = request.endpoint().parse().map_err(|e: AddrParseError| {
+            ReplyError::invalid_argument(ResourceKind::Unknown, "endpoint", e.to_string())
+        })?;
+
+        self.nodes.register_node(request.node().into(), ep).await;
         tracing::trace!(agent = request.node(), "node successfully registered");
         Ok(())
     }
 
+    #[tracing::instrument(level = "info", skip(self), err, fields(node.id = %request.node()))]
     async fn report_failed_nvme_paths(
         &self,
-        _request: &dyn ReportFailedPathsInfo,
+        request: &dyn ReportFailedPathsInfo,
         _context: Option<Context>,
     ) -> Result<(), ReplyError> {
-        Err(ReplyError::unimplemented(
-            "NVMe path reporting is not yet implemented".to_string(),
-        ))
+        let mut v: Vec<(String, String)> = Vec::new();
+
+        for x in request.failed_paths().into_iter() {
+            let nodes = self.nodes.clone();
+            _ = nodes
+                .report_failed_path(
+                    request.node().into(),
+                    x.target_nqn().to_string(),
+                    self.mover.clone(),
+                )
+                .await
+                .map_err(|e| {
+                    v.push((x.target_nqn().to_string(), e.to_string()));
+                });
+        }
+
+        if !v.is_empty() {
+            let mut e = ReplyError {
+                kind: ReplyErrorKind::WithMessage,
+                resource: ResourceKind::Unknown,
+                source: "".into(),
+                extra: "".into(),
+            };
+            v.iter().for_each(|x| {
+                e.extend(&x.0, &x.1);
+            });
+            return Err(e);
+        }
+        Ok(())
     }
 }

--- a/control-plane/agents/src/bin/ha/cluster/switchover.rs
+++ b/control-plane/agents/src/bin/ha/cluster/switchover.rs
@@ -1,0 +1,300 @@
+use crate::{etcd::EtcdStore, nodes::NodeList};
+use chrono::Utc;
+use common_lib::types::v0::{
+    store::{
+        switchover::{Operation, OperationState, SwitchOverSpec, SwitchOverTime},
+        SpecTransaction,
+    },
+    transport::VolumeId,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tracing::info;
+use utils::NVME_TARGET_NQN_PREFIX;
+
+use std::convert::TryFrom;
+
+/// Stage represents the steps for switchover request.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum Stage {
+    /// Initialize switchover request.
+    Init,
+    /// Shutdown original/old volume target.
+    ShutdownOriginal,
+    /// Create new volume target.
+    ReconstructTarget,
+    /// Update volume with new volume target.
+    SwitchOverTarget,
+    /// Delete old target.
+    DeleteTarget,
+    /// Publish updated path of volume to node-agent.
+    PublishPath,
+    /// Represet failed switchover request.
+    Errored,
+}
+
+/// SwitchOverRequest defines spec for switchover.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct SwitchOverRequest {
+    callback_uri: String,
+    pub volume_id: VolumeId,
+    stage: Stage,
+    // Timestamp when switchover request was initialized.
+    timestamp: SwitchOverTime,
+}
+
+impl From<&SwitchOverRequest> for SwitchOverSpec {
+    fn from(req: &SwitchOverRequest) -> Self {
+        let op = OperationState::new(req.stage.clone().into(), None);
+        Self {
+            callback_uri: req.callback_uri.clone(),
+            volume: req.volume_id.clone(),
+            operation: Some(op),
+            timestamp: req.timestamp,
+        }
+    }
+}
+
+impl From<Stage> for Operation {
+    fn from(stage: Stage) -> Self {
+        match stage {
+            Stage::Init => Operation::Init,
+            Stage::ShutdownOriginal => Operation::ShutdownOriginal,
+            Stage::ReconstructTarget => Operation::ReconstructTarget,
+            Stage::SwitchOverTarget => Operation::SwitchOverTarget,
+            Stage::DeleteTarget => Operation::DeleteTarget,
+            Stage::PublishPath => Operation::PublishPath,
+            Stage::Errored => Operation::Errored("".to_string()),
+        }
+    }
+}
+
+impl From<Operation> for Stage {
+    fn from(op: Operation) -> Self {
+        match op {
+            Operation::Init => Stage::Init,
+            Operation::ShutdownOriginal => Stage::ShutdownOriginal,
+            Operation::ReconstructTarget => Stage::ReconstructTarget,
+            Operation::SwitchOverTarget => Stage::SwitchOverTarget,
+            Operation::DeleteTarget => Stage::DeleteTarget,
+            Operation::PublishPath => Stage::PublishPath,
+            Operation::Errored(_) => Stage::Errored,
+        }
+    }
+}
+
+impl From<&SwitchOverSpec> for SwitchOverRequest {
+    fn from(req: &SwitchOverSpec) -> Self {
+        let mut stage = Stage::Init;
+        if let Some(op) = req.operation() {
+            stage = op.into();
+        }
+
+        Self {
+            callback_uri: req.callback_uri.clone(),
+            volume_id: req.volume.clone(),
+            stage,
+            timestamp: req.timestamp,
+        }
+    }
+}
+
+/// SwitchOverEngine defines spec for switchover engine.
+#[derive(Debug, Clone)]
+pub struct SwitchOverEngine {
+    etcd: EtcdStore,
+    nodes: NodeList,
+    channel: UnboundedSender<SwitchOverRequest>,
+}
+
+impl SwitchOverRequest {
+    pub fn new(callback_uri: String, volume: VolumeId) -> SwitchOverRequest {
+        SwitchOverRequest {
+            callback_uri,
+            volume_id: volume,
+            stage: Stage::Init,
+            timestamp: Utc::now(),
+        }
+    }
+
+    pub fn with_stage(&mut self, stage: Stage) {
+        self.stage = stage;
+    }
+
+    pub fn stage(&self) -> Stage {
+        self.stage.clone()
+    }
+
+    pub fn timestamp(&self) -> SwitchOverTime {
+        self.timestamp
+    }
+
+    /// Update stage with next stage.
+    /// If a stage is PublishPath or Errored then it will not be updated.
+    pub fn update_next_stage(&mut self) {
+        self.stage = match self.stage {
+            Stage::Init => Stage::ShutdownOriginal,
+            Stage::ShutdownOriginal => Stage::ReconstructTarget,
+            Stage::ReconstructTarget => Stage::SwitchOverTarget,
+            Stage::SwitchOverTarget => Stage::DeleteTarget,
+            Stage::DeleteTarget => Stage::PublishPath,
+            // PublishPath and Errored stage mark request as complete, so no need to update
+            Stage::PublishPath => Stage::PublishPath,
+            Stage::Errored => Stage::Errored,
+        };
+    }
+
+    /// Start_op must be called before starting the respective stage operation on the request.
+    /// Start_op will store the request with updated stage in formation in etcd.
+    pub async fn start_op(&self, stage: Stage, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+        let mut spec: SwitchOverSpec = self.into();
+        spec.start_op(stage.into());
+        etcd.store_obj(&spec).await
+    }
+
+    /// Complete_op must be called after completion of the respective stage operation on the
+    /// request.
+    /// Complete_op will store the request in etcd with either updated stage or error message.
+    pub async fn complete_op(
+        &self,
+        result: bool,
+        msg: String,
+        etcd: &EtcdStore,
+    ) -> Result<(), anyhow::Error> {
+        let mut spec = SwitchOverSpec::try_from(self)?;
+
+        if result {
+            spec.set_op_result(result);
+            spec.commit_op();
+        } else {
+            spec.set_error_msg(msg);
+        }
+        etcd.store_obj(&spec).await?;
+
+        Ok(())
+    }
+
+    pub async fn delete_request(&self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+        let spec = SwitchOverSpec::try_from(self)?;
+        etcd.delete_obj(&spec).await
+    }
+
+    /// Initialize the switchover request.
+    async fn initialize(&mut self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+        self.start_op(Stage::Init, etcd).await?;
+
+        info!(volume.uuid=%self.volume_id, "Initializing");
+
+        self.complete_op(true, "".to_string(), etcd).await?;
+        self.update_next_stage();
+        Ok(())
+    }
+
+    /// Shutdown original/old volume target.
+    async fn shutdown_original_target(&mut self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+        self.start_op(Stage::ShutdownOriginal, etcd).await?;
+
+        info!(volume.uuid=%self.volume_id, "Shutting down traget");
+
+        self.complete_op(true, "".to_string(), etcd).await?;
+        self.update_next_stage();
+        Ok(())
+    }
+
+    /// Create new volume target for the switchover.
+    async fn reconstruct_target(&mut self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+        self.start_op(Stage::ReconstructTarget, etcd).await?;
+
+        info!(volume.uuid=%self.volume_id, "Reconstructing volume target");
+
+        self.complete_op(true, "".to_string(), etcd).await?;
+        self.update_next_stage();
+        Ok(())
+    }
+
+    /// Update volume with newly constructed target.
+    async fn switchover_target(&mut self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+        self.start_op(Stage::SwitchOverTarget, etcd).await?;
+
+        info!(volume.uuid=%self.volume_id, "Switching volume target");
+
+        self.complete_op(true, "".to_string(), etcd).await?;
+        self.update_next_stage();
+        Ok(())
+    }
+
+    /// Destroy old/original target.
+    async fn delete_target(&mut self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+        self.start_op(Stage::DeleteTarget, etcd).await?;
+
+        info!(volume.uuid=%self.volume_id, "Deleting volume target");
+
+        self.complete_op(true, "".to_string(), etcd).await?;
+        self.update_next_stage();
+        Ok(())
+    }
+
+    /// Publish updated path for the volume to node-agent.
+    async fn publish_path(
+        &mut self,
+        etcd: &EtcdStore,
+        nodes: &NodeList,
+    ) -> Result<(), anyhow::Error> {
+        self.start_op(Stage::PublishPath, etcd).await?;
+
+        info!(volume.uuid=%self.volume_id, "Publishing volume target");
+
+        nodes
+            .remove_failed_path(format!("{}{}", NVME_TARGET_NQN_PREFIX, self.volume_id))
+            .await;
+        self.complete_op(true, "".to_string(), etcd).await?;
+        Ok(())
+    }
+}
+
+impl SwitchOverEngine {
+    pub fn new(etcd: EtcdStore, nodes: NodeList) -> Self {
+        let (rq_tx, rq_rx) = unbounded_channel();
+
+        let sw = SwitchOverEngine {
+            channel: rq_tx,
+            etcd,
+            nodes,
+        };
+
+        sw.mover(rq_rx);
+        sw
+    }
+
+    /// Mover is responsible for processing the switchover request sequentially.
+    pub fn mover(&self, mut recv: UnboundedReceiver<SwitchOverRequest>) {
+        let etcd = self.etcd.clone();
+        let nodes = self.nodes.clone();
+
+        tokio::spawn(async move {
+            loop {
+                if let Some(mut q) = recv.recv().await {
+                    loop {
+                        // TODO: error handling
+                        let _res = match q.stage {
+                            Stage::Init => q.initialize(&etcd).await,
+                            Stage::ShutdownOriginal => q.shutdown_original_target(&etcd).await,
+                            Stage::ReconstructTarget => q.reconstruct_target(&etcd).await,
+                            Stage::SwitchOverTarget => q.switchover_target(&etcd).await,
+                            Stage::DeleteTarget => q.delete_target(&etcd).await,
+                            Stage::PublishPath => match q.publish_path(&etcd, &nodes).await {
+                                Ok(_) => break,
+                                Err(e) => Err(e),
+                            },
+                            _ => break,
+                        };
+                    }
+                }
+            }
+        });
+    }
+
+    pub fn initiate(&self, req: SwitchOverRequest) {
+        self.channel.send(req).expect("sending req failed");
+    }
+}

--- a/control-plane/agents/src/bin/ha/cluster/volume.rs
+++ b/control-plane/agents/src/bin/ha/cluster/volume.rs
@@ -1,0 +1,59 @@
+use crate::{
+    etcd::EtcdStore,
+    nodes::NodeList,
+    switchover::{Stage, SwitchOverEngine, SwitchOverRequest},
+};
+use common_lib::types::v0::transport::VolumeId;
+use std::convert::TryFrom;
+use utils::NVME_TARGET_NQN_PREFIX;
+
+/// Defines spec for VolumeMover.
+#[derive(Debug, Clone)]
+pub struct VolumeMover {
+    etcd: EtcdStore,
+    engine: SwitchOverEngine,
+}
+
+impl VolumeMover {
+    pub fn new(etcd: EtcdStore, nodes: NodeList) -> Self {
+        let sw = SwitchOverEngine::new(etcd.clone(), nodes);
+
+        Self { engine: sw, etcd }
+    }
+
+    /// Switchover build the switchover request for the given nqn and send it to SwitchOverEngine.
+    #[tracing::instrument(level = "info", skip(self), err)]
+    pub async fn switchover(&self, uri: String, nqn: String) -> Result<(), anyhow::Error> {
+        if !nqn.starts_with(NVME_TARGET_NQN_PREFIX) {
+            return Err(anyhow::anyhow!("Invalid nqn"));
+        }
+
+        let volume = nqn
+            .strip_prefix(NVME_TARGET_NQN_PREFIX)
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse volume UUID"))?;
+
+        let volume_uuid = VolumeId::try_from(volume)?;
+
+        let req = SwitchOverRequest::new(uri, volume_uuid);
+
+        // calling start_op here to store the request in etcd
+        req.start_op(Stage::Init, &self.etcd).await?;
+        self.engine.initiate(req);
+        Ok(())
+    }
+
+    /// Send batch of switchover request to SwitchOverEngine.
+    #[tracing::instrument(level = "info", skip(self), err)]
+    pub async fn send_switchover_req(
+        &self,
+        mut req: Vec<SwitchOverRequest>,
+    ) -> Result<(), anyhow::Error> {
+        req.sort_by_key(|r| r.timestamp());
+
+        for entry in req {
+            entry.start_op(entry.stage(), &self.etcd).await?;
+            self.engine.initiate(entry);
+        }
+        Ok(())
+    }
+}

--- a/control-plane/grpc/src/operations/ha_node/server.rs
+++ b/control-plane/grpc/src/operations/ha_node/server.rs
@@ -79,10 +79,15 @@ impl HaRpc for ClusterAgentServer {
     }
     async fn report_failed_nvme_paths(
         &self,
-        _request: tonic::Request<ReportFailedNvmePathsRequest>,
+        request: tonic::Request<ReportFailedNvmePathsRequest>,
     ) -> Result<tonic::Response<()>, tonic::Status> {
-        Err(Status::unimplemented(
-            "NVMe path reporting is not yet implemented",
-        ))
+        let pathinfo = request.into_inner();
+        match self.service.report_failed_nvme_paths(&pathinfo, None).await {
+            Ok(_) => Ok(Response::new(())),
+            Err(err) => Err(Status::internal(format!(
+                "Failed to report path: {:?}",
+                err
+            ))),
+        }
     }
 }

--- a/control-plane/grpc/src/operations/ha_node/traits.rs
+++ b/control-plane/grpc/src/operations/ha_node/traits.rs
@@ -115,6 +115,19 @@ impl ReportFailedPathsInfo for ReportFailedPaths {
     }
 }
 
+impl ReportFailedPathsInfo for ReportFailedNvmePathsRequest {
+    fn node(&self) -> String {
+        self.nodename.clone()
+    }
+
+    fn failed_paths(&self) -> Vec<FailedPath> {
+        self.failed_paths
+            .iter()
+            .map(|p| FailedPath::new(p.target_nqn.to_string()))
+            .collect()
+    }
+}
+
 impl From<&dyn ReportFailedPathsInfo> for ReportFailedNvmePathsRequest {
     fn from(info: &dyn ReportFailedPathsInfo) -> Self {
         Self {

--- a/deployer/src/infra/agents/ha/cluster.rs
+++ b/deployer/src/infra/agents/ha/cluster.rs
@@ -5,12 +5,15 @@ use crate::infra::*;
 
 #[async_trait]
 impl ComponentAction for HaClusterAgent {
-    fn configure(&self, _options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
+    fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
         let mut spec = ContainerSpec::from_binary(
             "agent-ha-cluster",
             Binary::from_dbg("agent-ha-cluster").with_args(vec!["-g=0.0.0.0:11500"]),
         )
         .with_portmap("11500", "11500");
+
+        let etcd = format!("etcd.{}:2379", options.cluster_label.name());
+        spec = spec.with_args(vec!["--store", &etcd]);
 
         if cfg.container_exists("jaeger") {
             let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());

--- a/tests/bdd/features/ha/cluster-agent/test_cluster_agent.py
+++ b/tests/bdd/features/ha/cluster-agent/test_cluster_agent.py
@@ -78,7 +78,7 @@ def context():
 @pytest.fixture
 def register_node_agent(context):
     hdl = cluster_agent_rpc_handle()
-    req = pb.HaNodeInfo(nodename="test", endpoint="http://node-agent-test:1111")
+    req = pb.HaNodeInfo(nodename="test", endpoint="0.0.0.0:1111")
 
     context["attempt"] = hdl.api.RegisterNodeAgent(req)
 


### PR DESCRIPTION
changes:
- Added support to store switchover request in etcd
- Added support to process incomplete switchover request on cluster-agent restart

Signed-off-by: Mayank <mayank.patel@datacore.com>