### PR TITLE
fix(local): pin csi-nodes to io-engine nodes

### DIFF
--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -134,12 +134,6 @@ impl IoEngineApiClient {
         Ok(response.into_body())
     }
 
-    /// Get a particular node available in IoEngine cluster.
-    pub(crate) async fn get_node(&self, node_id: &str) -> Result<Node, ApiClientError> {
-        let response = self.rest_client.nodes_api().get_node(node_id).await?;
-        Ok(response.into_body())
-    }
-
     /// List all pools available in IoEngine cluster.
     pub(crate) async fn list_pools(&self) -> Result<Vec<Pool>, ApiClientError> {
         let response = self.rest_client.pools_api().get_pools().await?;


### PR DESCRIPTION
Publish directly to the control-plane, which will fail if the node is not an io-engine node and will also fail if the node is not online, rather than randomly selecting a node.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>