### PR TITLE
feat(hostnqn): use allowed hosts with initiator's hostnqn

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -67,3 +67,12 @@ pub use platform::init_cluster_info_or_panic;
 
 /// Prefix for all keys stored in the persistent store (ETCD).
 pub const ETCD_KEY_PREFIX: &str = "/openebs.io/mayastor";
+
+/// Enum defining the host access control kind.
+#[derive(Debug, Copy, Clone, strum_macros::ToString, strum_macros::EnumString, Eq, PartialEq)]
+#[strum(serialize_all = "lowercase")]
+pub enum HostAccessControl {
+    None,
+    Nexuses,
+    Replicas,
+}

--- a/common/src/types/v0/store/nexus.rs
+++ b/common/src/types/v0/store/nexus.rs
@@ -345,6 +345,7 @@ impl From<&NexusSpec> for transport::Nexus {
             device_uri: "".to_string(),
             rebuilds: 0,
             share: nexus.share,
+            allowed_hosts: vec![],
         }
     }
 }

--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -3,7 +3,7 @@ use crate::{
     types::v0::{
         openapi::models,
         store::definitions::{ObjectKey, StorableObject, StorableObjectType},
-        transport::{self, NodeId},
+        transport::{self, HostNqn, NodeId},
     },
     IntoOption,
 };
@@ -142,6 +142,9 @@ pub struct NodeSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)] // Ensure backwards compatibility in etcd when upgrading.
     cordon_drain_state: Option<CordonDrainState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)] // Ensure backwards compatibility in etcd when upgrading.
+    node_nqn: Option<HostNqn>,
 }
 
 impl NodeSpec {
@@ -151,13 +154,19 @@ impl NodeSpec {
         endpoint: std::net::SocketAddr,
         labels: NodeLabels,
         cordon_drain_state: Option<CordonDrainState>,
+        node_nqn: Option<HostNqn>,
     ) -> Self {
         Self {
             id,
             endpoint,
             labels,
             cordon_drain_state,
+            node_nqn,
         }
+    }
+    /// Node Nvme HOSTNQN.
+    pub fn node_nqn(&self) -> &Option<HostNqn> {
+        &self.node_nqn
     }
     /// Node identification.
     pub fn id(&self) -> &NodeId {
@@ -177,8 +186,12 @@ impl NodeSpec {
     }
 
     /// Node gRPC endpoint.
+    pub fn set_nqn(&mut self, nqn: Option<HostNqn>) {
+        self.node_nqn = nqn;
+    }
+    /// Node gRPC endpoint.
     pub fn set_endpoint(&mut self, endpoint: std::net::SocketAddr) {
-        self.endpoint = endpoint
+        self.endpoint = endpoint;
     }
 
     /// Cordon node by applying the label.

--- a/common/src/types/v0/transport/child.rs
+++ b/common/src/types/v0/transport/child.rs
@@ -51,6 +51,12 @@ impl ChildUri {
     pub fn is_local(&self) -> bool {
         self.0.starts_with("bdev://") || self.0.starts_with("loopback://")
     }
+
+    /// Add query parameter to the Uri.
+    #[must_use]
+    pub fn with_query(self, name: &str, value: &str) -> Self {
+        add_query(self.0, name, value).into()
+    }
 }
 impl PartialEq<Child> for ChildUri {
     fn eq(&self, other: &Child) -> bool {

--- a/common/src/types/v0/transport/misc.rs
+++ b/common/src/types/v0/transport/misc.rs
@@ -360,9 +360,9 @@ pub fn add_query(mut base: String, name: &str, value: &str) -> String {
 
 /// Update the Uri with the given allowed_host's nqn's.
 /// # Warning: Should be called only once.
-pub fn uri_with_hostnqn(base_uri: &str, hostnqns: &[String]) -> String {
+pub fn uri_with_hostnqn(base_uri: &str, hostnqns: &[HostNqn]) -> String {
     hostnqns.iter().fold(base_uri.to_string(), |acc, nqn| {
-        add_query(acc, "hostnqn", nqn)
+        add_query(acc, "hostnqn", &nqn.to_string())
     })
 }
 

--- a/common/src/types/v0/transport/misc.rs
+++ b/common/src/types/v0/transport/misc.rs
@@ -374,7 +374,7 @@ pub fn strip_queries(base: String, name: &str) -> String {
         .filter(|(n, _)| n != name)
         .map(|(n, v)| (n.to_string(), v.to_string()))
         .collect::<Vec<_>>();
-    url.query_pairs_mut().clear();
+    url.set_query(None);
     for (n, v) in qp {
         url.query_pairs_mut().append_pair(&n, &v);
     }

--- a/common/src/types/v0/transport/misc.rs
+++ b/common/src/types/v0/transport/misc.rs
@@ -1,7 +1,10 @@
 use super::*;
 
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt::Debug};
+use std::{
+    convert::TryFrom,
+    fmt::{Debug, Write},
+};
 
 use std::str::FromStr;
 use strum_macros::{EnumString, ToString};
@@ -344,3 +347,36 @@ impl From<Protocol> for models::Protocol {
 /// Liveness Probe.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Liveness {}
+
+/// Add query parameter to a Uri.
+pub fn add_query(mut base: String, name: &str, value: &str) -> String {
+    if base.contains('?') {
+        let _ = write!(base, "&{name}={value}");
+    } else {
+        let _ = write!(base, "?{name}={value}");
+    }
+    base
+}
+
+/// Update the Uri with the given allowed_host's nqn's.
+/// # Warning: Should be called only once.
+pub fn uri_with_hostnqn(base_uri: &str, hostnqns: &[String]) -> String {
+    hostnqns.iter().fold(base_uri.to_string(), |acc, nqn| {
+        add_query(acc, "hostnqn", nqn)
+    })
+}
+
+/// Strip all query parameters from the given `String`.
+pub fn strip_queries(base: String, name: &str) -> String {
+    let mut url = url::Url::from_str(&base).unwrap();
+    let qp = url
+        .query_pairs()
+        .filter(|(n, _)| n != name)
+        .map(|(n, v)| (n.to_string(), v.to_string()))
+        .collect::<Vec<_>>();
+    url.query_pairs_mut().clear();
+    for (n, v) in qp {
+        url.query_pairs_mut().append_pair(&n, &v);
+    }
+    url.to_string()
+}

--- a/common/src/types/v0/transport/nexus.rs
+++ b/common/src/types/v0/transport/nexus.rs
@@ -43,11 +43,18 @@ pub struct Nexus {
     pub rebuilds: u32,
     /// protocol used for exposing the nexus
     pub share: Protocol,
+    /// host nqn's allowed to connect to the target.
+    pub allowed_hosts: Vec<HostNqn>,
 }
 impl Nexus {
     /// Check if the nexus contains the provided `ChildUri`
     pub fn contains_child(&self, uri: &ChildUri) -> bool {
         self.children.iter().any(|c| &c.uri == uri)
+    }
+    /// Add query parameter to the Uri.
+    pub fn with_query(mut self, name: &str, value: &str) -> Self {
+        self.device_uri = add_query(self.device_uri, name, value);
+        self
     }
 }
 
@@ -548,17 +555,6 @@ impl ShareNexus {
             uuid: nexus.uuid.clone(),
             protocol,
             allowed_hosts: nqns.into_vec(),
-            ..Default::default()
-        }
-    }
-}
-impl From<(&Nexus, Option<String>, NexusShareProtocol)> for ShareNexus {
-    fn from((nexus, key, protocol): (&Nexus, Option<String>, NexusShareProtocol)) -> Self {
-        Self {
-            node: nexus.node.clone(),
-            uuid: nexus.uuid.clone(),
-            key,
-            protocol,
             ..Default::default()
         }
     }

--- a/common/src/types/v0/transport/node.rs
+++ b/common/src/types/v0/transport/node.rs
@@ -20,6 +20,8 @@ pub struct Register {
     pub api_versions: Option<Vec<ApiVersion>>,
     /// Used to identify dataplane process restarts.
     pub instance_uuid: Option<uuid::Uuid>,
+    /// Used to identify dataplane nvme hostnqn.
+    pub node_nqn: Option<HostNqn>,
 }
 
 /// Deregister message payload
@@ -125,6 +127,8 @@ pub struct NodeState {
     pub api_versions: Option<Vec<ApiVersion>>,
     /// Used to identify dataplane process restarts.
     instance_uuid: Option<uuid::Uuid>,
+    /// Used to identify dataplane nvme hostnqn.
+    pub node_nqn: Option<HostNqn>,
 }
 
 impl NodeState {
@@ -134,6 +138,7 @@ impl NodeState {
         grpc_endpoint: std::net::SocketAddr,
         status: NodeStatus,
         api_versions: Option<Vec<ApiVersion>>,
+        node_nqn: Option<HostNqn>,
     ) -> Self {
         Self {
             id,
@@ -141,6 +146,7 @@ impl NodeState {
             status,
             api_versions,
             instance_uuid: None,
+            node_nqn,
         }
     }
     /// Get the node identification.
@@ -169,6 +175,7 @@ impl From<Register> for NodeState {
             status: NodeStatus::Online,
             api_versions: src.api_versions,
             instance_uuid: src.instance_uuid,
+            node_nqn: src.node_nqn,
         }
     }
 }

--- a/common/src/types/v0/transport/nvme_nqn.rs
+++ b/common/src/types/v0/transport/nvme_nqn.rs
@@ -80,12 +80,19 @@ impl NvmeNqn {
         Self::Unique { uuid }
     }
     /// Generate a Mayastor type name.
-    pub fn new_prod_name(name: &str) -> Self {
+    pub fn from_nodename(name: &String) -> Self {
         Self::Org {
             date: "2019-05".to_string(),
             domain: "io.openebs".to_string(),
             name: format!("node-name:{name}"),
         }
+    }
+    /// Generate a Mayastor type name.
+    pub fn from_nodenames(nodenames: &[String]) -> Vec<Self> {
+        nodenames
+            .iter()
+            .map(Self::from_nodename)
+            .collect::<Vec<_>>()
     }
     fn parse_nqn_date(date: &str) -> Result<String, NvmeNqnParseError> {
         match date.split("").collect::<Vec<_>>()[..] {

--- a/common/src/types/v0/transport/replica.rs
+++ b/common/src/types/v0/transport/replica.rs
@@ -347,6 +347,14 @@ pub struct ShareReplica {
     pub allowed_hosts: Vec<HostNqn>,
 }
 
+impl ShareReplica {
+    /// Get `Self` with the provided allowed_hosts.
+    pub fn with_hosts(mut self, hosts: Vec<HostNqn>) -> Self {
+        self.allowed_hosts = hosts;
+        self
+    }
+}
+
 impl From<ShareReplica> for UnshareReplica {
     fn from(share: ShareReplica) -> Self {
         Self {

--- a/control-plane/agents/src/bin/core/controller/grpc.rs
+++ b/control-plane/agents/src/bin/core/controller/grpc.rs
@@ -360,6 +360,7 @@ impl GrpcClient {
                     grpc_endpoint: self.context.endpoint(),
                     api_versions: Some(vec![ApiVersion::V0]),
                     instance_uuid: None,
+                    node_nqn: None,
                 })
             }
             ApiVersion::V1 => {
@@ -408,6 +409,7 @@ impl GrpcClient {
                     instance_uuid: registration_info
                         .instance_uuid
                         .and_then(|u| uuid::Uuid::parse_str(&u).ok()),
+                    node_nqn: registration_info.hostnqn.and_then(|h| h.try_into().ok()),
                 })
             }
         }

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -98,6 +98,7 @@ impl ReplicaItem {
         self.replica_state.as_ref()
     }
     /// Get a reference to the child spec.
+    #[allow(dead_code)]
     pub(crate) fn uri(&self) -> &Option<ChildUri> {
         &self.child_uri
     }

--- a/control-plane/agents/src/bin/core/controller/wrapper.rs
+++ b/control-plane/agents/src/bin/core/controller/wrapper.rs
@@ -139,6 +139,16 @@ impl NodeWrapper {
                         node_state.instance_uuid()
                     );
                 }
+
+                // todo: what to do if this ever happens?
+                if self.node_state().node_nqn != node_state.node_nqn {
+                    tracing::error!(
+                        node.id=%node_state.id,
+                        "Node hostnqn changed from {:?} to {:?}",
+                        self.node_state().node_nqn,
+                        node_state.node_nqn
+                    );
+                }
             }
             self.node_state = node_state;
             true

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -146,6 +146,7 @@ impl Service {
                         grpc_endpoint: node.endpoint(),
                         api_versions: None,
                         instance_uuid: None,
+                        node_nqn: node.node_nqn().clone(),
                     },
                     true,
                 )

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -21,14 +21,21 @@ impl ResourceSpecsLocked {
             match specs.nodes.get(&node.id) {
                 Some(node_spec) => {
                     let mut node_spec = node_spec.lock();
-                    let changed = node_spec.endpoint() != node.grpc_endpoint;
+                    let changed = node_spec.endpoint() != node.grpc_endpoint
+                        || node_spec.node_nqn() != &node.node_nqn;
 
                     node_spec.set_endpoint(node.grpc_endpoint);
+                    node_spec.set_nqn(node.node_nqn.clone());
                     (changed, node_spec.clone())
                 }
                 None => {
-                    let node =
-                        NodeSpec::new(node.id.clone(), node.grpc_endpoint, NodeLabels::new(), None);
+                    let node = NodeSpec::new(
+                        node.id.clone(),
+                        node.grpc_endpoint,
+                        NodeLabels::new(),
+                        None,
+                        node.node_nqn.clone(),
+                    );
                     specs.nodes.insert(node.clone());
                     (true, node)
                 }

--- a/control-plane/agents/src/bin/core/tests/node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/node/mod.rs
@@ -16,8 +16,14 @@ fn new_node(
     let endpoint = std::str::FromStr::from_str(&endpoint).unwrap();
     Node::new(
         id.clone(),
-        Some(NodeSpec::new(id.clone(), endpoint, NodeLabels::new(), None)),
-        Some(NodeState::new(id, endpoint, status, api_versions)),
+        Some(NodeSpec::new(
+            id.clone(),
+            endpoint,
+            NodeLabels::new(),
+            None,
+            None,
+        )),
+        Some(NodeState::new(id, endpoint, status, api_versions, None)),
     )
 }
 

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -786,10 +786,10 @@ async fn disown_unused_replicas() {
             PublishVolumeBody::new_all(
                 HashMap::new(),
                 None,
-                Some(node.clone()),
+                node.clone().to_string(),
                 models::VolumeShareProtocol::Nvmf,
                 None,
-                "".to_string(),
+                cluster.csi_node(0),
             ),
         )
         .await

--- a/control-plane/agents/src/bin/core/tests/volume/capacity.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/capacity.rs
@@ -41,10 +41,10 @@ async fn fault_enospc_child() {
             PublishVolumeBody::new_all(
                 HashMap::new(),
                 None,
-                Some(cluster.node(0).to_string()),
+                cluster.node(0).to_string(),
                 models::VolumeShareProtocol::Nvmf,
                 None,
-                "".to_string(),
+                cluster.csi_node(0),
             ),
         )
         .await

--- a/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
@@ -159,10 +159,10 @@ async fn offline_replicas_reconcile(cluster: &Cluster, reconcile_period: Duratio
             PublishVolumeBody::new_all(
                 HashMap::new(),
                 None,
-                Some(free_node.clone()),
+                free_node.clone().to_string(),
                 models::VolumeShareProtocol::Nvmf,
                 None,
-                "".to_string(),
+                cluster.csi_node(0),
             ),
         )
         .await
@@ -227,10 +227,10 @@ async fn unused_nexus_reconcile(cluster: &Cluster) {
             PublishVolumeBody::new_all(
                 HashMap::new(),
                 None,
-                Some(cluster.node(0).to_string()),
+                cluster.node(0).to_string(),
                 models::VolumeShareProtocol::Nvmf,
                 None,
-                "".to_string(),
+                cluster.csi_node(0),
             ),
         )
         .await
@@ -314,10 +314,10 @@ async fn unused_reconcile(cluster: &Cluster) {
             PublishVolumeBody::new_all(
                 HashMap::new(),
                 None,
-                Some(nexus_node.id.to_string()),
+                nexus_node.id.to_string(),
                 models::VolumeShareProtocol::Nvmf,
                 None,
-                cluster.csi_node(0).to_string(),
+                cluster.csi_node(0),
             ),
         )
         .await
@@ -338,10 +338,10 @@ async fn unused_reconcile(cluster: &Cluster) {
             PublishVolumeBody::new_all(
                 HashMap::new(),
                 None,
-                Some(unused_node.id.to_string()),
+                unused_node.id.to_string(),
                 models::VolumeShareProtocol::Nvmf,
                 None,
-                "".to_string(),
+                cluster.csi_node(0),
             ),
         )
         .await
@@ -429,10 +429,10 @@ async fn missing_nexus_reconcile(cluster: &Cluster) {
             PublishVolumeBody::new_all(
                 HashMap::new(),
                 None,
-                Some(cluster.node(0).to_string()),
+                cluster.node(0).to_string(),
                 models::VolumeShareProtocol::Nvmf,
                 None,
-                cluster.csi_node(0).to_string(),
+                cluster.csi_node(0),
             ),
         )
         .await

--- a/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
@@ -9,7 +9,8 @@ use common_lib::types::v0::{
         tower::client::Error,
     },
     transport::{
-        CreateNexus, CreateVolume, DestroyVolume, Filter, NexusId, PublishVolume, VolumeId,
+        strip_queries, CreateNexus, CreateVolume, DestroyVolume, Filter, NexusId, PublishVolume,
+        VolumeId,
     },
 };
 use deployer_cluster::{Cluster, ClusterBuilder};
@@ -439,7 +440,8 @@ async fn missing_nexus_reconcile(cluster: &Cluster) {
 
     tracing::info!("Volume: {:?}", volume);
     let volume_state = volume.state;
-    let nexus = volume_state.target.unwrap();
+    let mut nexus = volume_state.target.unwrap();
+    nexus.device_uri = strip_queries(nexus.device_uri, "hostnqn");
 
     cluster.composer().stop(nexus.node.as_str()).await.unwrap();
     let curr_nexus = wait_till_nexus_state(cluster, &nexus.uuid, None).await;

--- a/control-plane/agents/src/bin/core/volume/registry.rs
+++ b/control-plane/agents/src/bin/core/volume/registry.rs
@@ -1,7 +1,7 @@
 use crate::controller::registry::Registry;
 use agents::errors::SvcError;
 use common_lib::types::v0::transport::{
-    NexusStatus, ReplicaTopology, Volume, VolumeId, VolumeState, VolumeStatus,
+    uri_with_hostnqn, NexusStatus, ReplicaTopology, Volume, VolumeId, VolumeState, VolumeStatus,
 };
 
 use crate::controller::reconciler::PollTriggerEvent;
@@ -52,7 +52,13 @@ impl Registry {
             );
         }
 
-        Ok(if let Some(nexus_state) = nexus_state {
+        Ok(if let Some(mut nexus_state) = nexus_state {
+            let nqns = nexus_state
+                .allowed_hosts
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            nexus_state.device_uri = uri_with_hostnqn(&nexus_state.device_uri, &nqns);
             VolumeState {
                 uuid: volume_spec.uuid.to_owned(),
                 size: nexus_state.size,

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -52,7 +52,10 @@ use grpc::operations::{PaginatedResult, Pagination};
 use std::collections::HashMap;
 
 use crate::controller::resources::operations::ResourceOwnerUpdate;
-use common_lib::types::v0::store::{replica::PoolRef, volume::TargetConfig};
+use common_lib::types::v0::{
+    store::{replica::PoolRef, volume::TargetConfig},
+    transport::{HostNqn, ShareReplica},
+};
 use grpc::operations::volume::traits::PublishVolumeInfo;
 use snafu::OptionExt;
 use std::convert::From;
@@ -635,30 +638,32 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         remove: &ReplicaItem,
     ) -> Result<(), SvcError> {
-        if let Some(child_uri) = remove.uri() {
-            // if the nexus is up, first remove the child from the nexus before deleting the replica
-            let mut nexus = self.get_volume_target_nexus_guard(spec_clone).await?;
-            let nexus = nexus
-                .iter_mut()
-                .find(|n| n.lock().children.iter().any(|c| &c.uri() == child_uri));
-            match nexus {
-                None => Ok(()),
-                Some(nexus) => {
-                    let nexus_spec = nexus.lock().clone();
-                    self.remove_nexus_replica(
-                        Some(nexus),
-                        registry,
-                        &RemoveNexusReplica {
-                            node: nexus_spec.node,
-                            nexus: nexus_spec.uuid,
-                            replica: ReplicaUri::new(&remove.spec().uuid, child_uri),
-                        },
-                    )
-                    .await
-                }
+        // if the nexus is up, first remove the child from the nexus before deleting the replica
+        let mut nexus = self.get_volume_target_nexus_guard(spec_clone).await?;
+        let nexus = nexus.iter_mut().find_map(|n| {
+            let found = n
+                .lock()
+                .children
+                .iter()
+                .flat_map(|c| c.as_replica())
+                .find(|r| r.uuid() == &remove.spec().uuid);
+            found.map(|r| (n, r))
+        });
+        match nexus {
+            None => Ok(()),
+            Some((nexus, replica)) => {
+                let nexus_spec = nexus.lock().clone();
+                self.remove_nexus_replica(
+                    Some(nexus),
+                    registry,
+                    &RemoveNexusReplica {
+                        node: nexus_spec.node,
+                        nexus: nexus_spec.uuid,
+                        replica: ReplicaUri::new(&remove.spec().uuid, replica.uri()),
+                    },
+                )
+                .await
             }
-        } else {
-            Ok(())
         }
     }
 
@@ -728,8 +733,10 @@ impl ResourceSpecsLocked {
         } else {
             // on a different node, so connect via an nvmf target
             let mut replica = self.replica(&replica_state.uuid).await?;
-            match replica.share(registry, &replica_state.into()).await {
-                Ok(uri) => Ok(uri.into()),
+            let host_nqn = HostNqn::new_prod_name(nexus_node.as_str());
+            let request = ShareReplica::from(replica_state).with_hosts(vec![host_nqn.clone()]);
+            match replica.share(registry, &request).await {
+                Ok(uri) => Ok(ChildUri::from(uri)),
                 Err(SvcError::AlreadyShared { .. }) => Ok(replica_state.uri.clone().into()),
                 Err(error) => Err(error),
             }

--- a/control-plane/agents/src/common/msg_translation/v0.rs
+++ b/control-plane/agents/src/common/msg_translation/v0.rs
@@ -148,6 +148,15 @@ impl TryIoEngineToAgent for v0_rpc::NexusV2 {
             rebuilds: self.rebuilds,
             // todo: do we need an "other" Protocol variant in case we don't recognise it?
             share: Protocol::try_from(self.device_uri.as_str()).unwrap_or(Protocol::None),
+            allowed_hosts: self
+                .allowed_hosts
+                .iter()
+                .map(|n| {
+                    // should we allow for invalid here since it comes directly from the dataplane?
+                    transport::HostNqn::try_from(n)
+                        .unwrap_or(transport::HostNqn::Invalid { nqn: n.to_string() })
+                })
+                .collect(),
         })
     }
 }
@@ -168,6 +177,15 @@ impl TryIoEngineToAgent for v0_rpc::Nexus {
             rebuilds: self.rebuilds,
             // todo: do we need an "other" Protocol variant in case we don't recognise it?
             share: Protocol::try_from(self.device_uri.as_str()).unwrap_or(Protocol::None),
+            allowed_hosts: self
+                .allowed_hosts
+                .iter()
+                .map(|n| {
+                    // should we allow for invalid here since it comes directly from the dataplane?
+                    transport::HostNqn::try_from(n)
+                        .unwrap_or(transport::HostNqn::Invalid { nqn: n.to_string() })
+                })
+                .collect(),
         })
     }
 }
@@ -325,12 +343,7 @@ impl AgentToIoEngine for transport::ShareNexus {
             uuid: self.uuid.clone().into(),
             key: self.key.clone().unwrap_or_default(),
             share: self.protocol as i32,
-            allowed_hosts: self
-                .allowed_hosts
-                .clone()
-                .into_iter()
-                .map(|host_nqn| host_nqn.to_string())
-                .collect(),
+            allowed_hosts: self.allowed_hosts.clone().into_vec(),
         }
     }
 }

--- a/control-plane/agents/src/common/msg_translation/v1.rs
+++ b/control-plane/agents/src/common/msg_translation/v1.rs
@@ -194,6 +194,15 @@ impl TryIoEngineToAgent for v1_rpc::nexus::Nexus {
             rebuilds: self.rebuilds,
             // todo: do we need an "other" Protocol variant in case we don't recognise it?
             share: Protocol::try_from(self.device_uri.as_str()).unwrap_or(Protocol::None),
+            allowed_hosts: self
+                .allowed_hosts
+                .iter()
+                .map(|n| {
+                    // should we allow for invalid here since it comes directly from the dataplane?
+                    transport::HostNqn::try_from(n)
+                        .unwrap_or(transport::HostNqn::Invalid { nqn: n.to_string() })
+                })
+                .collect(),
         })
     }
 }
@@ -293,12 +302,7 @@ impl AgentToIoEngine for transport::ShareNexus {
             uuid: self.uuid.clone().into(),
             key: self.key.clone().unwrap_or_default(),
             share: self.protocol as i32,
-            allowed_hosts: self
-                .allowed_hosts
-                .clone()
-                .into_iter()
-                .map(|host_nqn| host_nqn.to_string())
-                .collect(),
+            allowed_hosts: self.allowed_hosts.clone().into_vec(),
         }
     }
 }

--- a/control-plane/grpc/src/operations/nexus/traits.rs
+++ b/control-plane/grpc/src/operations/nexus/traits.rs
@@ -117,6 +117,7 @@ impl TryFrom<nexus::Nexus> for Nexus {
                     ))
                 }
             },
+            allowed_hosts: vec![],
         };
         Ok(nexus)
     }

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -78,6 +78,7 @@ impl TryFrom<node::Node> for Node {
                     },
                     None => None,
                 },
+                None,
             )),
             None => None,
         };
@@ -102,6 +103,7 @@ impl TryFrom<node::Node> for Node {
                         )
                     })?,
                     status,
+                    None,
                     None,
                 ))
             }

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -291,10 +291,10 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
             PublishVolumeBody::new_all(
                 HashMap::new(),
                 None,
-                Some(io_engine1.to_string()),
+                io_engine1.to_string(),
                 models::VolumeShareProtocol::Nvmf,
                 None,
-                "".to_string(),
+                cluster.csi_node(0),
             ),
         )
         .await

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -65,10 +65,7 @@ impl ComponentAction for CoreAgent {
             binary = binary.with_args(vec!["--max-rebuilds", &max_rebuilds.to_string()]);
         }
         Ok(cfg.add_container_spec(
-            ContainerSpec::from_binary(name, binary)
-                .with_portmap("50051", "50051")
-                .with_env("VOLUME_ALLOWED_HOSTS", "yes")
-                .with_env("REPLICA_ALLOWED_HOSTS", "yes"),
+            ContainerSpec::from_binary(name, binary).with_portmap("50051", "50051"),
         ))
     }
     async fn start(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -65,7 +65,10 @@ impl ComponentAction for CoreAgent {
             binary = binary.with_args(vec!["--max-rebuilds", &max_rebuilds.to_string()]);
         }
         Ok(cfg.add_container_spec(
-            ContainerSpec::from_binary(name, binary).with_portmap("50051", "50051"),
+            ContainerSpec::from_binary(name, binary)
+                .with_portmap("50051", "50051")
+                .with_env("VOLUME_ALLOWED_HOSTS", "yes")
+                .with_env("REPLICA_ALLOWED_HOSTS", "yes"),
         ))
     }
     async fn start(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -40,7 +40,6 @@ impl ComponentAction for IoEngine {
             ])
             .with_args(vec!["--ptpl-dir", &ptpl_dir])
             .with_env("MAYASTOR_NVMF_HOSTID", Uuid::new_v4().to_string().as_str())
-            .with_env("HOSTNQN", Self::nqn(i, options).as_str())
             .with_env("NEXUS_NVMF_RESV_ENABLE", "1")
             .with_env("NEXUS_NVMF_ANA_ENABLE", "1")
             .with_bind("/tmp", "/host/tmp");
@@ -112,7 +111,11 @@ impl IoEngine {
         format!("io-engine-{}", i + 1)
     }
     pub fn nqn(i: u32, options: &StartOptions) -> String {
-        format!("nqn.2019-05.io.openebs:{}", Self::name(i, options))
+        format!(
+            "{}{}",
+            utils::constants::NVME_INITIATOR_NQN_PREFIX,
+            Self::name(i, options)
+        )
     }
     /// Get the persistent reservation base path for host and container.
     pub fn ptpl() -> (&'static str, &'static str) {

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -165,6 +165,10 @@ pub struct StartOptions {
     #[structopt(long)]
     pub io_engine_isolate: bool,
 
+    /// Setup a unique hostnqn for each io-engine.
+    #[structopt(long)]
+    pub io_engine_host_nqn: bool,
+
     /// Add the following environment variables to the io_engine containers.
     #[structopt(long, env = "IO_ENGINE_ENV", value_delimiter=",", parse(try_from_str = utils::tracing_telemetry::parse_key_value))]
     pub io_engine_env: Option<Vec<KeyValue>>,
@@ -414,6 +418,11 @@ impl StartOptions {
     #[must_use]
     pub fn with_isolated_io_engine(mut self, isolate: bool) -> Self {
         self.io_engine_isolate = isolate;
+        self
+    }
+    #[must_use]
+    pub fn with_io_engine_hostnqn(mut self, yes: bool) -> Self {
+        self.io_engine_host_nqn = yes;
         self
     }
     #[must_use]

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -165,10 +165,6 @@ pub struct StartOptions {
     #[structopt(long)]
     pub io_engine_isolate: bool,
 
-    /// Setup a unique hostnqn for each io-engine.
-    #[structopt(long)]
-    pub io_engine_host_nqn: bool,
-
     /// Add the following environment variables to the io_engine containers.
     #[structopt(long, env = "IO_ENGINE_ENV", value_delimiter=",", parse(try_from_str = utils::tracing_telemetry::parse_key_value))]
     pub io_engine_env: Option<Vec<KeyValue>>,
@@ -418,11 +414,6 @@ impl StartOptions {
     #[must_use]
     pub fn with_isolated_io_engine(mut self, isolate: bool) -> Self {
         self.io_engine_isolate = isolate;
-        self
-    }
-    #[must_use]
-    pub fn with_io_engine_hostnqn(mut self, yes: bool) -> Self {
-        self.io_engine_host_nqn = yes;
         self
     }
     #[must_use]

--- a/tests/bdd/common/fio.py
+++ b/tests/bdd/common/fio.py
@@ -1,12 +1,18 @@
 import shutil
+from typing import Optional
+from urllib.parse import parse_qs, ParseResult
 
 
 class Fio(object):
     def __init__(
-        self, name, rw, device="", runtime=15, optstr="", traddr="", subnqn=""
+        self,
+        name,
+        rw,
+        device="",
+        runtime=15,
+        optstr="",
+        uri: Optional[ParseResult] = None,
     ):
-        self.subnqn = subnqn
-        self.traddr = traddr
         self.name = name
         self.rw = rw
         self.device = device
@@ -15,6 +21,7 @@ class Fio(object):
         self.success = {}
         self.runtime = runtime
         self.optstr = optstr
+        self.uri = uri
 
     def build(self):
         devs = [self.device] if isinstance(self.device, str) else self.device
@@ -31,11 +38,19 @@ class Fio(object):
         return command
 
     def build_for_userspace(self):
+        uri_query = parse_qs(self.uri.query)
+        traddr = self.uri.hostname
+        subnqn = self.uri.path[1:]
+        hostnqn = ""
+
+        if uri_query.keys().__contains__("hostnqn"):
+            hostnqn = "--hostnqn={}".format(uri_query["hostnqn"][0])
+
         command = (
             "docker exec -i fio-spdk fio --name={} --filename='trtype=tcp adrfam=IPv4 traddr={} trsvcid=8420 "
             "subnqn={} ns=1' --direct=1 --rw={} --ioengine=spdk --bs=4k --iodepth=64 --numjobs=1 --thread=1 "
-            "--size=50M --norandommap=1".format(
-                self.name, self.traddr, self.subnqn.replace(":", "\\:"), self.rw
+            "--size=50M --norandommap=1 {}".format(
+                self.name, traddr, subnqn.replace(":", "\\:"), self.rw, hostnqn
             )
         )
         return command

--- a/tests/bdd/features/csi/controller/test_controller.py
+++ b/tests/bdd/features/csi/controller/test_controller.py
@@ -13,7 +13,7 @@ import grpc
 from time import sleep
 import subprocess
 
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 import json
 
 from common.apiclient import ApiClient
@@ -738,8 +738,9 @@ def check_nvmf_target(uri):
     port = u.port
     host = u.hostname
     nqn = u.path[1:]
+    hostnqn = parse_qs(u.query)["hostnqn"][0]
 
-    command = "sudo nvme discover -t tcp -s {0} -a {1} -o json".format(port, host)
+    command = f"sudo nvme discover -t tcp -s {port} -a {host} -q {hostnqn} -o json"
     status = subprocess.run(
         command, shell=True, check=True, text=True, capture_output=True
     )

--- a/tests/bdd/features/ha/node-agent/test_path_replacement.py
+++ b/tests/bdd/features/ha/node-agent/test_path_replacement.py
@@ -112,8 +112,6 @@ def background():
         node_agent=True,
         cluster_agent=True,
         cache_period="1s",
-        io_engine_env="NEXUS_NVMF_ANA_ENABLE=1,NEXUS_NVMF_RESV_ENABLE=1",
-        agents_env="TEST_NEXUS_NVMF_ANA_ENABLE=1",
     )
 
     ApiClient.pools_api().put_node_pool(

--- a/tests/io-engine/tests/allowed_hosts.rs
+++ b/tests/io-engine/tests/allowed_hosts.rs
@@ -10,7 +10,6 @@ async fn allowed_hosts() {
     let cluster = ClusterBuilder::builder()
         .with_io_engines(3)
         .with_tmpfs_pool(size * 4)
-        .with_options(|o| o.with_io_engine_hostnqn(true))
         .build()
         .await
         .unwrap();
@@ -145,6 +144,7 @@ async fn volume_allowed_host() {
                 Some(cluster.node(0).to_string()),
                 models::VolumeShareProtocol::Nvmf,
                 None,
+                cluster.csi_node(0),
             ),
         )
         .await

--- a/tests/io-engine/tests/reservations.rs
+++ b/tests/io-engine/tests/reservations.rs
@@ -62,7 +62,7 @@ async fn preservation() {
         )
         .await
         .unwrap();
-    let share = v0::ShareNexus::from((&nexus1, None, v0::NexusShareProtocol::Nvmf));
+    let share = v0::ShareNexus::new(&nexus1, v0::NexusShareProtocol::Nvmf, vec![]);
     let _nexus1_uri = nexus_client.share(&share, None).await.unwrap();
 
     nexus_client

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -89,6 +89,8 @@ pub const DEFAULT_REST_MAX_WORKER_THREADS: &str = "8";
 pub const DEFAULT_NAMESPACE: &str = "mayastor";
 /// NQN prefix for NVMe targets created by the product.
 pub const NVME_TARGET_NQN_PREFIX: &str = "nqn.2019-05.io.openebs:";
+/// NQN prefix for NVMe HOSTNQN used by the product.
+pub const NVME_INITIATOR_NQN_PREFIX: &str = "nqn.2019-05.io.openebs:node-name:";
 
 /// NVMe path check period.
 pub const NVME_PATH_CHECK_PERIOD: &str = "3s";

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -100,3 +100,6 @@ pub const NVME_PATH_RETRANSMISSION_PERIOD: &str = "10s";
 
 /// Period for aggregating multiple failed paths before reporting them.
 pub const NVME_PATH_AGGREGATION_PERIOD: &str = "1s";
+
+/// Period for aggregating multiple failed paths before reporting them.
+pub const DEFAULT_HOST_ACCESS_CONTROL: &str = "nexuses,replicas";


### PR DESCRIPTION
feat(hostnqn): use allowed hosts with auto-generated hostnqn within device uri

Uses the "initiator" node to restricted the nvmf targets to a specific node.
Ex: if the nexus that connects to a replica is on node "super-sayan" then the
replica is setup with allowed hosts: [nqn.2019-05.io.openebs:node-name:super-sayan]
The nexus is then created with replica uri as such:
nvmf://10.1.0.9:8420/nqn.2019-05.io.openebs:9fdebe7c-2fe3-4647-89c0-9f12576709c5?uuid=9fdebe7c-2f
e3-4647-89c0-9f12576709c5&hostnqn=nqn.2019-05.io.openebs:node-name:super-sayan

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(csi-hostnqn): use nexus uuid to generate hostnqn within device uri

Uses the nexus uuid to restricted the nvmf target access.
todo: use the csi nodename instead, which will be done once the PR
that pass this down the stack gets merged.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix: use hostnqn from dataplane registration

This allows us to use whatever the node is configured for.
TODO: update cli to report hostnqn?

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>