### PR TITLE
feat(nvme-resv): use reservations to gate access to replicas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
+checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -476,6 +476,8 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1858,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
+checksum = "ef5528d9c2817db4e10cc78f8d4c8228906e5854f389ff6b076cee3572a09d35"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "serde_tuple",
  "snafu",
  "strum",
  "strum_macros",
@@ -3481,6 +3482,27 @@ dependencies = [
  "itoa 1.0.3",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_tuple"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f025b91216f15a2a32aa39669329a475733590a015835d1783549a56d09427"
+dependencies = [
+ "serde",
+ "serde_tuple_macros",
+]
+
+[[package]]
+name = "serde_tuple_macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1.20.1", features = [ "full" ] }
 snafu = "0.7.1"
 etcd-client = "0.10.1"
 serde = { version = "1.0.140", features = ["derive"] }
+serde_tuple = "0.5.0"
 async-trait = "0.1.51"
 dyn-clonable = "0.9.0"
 openapi = { path = "../openapi", features = [ "actix-server", "tower-client", "tower-trace" ] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -31,6 +31,23 @@ impl<F: Into<T>, T> IntoOption<T> for Option<F> {
     }
 }
 
+/// Helper to convert from Option<F> into Option<T>
+pub trait TryIntoOption<T>: Sized {
+    type Error;
+    /// Performs the conversion.
+    fn try_into_opt(self) -> Result<Option<T>, Self::Error>;
+}
+
+impl<F: TryInto<T>, T> TryIntoOption<T> for Option<F> {
+    type Error = <F as TryInto<T>>::Error;
+    fn try_into_opt(self) -> Result<Option<T>, Self::Error> {
+        match self {
+            Some(v) => v.try_into().map(Some),
+            None => Ok(None),
+        }
+    }
+}
+
 /// Pre-init the Platform information.
 pub use platform::init_cluster_info_or_panic;
 

--- a/common/src/store/etcd.rs
+++ b/common/src/store/etcd.rs
@@ -82,10 +82,11 @@ impl Etcd {
     }
 
     /// Revokes the lease and releases the associated lock
-    pub async fn revoke(&self) {
+    pub async fn revoke(&self) -> Result<(), StoreError> {
         if let Some(info) = &self.lease_lock_info {
-            info.revoke().await;
+            info.revoke().await?;
         }
+        Ok(())
     }
 }
 

--- a/common/src/types/v0/store/definitions.rs
+++ b/common/src/types/v0/store/definitions.rs
@@ -60,6 +60,8 @@ pub enum StoreError {
     },
     #[snafu(display("Failed to grab the lease lock, reason: '{}'", reason))]
     FailedLock { reason: String },
+    #[snafu(display("Failed to unlock the lease. Error {}", source))]
+    FailedUnlock { source: Error },
     #[snafu(display("Etcd is not ready, reason: '{}'", reason))]
     NotReady { reason: String },
     #[snafu(display("Minimum paged value is 2"))]

--- a/common/src/types/v0/store/volume.rs
+++ b/common/src/types/v0/store/volume.rs
@@ -171,7 +171,8 @@ impl VolumeSpec {
     pub fn config(&self) -> &Option<TargetConfig> {
         &self.target_config
     }
-    pub fn last_nexus_id(&self) -> Option<&NexusId> {
+    /// Get the health info key which is used to retrieve the volume's replica health information.
+    pub fn health_info_id(&self) -> Option<&NexusId> {
         if let Some(id) = &self.last_nexus_id {
             return Some(id);
         }

--- a/common/src/types/v0/store/volume.rs
+++ b/common/src/types/v0/store/volume.rs
@@ -8,8 +8,8 @@ use crate::{
             AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
         },
         transport::{
-            self, CreateVolume, NexusId, NodeId, ReplicaId, Topology, VolumeId, VolumeLabels,
-            VolumePolicy, VolumeShareProtocol, VolumeStatus,
+            self, CreateVolume, NexusId, NexusNvmfConfig, NodeId, ReplicaId, Topology, VolumeId,
+            VolumeLabels, VolumePolicy, VolumeShareProtocol, VolumeStatus,
         },
     },
     IntoOption,
@@ -39,15 +39,15 @@ impl ObjectKey for VolumeStateKey {
 /// Volume Target (node and nexus)
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct VolumeTarget {
-    /// The node where front-end IO will be sent to
+    /// The node where front-end IO will be sent to.
     node: NodeId,
-    /// The identification of the nexus where the frontend-IO will be sent to
+    /// The identification of the nexus where the frontend-IO will be sent to.
     nexus: NexusId,
-    /// The protocol to use on the target
+    /// The protocol to use on the target.
     protocol: Option<VolumeShareProtocol>,
 }
 impl VolumeTarget {
-    /// Create a new `Self` based on the given parameters
+    /// Create a new `Self` based on the given parameters.
     pub fn new(node: NodeId, nexus: NexusId, protocol: Option<VolumeShareProtocol>) -> Self {
         Self {
             node,
@@ -55,15 +55,15 @@ impl VolumeTarget {
             protocol,
         }
     }
-    /// Get a reference to the node identification
+    /// Get a reference to the node identification.
     pub fn node(&self) -> &NodeId {
         &self.node
     }
-    /// Get a reference to the nexus identification
+    /// Get a reference to the nexus identification.
     pub fn nexus(&self) -> &NexusId {
         &self.nexus
     }
-    /// Get a reference to the volume protocol
+    /// Get a reference to the volume protocol.
     pub fn protocol(&self) -> Option<&VolumeShareProtocol> {
         self.protocol.as_ref()
     }
@@ -77,7 +77,7 @@ impl From<VolumeTarget> for models::VolumeTarget {
 /// User specification of a volume.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct VolumeSpec {
-    /// Volume Id
+    /// Volume Id.
     pub uuid: VolumeId,
     /// Size that the volume should be.
     pub size: u64,
@@ -87,22 +87,52 @@ pub struct VolumeSpec {
     pub num_replicas: u8,
     /// Status that the volume should eventually achieve.
     pub status: VolumeSpecStatus,
-    /// The target where front-end IO will be sent to
+    /// The target where front-end IO will be sent to.
     pub target: Option<VolumeTarget>,
-    /// volume policy
+    /// Volume policy.
     pub policy: VolumePolicy,
-    /// replica placement topology for the volume creation only
+    /// Replica placement topology for the volume creation only.
     pub topology: Option<Topology>,
-    /// Update of the state in progress
+    /// Update of the state in progress.
     #[serde(skip)]
     pub sequencer: OperationSequence,
-    /// Id of the last Nexus used by the volume
+    /// Id of the last Nexus used by the volume.
     pub last_nexus_id: Option<NexusId>,
     /// Record of the operation in progress
     pub operation: Option<VolumeOperationState>,
-    /// Flag indicating whether the volume should be thin provisioned
+    /// Flag indicating whether the volume should be thin provisioned.
     #[serde(default)]
     pub thin: bool,
+    /// Last used Target Configuration.
+    #[serde(default)]
+    pub target_config: Option<TargetConfig>,
+}
+
+/// The volume's Nvmf Configuration.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct TargetConfig {
+    /// Uuid of the last target used by the volume.
+    target: VolumeTarget,
+    /// The nexus target configuration.
+    config: NexusNvmfConfig,
+}
+impl TargetConfig {
+    /// Get the uuid of the target.
+    pub fn new(target: VolumeTarget, config: NexusNvmfConfig) -> Self {
+        Self { target, config }
+    }
+    /// Get the target.
+    pub fn target(&self) -> &VolumeTarget {
+        &self.target
+    }
+    /// Get the uuid of the target.
+    pub fn uuid(&self) -> &NexusId {
+        &self.target.nexus
+    }
+    /// Get the target configuration.
+    pub fn config(&self) -> &NexusNvmfConfig {
+        &self.config
+    }
 }
 
 impl AsOperationSequencer for VolumeSpec {
@@ -116,7 +146,7 @@ impl AsOperationSequencer for VolumeSpec {
 }
 
 impl VolumeSpec {
-    /// explicitly selected allowed_nodes
+    /// Explicitly selected allowed_nodes.
     pub fn allowed_nodes(&self) -> Vec<NodeId> {
         match &self.topology {
             None => vec![],
@@ -126,8 +156,8 @@ impl VolumeSpec {
                 .unwrap_or_default(),
         }
     }
-    /// desired volume replica count if during `SetReplica` operation
-    /// or otherwise the current num_replicas
+    /// Desired volume replica count if during `SetReplica` operation
+    /// or otherwise the current num_replicas.
     pub fn desired_num_replicas(&self) -> u8 {
         match &self.operation {
             Some(operation) => match operation.operation {
@@ -137,14 +167,24 @@ impl VolumeSpec {
             _ => self.num_replicas,
         }
     }
+    /// Get the last target configuration.
+    pub fn config(&self) -> &Option<TargetConfig> {
+        &self.target_config
+    }
+    pub fn last_nexus_id(&self) -> Option<&NexusId> {
+        if let Some(id) = &self.last_nexus_id {
+            return Some(id);
+        }
+        self.target_config.as_ref().map(|c| &c.target.nexus)
+    }
 }
 
-/// Operation State for a Nexus spec resource
+/// Operation State for a Nexus spec resource.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct VolumeOperationState {
-    /// Record of the operation
+    /// Record of the operation.
     pub operation: VolumeOperation,
-    /// Result of the operation
+    /// Result of the operation.
     pub result: Option<bool>,
 }
 
@@ -180,13 +220,20 @@ impl SpecTransaction<VolumeOperation> for VolumeSpec {
                 }
                 VolumeOperation::SetReplica(count) => self.num_replicas = count,
                 VolumeOperation::RemoveUnusedReplica(_) => {}
-                VolumeOperation::Publish((node, nexus, protocol)) => {
-                    self.target = Some(VolumeTarget::new(node, nexus.clone(), protocol));
-                    self.last_nexus_id = Some(nexus);
+                VolumeOperation::Publish(args) => {
+                    let (node, nexus, protocol) = (args.node, args.nexus, args.protocol);
+                    let target = VolumeTarget::new(node, nexus, protocol);
+                    self.target = Some(target.clone());
+                    self.last_nexus_id = None;
+                    self.target_config =
+                        Some(TargetConfig::new(target, args.config.unwrap_or_default()));
                 }
-                VolumeOperation::Republish((node, nexus, protocol)) => {
-                    self.target = Some(VolumeTarget::new(node, nexus.clone(), Some(protocol)));
-                    self.last_nexus_id = Some(nexus);
+                VolumeOperation::Republish(args) => {
+                    let (node, nexus, protocol) = (args.node, args.nexus, args.protocol);
+                    let target = VolumeTarget::new(node, nexus, Some(protocol));
+                    self.target = Some(target.clone());
+                    self.last_nexus_id = None;
+                    self.target_config = Some(TargetConfig::new(target, args.config));
                 }
                 VolumeOperation::Unpublish => {
                     self.target = None;
@@ -214,7 +261,7 @@ impl SpecTransaction<VolumeOperation> for VolumeSpec {
     }
 }
 
-/// Available Volume Operations
+/// Available Volume Operations.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum VolumeOperation {
     Create,
@@ -222,10 +269,97 @@ pub enum VolumeOperation {
     Share(VolumeShareProtocol),
     Unshare,
     SetReplica(u8),
-    Publish((NodeId, NexusId, Option<VolumeShareProtocol>)),
-    Republish((NodeId, NexusId, VolumeShareProtocol)),
+    Publish(PublishOperation),
+    Republish(RepublishOperation),
     Unpublish,
     RemoveUnusedReplica(ReplicaId),
+}
+
+#[test]
+fn volume_op_deserializer() {
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+    struct TestSpec {
+        op: VolumeOperation,
+    }
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+    struct Test<'a> {
+        input: &'a str,
+        expected: VolumeOperation,
+    }
+    let tests: Vec<Test> = vec![Test {
+        input: r#"{"op":{"Publish":["4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e","4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e",null]}}"#,
+        expected: VolumeOperation::Publish(PublishOperation::new(
+            "4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e".try_into().unwrap(),
+            "4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e".try_into().unwrap(),
+            None,
+            None,
+        )),
+    }];
+
+    for test in &tests {
+        println!("{}", serde_json::to_string(&test.expected).unwrap());
+        let spec: TestSpec = serde_json::from_str(test.input).unwrap();
+        assert_eq!(test.expected, spec.op);
+    }
+}
+
+/// The `PublishOperation` which is easier to manage and update.
+#[derive(serde_tuple::Serialize_tuple, serde_tuple::Deserialize_tuple, Debug, Clone, PartialEq)]
+pub struct PublishOperation {
+    node: NodeId,
+    nexus: NexusId,
+    protocol: Option<VolumeShareProtocol>,
+    #[serde(default)]
+    config: Option<NexusNvmfConfig>,
+}
+impl PublishOperation {
+    /// Return new `Self` from the given parameters.
+    pub fn new(
+        node: NodeId,
+        nexus: NexusId,
+        protocol: Option<VolumeShareProtocol>,
+        config: Option<NexusNvmfConfig>,
+    ) -> Self {
+        Self {
+            node,
+            nexus,
+            protocol,
+            config,
+        }
+    }
+    /// Get the share protocol.
+    pub fn protocol(&self) -> Option<VolumeShareProtocol> {
+        self.protocol
+    }
+}
+
+/// Volume Republish Operation parameters.
+#[derive(serde_tuple::Serialize_tuple, serde_tuple::Deserialize_tuple, Debug, Clone, PartialEq)]
+pub struct RepublishOperation {
+    node: NodeId,
+    nexus: NexusId,
+    protocol: VolumeShareProtocol,
+    config: NexusNvmfConfig,
+}
+impl RepublishOperation {
+    /// Return new `Self` from the given parameters.
+    pub fn new(
+        node: NodeId,
+        nexus: NexusId,
+        protocol: VolumeShareProtocol,
+        config: NexusNvmfConfig,
+    ) -> Self {
+        Self {
+            node,
+            nexus,
+            protocol,
+            config,
+        }
+    }
+    /// Get the share protocol.
+    pub fn protocol(&self) -> VolumeShareProtocol {
+        self.protocol
+    }
 }
 
 impl From<VolumeOperation> for models::volume_spec_operation::Operation {
@@ -273,7 +407,7 @@ impl StorableObject for VolumeSpec {
     }
 }
 
-/// State of the Volume Spec
+/// State of the Volume Spec.
 pub type VolumeSpecStatus = SpecStatus<transport::VolumeStatus>;
 
 impl From<&CreateVolume> for VolumeSpec {
@@ -291,6 +425,7 @@ impl From<&CreateVolume> for VolumeSpec {
             last_nexus_id: None,
             operation: None,
             thin: request.thin,
+            target_config: None,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
@@ -248,7 +248,7 @@ async fn is_replica_healthy(
         None => {
             *nexus_info = context
                 .registry()
-                .get_nexus_info(Some(&volume_spec.uuid), volume_spec.last_nexus_id(), true)
+                .get_nexus_info(Some(&volume_spec.uuid), volume_spec.health_info_id(), true)
                 .await?;
             match nexus_info {
                 Some(info) => info,

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
@@ -248,11 +248,7 @@ async fn is_replica_healthy(
         None => {
             *nexus_info = context
                 .registry()
-                .get_nexus_info(
-                    Some(&volume_spec.uuid),
-                    volume_spec.last_nexus_id.as_ref(),
-                    true,
-                )
+                .get_nexus_info(Some(&volume_spec.uuid), volume_spec.last_nexus_id(), true)
                 .await?;
             match nexus_info {
                 Some(info) => info,

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -253,7 +253,7 @@ impl Registry {
     pub(crate) async fn stop(&self) {
         tokio::time::timeout(std::time::Duration::from_secs(1), async move {
             let store = self.store.lock().await;
-            store.revoke().await;
+            store.revoke().await
         })
         .await
         .ok();

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -590,7 +590,7 @@ pub(crate) trait SpecOperationsHelper:
     /// Check if the object is free to be modified or if it's still busy
     fn busy(&self) -> Result<(), SvcError> {
         if self.dirty() {
-            return Err(SvcError::StoreSave {
+            return Err(SvcError::StoreDirty {
                 kind: self.kind(),
                 id: self.uuid_str(),
             });

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -110,7 +110,7 @@ impl PoolFilters {
         request: &GetSuitablePoolsContext,
         item: &PoolItem,
     ) -> bool {
-        match request.thin && request.last_nexus_id.is_none() {
+        match request.thin && request.config().is_none() {
             true => item.pool.free_space() > Self::free_space_watermark(),
             false => item.pool.free_space() > request.size,
         }

--- a/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
@@ -49,7 +49,7 @@ impl GetPersistedNexusChildren {
     /// Get the current nexus persistent information Id.
     pub(crate) fn nexus_info_id(&self) -> Option<&NexusId> {
         match self {
-            Self::Create((vol, _)) => vol.last_nexus_id.as_ref(),
+            Self::Create((vol, _)) => vol.last_nexus_id(),
             Self::ReCreate(nexus) => Some(&nexus.uuid),
         }
     }

--- a/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
@@ -49,7 +49,7 @@ impl GetPersistedNexusChildren {
     /// Get the current nexus persistent information Id.
     pub(crate) fn nexus_info_id(&self) -> Option<&NexusId> {
         match self {
-            Self::Create((vol, _)) => vol.last_nexus_id(),
+            Self::Create((vol, _)) => vol.health_info_id(),
             Self::ReCreate(nexus) => Some(&nexus.uuid),
         }
     }

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
@@ -197,7 +197,11 @@ impl std::fmt::Debug for GetChildForRemovalContext {
 impl GetChildForRemovalContext {
     async fn new(registry: &Registry, request: &GetChildForRemoval) -> Result<Self, SvcError> {
         let nexus_info = registry
-            .get_nexus_info(Some(&request.spec.uuid), request.spec.last_nexus_id(), true)
+            .get_nexus_info(
+                Some(&request.spec.uuid),
+                request.spec.health_info_id(),
+                true,
+            )
             .await?;
 
         Ok(GetChildForRemovalContext {

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
@@ -197,11 +197,7 @@ impl std::fmt::Debug for GetChildForRemovalContext {
 impl GetChildForRemovalContext {
     async fn new(registry: &Registry, request: &GetChildForRemoval) -> Result<Self, SvcError> {
         let nexus_info = registry
-            .get_nexus_info(
-                Some(&request.spec.uuid),
-                request.spec.last_nexus_id.as_ref(),
-                true,
-            )
+            .get_nexus_info(Some(&request.spec.uuid), request.spec.last_nexus_id(), true)
             .await?;
 
         Ok(GetChildForRemovalContext {

--- a/control-plane/agents/src/bin/core/controller/wrapper.rs
+++ b/control-plane/agents/src/bin/core/controller/wrapper.rs
@@ -342,7 +342,7 @@ impl NodeWrapper {
         self.node_state.api_versions = Some(vec![ApiVersion::V0]);
         let client = self.grpc_client_timeout(timeouts).await?;
         client.liveness_probe().await.map_err(|error| {
-            tracing::error!(?error, "V0 liveness probe failed");
+            tracing::error!(?error, node.id = %self.id(), "V0 liveness probe failed");
             SvcError::NodeNotOnline {
                 node: self.id().clone(),
             }

--- a/control-plane/agents/src/bin/core/controller/wrapper.rs
+++ b/control-plane/agents/src/bin/core/controller/wrapper.rs
@@ -1018,21 +1018,16 @@ impl ClientOps for Arc<tokio::sync::RwLock<NodeWrapper>> {
             Ok(nexus) => Ok(nexus),
             Err(error) => {
                 let nexus_name = request.name();
-                match self
-                    .read()
-                    .await
-                    .nexuses()
-                    .iter()
-                    .find(|nexus| nexus.uuid == request.uuid && nexus.name == nexus_name)
-                {
+                let mut nexuses = self.read().await.nexuses().into_iter();
+                match nexuses.find(|nexus| nexus.uuid == request.uuid && nexus.name == nexus_name) {
                     Some(nexus) => {
-                        // return Ok if nexus with the requested uuid and name already exists
                         tracing::warn!(
-                            "Trying to create nexus with uuid '{}' and name '{}' which already exists.Ok",
-                            request.uuid,
-                            nexus_name
+                            node.id = request.node.as_str(),
+                            nexus.uuid = request.uuid.as_str(),
+                            nexus.name = nexus_name,
+                            "Trying to create a nexus which already exists"
                         );
-                        Ok(nexus.clone())
+                        Ok(nexus)
                     }
                     None => Err(error),
                 }
@@ -1091,13 +1086,13 @@ impl ClientOps for Arc<tokio::sync::RwLock<NodeWrapper>> {
             Ok(child) => Ok(child),
             Err(error) => {
                 if let Some(nexus) = self.read().await.nexus(&request.nexus) {
-                    if let Some(child) = nexus.children.iter().find(|c| c.uri == request.uri) {
+                    if let Some(child) = nexus.children.into_iter().find(|c| c.uri == request.uri) {
                         tracing::warn!(
                             "Trying to add Child '{}' which is already part of nexus '{}'.Ok",
                             request.uri,
                             request.nexus
                         );
-                        return Ok(child.clone());
+                        return Ok(child);
                     }
                 }
                 Err(error)

--- a/control-plane/agents/src/bin/core/node/watchdog.rs
+++ b/control-plane/agents/src/bin/core/node/watchdog.rs
@@ -2,7 +2,7 @@ use crate::node::service::Service;
 use common_lib::types::v0::transport::NodeId;
 
 /// Watchdog which must be pet within the deadline, otherwise
-/// it triggers the `on_timeout` callback from the node `Service`
+/// it triggers the `on_timeout` callback from the node `Service`.
 #[derive(Debug, Clone)]
 pub(crate) struct Watchdog {
     node_id: NodeId,
@@ -13,7 +13,7 @@ pub(crate) struct Watchdog {
 }
 
 impl Watchdog {
-    /// new empty watchdog with a deadline timeout for node `node_id`
+    /// New empty watchdog with a deadline timeout for node `node_id`.
     pub(crate) fn new(node_id: &NodeId, deadline: std::time::Duration) -> Self {
         Self {
             deadline,
@@ -24,20 +24,19 @@ impl Watchdog {
         }
     }
 
-    /// the set deadline
+    /// Get the deadline.
     pub(crate) fn deadline(&self) -> std::time::Duration {
         self.deadline
     }
 
-    /// last time the node was seen
+    /// Get the last time the node was seen.
     pub(crate) fn timestamp(&self) -> std::time::Instant {
         self.timestamp
     }
 
-    /// arm watchdog with self timeout and execute error callback if
-    /// the deadline is not met
+    /// Arm watchdog with self timeout and execute error callback if the deadline is not met.
     pub(crate) fn arm(&mut self, service: Service) {
-        tracing::debug!("Arming the watchdog for node '{}'", self.node_id);
+        tracing::debug!(node.id = %self.node_id, "Arming the node's watchdog");
         let (s, mut r) = tokio::sync::mpsc::channel(1);
         self.pet_chan = Some(s);
         self.service = Some(service.clone());
@@ -49,7 +48,7 @@ impl Watchdog {
                 match result {
                     Err(_) => Service::on_timeout(&service, &id).await,
                     Ok(None) => {
-                        tracing::warn!("Stopping Watchdog for node '{}'", id);
+                        tracing::warn!(node.id = %id, "Stopping Watchdog for node");
                         break;
                     }
                     _ => (),
@@ -58,7 +57,7 @@ impl Watchdog {
         });
     }
 
-    /// meet the deadline
+    /// Meet the deadline.
     pub(crate) async fn pet(&mut self) -> Result<(), tokio::sync::mpsc::error::SendError<()>> {
         self.timestamp = std::time::Instant::now();
         if let Some(chan) = &mut self.pet_chan {
@@ -71,9 +70,9 @@ impl Watchdog {
             Ok(())
         }
     }
-    /// stop the watchdog
+    /// Stop the watchdog.
     pub(crate) fn disarm(&mut self) {
-        tracing::debug!("Disarming the watchdog for node '{}'", self.node_id);
+        tracing::debug!(node.id = %self.node_id, "Disarming the node's watchdog");
         let _ = self.pet_chan.take();
     }
 }

--- a/control-plane/agents/src/bin/ha/cluster/volume.rs
+++ b/control-plane/agents/src/bin/ha/cluster/volume.rs
@@ -38,8 +38,7 @@ impl VolumeMover {
 
         // calling start_op here to store the request in etcd
         req.start_op(Stage::Init, &self.etcd).await?;
-        self.engine.initiate(req);
-        Ok(())
+        self.engine.initiate(req)
     }
 
     /// Send batch of switchover request to SwitchOverEngine.
@@ -52,7 +51,7 @@ impl VolumeMover {
 
         for entry in req {
             entry.start_op(entry.stage(), &self.etcd).await?;
-            self.engine.initiate(entry);
+            self.engine.initiate(entry)?;
         }
         Ok(())
     }

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -146,7 +146,7 @@ pub enum SvcError {
     #[snafu(display("Storage Error: {}", source))]
     Store { source: StoreError },
     #[snafu(display("Storage Error: {} Config for Resource id {} not committed to the store", kind.to_string(), id))]
-    StoreSave { kind: ResourceKind, id: String },
+    StoreDirty { kind: ResourceKind, id: String },
     #[snafu(display("Watch Config Not Found"))]
     WatchNotFound {},
     #[snafu(display("{} Resource to be watched does not exist", kind.to_string()))]
@@ -239,7 +239,7 @@ impl From<SvcError> for ReplyError {
         let desc: &String = &error.description().to_string();
         let error_str = error.full_string();
         match error {
-            SvcError::StoreSave { kind, .. } => ReplyError {
+            SvcError::StoreDirty { kind, .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPersist,
                 resource: kind,
                 source: desc.to_string(),

--- a/control-plane/grpc/proto/v1/nexus/nexus.proto
+++ b/control-plane/grpc/proto/v1/nexus/nexus.proto
@@ -104,6 +104,8 @@ message NexusSpec {
   google.protobuf.StringValue owner = 9;
   // Record of the operation in progress
   optional common.SpecOperation operation = 10;
+  // Nexus Nvmf Configuration
+  optional NexusNvmfConfig nvmf_config = 11;
 }
 
 // Nexus children (replica or "raw" URI)

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -7,13 +7,13 @@ import "google/protobuf/wrappers.proto";
 
 package v1.volume;
 
-// An IoEngine Volume
+// A Volume
 // It has a spec which is the specification provided by the creator
-// It has a state if such state is retrieved from an io-engine storage nodes
+// It has a state if such state is retrieved from io-engine storage nodes
 message Volume {
-  // Desired specification of the pool and metadata
+  // Desired specification of the volume
   VolumeDefinition definition = 1;
-  // Runtime state of the pool.
+  // Runtime state of the volume.
   VolumeState state = 2;
 }
 
@@ -58,6 +58,15 @@ message VolumeSpec {
 message Metadata {
   // spec status of the volume
   common.SpecStatus spec_status = 1;
+  // Persistent Configuration of the target (current/last)
+  TargetConfig target_config = 2;
+}
+
+message TargetConfig {
+  // Persistent Configuration of the target (current/last)
+  VolumeTarget target = 1;
+  // The nvmf configuration
+  nexus.NexusNvmfConfig config = 2;
 }
 
 message VolumeTarget {

--- a/control-plane/grpc/src/operations/nexus/traits.rs
+++ b/control-plane/grpc/src/operations/nexus/traits.rs
@@ -22,6 +22,7 @@ use common_lib::{
             RemoveNexusChild, ReplicaId, ShareNexus, UnshareNexus, VolumeId,
         },
     },
+    IntoOption, TryIntoOption,
 };
 use std::convert::TryFrom;
 
@@ -357,6 +358,7 @@ impl TryFrom<nexus::NexusSpec> for NexusSpec {
                 operation: NexusOperation::Create,
                 result: op.result,
             }),
+            nvmf_config: value.nvmf_config.try_into_opt()?,
         })
     }
 }
@@ -382,6 +384,7 @@ impl From<NexusSpec> for nexus::NexusSpec {
             operation: value.operation.map(|operation| common::SpecOperation {
                 result: operation.result,
             }),
+            nvmf_config: value.nvmf_config.into_opt(),
         }
     }
 }

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -97,7 +97,7 @@ pub trait VolumeOperations: Send + Sync {
 
 impl From<VolumeSpec> for volume::VolumeDefinition {
     fn from(volume_spec: VolumeSpec) -> Self {
-        let nexus_id = volume_spec.last_nexus_id().cloned();
+        let nexus_id = volume_spec.health_info_id().cloned();
         let spec_status: common::SpecStatus = volume_spec.status.into();
         Self {
             spec: Some(volume::VolumeSpec {

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -14,7 +14,7 @@ use crate::{
 use common_lib::{
     transport_api::{v0::Volumes, ReplyError, ResourceKind},
     types::v0::{
-        store::volume::{VolumeSpec, VolumeTarget},
+        store::volume::{TargetConfig, VolumeSpec, VolumeTarget},
         transport::{
             CreateVolume, DestroyShutdownTargets, DestroyVolume, ExplicitNodeTopology, Filter,
             LabelledTopology, Nexus, NexusId, NodeId, NodeTopology, PoolTopology, PublishVolume,
@@ -23,6 +23,7 @@ use common_lib::{
             VolumePolicy, VolumeShareProtocol, VolumeState,
         },
     },
+    IntoOption,
 };
 use std::{collections::HashMap, convert::TryFrom};
 
@@ -96,6 +97,7 @@ pub trait VolumeOperations: Send + Sync {
 
 impl From<VolumeSpec> for volume::VolumeDefinition {
     fn from(volume_spec: VolumeSpec) -> Self {
+        let nexus_id = volume_spec.last_nexus_id().cloned();
         let spec_status: common::SpecStatus = volume_spec.status.into();
         Self {
             spec: Some(volume::VolumeSpec {
@@ -108,11 +110,12 @@ impl From<VolumeSpec> for volume::VolumeDefinition {
                 target: volume_spec.target.map(|target| target.into()),
                 policy: Some(volume_spec.policy.into()),
                 topology: volume_spec.topology.map(|topology| topology.into()),
-                last_nexus_id: volume_spec.last_nexus_id.map(|id| id.to_string()),
+                last_nexus_id: nexus_id.map(|id| id.to_string()),
                 thin: volume_spec.thin,
             }),
             metadata: Some(volume::Metadata {
                 spec_status: spec_status as i32,
+                target_config: volume_spec.target_config.into_opt(),
             }),
         }
     }
@@ -228,6 +231,7 @@ impl TryFrom<volume::VolumeDefinition> for VolumeSpec {
             },
             operation: None,
             thin: volume_spec.thin,
+            target_config: None,
         };
         Ok(volume_spec)
     }
@@ -556,7 +560,7 @@ impl TryFrom<volume::VolumeTarget> for VolumeTarget {
                         return Err(ReplyError::invalid_argument(
                             ResourceKind::Volume,
                             "target.protocol",
-                            "".to_string(),
+                            "is empty".to_string(),
                         ))
                     }
                 },
@@ -566,7 +570,6 @@ impl TryFrom<volume::VolumeTarget> for VolumeTarget {
         Ok(target)
     }
 }
-
 impl From<VolumeTarget> for volume::VolumeTarget {
     fn from(target: VolumeTarget) -> Self {
         volume::VolumeTarget {
@@ -579,6 +582,36 @@ impl From<VolumeTarget> for volume::VolumeTarget {
                     Some(protocol as i32)
                 }
             },
+        }
+    }
+}
+
+impl TryFrom<volume::TargetConfig> for TargetConfig {
+    type Error = ReplyError;
+    fn try_from(src: volume::TargetConfig) -> Result<Self, Self::Error> {
+        Ok(Self::new(
+            match src.target {
+                Some(t) => t.try_into(),
+                None => Err(ReplyError::missing_argument(
+                    ResourceKind::Volume,
+                    "target_config.target",
+                )),
+            }?,
+            match src.config {
+                Some(c) => c.try_into(),
+                None => Err(ReplyError::missing_argument(
+                    ResourceKind::Volume,
+                    "target_config.config",
+                )),
+            }?,
+        ))
+    }
+}
+impl From<TargetConfig> for volume::TargetConfig {
+    fn from(src: TargetConfig) -> Self {
+        volume::TargetConfig {
+            target: Some(src.target().clone().into()),
+            config: Some(src.config().clone().into()),
         }
     }
 }

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -37,6 +37,8 @@ impl ComponentAction for IoEngine {
                 format!("/host/tmp/{}.sock", Self::name(i, options)).as_str(),
             ])
             .with_env("MAYASTOR_NVMF_HOSTID", Uuid::new_v4().to_string().as_str())
+            .with_env("NEXUS_NVMF_RESV_ENABLE", "1")
+            .with_env("NEXUS_NVMF_ANA_ENABLE", "1")
             .with_bind("/tmp", "/host/tmp");
 
             if options.io_engine_isolate {


### PR DESCRIPTION
Use reservations to ensure "old" targets are locked out from the replicas. Stores information from the last target persistently as it may be useful as for the moment use it to increment the controller id.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>