### PR TITLE
chore(ha_nexus): allow errored and successful requests to be enqueued at startup

### DIFF
--- a/common/src/types/v0/store/switchover.rs
+++ b/common/src/types/v0/store/switchover.rs
@@ -78,7 +78,7 @@ impl SwitchOverSpec {
         if let Some(op) = &self.operation {
             match op.operation {
                 Operation::Errored(_) => true,
-                Operation::ReplacePath => matches!(op.result.unwrap_or(false), true),
+                Operation::Successful => matches!(op.result.unwrap_or(false), true),
                 _ => false,
             }
         } else {

--- a/control-plane/agents/src/bin/ha/cluster/volume.rs
+++ b/control-plane/agents/src/bin/ha/cluster/volume.rs
@@ -48,8 +48,7 @@ impl VolumeMover {
         &self,
         mut req: Vec<SwitchOverRequest>,
     ) -> Result<(), anyhow::Error> {
-        req.sort_by_key(|r| r.timestamp());
-
+        req.sort();
         for entry in req {
             entry.start_op(entry.stage(), &self.etcd).await?;
             self.engine.enqueue(entry);


### PR DESCRIPTION
When cluster agent starts. It gets Switchover request from Etcd and enqueues them in channel so they can get process. We were sending only In progress requests. Now with this change all requests present in Etcd irrespective of the stage will be enqueued and precossed to completion.

Added debug in Etcd store failure to get actual store error.

Signed-off-by: Abhilash Shetty <abhilash.shetty@datacore.com>