### PR TITLE
feat(ha_nexus): implementing HA Cluster agent stages

### DIFF
--- a/common/src/transport_api/mod.rs
+++ b/common/src/transport_api/mod.rs
@@ -160,8 +160,11 @@ impl From<tonic::Status> for ReplyError {
 }
 
 impl From<ReplyError> for tonic::Status {
-    fn from(err: ReplyError) -> Self {
-        tonic::Status::new(Code::Aborted, err.full_string())
+    fn from(error: ReplyError) -> Self {
+        match error.kind {
+            ReplyErrorKind::InvalidArgument => tonic::Status::invalid_argument(error.full_string()),
+            _ => tonic::Status::internal(error.full_string()),
+        }
     }
 }
 

--- a/common/src/types/v0/transport/cluster_agent.rs
+++ b/common/src/types/v0/transport/cluster_agent.rs
@@ -11,6 +11,8 @@ pub struct NodeAgentInfo {
 }
 
 impl NodeAgentInfo {
+    /// Creates an instance containing node name and node agent's grpc endpoint. Used for
+    /// registering node agent with cluster agent.
     pub fn new(node_name: String, endpoint: SocketAddr) -> Self {
         NodeAgentInfo {
             node_name,
@@ -18,10 +20,12 @@ impl NodeAgentInfo {
         }
     }
 
+    /// Get node name.
     pub fn node_name(&self) -> &str {
         &self.node_name
     }
 
+    /// Get node agents grpc address.
     pub fn endpoint(&self) -> SocketAddr {
         self.endpoint
     }
@@ -34,7 +38,7 @@ pub struct FailedPath {
 }
 
 impl FailedPath {
-    /// Create a new instance of FailedPath for a given NVMe target NQN.
+    /// Create a new instance with FailedPath for a given NVMe target NQN.
     pub fn new(target_nqn: String) -> Self {
         Self { target_nqn }
     }
@@ -49,19 +53,59 @@ impl FailedPath {
 #[derive(Debug)]
 pub struct ReportFailedPaths {
     node: String,
+    endpoint: SocketAddr,
     failed_paths: Vec<FailedPath>,
 }
 
 impl ReportFailedPaths {
-    pub fn new(node: String, failed_paths: Vec<FailedPath>) -> Self {
-        Self { node, failed_paths }
+    /// Creates instance listing failed paths, reporting node id and node agent's grpc address.
+    pub fn new(node: String, failed_paths: Vec<FailedPath>, endpoint: SocketAddr) -> Self {
+        Self {
+            node,
+            failed_paths,
+            endpoint,
+        }
     }
 
+    /// Get node name reporting Nvme path failures.
     pub fn node_name(&self) -> &str {
         &self.node
     }
 
+    /// Get the grpc address of node reporting failed paths.
+    pub fn endpoint(&self) -> SocketAddr {
+        self.endpoint
+    }
+
+    /// Get list of all failed paths in the request.
     pub fn failed_paths(&self) -> &Vec<FailedPath> {
         &self.failed_paths
+    }
+}
+
+#[derive(Debug)]
+pub struct ReplacePath {
+    target_nqn: String,
+    new_path: String,
+}
+
+impl ReplacePath {
+    /// Creates an instance containing failed and new nexus path to be reported back to node agent
+    /// for Nvme connect.
+    pub fn new(target_nqn: String, new_path: String) -> Self {
+        Self {
+            target_nqn,
+            new_path,
+        }
+    }
+
+    /// Get failed nexus path.
+    pub fn target(&self) -> &str {
+        &self.target_nqn
+    }
+
+    /// Get newly published nexus path.
+    pub fn new_path(&self) -> &str {
+        &self.new_path
     }
 }

--- a/common/src/types/v0/transport/mod.rs
+++ b/common/src/types/v0/transport/mod.rs
@@ -137,6 +137,8 @@ pub enum MessageIdVs {
     ReportFailedPaths,
     /// Shutdown Nexus
     ShutdownNexus,
+    /// Replace Path
+    ReplacePathInfo,
 }
 
 impl From<MessageIdVs> for MessageId {

--- a/control-plane/agents/src/bin/ha/cluster/volume.rs
+++ b/control-plane/agents/src/bin/ha/cluster/volume.rs
@@ -4,7 +4,7 @@ use crate::{
     switchover::{Stage, SwitchOverEngine, SwitchOverRequest},
 };
 use common_lib::types::v0::transport::VolumeId;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, net::SocketAddr};
 use utils::NVME_TARGET_NQN_PREFIX;
 
 /// Defines spec for VolumeMover.
@@ -23,7 +23,7 @@ impl VolumeMover {
 
     /// Switchover build the switchover request for the given nqn and send it to SwitchOverEngine.
     #[tracing::instrument(level = "info", skip(self), err)]
-    pub async fn switchover(&self, uri: String, nqn: String) -> Result<(), anyhow::Error> {
+    pub async fn switchover(&self, uri: SocketAddr, nqn: String) -> Result<(), anyhow::Error> {
         if !nqn.starts_with(NVME_TARGET_NQN_PREFIX) {
             return Err(anyhow::anyhow!("Invalid nqn"));
         }
@@ -34,7 +34,7 @@ impl VolumeMover {
 
         let volume_uuid = VolumeId::try_from(volume)?;
 
-        let req = SwitchOverRequest::new(uri, volume_uuid);
+        let req = SwitchOverRequest::new(uri, volume_uuid, nqn);
 
         // calling start_op here to store the request in etcd
         req.start_op(Stage::Init, &self.etcd).await?;

--- a/control-plane/agents/src/bin/ha/node/reporter.rs
+++ b/control-plane/agents/src/bin/ha/node/reporter.rs
@@ -1,4 +1,4 @@
-use crate::cluster_agent_client;
+use crate::{cluster_agent_client, Cli};
 use common_lib::types::v0::transport::{FailedPath, ReportFailedPaths};
 use grpc::operations::ha_node::traits::ClusterAgentOperations;
 use tokio::{
@@ -68,8 +68,8 @@ impl PathReporter {
                     .iter()
                     .map(|p| FailedPath::new(p.to_string()))
                     .collect::<Vec<FailedPath>>();
-
-                let req = ReportFailedPaths::new(node_name.clone(), failed_paths);
+                let node_ep = Cli::args().grpc_endpoint;
+                let req = ReportFailedPaths::new(node_name.clone(), failed_paths, node_ep);
 
                 // Report all paths in a separate task, continue till transmission succeeds.
                 tokio::spawn(async move {

--- a/control-plane/grpc/proto/v1/ha/cluster_agent.proto
+++ b/control-plane/grpc/proto/v1/ha/cluster_agent.proto
@@ -26,9 +26,10 @@ message FailedNvmePath {
 message ReportFailedNvmePathsRequest {
   // Node which reports failed paths.
   string nodename = 1;
-
+  // Grpc node endpoint.
+  string endpoint = 2;
   // List of failed
-  repeated FailedNvmePath failed_paths = 4;
+  repeated FailedNvmePath failed_paths = 3;
 }
 
 // Service for managing node-agent rpc calls

--- a/control-plane/grpc/src/operations/ha_node/server.rs
+++ b/control-plane/grpc/src/operations/ha_node/server.rs
@@ -6,7 +6,7 @@ use crate::{
         ha_rpc_server::{HaRpc, HaRpcServer},
         HaNodeInfo, ReplacePathRequest, ReportFailedNvmePathsRequest,
     },
-    operations::ha_node::traits::{ClusterAgentOperations, NodeAgentOperations},
+    operations::ha_node::traits::{ClusterAgentOperations, NodeAgentOperations, NodeInfoConv},
 };
 use std::sync::Arc;
 
@@ -69,7 +69,11 @@ impl HaRpc for ClusterAgentServer {
         request: tonic::Request<HaNodeInfo>,
     ) -> Result<tonic::Response<()>, tonic::Status> {
         let nodeinfo = request.into_inner();
-        match self.service.register(&nodeinfo, None).await {
+        match self
+            .service
+            .register(&NodeInfoConv::try_from(nodeinfo)?, None)
+            .await
+        {
             Ok(_) => Ok(Response::new(())),
             Err(err) => Err(Status::internal(format!(
                 "Failed to register node-agent: {:?}",

--- a/deployer/src/infra/agents/ha/node.rs
+++ b/deployer/src/infra/agents/ha/node.rs
@@ -10,9 +10,12 @@ use tonic::transport::Endpoint;
 #[async_trait]
 impl ComponentAction for HaNodeAgent {
     fn configure(&self, _options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
+        let socket = format!("-g{}:11600", cfg.next_ip_for_name("agent-ha-node")?);
         let mut spec = ContainerSpec::from_binary(
             "agent-ha-node",
-            Binary::from_dbg("agent-ha-node").with_arg(format!("-n{}", CsiNode::name(0)).as_str()),
+            Binary::from_dbg("agent-ha-node")
+                .with_arg(format!("-n{}", CsiNode::name(0)).as_str())
+                .with_arg(socket.as_str()),
         )
         .with_bind("/run/udev", "/run/udev:ro")
         .with_bind("/dev", "/dev:ro")

--- a/scripts/python/test.sh
+++ b/scripts/python/test.sh
@@ -27,3 +27,4 @@ if [ $# -eq 0 ]; then
 else
   pytest "$@"
 fi
+

--- a/tests/bdd/features/ha/cluster-agent/test_cluster_agent.py
+++ b/tests/bdd/features/ha/cluster-agent/test_cluster_agent.py
@@ -7,6 +7,7 @@ from pytest_bdd import (
     when,
 )
 
+from time import sleep
 import pytest
 import cluster_agent_pb2 as pb
 import grpc
@@ -55,7 +56,7 @@ def the_request_should_be_failed(context):
     """the request should be failed."""
     e = context["attempt"]
     assert (
-        e.value.code() == grpc.StatusCode.INTERNAL
+        e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
     ), "Unexpected error code: %s" + str(e.value.code())
 
 
@@ -87,7 +88,6 @@ def register_node_agent(context):
 def register_node_agent_with_empty_data(context):
     hdl = cluster_agent_rpc_handle()
     req = pb.HaNodeInfo()
-
     with pytest.raises(grpc.RpcError) as error:
         hdl.api.RegisterNodeAgent(req)
     context["attempt"] = error


### PR DESCRIPTION
HA Cluster agents has to implement different stages when it receives Nvme path failover request from HA Node agent. This PR includes code to support those stages.

This also includes node socket information as well in ReportFailedPath which allows cluster agent to register node upon receiving new request incase Cluster agent got restarted and node is not registered.

Signed-off-by: Abhilash Shetty <abhilash.shetty@datacore.com>