### PR TITLE
chore: use rustup with path

### DIFF
--- a/scripts/rust/env-setup.sh
+++ b/scripts/rust/env-setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Meant to be called only from the nix-shell shellHook
+
+# these are provided by the shellHook
+dev_rustup=${dev_rustup:-}
+devrustup_moth=${devrustup_moth:-}
+rustup_channel=${rustup_channel:-}
+
+if [ -z "$CI" ]; then
+  if ! diff -r --exclude Cargo.lock "$RUST_TOOLCHAIN_NIX" "$RUST_TOOLCHAIN_NIX" &>/dev/null; then
+    rm -rf "$RUST_TOOLCHAIN"
+    mkdir -p "$RUST_TOOLCHAIN" 2>/dev/null
+    cp -r "$RUST_TOOLCHAIN_NIX"/* "$RUST_TOOLCHAIN"
+    chmod -R +w "$RUST_TOOLCHAIN"
+  fi
+  if [ "$dev_rustup" == "1" ] && [ "$IN_NIX_SHELL" == "impure" ]; then
+    cowsay "$devrustup_moth"
+    unset dev_rustup
+    unset USE_NIX_RUST
+    RUSTUP_CUSTOM=
+    path_remove () { export PATH=`echo -n $PATH | awk -v RS=: -v ORS=: '$0 != "'$1'"' | sed 's/:$//'`; }
+    path_remove "$RUST_TOOLCHAIN_NIX/bin"
+
+    # https://discourse.nixos.org/t/nix-shell-with-rustup/22452
+    if [ -f /usr/bin/ldd ]; then
+      NIX_LDD=$(ldd --version | head -n 1 | awk '{ print $NF }')
+      USR_LDD=$(/usr/bin/ldd --version | head -n 1 | awk '{ print $NF }')
+      if [ "$NIX_LDD" != "$USR_LDD" ]; then
+        RUSTUP_CUSTOM="1"
+      fi
+    fi
+    if [ -n "$RUSTUP_CUSTOM" ]; then
+      cat <<EOF >rust-toolchain.toml
+[toolchain]
+path = "$RUST_TOOLCHAIN"
+EOF
+      # Use rust-toolchain.toml so the IDE can work correctly but use the
+      # RUSTUP_TOOLCHAIN under nix so we can use rustup properly
+      export RUSTUP_TOOLCHAIN="$rustup_channel"
+      # Adding ~/.cargo/bin to the path let's us carry on using rustup but it lowers its
+      # priority: https://github.com/rust-lang/cargo/pull/11023
+      export PATH=$RUST_TOOLCHAIN/bin:$PATH:~/.cargo/bin
+    else
+      cat <<EOF >rust-toolchain.toml
+[toolchain]
+channel = "$rustup_channel"
+components = [ "rust-src" ]
+EOF
+    fi
+    if ! rustup toolchain list | grep "$rustup_channel" >/dev/null; then
+      rustup toolchain install "$rustup_channel"
+    fi
+  elif [ -n "$USE_NIX_RUST" ]; then
+    export PATH=$RUST_TOOLCHAIN/bin:$PATH
+  fi
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -60,7 +60,7 @@ mkShell {
   # copy the rust toolchain to a writable directory, see: https://github.com/rust-lang/cargo/issues/10096
   # the whole toolchain is copied to allow the src to be retrievable through "rustc --print sysroot"
   RUST_TOOLCHAIN = "/tmp/rust-toolchain/${rust.version}";
-  DEV_RUSTUP = "${toString (devrustup)}";
+  RUST_TOOLCHAIN_NIX = "${rust}";
 
   NODE_PATH = "${nodePackages."@commitlint/config-conventional"}/lib/node_modules";
 
@@ -68,35 +68,18 @@ mkShell {
     ./scripts/nix/git-submodule-init.sh
     pre-commit install
     pre-commit install --hook commit-msg
+
     ${pkgs.lib.optionalString (norust) "cowsay ${norust_moth}"}
     ${pkgs.lib.optionalString (norust) "echo"}
-    if [ -z "$CI" ]; then
-      if [ "$DEV_RUSTUP" == "1" ] && [ "$IN_NIX_SHELL" == "impure" ]; then
-        unset DEV_RUSTUP
-        unset USE_NIX_RUST
-        cowsay "${devrustup_moth}"
-        path_remove ()  { export PATH=`echo -n $PATH | awk -v RS=: -v ORS=: '$0 != "'$1'"' | sed 's/:$//'`; }
-        path_remove "${rust}/bin"
-        cat <<EOF >rust-toolchain.toml
-    [toolchain]
-    channel = "${lib.strings.concatMapStringsSep "-" (x: x) (lib.lists.drop 1 (lib.strings.splitString "-" rust.version))}"
-    components = [ "rust-src" ]
-    EOF
-      elif [ -n "$USE_NIX_RUST" ]; then
-        RUST_TOOLCHAIN_RD="${rust}"
-        if ! diff -r --exclude Cargo.lock "$RUST_TOOLCHAIN_RD" "$RUST_TOOLCHAIN" &>/dev/null; then
-          rm -rf "$RUST_TOOLCHAIN"
-          mkdir -p "$RUST_TOOLCHAIN" 2>/dev/null
-          cp -r "$RUST_TOOLCHAIN_RD"/* "$RUST_TOOLCHAIN"
-          chmod -R +w "$RUST_TOOLCHAIN"
-        fi
-        export PATH=$RUST_TOOLCHAIN/bin:$PATH
-      fi
-    fi
+
+    rustup_channel="${lib.strings.concatMapStringsSep "-" (x: x) (lib.lists.drop 1 (lib.strings.splitString "-" rust.version))}" \
+    dev_rustup="${toString (devrustup)}" devrustup_moth="${devrustup_moth}" . ./scripts/rust/env-setup.sh
+
     export WORKSPACE_ROOT=`pwd`
     [ ! -z "${io-engine}" ] && cowsay "${io-engine-moth}"
     [ ! -z "${io-engine}" ] && export IO_ENGINE_BIN="${io-engine-moth}"
     export PATH="$PATH:$(pwd)/target/debug"
+
     DOCKER_CONFIG=~/.docker/config.json
     if [ -f "$DOCKER_CONFIG" ]; then
       DOCKER_TOKEN=$(cat ~/.docker/config.json | jq '.auths."https://index.docker.io/v1/".auth // empty' | tr -d '"' | base64 -d)


### PR DESCRIPTION
On non-nixos when using rustup and the system's libc is not the same as the nix-shell's libc seems
 we get some odd errors:
https://discourse.nixos.org/t/nix-shell-with-rustup/22452 This is likely because the binaries from rustup haven't been patched to point to the nix env. So, instead of using the binaries from rustup just point rustup to a copy of the nix binaries. This allows us to both use the right binaries and carry on using rustup so we can configure our favourite IDE to the same rustup path.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>