### PR TITLE
build!: set openebs as image registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
           }
           agent { label 'nixos-mayastor' }
           steps {
-            withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+            withCredentials([usernamePassword(credentialsId: 'OPENEBS_DOCKERHUB', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
               sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
             }
             sh 'printenv'
@@ -138,7 +138,7 @@ pipeline {
           }
           agent { label 'nixos-mayastor' }
           steps {
-            withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+            withCredentials([usernamePassword(credentialsId: 'OPENEBS_DOCKERHUB', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
               sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
             }
             sh 'printenv'
@@ -178,7 +178,7 @@ pipeline {
         }
       }
       steps {
-        withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+        withCredentials([usernamePassword(credentialsId: 'OPENEBS_DOCKERHUB', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
             sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
         }
         sh 'printenv'

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -16,7 +16,7 @@ let
     dockerTools.buildImage {
       tag = control-plane.version;
       created = "now";
-      name = "mayadata/mayastor-${name}${image_suffix.${buildType}}";
+      name = "openebs/mayastor-${name}${image_suffix.${buildType}}";
       contents = [ tini busybox package ];
       config = {
         Entrypoint = [ "tini" "--" package.binary ];

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -15,7 +15,7 @@ pub const STORE_OP_TIMEOUT: &str = "5s";
 pub const STORE_LEASE_LOCK_TTL: &str = "30s";
 
 /// Io-Engine container image used for testing
-pub const IO_ENGINE_IMAGE: &str = "mayadata/mayastor-io-engine:release-2.0";
+pub const IO_ENGINE_IMAGE: &str = "openebs/mayastor-io-engine:release-2.0";
 
 /// Environment variable that points to an io-engine binary
 /// This must be in sync with shell.nix


### PR DESCRIPTION
BREAKING CHANGE: Build container images using openebs not mayadata as the registry

Signed-off-by: GlennBullingham <glenn.bullingham@datacore.com>