### PR TITLE
fix(csi-controller): cherry-pick unpublish regardless of the node

### DIFF
--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -457,15 +457,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             Err(e) => return Err(Status::from(e)),
         };
 
-        // Check if target volume is published and the node matches.
-        if let Some(target) = &volume.spec.target.as_ref() {
-            if !args.node_id.is_empty() && target.node != args.node_id {
-                return Err(Status::not_found(format!(
-                    "Volume {} is published on a different node: {}",
-                    &args.volume_id, target.node
-                )));
-            }
-        } else {
+        if volume.spec.target.is_none() {
             // Volume is not published, bail out.
             debug!(
                 "Volume {} is not published, not unpublishing",

--- a/tests/bdd/features/csi/controller/test_controller.py
+++ b/tests/bdd/features/csi/controller/test_controller.py
@@ -161,6 +161,7 @@ def test_unpublish_volume_idempotency(setup):
     """unpublish volume idempotency"""
 
 
+@pytest.mark.skip("This test is no longer valid as local restriction is revoked")
 @scenario("controller.feature", "unpublish volume from a different node")
 def test_unpublish_volume_from_a_different_node(setup):
     """unpublish volume on a different node"""


### PR DESCRIPTION
When unpublishing don't compare app node to target node.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

Signed-off-by: Abhinandan Purkait <purkaitabhinandan@gmail.com>