### PR TITLE
chore: cluster agent to reuse existing target for switchover

### DIFF
--- a/common/src/types/v0/store/nexus.rs
+++ b/common/src/types/v0/store/nexus.rs
@@ -134,7 +134,7 @@ impl From<&NexusSpec> for CreateNexus {
             &spec.children,
             spec.managed,
             spec.owner.as_ref(),
-            None,
+            spec.nvmf_config.clone(),
         )
     }
 }

--- a/common/src/types/v0/store/switchover.rs
+++ b/common/src/types/v0/store/switchover.rs
@@ -60,6 +60,8 @@ pub struct SwitchOverSpec {
     pub new_path: Option<String>,
     /// Number of failed attempts in the current Stage.
     pub retry_count: u64,
+    /// Reuse the existing target.
+    pub reuse_existing: bool,
 }
 
 impl SwitchOverSpec {

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/nexus.rs
@@ -63,7 +63,7 @@ async fn volume_nexus_reconcile(
 
             if volume_state.status != VolumeStatus::Online {
                 faulted_nexus_remover(&mut nexus, context).await?;
-                missing_nexus_recreate(&mut nexus, context, false).await?;
+                missing_nexus_recreate(&mut nexus, context).await?;
                 enospc_children_faulter(&mut nexus, context).await?;
             }
             fixup_nexus_protocol(&mut nexus, context).await

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -83,6 +83,15 @@ impl NodeFilters {
             .into_iter()
             .any(|node_spec| node_spec.id() == item.node_wrapper().id())
     }
+
+    /// Should only attempt to use node where current target is not present.
+    pub(crate) fn current_target(request: &GetSuitableNodesContext, item: &NodeItem) -> bool {
+        if let Some(target) = &request.target {
+            target.node() != item.node_wrapper().id()
+        } else {
+            true
+        }
+    }
 }
 
 /// Filter pools used for replica creation.

--- a/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
@@ -338,21 +338,12 @@ impl NexusTargetNode {
                 spec: request.spec.clone(),
             },
             list: {
-                let current_target = request.spec.target;
                 let nodes = registry.get_node_wrappers().await;
                 let mut node_items = Vec::with_capacity(nodes.len());
                 for node in nodes {
                     let node = node.read().await;
+
                     node_items.push(NodeItem::new(node.clone()));
-                }
-                // exclude the current target node from the list of candidates
-                if current_target.is_some() {
-                    node_items = node_items
-                        .into_iter()
-                        .filter(|node| {
-                            node.node_wrapper().id() != current_target.as_ref().unwrap().node()
-                        })
-                        .collect();
                 }
                 node_items
             },
@@ -371,6 +362,7 @@ impl NexusTargetNode {
             .await
             .filter(NodeFilters::online)
             .filter(NodeFilters::cordoned)
+            .filter(NodeFilters::current_target)
             .sort(NodeSorters::number_targets)
     }
 }

--- a/control-plane/agents/src/bin/core/controller/task_poller.rs
+++ b/control-plane/agents/src/bin/core/controller/task_poller.rs
@@ -24,9 +24,6 @@ pub(crate) enum PollTriggerEvent {
     VolumeDegraded,
     /// The Agent is starting up
     Start,
-    /// A volume has been republished and the older nexus
-    /// needs to be reused.
-    VolumeRepublish,
 }
 
 /// State of a poller

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -1,6 +1,6 @@
 use crate::{
     controller::{
-        reconciler::{nexus::nexus_recreate, PollTriggerEvent},
+        reconciler::PollTriggerEvent,
         registry::Registry,
         resources::{
             operations::{
@@ -413,9 +413,7 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
             Ok(_) => {
                 if request.reuse_existing
                     && !older_nexus.as_ref().is_shutdown()
-                    && nexus_recreate(registry, &mut older_nexus, true)
-                        .await
-                        .is_ok()
+                    && older_nexus.missing_nexus_recreate(registry).await.is_ok()
                 {
                     move_nexus = false;
                 }

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -216,6 +216,8 @@ pub enum SvcError {
     MaxRebuilds { max_rebuilds: u32 },
     #[snafu(display("The api version: {:?} is not valid", api_version))]
     InvalidApiVersion { api_version: Option<ApiVersion> },
+    #[snafu(display("The subsystem with nqn: {} is not found", nqn))]
+    SubsystemNotFound { nqn: String },
 }
 
 impl SvcError {
@@ -614,6 +616,12 @@ impl From<SvcError> for ReplyError {
             },
             SvcError::InvalidApiVersion { .. } => ReplyError {
                 kind: ReplyErrorKind::InvalidArgument,
+                resource: ResourceKind::Unknown,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+            SvcError::SubsystemNotFound { .. } => ReplyError {
+                kind: ReplyErrorKind::NotFound,
                 resource: ResourceKind::Unknown,
                 source: desc.to_string(),
                 extra: error.full_string(),


### PR DESCRIPTION
Cluster agent would now try to reuse the existing target first and if that fails, it would do a mandatory move of the target for switchover.

Signed-off-by: Abhinandan Purkait <purkaitabhinandan@gmail.com>