### PR TITLE
feat: handle new nvme configuration parameters

### DIFF
--- a/common/src/transport_api/mod.rs
+++ b/common/src/transport_api/mod.rs
@@ -389,6 +389,7 @@ pub struct TimeoutOptions {
 pub struct RequestMinTimeout {
     replica: Duration,
     nexus: Duration,
+    pool: Duration,
 }
 
 impl Default for RequestMinTimeout {
@@ -396,6 +397,7 @@ impl Default for RequestMinTimeout {
         Self {
             replica: Duration::from_secs(10),
             nexus: Duration::from_secs(30),
+            pool: Duration::from_secs(20),
         }
     }
 }
@@ -407,6 +409,10 @@ impl RequestMinTimeout {
     /// minimum timeout for a nexus operation.
     pub fn nexus(&self) -> Duration {
         self.nexus
+    }
+    /// minimum timeout for a pool operation.
+    pub fn pool(&self) -> Duration {
+        self.pool
     }
 }
 

--- a/common/src/types/v0/store/mod.rs
+++ b/common/src/types/v0/store/mod.rs
@@ -80,6 +80,7 @@ pub trait SpecTransaction<Operation> {
 pub struct OperationSequence {
     uuid: String,
     state: OperationSequenceState,
+    log_error: bool,
 }
 impl OperationSequence {
     /// Create new `Self` with a uuid for observability
@@ -87,6 +88,7 @@ impl OperationSequence {
         Self {
             uuid: uuid.into(),
             state: Default::default(),
+            log_error: true,
         }
     }
 }
@@ -119,10 +121,10 @@ pub trait OperationSequencer: Debug + Clone {
     /// Check if the transition is valid.
     fn valid(&self, next: OperationSequenceState) -> bool;
     /// Try to transition from current to next state.
-    fn transition(&self, next: OperationSequenceState) -> Option<OperationSequenceState>;
+    fn transition(&self, next: OperationSequenceState) -> Result<OperationSequenceState, bool>;
     /// Sequence an operation using the provided `OperationMode`.
     /// It returns the state which must be used to revert this operation.
-    fn sequence(&self, mode: OperationMode) -> Option<OperationSequenceState>;
+    fn sequence(&self, mode: OperationMode) -> Result<OperationSequenceState, bool>;
     /// Complete the operation sequenced using the provided `OperationMode`.
     fn complete(&self, revert: OperationSequenceState);
 }
@@ -183,23 +185,29 @@ impl OperationSequence {
         }
     }
     /// Try to transition from current to next state.
-    pub fn transition(&mut self, next: OperationSequenceState) -> Option<OperationSequenceState> {
+    pub fn transition(
+        &mut self,
+        next: OperationSequenceState,
+    ) -> Result<OperationSequenceState, bool> {
         if self.valid(next) {
             let previous = self.state;
             self.state = next;
-            Some(previous)
+            self.log_error = true;
+            Ok(previous)
         } else {
-            None
+            let first_error = self.log_error;
+            self.log_error = false;
+            Err(first_error)
         }
     }
     /// Sequence an operation using the provided `OperationMode`.
     /// It returns the state which must be used to revert this operation.
-    pub fn sequence(&mut self, mode: OperationMode) -> Option<OperationSequenceState> {
+    pub fn sequence(&mut self, mode: OperationMode) -> Result<OperationSequenceState, bool> {
         self.transition(mode.apply())
     }
     /// Complete the operation sequenced using the provided `OperationMode`.
     pub fn complete(&mut self, revert: OperationSequenceState) {
-        if self.transition(revert).is_none() {
+        if self.transition(revert).is_err() {
             debug_assert!(false, "Invalid revert from '{:?}' to '{:?}'", self, revert);
             self.state = OperationSequenceState::Idle;
         }

--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
@@ -40,6 +40,9 @@ impl TaskPoller for PoolReconciler {
         let pools = context.specs().get_locked_pools();
         let mut results = Vec::with_capacity(pools.len());
         for pool in pools {
+            if pool.lock().dirty() {
+                continue;
+            }
             let mut pool = match pool.operation_guard() {
                 Ok(guard) => guard,
                 Err(_) => continue,

--- a/control-plane/agents/src/bin/core/controller/reconciler/replica/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/replica/mod.rs
@@ -33,6 +33,9 @@ impl TaskPoller for ReplicaReconciler {
         let mut results = Vec::with_capacity(replicas.len());
 
         for replica in replicas {
+            if replica.lock().dirty() {
+                continue;
+            }
             let mut replica = match replica.operation_guard() {
                 Ok(guard) => guard,
                 Err(_) => continue,

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -679,10 +679,13 @@ impl<T: AsOperationSequencer + SpecOperationsHelper> OperationSequenceGuard<T>
 {
     fn operation_guard_mode(&self, mode: OperationMode) -> Result<OperationGuardArc<T>, SvcError> {
         let get_value = |s: &Self| s.lock().clone();
+
         match OperationGuardArc::try_sequence(self, get_value, mode) {
             Ok(guard) => Ok(guard),
-            Err(error) => {
-                tracing::debug!("Resource '{}' is busy: {}", self.lock().uuid_str(), error);
+            Err((error, log)) => {
+                if log {
+                    tracing::debug!("Resource '{}' is busy: {}", self.lock().uuid_str(), error);
+                }
                 Err(SvcError::Conflict {})
             }
         }

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -199,7 +199,14 @@ impl Service {
                 };
 
                 let result = match result {
-                    Ok(result) => node.load(startup).await.map(|_| result),
+                    Ok(mut result) => {
+                        // old v0 doesn't have the instance uuid
+                        if result.instance_uuid().is_none() && node_state.instance_uuid().is_some()
+                        {
+                            result.instance_uuid = *node_state.instance_uuid();
+                        }
+                        node.load(startup).await.map(|_| result)
+                    }
                     Err(e) => Err(e),
                 };
                 match result {

--- a/control-plane/agents/src/bin/core/tests/volume/capacity.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/capacity.rs
@@ -95,7 +95,7 @@ async fn fault_enospc_child() {
         .await
         .unwrap();
 
-    tracing::info!("\n{}", output.unwrap());
+    tracing::info!("\n{:?}", output.unwrap());
 
     let volume_client = cluster.grpc_client().volume();
     let _ = wait_till_volume_children(&volume_1.spec.uuid.into(), 1, &volume_client).await;

--- a/control-plane/agents/src/common/msg_translation/v0.rs
+++ b/control-plane/agents/src/common/msg_translation/v0.rs
@@ -6,8 +6,9 @@ use common_lib::{
     types::v0::{
         openapi::apis::IntoVec,
         transport::{
-            self, ChildState, ChildStateReason, Nexus, NexusId, NexusStatus, NodeId, PoolState,
-            Protocol, Replica, ReplicaId, ReplicaName, ReplicaStatus,
+            self, ChildState, ChildStateReason, Nexus, NexusId, NexusNvmePreemption, NexusStatus,
+            NodeId, NvmeReservation, PoolState, Protocol, Replica, ReplicaId, ReplicaName,
+            ReplicaStatus,
         },
     },
 };
@@ -291,6 +292,12 @@ impl AgentToIoEngine for transport::CreateNexus {
             preempt_key: nexus_config.preempt_key(),
             children: self.children.clone().into_vec(),
             nexus_info_key: self.nexus_info_key(),
+            resv_type: Some(
+                v0_rpc::NvmeReservation::from(ExternalType(nexus_config.resv_type())) as i32,
+            ),
+            preempt_policy: v0_rpc::NexusNvmePreemption::from(ExternalType(
+                nexus_config.preempt_policy(),
+            )) as i32,
         }
     }
 }
@@ -394,4 +401,26 @@ pub fn rpc_pool_to_agent(rpc_pool: &rpc::io_engine::Pool, id: &NodeId) -> PoolSt
     let mut pool = rpc_pool.to_agent();
     pool.node = id.clone();
     pool
+}
+
+impl From<ExternalType<NvmeReservation>> for v0_rpc::NvmeReservation {
+    fn from(value: ExternalType<NvmeReservation>) -> Self {
+        match value.0 {
+            NvmeReservation::Reserved => Self::Reserved,
+            NvmeReservation::WriteExclusive => Self::WriteExclusive,
+            NvmeReservation::ExclusiveAccess => Self::ExclusiveAccess,
+            NvmeReservation::WriteExclusiveRegsOnly => Self::WriteExclusiveRegsOnly,
+            NvmeReservation::ExclusiveAccessRegsOnly => Self::ExclusiveAccessRegsOnly,
+            NvmeReservation::WriteExclusiveAllRegs => Self::WriteExclusiveAllRegs,
+            NvmeReservation::ExclusiveAccessAllRegs => Self::ExclusiveAccessAllRegs,
+        }
+    }
+}
+impl From<ExternalType<NexusNvmePreemption>> for v0_rpc::NexusNvmePreemption {
+    fn from(value: ExternalType<NexusNvmePreemption>) -> Self {
+        match value.0 {
+            NexusNvmePreemption::ArgKey(_) => Self::ArgKey,
+            NexusNvmePreemption::Holder => Self::Holder,
+        }
+    }
 }

--- a/control-plane/agents/src/common/msg_translation/v1.rs
+++ b/control-plane/agents/src/common/msg_translation/v1.rs
@@ -243,7 +243,7 @@ impl AgentToIoEngine for transport::CreateNexus {
     type IoEngineMessage = v1_rpc::nexus::CreateNexusRequest;
     fn to_rpc(&self) -> Self::IoEngineMessage {
         let nexus_config = self.config.clone().unwrap_or_default();
-        let create = Self::IoEngineMessage {
+        Self::IoEngineMessage {
             name: self.name(),
             uuid: self.uuid.clone().into(),
             size: self.size,
@@ -259,9 +259,7 @@ impl AgentToIoEngine for transport::CreateNexus {
             preempt_policy: v1_rpc::nexus::NexusNvmePreemption::from(ExternalType(
                 nexus_config.preempt_policy(),
             )) as i32,
-        };
-        tracing::error!("{:?}", create);
-        create
+        }
     }
 }
 

--- a/control-plane/grpc/proto/v1/nexus/nexus.proto
+++ b/control-plane/grpc/proto/v1/nexus/nexus.proto
@@ -179,6 +179,25 @@ message NexusNvmfConfig {
   uint64 reservation_key = 2;
   // preempts this reservation key
   optional uint64 preempt_reservation_key = 3;
+  optional NvmeReservation reservation_type = 4; // the reservation type to use
+  NexusNvmePreemption preempt_policy = 5; // the preemption policy to use
+}
+
+// Nexus NVMe preemption policy.
+enum NexusNvmePreemption {
+  ArgKey = 0; // preempts using the preemptKey argument, if any
+  Holder = 1; // preempts the current reservation holder, if any
+}
+
+// NVMe reservation types.
+enum NvmeReservation {
+  Reserved = 0;
+  WriteExclusive = 1;
+  ExclusiveAccess = 2;
+  WriteExclusiveRegsOnly = 3;
+  ExclusiveAccessRegsOnly = 4;
+  WriteExclusiveAllRegs = 5;
+  ExclusiveAccessAllRegs = 6;
 }
 
 // Reply type for CreateNexusRequest

--- a/control-plane/grpc/src/context.rs
+++ b/control-plane/grpc/src/context.rs
@@ -58,6 +58,9 @@ pub fn timeout_grpc(op_id: MessageId, timeout_opts: TimeoutOptions) -> Duration 
 
                 MessageIdVs::CreateReplica => min_timeouts.replica(),
                 MessageIdVs::DestroyReplica => min_timeouts.replica(),
+
+                MessageIdVs::CreatePool => min_timeouts.pool(),
+                MessageIdVs::DestroyPool => min_timeouts.pool(),
                 _ => base,
             },
         };
@@ -124,7 +127,10 @@ impl Context {
             // we use the same timeout for the connection so we can pass the existing nats tests
             // todo: use a shorter connect timeout
             .connect_timeout(timeout)
-            .timeout(timeout)
+            // todo: Channel will pick the shorter timeout, rather than override the default
+            // timeout with a per-request timeout. For now set this default timeout high, but
+            // we probably want to use our own timeout logic instead.
+            .timeout(std::time::Duration::from_secs(60))
             .http2_keep_alive_interval(self.keep_alive_interval())
             .keep_alive_timeout(self.keep_alive_timeout())
             .concurrency_limit(utils::DEFAULT_GRPC_CLIENT_CONCURRENCY)

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -1,6 +1,11 @@
-use crate::infra::*;
+use crate::{
+    build_error,
+    infra::{async_trait, Builder, ComponentAction, ComposeTest, CoreAgent, Error, StartOptions},
+};
 use common_lib::types::v0::transport::{Filter, NodeStatus};
+use composer::{Binary, ContainerSpec};
 use grpc::operations::node::traits::NodeOperations;
+use std::str::FromStr;
 
 #[async_trait]
 impl ComponentAction for CoreAgent {

--- a/deployer/src/infra/agents/ha/cluster.rs
+++ b/deployer/src/infra/agents/ha/cluster.rs
@@ -1,7 +1,11 @@
+use std::convert::TryFrom;
 use tokio::time::{sleep, Duration};
 use tonic::transport::Endpoint;
 
-use crate::infra::*;
+use crate::infra::{
+    async_trait, Builder, ComponentAction, ComposeTest, Error, HaClusterAgent, StartOptions,
+};
+use composer::{Binary, ContainerSpec};
 
 #[async_trait]
 impl ComponentAction for HaClusterAgent {

--- a/deployer/src/infra/agents/ha/node.rs
+++ b/deployer/src/infra/agents/ha/node.rs
@@ -1,4 +1,8 @@
-use crate::infra::*;
+use crate::infra::{
+    async_trait, Builder, ComponentAction, ComposeTest, CsiNode, Error, HaNodeAgent, StartOptions,
+};
+use composer::{Binary, ContainerSpec};
+use std::convert::TryFrom;
 
 use tokio::time::{sleep, Duration};
 use tonic::transport::Endpoint;

--- a/deployer/src/infra/agents/jsongrpc.rs
+++ b/deployer/src/infra/agents/jsongrpc.rs
@@ -1,5 +1,12 @@
-use crate::infra::*;
+use crate::{
+    build_error,
+    infra::{
+        async_trait, Builder, ComponentAction, ComposeTest, Error, JsonGrpcAgent, StartOptions,
+    },
+};
+use composer::Binary;
 use grpc::operations::jsongrpc::client::JsonGrpcClient;
+use std::str::FromStr;
 
 #[async_trait]
 impl ComponentAction for JsonGrpcAgent {

--- a/deployer/src/infra/csi-driver/controller.rs
+++ b/deployer/src/infra/csi-driver/controller.rs
@@ -1,4 +1,8 @@
-use crate::infra::*;
+use crate::infra::{
+    async_trait, Builder, ComponentAction, ComposeTest, CsiController, Error, StartOptions,
+};
+use composer::{Binary, ContainerSpec};
+use std::convert::TryFrom;
 use tokio::{
     net::UnixStream,
     time::{sleep, Duration},

--- a/deployer/src/infra/csi-driver/node.rs
+++ b/deployer/src/infra/csi-driver/node.rs
@@ -1,4 +1,8 @@
-use crate::infra::*;
+use crate::infra::{
+    async_trait, Builder, ComponentAction, ComposeTest, CsiNode, Error, StartOptions,
+};
+use composer::{Binary, ContainerSpec};
+use std::convert::TryFrom;
 use tokio::{
     net::UnixStream,
     time::{sleep, Duration},

--- a/deployer/src/infra/fio_spdk.rs
+++ b/deployer/src/infra/fio_spdk.rs
@@ -1,0 +1,29 @@
+use crate::infra::{
+    async_trait, Builder, ComponentAction, ComposeTest, Error, FioSpdk, StartOptions,
+};
+use composer::ContainerSpec;
+
+#[async_trait]
+impl ComponentAction for FioSpdk {
+    fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
+        Ok(if options.fio_spdk {
+            cfg.add_container_spec(
+                ContainerSpec::from_image("fio-spdk", utils::FIO_SPDK_IMAGE)
+                    .with_entrypoint("sleep")
+                    .with_arg("infinity"),
+            )
+        } else {
+            cfg
+        })
+    }
+    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+        if options.fio_spdk {
+            cfg.start("fio-spdk").await?;
+        }
+        Ok(())
+    }
+    async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+        // this is fine 🔥
+        Ok(())
+    }
+}

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -1,6 +1,7 @@
 use crate::infra::{
     async_trait, Builder, ComponentAction, ComposeTest, Error, IoEngine, StartOptions,
 };
+use common_lib::types::v0::openapi::apis::Uuid;
 use composer::{Binary, ContainerSpec};
 use rpc::io_engine::{IoEngineApiVersion, RpcHandle};
 use std::net::{IpAddr, SocketAddr};
@@ -35,6 +36,7 @@ impl ComponentAction for IoEngine {
                 "-r",
                 format!("/host/tmp/{}.sock", Self::name(i, options)).as_str(),
             ])
+            .with_env("MAYASTOR_NVMF_HOSTID", Uuid::new_v4().to_string().as_str())
             .with_bind("/tmp", "/host/tmp");
 
             if options.io_engine_isolate {

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -5,6 +5,7 @@ pub mod dns;
 mod elastic;
 mod empty;
 mod etcd;
+mod fio_spdk;
 mod io_engine;
 mod jaeger;
 mod kibana;
@@ -13,7 +14,7 @@ mod rest;
 use super::StartOptions;
 use async_trait::async_trait;
 
-use composer::{Binary, Builder, BuilderConfigure, ComposeTest, ContainerSpec};
+use composer::{Builder, BuilderConfigure, ComposeTest};
 use futures::future::{join_all, try_join_all};
 use paste::paste;
 use std::{cmp::Ordering, convert::TryFrom, str::FromStr};
@@ -426,6 +427,7 @@ impl_component! {
     JsonGrpcAgent,  3,
     Rest,           3,
     HaClusterAgent, 3,
+    FioSpdk,        3,
     IoEngine,       4,
     CsiNode,        5,
     CsiController,  5,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -348,10 +348,10 @@ pub mod v1 {
         pub use super::pb::{
             nexus_rpc_client, AddChildNexusRequest, AddChildNexusResponse, Child, ChildState,
             ChildStateReason, CreateNexusRequest, CreateNexusResponse, DestroyNexusRequest,
-            FaultNexusChildRequest, ListNexusOptions, ListNexusResponse, Nexus, NexusState,
-            NvmeAnaState, PublishNexusRequest, PublishNexusResponse, RemoveChildNexusRequest,
-            RemoveChildNexusResponse, ShutdownNexusRequest, UnpublishNexusRequest,
-            UnpublishNexusResponse,
+            FaultNexusChildRequest, ListNexusOptions, ListNexusResponse, Nexus,
+            NexusNvmePreemption, NexusState, NvmeAnaState, NvmeReservation, PublishNexusRequest,
+            PublishNexusResponse, RemoveChildNexusRequest, RemoveChildNexusResponse,
+            ShutdownNexusRequest, UnpublishNexusRequest, UnpublishNexusResponse,
         };
     }
 

--- a/tests/io-engine/tests/rebuild.rs
+++ b/tests/io-engine/tests/rebuild.rs
@@ -98,7 +98,7 @@ async fn concurrent_rebuilds() {
     ) {
         let start = std::time::Instant::now();
         let mut timeout = std::time::Duration::from_secs(120);
-        let timeout_slack = timeout / 2;
+        let timeout_slack = timeout;
         let mut added_slack = false;
         let check_interval = std::time::Duration::from_secs(5);
         loop {

--- a/tests/io-engine/tests/reservations.rs
+++ b/tests/io-engine/tests/reservations.rs
@@ -1,0 +1,115 @@
+use common_lib::types::v0::{
+    transport as v0,
+    transport::{NexusNvmePreemption, NvmeReservation},
+};
+use deployer_cluster::{Cluster, ClusterBuilder};
+use grpc::operations::nexus::traits::NexusOperations;
+use std::convert::From;
+
+#[tokio::test]
+async fn preservation() {
+    let size = 20 * 1024 * 1024;
+    let cluster = ClusterBuilder::builder()
+        .with_io_engines(3)
+        .with_tmpfs_pool(size * 2)
+        .with_replicas(1, size, v0::Protocol::Nvmf)
+        .with_options(|o| {
+            o.with_io_engine_env("NEXUS_NVMF_RESV_ENABLE", "1")
+                .with_fio_spdk(true)
+        })
+        .build()
+        .await
+        .unwrap();
+    let nexus_client = cluster.grpc_client().nexus();
+
+    let replica = cluster
+        .rest_v00()
+        .replicas_api()
+        .get_replica(&Cluster::replica(2, 0, 0))
+        .await
+        .unwrap();
+    let replica_uri = replica.uri.clone();
+
+    let nexus1 = nexus_client
+        .create(
+            &v0::CreateNexus {
+                node: cluster.node(0),
+                uuid: v0::NexusId::new(),
+                size,
+                children: vec![replica_uri.clone().into()],
+                config: Some(v0::NexusNvmfConfig::new(
+                    v0::NvmfControllerIdRange::default(),
+                    0x12345678911,
+                    NvmeReservation::ExclusiveAccess,
+                    NexusNvmePreemption::ArgKey(None),
+                )),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let share = v0::ShareNexus::from((&nexus1, None, v0::NexusShareProtocol::Nvmf));
+    let _nexus1_uri = nexus_client.share(&share, None).await.unwrap();
+
+    let nexus_1_ip = cluster.composer().container_ip(cluster.node(0).as_str());
+    let fio_builder = |ip: &str, uuid: &str| {
+        let nqn = format!("nqn.2019-05.io.openebs\\:{uuid}");
+        let filename =
+            format!("--filename=trtype=tcp adrfam=IPv4 traddr={ip} trsvcid=8420 subnqn={nqn} ns=1");
+        vec![
+            "fio",
+            "--name=benchtest",
+            filename.as_str(),
+            "--direct=1",
+            "--rw=randwrite",
+            "--ioengine=spdk",
+            "--bs=64k",
+            "--iodepth=64",
+            "--numjobs=1",
+            "--thread=1",
+            "--size=8M",
+            "--norandommap=1",
+        ]
+        .into_iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+    };
+    let fio_cmd = fio_builder(&nexus_1_ip, nexus1.uuid.as_str());
+    let (code, out) = cluster.composer().exec("fio-spdk", fio_cmd).await.unwrap();
+    tracing::info!("{}", out);
+    assert_eq!(code, Some(0));
+
+    let nexus2_uuid = v0::NexusId::new();
+    let nexus2 = nexus_client
+        .create(
+            &v0::CreateNexus {
+                node: cluster.node(1),
+                uuid: nexus2_uuid.clone(),
+                size,
+                children: vec![replica_uri.into()],
+                config: Some(v0::NexusNvmfConfig::new(
+                    v0::NvmfControllerIdRange::default(),
+                    nexus2_uuid.as_u128() as u64,
+                    NvmeReservation::ExclusiveAccess,
+                    NexusNvmePreemption::Holder,
+                )),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let share = v0::ShareNexus::from((&nexus2, None, v0::NexusShareProtocol::Nvmf));
+    let _nexus2_uri = nexus_client.share(&share, None).await.unwrap();
+
+    let nexus_2_ip = cluster.composer().container_ip(cluster.node(1).as_str());
+    let fio_cmd = fio_builder(&nexus_2_ip, nexus2.uuid.as_str());
+    let (code, out) = cluster.composer().exec("fio-spdk", fio_cmd).await.unwrap();
+    tracing::info!("{}", out);
+    assert_eq!(code, Some(0));
+
+    let fio_cmd = fio_builder(&nexus_1_ip, nexus1.uuid.as_str());
+    let (code, out) = cluster.composer().exec("fio-spdk", fio_cmd).await.unwrap();
+    assert_eq!(code, Some(1), "{}", out);
+}

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -1,33 +1,36 @@
-/// Various common constants used by the control plane
+/// Various common constants used by the control plane.
 ///
-/// Default request timeout for any NATS or GRPC request
+/// Default request timeout for any NATS or GRPC request.
 pub const DEFAULT_REQ_TIMEOUT: &str = "5s";
 
-/// Default connection timeout for a GRPC connection
+/// Default connection timeout for a GRPC connection.
 pub const DEFAULT_CONN_TIMEOUT: &str = "1s";
 
-/// Use a set of minimum timeouts for specific requests
+/// Use a set of minimum timeouts for specific requests.
 pub const ENABLE_MIN_TIMEOUTS: bool = true;
 
-/// The timeout for all persistent store operations
+/// The timeout for all persistent store operations.
 pub const STORE_OP_TIMEOUT: &str = "5s";
-/// The lease lock ttl for the persistent store after which we'll lose the exclusive access
+/// The lease lock ttl for the persistent store after which we'll lose the exclusive access.
 pub const STORE_LEASE_LOCK_TTL: &str = "30s";
 
-/// Io-Engine container image used for testing
+/// Fio Spdk image.
+pub const FIO_SPDK_IMAGE: &str = "mayadata/mayastor-fio-spdk:develop";
+
+/// Io-Engine container image used for testing.
 pub const IO_ENGINE_IMAGE: &str = "mayadata/mayastor-io-engine:develop";
 
-/// Environment variable that points to an io-engine binary
-/// This must be in sync with shell.nix
+/// Environment variable that points to an io-engine binary.
+/// This must be in sync with shell.nix.
 pub const DATA_PLANE_BINARY: &str = "IO_ENGINE_BIN";
 
-/// The period at which a component updates its resource cache
+/// The period at which a component updates its resource cache.
 pub const CACHE_POLL_PERIOD: &str = "30s";
 
-/// The key to mark the creation source of a pool in labels
+/// The key to mark the creation source of a pool in labels.
 pub const CREATED_BY_KEY: &str = "openebs.io/created-by";
 
-/// The value to mark the creation source of a pool to be disk pool operator in labels
+/// The value to mark the creation source of a pool to be disk pool operator in labels.
 pub const DSP_OPERATOR: &str = "operator-diskpool";
 
 /// The service label for the api-rest service.
@@ -45,16 +48,16 @@ pub const LOKI_LABEL: &str = "app=loki";
 /// The service port for the loki.
 pub const LOKI_PORT: &str = "http-metrics";
 
-/// The default value to be assigned as GRPC server addr if not overridden
+/// The default value to be assigned as GRPC server addr if not overridden.
 pub const DEFAULT_GRPC_SERVER_ADDR: &str = "0.0.0.0:50051";
 
-/// The default value to be assigned as GRPC client addr if not overridden
+/// The default value to be assigned as GRPC client addr if not overridden.
 pub const DEFAULT_GRPC_CLIENT_ADDR: &str = "https://core:50051";
 
-/// The default value to be assigned as JSON GRPC server addr if not overridden
+/// The default value to be assigned as JSON GRPC server addr if not overridden.
 pub const DEFAULT_JSON_GRPC_SERVER_ADDR: &str = "0.0.0.0:50052";
 
-/// The default value to be assigned as JSON GRPC client addr if not overridden
+/// The default value to be assigned as JSON GRPC client addr if not overridden.
 pub const DEFAULT_JSON_GRPC_CLIENT_ADDR: &str = "https://jsongrpc:50052";
 
 /// The default value for a concurrency limit.
@@ -64,13 +67,13 @@ pub const DEFAULT_GRPC_CLIENT_CONCURRENCY: usize = 25;
 pub const RUST_LOG_SILENCE_DEFAULTS: &str =
     "actix_web=info,actix_server=info,h2=info,hyper=info,tower_buffer=info,tower=info,rustls=info,reqwest=info,tokio_util=info,tokio_tungstenite=info,tungstenite=info,async_io=info,polling=info,tonic=info,want=info,mio=info";
 
-/// The default value to be assigned as cluster agent GRPC server addr if not overridden
+/// The default value to be assigned as cluster agent GRPC server addr if not overridden.
 pub const DEFAULT_CLUSTER_AGENT_SERVER_ADDR: &str = "0.0.0.0:11500";
 
-/// The default value to be assigned as cluster agent GRPC client addr if not overridden
+/// The default value to be assigned as cluster agent GRPC client addr if not overridden.
 pub const DEFAULT_CLUSTER_AGENT_CLIENT_ADDR: &str = "https://agent-ha-cluster:11500";
 
-/// The default value to be assigned as node-agent GRPC server addr if not overridden
+/// The default value to be assigned as node-agent GRPC server addr if not overridden.
 pub const DEFAULT_NODE_AGENT_SERVER_ADDR: &str = "0.0.0.0:11600";
 
 /// The default worker threads cap for the api-rest service.


### PR DESCRIPTION
test: add fio-spdk container to deployer

This allows us to run IO against nvmf targets completely in userspace.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat: handle new nvme configuration parameters

Add new nvme parameters to follow the io-engine rpc changes.
This allows to preempt any previous reservation holder.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

test: add reservation test

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix: set pool time timeouts and silence duplicate logs

Adds a higher than base timeout for pool lifecycle operations.
Add a higher base grpc timeout for the rest service. This is because I've found out
that the default tonic impl of timeout prefers the shorter timeout. So we can't easily
set a timeout per request.
TODO: use our own timeout layer impl
Silence logs for busy resources when they've been reported once.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>