### PR TITLE
fix: cherry-pick pool timeouts and silence duplicate logs

### DIFF
--- a/common/src/transport_api/mod.rs
+++ b/common/src/transport_api/mod.rs
@@ -389,6 +389,7 @@ pub struct TimeoutOptions {
 pub struct RequestMinTimeout {
     replica: Duration,
     nexus: Duration,
+    pool: Duration,
 }
 
 impl Default for RequestMinTimeout {
@@ -396,6 +397,7 @@ impl Default for RequestMinTimeout {
         Self {
             replica: Duration::from_secs(10),
             nexus: Duration::from_secs(30),
+            pool: Duration::from_secs(20),
         }
     }
 }
@@ -407,6 +409,10 @@ impl RequestMinTimeout {
     /// minimum timeout for a nexus operation.
     pub fn nexus(&self) -> Duration {
         self.nexus
+    }
+    /// minimum timeout for a pool operation.
+    pub fn pool(&self) -> Duration {
+        self.pool
     }
 }
 

--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
@@ -40,6 +40,9 @@ impl TaskPoller for PoolReconciler {
         let pools = context.specs().get_locked_pools();
         let mut results = Vec::with_capacity(pools.len());
         for pool in pools {
+            if pool.lock().dirty() {
+                continue;
+            }
             let mut pool = match pool.operation_guard() {
                 Ok(guard) => guard,
                 Err(_) => continue,

--- a/control-plane/agents/src/bin/core/controller/reconciler/replica/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/replica/mod.rs
@@ -33,6 +33,9 @@ impl TaskPoller for ReplicaReconciler {
         let mut results = Vec::with_capacity(replicas.len());
 
         for replica in replicas {
+            if replica.lock().dirty() {
+                continue;
+            }
             let mut replica = match replica.operation_guard() {
                 Ok(guard) => guard,
                 Err(_) => continue,

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -679,10 +679,13 @@ impl<T: AsOperationSequencer + SpecOperationsHelper> OperationSequenceGuard<T>
 {
     fn operation_guard_mode(&self, mode: OperationMode) -> Result<OperationGuardArc<T>, SvcError> {
         let get_value = |s: &Self| s.lock().clone();
+
         match OperationGuardArc::try_sequence(self, get_value, mode) {
             Ok(guard) => Ok(guard),
-            Err(error) => {
-                tracing::debug!("Resource '{}' is busy: {}", self.lock().uuid_str(), error);
+            Err((error, log)) => {
+                if log {
+                    tracing::debug!("Resource '{}' is busy: {}", self.lock().uuid_str(), error);
+                }
                 Err(SvcError::Conflict {})
             }
         }

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -199,7 +199,14 @@ impl Service {
                 };
 
                 let result = match result {
-                    Ok(result) => node.load(startup).await.map(|_| result),
+                    Ok(mut result) => {
+                        // old v0 doesn't have the instance uuid
+                        if result.instance_uuid().is_none() && node_state.instance_uuid().is_some()
+                        {
+                            result.instance_uuid = *node_state.instance_uuid();
+                        }
+                        node.load(startup).await.map(|_| result)
+                    }
                     Err(e) => Err(e),
                 };
                 match result {

--- a/control-plane/grpc/src/context.rs
+++ b/control-plane/grpc/src/context.rs
@@ -58,6 +58,9 @@ pub fn timeout_grpc(op_id: MessageId, timeout_opts: TimeoutOptions) -> Duration 
 
                 MessageIdVs::CreateReplica => min_timeouts.replica(),
                 MessageIdVs::DestroyReplica => min_timeouts.replica(),
+
+                MessageIdVs::CreatePool => min_timeouts.pool(),
+                MessageIdVs::DestroyPool => min_timeouts.pool(),
                 _ => base,
             },
         };
@@ -124,7 +127,10 @@ impl Context {
             // we use the same timeout for the connection so we can pass the existing nats tests
             // todo: use a shorter connect timeout
             .connect_timeout(timeout)
-            .timeout(timeout)
+            // todo: Channel will pick the shorter timeout, rather than override the default
+            // timeout with a per-request timeout. For now set this default timeout high, but
+            // we probably want to use our own timeout logic instead.
+            .timeout(std::time::Duration::from_secs(60))
             .http2_keep_alive_interval(self.keep_alive_interval())
             .keep_alive_timeout(self.keep_alive_timeout())
             .concurrency_limit(utils::DEFAULT_GRPC_CLIENT_CONCURRENCY)


### PR DESCRIPTION
Adds a higher than base timeout for pool lifecycle operations. Add a higher base grpc timeout for the rest service. This is because I've found out that the default tonic impl of timeout prefers the shorter timeout. So we can't easily set a timeout per request.
TODO: use our own timeout layer impl
Silence logs for busy resources when they've been reported once.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>