### PR TITLE
feat(nexus-shutdown): adding changes for nexus shutdown api call

### DIFF
--- a/common/src/transport_api/v0.rs
+++ b/common/src/transport_api/v0.rs
@@ -46,6 +46,7 @@ impl_message!(UnshareNexus);
 impl_message!(RemoveNexusChild);
 impl_message!(AddNexusChild);
 impl_message!(FaultNexusChild);
+impl_message!(ShutdownNexus);
 
 impl_vector_request_token!(Volumes, Volume);
 impl_message!(GetVolumes);

--- a/common/src/types/v0/transport/mod.rs
+++ b/common/src/types/v0/transport/mod.rs
@@ -135,6 +135,8 @@ pub enum MessageIdVs {
     RegisterHaNode,
     /// Report failed NVMe paths.
     ReportFailedPaths,
+    /// Shutdown Nexus
+    ShutdownNexus,
 }
 
 impl From<MessageIdVs> for MessageId {

--- a/control-plane/agents/src/common/msg_translation/v0.rs
+++ b/control-plane/agents/src/common/msg_translation/v0.rs
@@ -355,6 +355,16 @@ impl AgentToIoEngine for transport::FaultNexusChild {
     }
 }
 
+/// Converts Control plane Nexus shutdown struct to IO Engine message
+impl AgentToIoEngine for transport::ShutdownNexus {
+    type IoEngineMessage = v0_rpc::ShutdownNexusRequest;
+    fn to_rpc(&self) -> Self::IoEngineMessage {
+        Self::IoEngineMessage {
+            uuid: self.uuid().into(),
+        }
+    }
+}
+
 /// convert rpc replica to a agent replica
 pub fn rpc_replica_to_agent(
     rpc_replica: &v0_rpc::ReplicaV2,

--- a/control-plane/agents/src/common/msg_translation/v1.rs
+++ b/control-plane/agents/src/common/msg_translation/v1.rs
@@ -316,6 +316,15 @@ impl AgentToIoEngine for transport::FaultNexusChild {
     }
 }
 
+impl AgentToIoEngine for transport::ShutdownNexus {
+    type IoEngineMessage = v1_rpc::nexus::ShutdownNexusRequest;
+    fn to_rpc(&self) -> Self::IoEngineMessage {
+        Self::IoEngineMessage {
+            uuid: self.uuid().into(),
+        }
+    }
+}
+
 /// convert rpc nexus to a agent nexus
 pub fn rpc_nexus_to_agent(
     rpc_nexus: &v1_rpc::nexus::Nexus,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -350,7 +350,8 @@ pub mod v1 {
             ChildStateReason, CreateNexusRequest, CreateNexusResponse, DestroyNexusRequest,
             FaultNexusChildRequest, ListNexusOptions, ListNexusResponse, Nexus, NexusState,
             NvmeAnaState, PublishNexusRequest, PublishNexusResponse, RemoveChildNexusRequest,
-            RemoveChildNexusResponse, UnpublishNexusRequest, UnpublishNexusResponse,
+            RemoveChildNexusResponse, ShutdownNexusRequest, UnpublishNexusRequest,
+            UnpublishNexusResponse,
         };
     }
 


### PR DESCRIPTION
This PR includes implementation to call io-engine nexus shutdown api from control plane.

Signed-off-by: Abhilash Shetty <abhilash.shetty@datacore.com>