### PR TITLE
ci: make control plane sees nodes as online before completing node wait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__
 /tests/bdd/autogen/
 /terraform/cluster/ansible-hosts
 /terraform/cluster/current_user.txt
+/rust-toolchain.toml

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -1,4 +1,6 @@
 use crate::infra::*;
+use common_lib::types::v0::transport::{Filter, NodeStatus};
+use grpc::operations::node::traits::NodeOperations;
 
 #[async_trait]
 impl ComponentAction for CoreAgent {
@@ -78,5 +80,30 @@ impl ComponentAction for CoreAgent {
         })?;
 
         Ok(())
+    }
+}
+
+impl CoreAgent {
+    /// Wait for a node to become online.
+    pub(crate) async fn wait_node_online(cfg: &ComposeTest, node: &str) {
+        let ip = cfg.container_ip("core");
+        let uri = tonic::transport::Uri::from_str(&format!("https://{}:50051", ip)).unwrap();
+
+        let timeout = grpc::context::TimeoutOptions::new()
+            .with_req_timeout(std::time::Duration::from_millis(100));
+        let core =
+            grpc::client::CoreClient::new(uri, Some(timeout.with_max_retries(Some(10)))).await;
+
+        loop {
+            let filter = Filter::Node(node.into());
+            if let Ok(nodes) = core.node().get(filter, None).await {
+                if let Some(node) = nodes.0.into_iter().find(|n| n.id().as_str() == node) {
+                    if node.state().map(|s| &s.status) == Some(&NodeStatus::Online) {
+                        return;
+                    }
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
     }
 }

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -82,6 +82,10 @@ impl ComponentAction for IoEngine {
                 RpcHandle::connect(options.latest_io_api_version(), &name, socket).await?;
             hdl.ping().await.unwrap();
         }
+        for i in 0 .. options.io_engines {
+            let name = Self::name(i, options);
+            super::CoreAgent::wait_node_online(cfg, &name).await;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
chore: enable rustup for dev environments

When not running on CI (env CI set) and the arg devrustup is true then the nix-shell
setups an appropriate rust toolchain toml file.
This makes it easier to integrate with custom (non-nix) environments (or so I hope)

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

ci: make control plane sees nodes as online before completing node wait

This should resolve some CI errors we've seen where we start testing before the nodes are ready.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>