### PR TITLE
feat(plugin): collect all ha node logs

### DIFF
--- a/k8s/supportability/src/collect/constants.rs
+++ b/k8s/supportability/src/collect/constants.rs
@@ -20,7 +20,7 @@ pub(crate) const POOL_OPERATOR_SERVICE: &str = "operator-diskpool";
 pub(crate) const REST_SERVICE: &str = "api-rest";
 
 /// Defines the name of agent-ha-node
-pub(crate) const AGENT_HA_NODE: &str = "agent-ha-node";
+pub(crate) const AGENT_HA_NODE_SERVICE: &str = "agent-ha-node";
 
 /// Defines the name of the csi node daemon service
 pub(crate) const CSI_NODE_SERVICE: &str = "csi-node";
@@ -52,7 +52,7 @@ lazy_static! {
             (REST_SERVICE, true),
             (CSI_NODE_SERVICE, true),
             (ETCD_SERVICE, true),
-            (AGENT_HA_NODE, true),
+            (AGENT_HA_NODE_SERVICE, true),
         ]);
 
     /// List of resources fall under data plane services
@@ -67,5 +67,6 @@ lazy_static! {
             (MAYASTOR_SERVICE, true),
             (ETCD_SERVICE, true),
             (CSI_NODE_SERVICE, true),
+            (AGENT_HA_NODE_SERVICE, true),
         ]);
 }


### PR DESCRIPTION
Signed-off-by: sinhaashish <ashi.sinha.87@gmail.com>


This PR is a fix for  issue where in _Mayastor support bundle tool not generating logs for all agent ha node pods in mayastor namespace_