### PR TITLE
fix: make unmount not lazy

### DIFF
--- a/control-plane/csi-driver/src/bin/node/mount.rs
+++ b/control-plane/csi-driver/src/bin/node/mount.rs
@@ -158,10 +158,8 @@ pub(crate) fn filesystem_mount(
 /// Unmount a device from a directory (mountpoint)
 /// Should not be used for removing bind mounts.
 pub(crate) fn filesystem_unmount(target: &str) -> Result<(), Error> {
-    let mut flags = UnmountFlags::empty();
-
-    flags.insert(UnmountFlags::DETACH);
-
+    let flags = UnmountFlags::empty();
+    // read more about the umount system call and it's flags at `man 2 umount`
     unmount(target, flags)?;
 
     debug!("Target {} unmounted", target);

--- a/tests/io-engine/tests/rebuild.rs
+++ b/tests/io-engine/tests/rebuild.rs
@@ -97,7 +97,7 @@ async fn concurrent_rebuilds() {
     ) {
         let start = std::time::Instant::now();
         let mut timeout = std::time::Duration::from_secs(120);
-        let timeout_slack = timeout / 2;
+        let timeout_slack = timeout;
         let mut added_slack = false;
         let check_interval = std::time::Duration::from_secs(5);
         loop {


### PR DESCRIPTION
on removing the MNT_DETACH flag, the unmount operation is no longer lazy more info: `man 2 umount`

Signed-off-by: Harsh Vardhan <harsh59v@gmail.com>