### PR TITLE
fix(csi-node): add several fixes

### DIFF
--- a/control-plane/csi-driver/src/bin/node/filesystem_vol.rs
+++ b/control-plane/csi-driver/src/bin/node/filesystem_vol.rs
@@ -59,15 +59,21 @@ pub(crate) async fn stage_fs_volume(
         }
     };
 
-    if mount::find_mount(Some(device_path), Some(fs_staging_path)).is_some() {
+    if let Some(existing) = mount::find_mount(Some(device_path), Some(fs_staging_path)) {
         debug!(
             "Device {} is already mounted onto {}",
             device_path, fs_staging_path
         );
         info!(
-            "Volume {} is already staged to {}",
-            volume_id, fs_staging_path
+            %existing,
+            "Volume {} is already staged to {}", volume_id, fs_staging_path
         );
+
+        // todo: validate other flags?
+        if mnt.mount_flags.readonly() != existing.options.readonly() {
+            mount::remount(fs_staging_path, mnt.mount_flags.readonly())?;
+        }
+
         return Ok(());
     }
 
@@ -151,6 +157,12 @@ pub(crate) async fn unstage_fs_volume(msg: &NodeUnstageVolumeRequest) -> Result<
                 unkown_mount.source
             ));
         }
+
+        // Sometimes after/during disconnect we get some page write errors, triggered by a journal
+        // update by the JBD2 worker task. We don't really know how we can "flush" these
+        // tasks so at the moment the best solution we have is to remount the staging path
+        // as RO before we umount it for good, which seems to help.
+        mount::remount(fs_staging_path, true)?;
         if let Err(error) = mount::filesystem_unmount(fs_staging_path) {
             return Err(failure!(
                 Code::Internal,

--- a/control-plane/csi-driver/src/bin/node/filesystem_vol.rs
+++ b/control-plane/csi-driver/src/bin/node/filesystem_vol.rs
@@ -131,6 +131,26 @@ pub(crate) async fn unstage_fs_volume(msg: &NodeUnstageVolumeRequest) -> Result<
             "Unstaging filesystem volume {}, unmounting device {:?} from {}",
             volume_id, mount.source, fs_staging_path
         );
+        let device = mount.source.to_string_lossy().to_string();
+        let mounts = mount::find_src_mounts(&device, Some(fs_staging_path));
+        if let Some(unkown_mount) = mounts.first().cloned() {
+            for mount in mounts {
+                tracing::error!(
+                    volume.uuid = %volume_id,
+                    "Found unknown bind mount {} for device {:?}",
+                    device,
+                    mount.dest,
+                );
+            }
+
+            return Err(failure!(
+                Code::Internal,
+                "Failed to unstage volume {}: existing unknown bind mount {:?} for device {:?}",
+                volume_id,
+                unkown_mount.dest,
+                unkown_mount.source
+            ));
+        }
         if let Err(error) = mount::filesystem_unmount(fs_staging_path) {
             return Err(failure!(
                 Code::Internal,

--- a/control-plane/csi-driver/src/bin/node/mount.rs
+++ b/control-plane/csi-driver/src/bin/node/mount.rs
@@ -245,6 +245,22 @@ pub(crate) fn bind_unmount(target: &str) -> Result<(), Error> {
     Ok(())
 }
 
+/// Remount existing mount as read only or read write.
+pub(crate) fn remount(target: &str, ro: bool) -> Result<Mount, Error> {
+    let mut flags = MountFlags::empty();
+    flags.insert(MountFlags::REMOUNT);
+
+    if ro {
+        flags.insert(MountFlags::RDONLY);
+    }
+
+    let mount = Mount::new("", target, FilesystemType::Manual("none"), flags, None)?;
+
+    debug!("Target {} remounted with {:?}", target, flags);
+
+    Ok(mount)
+}
+
 /// Mount a block device
 pub(crate) fn blockdevice_mount(
     source: &str,

--- a/control-plane/csi-driver/src/bin/node/mount.rs
+++ b/control-plane/csi-driver/src/bin/node/mount.rs
@@ -51,6 +51,22 @@ pub(crate) fn find_mount(source: Option<&str>, target: Option<&str>) -> Option<M
     found.map(MountInfo::from)
 }
 
+/// Return all mounts for a matching source.
+/// Optionally ignore the given destination path.
+pub(crate) fn find_src_mounts(source: &str, dest_ignore: Option<&str>) -> Vec<MountInfo> {
+    MountIter::new()
+        .unwrap()
+        .flatten()
+        .filter(|mount| {
+            mount.source.to_string_lossy() == source
+                && match dest_ignore {
+                    None => true,
+                    Some(ignore) => ignore != mount.dest.to_string_lossy(),
+                }
+        })
+        .collect()
+}
+
 /// Check if options in "first" are also present in "second",
 /// but exclude values "ro" and "rw" from the comparison.
 pub(super) fn subset(first: &[String], second: &[String]) -> bool {

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -610,6 +610,12 @@ impl node_server::Node for Node {
         // found.
         unstage_fs_volume(&msg).await?;
 
+        // Sometimes when disconnecting we see page read errors due to ENXIO.
+        // There seems to be some race in the kernel when removing a device with queued IOs.
+        // While this is not strictly an issue, it may confuse or hide other problems.
+        // Sleeping between umount and disconnect seems to alleviate this.
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
         // unmounts (if any) are complete.
         // If the device is attached, detach the device.
         // Device::lookup will return None for nbd devices,

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -142,6 +142,7 @@ async fn detach(uuid: &Uuid, errheader: String) -> Result<(), Status> {
     })? {
         let device_path = device.devname();
         debug!("Detaching device {}", device_path);
+
         if let Err(error) = device.detach().await {
             return Err(failure!(
                 Code::Internal,


### PR DESCRIPTION
fix(csi-node): don't unstage if bind mount exists

If an application creates a bind mount for our volume unstaging can be very troublesome as it
leaves the mount in a really bad state.
Even if we reconnect the device, it's very unlikely things won't recover.

This commit adds a check on node_unstage for unknown mounts (as in, not a csi publish mount).
Should there be any we output this as a trace and simply fail the unstage.
It's up to the user to clean up non-csi mounts, otherwise we can never unstage.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix(csi-node): remount staging path as ro before final umount

Sometimes after/during disconnect we get some page write errors, triggered by a journal update by
the JBD2 worker task.
We don't really know how we can "flush" these tasks so at the moment the best solution we have is
to remount the staging path as RO before we umount it for good, which seems to help.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix(csi-node): add noddy sleep between umount and disconnect

Sometimes when disconnecting we see page read errors due to ENXIO.
There seems to be some race in the kernel when removing a device with queued IOs.
While this is not strictly an issue, it may confuse or hide other problems.
Although an ugly WA, sleeping between umount and disconnect seems to alleviate this.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>