### PR TITLE
ci: make control plane sees nodes as online before completing node wait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__
 /tests/bdd/autogen/
 /terraform/cluster/ansible-hosts
 /terraform/cluster/current_user.txt
+/rust-toolchain.toml

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -82,6 +82,10 @@ impl ComponentAction for IoEngine {
                 RpcHandle::connect(options.latest_io_api_version(), &name, socket).await?;
             hdl.ping().await.unwrap();
         }
+        for i in 0 .. options.io_engines {
+            let name = Self::name(i, options);
+            super::CoreAgent::wait_node_online(cfg, &name).await;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
chore: enable rustup for dev environments

When not running on CI (env CI set) and the arg devrustup is true then the nix-shell
setups an appropriate rust toolchain toml file.
This makes it easier to integrate with custom (non-nix) environments (or so I hope)

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

ci: make control plane sees nodes as online before completing node wait

This should resolve some CI errors we've seen where we start testing before the nodes are ready.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>