### PR TITLE
fix(kubectl-plugin): add arch prefix to the tar name

### DIFF
--- a/.github/workflows/release_artifacts.yml
+++ b/.github/workflows/release_artifacts.yml
@@ -13,10 +13,13 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-musl
+            arch: x86_64
           - os: macos-latest
             target: apple-darwin
+            arch: x86_64
           - os: ubuntu-latest
             target: windows-gnu
+            arch: x86_64
             suffix: .exe
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +31,6 @@ jobs:
       - run: nix-build -A utils.release.${{ matrix.target }}.kubectl-plugin --arg incremental false
       - uses: actions/upload-artifact@v3
         with:
-          name: kubectl-mayastor-${{ matrix.target }}
+          name: kubectl-mayastor-${{ matrix.arch }}-${{ matrix.target }}
           path: ./result/bin/kubectl-mayastor${{ matrix.suffix }}
           if-no-files-found: error

--- a/nix/pkgs/utils/default.nix
+++ b/nix/pkgs/utils/default.nix
@@ -92,11 +92,11 @@ let
     # Can only be built on apple-darwin
     apple-darwin = rec {
       target = channel.makeRustTarget pkgs.pkgsStatic.hostPlatform;
-      x84_64-apple-darwin = channel.makeRustTarget pkgs.pkgsCross.x86_64-darwin.hostPlatform;
+      x86_64-apple-darwin = channel.makeRustTarget pkgs.pkgsCross.x86_64-darwin.hostPlatform;
       naersk = naersk_package (channel.static {
         inherit target;
       });
-      check_assert = lib.asserts.assertMsg (target == x84_64-apple-darwin) "This may only be built on ${x84_64-apple-darwin}";
+      check_assert = lib.asserts.assertMsg (target == x86_64-apple-darwin) "This may only be built on ${x86_64-apple-darwin}";
 
       kubectl-plugin = naersk.buildPackage {
         inherit release src version singleStep check_assert;


### PR DESCRIPTION
This way we make it obvious that the static binaries we publish are only x86_64 (for now).

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>