### PR TITLE
feat: implement node drain reconciler

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod nexus;
+mod node;
 mod persistent_store;
 pub(crate) mod poller;
 mod pool;

--- a/control-plane/agents/src/bin/core/controller/reconciler/node/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/node/mod.rs
@@ -1,0 +1,41 @@
+mod nexus;
+
+use crate::controller::{
+    reconciler::node::nexus::NodeNexusReconciler,
+    task_poller::{PollContext, PollPeriods, PollResult, PollTimer, TaskPoller},
+};
+
+/// Node reconciler loop which moves nexuses from draining nodes.
+#[derive(Debug)]
+pub(crate) struct NodeReconciler {
+    counter: PollTimer,
+    poll_targets: Vec<Box<dyn TaskPoller>>,
+}
+impl NodeReconciler {
+    /// Return new `Self` with the provided period.
+    pub(crate) fn from(period: PollPeriods) -> Self {
+        NodeReconciler {
+            counter: PollTimer::from(period),
+            poll_targets: vec![Box::new(NodeNexusReconciler::new())],
+        }
+    }
+    /// Return new `Self` with the default period.
+    pub(crate) fn new() -> Self {
+        Self::from(1)
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for NodeReconciler {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        let mut results = Vec::with_capacity(self.poll_targets.len());
+        for target in &mut self.poll_targets {
+            results.push(target.try_poll(context).await);
+        }
+        Self::squash_results(results)
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        self.counter.poll()
+    }
+}

--- a/control-plane/agents/src/bin/core/controller/reconciler/node/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/node/nexus.rs
@@ -1,0 +1,164 @@
+use crate::controller::{
+    reconciler::{PollContext, TaskPoller},
+    resources::{
+        operations::ResourcePublishing, operations_helper::OperationSequenceGuard, OperationGuard,
+        ResourceMutex,
+    },
+    task_poller::{PollEvent, PollResult, PollTimer, PollerState},
+};
+use agents::errors::SvcError;
+use common_lib::types::v0::{
+    store::{node::NodeSpec, volume::VolumeSpec},
+    transport::{NodeId, RepublishVolume, VolumeId, VolumeShareProtocol},
+};
+/// Node drain reconciler.
+#[derive(Debug)]
+pub(super) struct NodeNexusReconciler {
+    counter: PollTimer,
+}
+impl NodeNexusReconciler {
+    /// Return a new `Self`.
+    pub(super) fn new() -> Self {
+        Self {
+            counter: PollTimer::from(1), // sets the reconciler polling rate
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for NodeNexusReconciler {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        let nodes = context.specs().get_nodes();
+        let mut results = Vec::with_capacity(nodes.len());
+
+        for node in nodes {
+            results.push(check_and_drain_node(context, &node).await);
+        }
+        Self::squash_results(results)
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        self.counter.poll()
+    }
+
+    async fn poll_event(&mut self, context: &PollContext) -> bool {
+        matches!(context.event(), PollEvent::TimedRun)
+    }
+}
+
+/// Republish the specified volume on any node other than its current node.
+async fn republish_volume(
+    volume: &mut OperationGuard<ResourceMutex<VolumeSpec>, VolumeSpec>,
+    context: &PollContext,
+    vol_uuid: &VolumeId,
+    frontend_node: &NodeId,
+) -> Result<(), SvcError> {
+    let request = RepublishVolume::new(
+        vol_uuid.clone(),
+        None,
+        frontend_node.clone(),
+        VolumeShareProtocol::Nvmf,
+        false,
+    );
+    tracing::info!(
+        volume.uuid = vol_uuid.as_str(),
+        "Attempting to republish volume"
+    );
+
+    volume.republish(context.registry(), &request).await?;
+
+    Ok(())
+}
+
+/// Drain the specified node if in draining state
+async fn check_and_drain_node(context: &PollContext, node_spec: &NodeSpec) -> PollResult {
+    if !node_spec.is_draining() {
+        return PollResult::Ok(PollerState::Idle);
+    }
+
+    let node_id = node_spec.id();
+    tracing::trace!(node.id = node_spec.id().as_str(), "Draining node");
+    let vol_specs = context.specs().get_locked_volumes();
+
+    let mut move_failures = false;
+
+    // Iterate through all the volumes, find those with a nexus hosted on the
+    // node and move each one away.
+    for vol_spec in vol_specs {
+        match vol_spec.operation_guard() {
+            Ok(mut guarded_vol_spec) => {
+                if let Some(target) = guarded_vol_spec.as_ref().target() {
+                    if target.node() != node_id {
+                        continue; // some other node's volume, ignore
+                    }
+                    let nexus_id = target.nexus().clone();
+                    let vol_id = guarded_vol_spec.as_ref().uuid.clone();
+
+                    let config = match guarded_vol_spec.as_ref().config() {
+                        None => {
+                            tracing::error!("Failed to get config");
+                            move_failures = true;
+                            continue;
+                        }
+                        Some(config) => config,
+                    };
+                    let frontend_node = config
+                        .frontend()
+                        .node_names()
+                        .first()
+                        .unwrap_or(&String::default())
+                        .clone();
+                    let frontend_node_id: NodeId = frontend_node.into();
+                    // frontend_node could be "", republish will still be allowed.
+                    tracing::info!(
+                        volume.uuid = vol_id.as_str(),
+                        nexus.uuid = nexus_id.as_str(),
+                        node.id = node_spec.id().as_str(),
+                        "Moving volume"
+                    );
+                    if let Err(e) =
+                        republish_volume(&mut guarded_vol_spec, context, &vol_id, &frontend_node_id)
+                            .await
+                    {
+                        tracing::error!(
+                            error=%e,
+                            volume.uuid = vol_id.as_str(),
+                            nexus.uuid = nexus_id.as_str(),
+                            node.id = node_spec.id().as_str(),
+                            "Failed to republish volume"
+                        );
+                        move_failures = true;
+                        continue;
+                    }
+                    tracing::info!(
+                        volume.uuid = vol_id.as_str(),
+                        nexus.uuid = nexus_id.as_str(),
+                        node.id = node_spec.id().as_str(),
+                        "Moved volume"
+                    );
+                }
+            }
+            Err(_) => {
+                // we can't get to the volume so we don't know if it belongs to this node
+                move_failures = true;
+            }
+        };
+    }
+    // Change the node state to "drained"
+    if !move_failures {
+        if let Err(e) = context
+            .specs()
+            .set_node_drained(context.registry(), node_spec.id())
+            .await
+        {
+            tracing::error!(
+                error=%e,
+                node.id = node_id.as_str(),
+                "Failed to set node to state drained"
+            );
+            return PollResult::Err(e);
+        }
+        tracing::info!(node.id = node_id.as_str(), "Set node to state drained");
+    }
+    PollResult::Ok(PollerState::Idle)
+}

--- a/control-plane/agents/src/bin/core/controller/reconciler/poller.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/poller.rs
@@ -1,5 +1,5 @@
 use crate::controller::{
-    reconciler::{nexus, persistent_store::PersistentStoreReconciler, pool, replica, volume},
+    reconciler::{nexus, node, persistent_store::PersistentStoreReconciler, pool, replica, volume},
     registry::Registry,
     task_poller::{
         squash_results, PollContext, PollEvent, PollResult, PollTimer, PollTriggerEvent,
@@ -32,6 +32,7 @@ impl ReconcilerWorker {
             Box::new(volume::VolumeReconciler::new()),
             Box::new(PersistentStoreReconciler::new()),
             Box::new(replica::ReplicaReconciler::new()),
+            Box::new(node::NodeReconciler::new()),
         ];
 
         // if events are sent before the worker is started they may fill up the buffer

--- a/control-plane/agents/src/bin/core/volume/registry.rs
+++ b/control-plane/agents/src/bin/core/volume/registry.rs
@@ -102,8 +102,8 @@ impl Registry {
         }
     }
 
-    /// Get all volumes
-    pub(super) async fn get_volumes(&self) -> Vec<Volume> {
+    /// Get all volumes.
+    pub(crate) async fn get_volumes(&self) -> Vec<Volume> {
         let volume_specs = self.specs().get_volumes();
         let replicas = self.specs().get_cloned_replicas();
         let mut volumes = Vec::with_capacity(volume_specs.len());
@@ -115,7 +115,7 @@ impl Registry {
         volumes
     }
 
-    /// Get a paginated subset of volumes
+    /// Get a paginated subset of volumes.
     pub(super) async fn get_paginated_volume(
         &self,
         pagination: &Pagination,
@@ -139,7 +139,7 @@ impl Registry {
         ))
     }
 
-    /// Notify the reconcilers if the volume is degraded
+    /// Notify the reconcilers if the volume is degraded.
     pub(crate) async fn notify_if_degraded(&self, volume: &Volume, event: PollTriggerEvent) {
         if volume.status() == Some(VolumeStatus::Degraded) {
             self.notify(event).await;


### PR DESCRIPTION
Implement the reconciler for draining nodes.
This uses republish_volume to initiate the move for all volumes on a node in the draining state,
and then waits for the nexus to be removed.
On success, the node's state is set to drained.
Nodes are processed serially within the loop.

Signed-off-by: chriswldenyer <christopher.denyer@mayadata.io>