### PR TITLE
feat(core-agent): reject outdated republishes from cluster-agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ String cron_schedule = mainBranches() ? "0 2 * * *" : ""
 pipeline {
   agent none
   options {
-    timeout(time: 1, unit: 'HOURS')
+    timeout(time: 2, unit: 'HOURS')
   }
   parameters {
     booleanParam(defaultValue: false, name: 'build_images')

--- a/common/src/types/v0/store/switchover.rs
+++ b/common/src/types/v0/store/switchover.rs
@@ -3,7 +3,7 @@ use crate::types::v0::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
         SpecTransaction,
     },
-    transport::VolumeId,
+    transport::{NodeId, VolumeId},
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -48,6 +48,8 @@ pub type SwitchOverTime = DateTime<Utc>;
 pub struct SwitchOverSpec {
     /// Uri of node-agent to report new path.
     pub callback_uri: SocketAddr,
+    /// The nodename of the node-agent node.
+    pub node_name: NodeId,
     /// Volume for which switchover needs to be executed.
     pub volume: VolumeId,
     /// Operation represent current running operation on SwitchOverSpec.

--- a/common/src/types/v0/store/switchover.rs
+++ b/common/src/types/v0/store/switchover.rs
@@ -34,13 +34,13 @@ pub struct OperationState {
 }
 
 impl OperationState {
-    /// Create a new OperationState.
+    /// Create a new `OperationState`.
     pub fn new(operation: Operation, result: Option<bool>) -> Self {
         Self { operation, result }
     }
 }
 
-/// Defines timestamp for switchoverspec.
+/// Defines timestamp for the `SwitchOverSpec`.
 pub type SwitchOverTime = DateTime<Utc>;
 
 /// Represent switchover spec.
@@ -77,7 +77,7 @@ impl SwitchOverSpec {
         })
     }
 
-    /// If switchoverspec is marked as completed or not.
+    /// If `Self` is marked as completed or not.
     pub fn is_completed(&self) -> bool {
         if let Some(op) = &self.operation {
             match op.operation {
@@ -99,12 +99,13 @@ impl SwitchOverSpec {
         }
     }
 
-    /// Returns current Operation for SwitchOverSpec.
+    /// Returns current `Operation` for `SwitchOverSpec`.
     pub fn operation(&self) -> Option<Operation> {
         self.operation.as_ref().map(|op| op.operation.clone())
     }
 }
 
+/// Persistent Store key for `SwitchOverSpec`.
 pub struct SwitchOverSpecKey(VolumeId);
 
 impl StorableObject for SwitchOverSpec {
@@ -156,7 +157,6 @@ impl SpecTransaction<Operation> for SwitchOverSpec {
     }
 
     fn clear_op(&mut self) {
-        println!("TODO clear_op");
         self.operation = None;
     }
 

--- a/common/src/types/v0/store/volume.rs
+++ b/common/src/types/v0/store/volume.rs
@@ -87,8 +87,6 @@ pub struct VolumeSpec {
     pub num_replicas: u8,
     /// Status that the volume should eventually achieve.
     pub status: VolumeSpecStatus,
-    /// The target where front-end IO will be sent to.
-    pub target: Option<VolumeTarget>,
     /// Volume policy.
     pub policy: VolumePolicy,
     /// Replica placement topology for the volume creation only.
@@ -103,8 +101,8 @@ pub struct VolumeSpec {
     /// Flag indicating whether the volume should be thin provisioned.
     #[serde(default)]
     pub thin: bool,
-    /// Last used Target Configuration.
-    #[serde(default)]
+    /// Last used Target or current Configuration.
+    #[serde(default, rename = "target")]
     pub target_config: Option<TargetConfig>,
     /// The publish context of the volume.
     #[serde(default)]
@@ -114,15 +112,24 @@ pub struct VolumeSpec {
 /// The volume's Nvmf Configuration.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct TargetConfig {
-    /// Uuid of the last target used by the volume.
+    /// Back-compat target parameters.
+    #[serde(flatten)]
     target: VolumeTarget,
-    /// The nexus target configuration.
+    /// Indicates whether the target is active.
+    /// We keep this config even if the target is no longer active so we can inspect
+    /// what the previous config was like.
+    active: bool,
+    /// The nexus nvmf configuration.
     config: NexusNvmfConfig,
 }
 impl TargetConfig {
     /// Get the uuid of the target.
     pub fn new(target: VolumeTarget, config: NexusNvmfConfig) -> Self {
-        Self { target, config }
+        Self {
+            target,
+            active: true,
+            config,
+        }
     }
     /// Get the target.
     pub fn target(&self) -> &VolumeTarget {
@@ -132,7 +139,7 @@ impl TargetConfig {
     pub fn uuid(&self) -> &NexusId {
         &self.target.nexus
     }
-    /// Get the target configuration.
+    /// Get the target's nvmf configuration.
     pub fn config(&self) -> &NexusNvmfConfig {
         &self.config
     }
@@ -149,6 +156,17 @@ impl AsOperationSequencer for VolumeSpec {
 }
 
 impl VolumeSpec {
+    /// Get the currently active target.
+    pub fn target(&self) -> Option<&VolumeTarget> {
+        self.target_config
+            .as_ref()
+            .filter(|t| t.active)
+            .map(|t| &t.target)
+    }
+    /// Get the target.
+    pub fn target_mut(&mut self) -> Option<&mut VolumeTarget> {
+        self.target_config.as_mut().map(|t| &mut t.target)
+    }
     /// Explicitly selected allowed_nodes.
     pub fn allowed_nodes(&self) -> Vec<NodeId> {
         match &self.topology {
@@ -170,9 +188,17 @@ impl VolumeSpec {
             _ => self.num_replicas,
         }
     }
-    /// Get the last target configuration.
+    /// Get the last known target configuration.
+    /// # Warning: the target may no longer be active.
+    /// To get the current active target use `VolumeSpec::target`.
     pub fn config(&self) -> &Option<TargetConfig> {
         &self.target_config
+    }
+    /// Deactivate the current target but keep it's information around.
+    pub fn deactivate_target(&mut self) {
+        if let Some(cfg) = self.target_config.as_mut() {
+            cfg.active = false;
+        }
     }
     /// Get the health info key which is used to retrieve the volume's replica health information.
     pub fn health_info_id(&self) -> Option<&NexusId> {
@@ -213,34 +239,37 @@ impl SpecTransaction<VolumeOperation> for VolumeSpec {
                     self.status = SpecStatus::Created(transport::VolumeStatus::Online);
                 }
                 VolumeOperation::Share(share) => {
-                    if let Some(target) = &mut self.target {
+                    if let Some(target) = self.target_mut() {
                         target.protocol = share.into();
                     }
                 }
                 VolumeOperation::Unshare => {
-                    if let Some(target) = self.target.as_mut() {
+                    if let Some(target) = self.target_mut() {
                         target.protocol = None
                     }
                 }
                 VolumeOperation::SetReplica(count) => self.num_replicas = count,
                 VolumeOperation::RemoveUnusedReplica(_) => {}
-                VolumeOperation::Publish(args) => {
+                VolumeOperation::PublishOld(args) => {
                     let (node, nexus, protocol) = (args.node, args.nexus, args.protocol);
                     let target = VolumeTarget::new(node, nexus, protocol);
-                    self.target = Some(target.clone());
                     self.last_nexus_id = None;
-                    self.target_config =
-                        Some(TargetConfig::new(target, args.config.unwrap_or_default()));
+                    self.target_config = Some(TargetConfig::new(
+                        target,
+                        NexusNvmfConfig::default().with_no_resv(),
+                    ));
+                }
+                VolumeOperation::Publish(args) => {
+                    self.last_nexus_id = None;
+                    self.target_config = Some(args.config);
+                    self.publish_context = Some(args.publish_context);
                 }
                 VolumeOperation::Republish(args) => {
-                    let (node, nexus, protocol) = (args.node, args.nexus, args.protocol);
-                    let target = VolumeTarget::new(node, nexus, Some(protocol));
-                    self.target = Some(target.clone());
                     self.last_nexus_id = None;
-                    self.target_config = Some(TargetConfig::new(target, args.config));
+                    self.target_config = Some(args.config);
                 }
                 VolumeOperation::Unpublish => {
-                    self.target = None;
+                    self.deactivate_target();
                 }
             }
         }
@@ -273,6 +302,9 @@ pub enum VolumeOperation {
     Share(VolumeShareProtocol),
     Unshare,
     SetReplica(u8),
+    #[serde(rename = "Publish")]
+    PublishOld(OldPublishOperation),
+    #[serde(rename = "Publish2")]
     Publish(PublishOperation),
     Republish(RepublishOperation),
     Unpublish,
@@ -292,13 +324,11 @@ fn volume_op_deserializer() {
     }
     let tests: Vec<Test> = vec![Test {
         input: r#"{"op":{"Publish":["4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e","4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e",null]}}"#,
-        expected: VolumeOperation::Publish(PublishOperation::new(
-            "4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e".try_into().unwrap(),
-            "4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e".try_into().unwrap(),
-            None,
-            None,
-            HashMap::new(),
-        )),
+        expected: VolumeOperation::PublishOld(OldPublishOperation {
+            node: "4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e".try_into().unwrap(),
+            nexus: "4ffe7e43-46dd-4912-9d0f-6c9844fa7c6e".try_into().unwrap(),
+            protocol: None,
+        }),
     }];
 
     for test in &tests {
@@ -310,35 +340,29 @@ fn volume_op_deserializer() {
 
 /// The `PublishOperation` which is easier to manage and update.
 #[derive(serde_tuple::Serialize_tuple, serde_tuple::Deserialize_tuple, Debug, Clone, PartialEq)]
-pub struct PublishOperation {
+pub struct OldPublishOperation {
     node: NodeId,
     nexus: NexusId,
     protocol: Option<VolumeShareProtocol>,
-    #[serde(default)]
-    config: Option<NexusNvmfConfig>,
-    #[serde(default)]
+}
+
+/// The `PublishOperation` which is easier to manage and update.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PublishOperation {
+    config: TargetConfig,
     publish_context: HashMap<String, String>,
 }
 impl PublishOperation {
     /// Return new `Self` from the given parameters.
-    pub fn new(
-        node: NodeId,
-        nexus: NexusId,
-        protocol: Option<VolumeShareProtocol>,
-        config: Option<NexusNvmfConfig>,
-        publish_context: HashMap<String, String>,
-    ) -> Self {
+    pub fn new(config: TargetConfig, publish_context: HashMap<String, String>) -> Self {
         Self {
-            node,
-            nexus,
-            protocol,
             config,
             publish_context,
         }
     }
     /// Get the share protocol.
     pub fn protocol(&self) -> Option<VolumeShareProtocol> {
-        self.protocol
+        self.config.target.protocol
     }
     /// Get the publish context.
     pub fn publish_context(&self) -> HashMap<String, String> {
@@ -347,31 +371,18 @@ impl PublishOperation {
 }
 
 /// Volume Republish Operation parameters.
-#[derive(serde_tuple::Serialize_tuple, serde_tuple::Deserialize_tuple, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RepublishOperation {
-    node: NodeId,
-    nexus: NexusId,
-    protocol: VolumeShareProtocol,
-    config: NexusNvmfConfig,
+    config: TargetConfig,
 }
 impl RepublishOperation {
     /// Return new `Self` from the given parameters.
-    pub fn new(
-        node: NodeId,
-        nexus: NexusId,
-        protocol: VolumeShareProtocol,
-        config: NexusNvmfConfig,
-    ) -> Self {
-        Self {
-            node,
-            nexus,
-            protocol,
-            config,
-        }
+    pub fn new(config: TargetConfig) -> Self {
+        Self { config }
     }
     /// Get the share protocol.
     pub fn protocol(&self) -> VolumeShareProtocol {
-        self.protocol
+        self.config.target.protocol.unwrap_or_default()
     }
 }
 
@@ -383,6 +394,7 @@ impl From<VolumeOperation> for models::volume_spec_operation::Operation {
             VolumeOperation::Share(_) => models::volume_spec_operation::Operation::Share,
             VolumeOperation::Unshare => models::volume_spec_operation::Operation::Unshare,
             VolumeOperation::SetReplica(_) => models::volume_spec_operation::Operation::SetReplica,
+            VolumeOperation::PublishOld(_) => models::volume_spec_operation::Operation::Publish,
             VolumeOperation::Publish(_) => models::volume_spec_operation::Operation::Publish,
             VolumeOperation::Republish(_) => models::volume_spec_operation::Operation::Republish,
             VolumeOperation::Unpublish => models::volume_spec_operation::Operation::Unpublish,
@@ -431,7 +443,6 @@ impl From<&CreateVolume> for VolumeSpec {
             labels: request.labels.clone(),
             num_replicas: request.replicas as u8,
             status: VolumeSpecStatus::Creating,
-            target: None,
             policy: request.policy.clone(),
             topology: request.topology.clone(),
             sequencer: OperationSequence::new(request.uuid.clone()),
@@ -464,7 +475,7 @@ impl From<&VolumeSpec> for transport::VolumeState {
 }
 impl PartialEq<transport::VolumeState> for VolumeSpec {
     fn eq(&self, other: &transport::VolumeState) -> bool {
-        match &self.target {
+        match self.target() {
             None => other.target_node().flatten().is_none(),
             Some(target) => {
                 target.protocol == other.target_protocol()
@@ -477,13 +488,14 @@ impl PartialEq<transport::VolumeState> for VolumeSpec {
 
 impl From<VolumeSpec> for models::VolumeSpec {
     fn from(src: VolumeSpec) -> Self {
+        let target = src.target().cloned();
         Self::new_all(
             src.labels,
             src.num_replicas,
             src.operation.into_opt(),
             src.size,
             src.status,
-            src.target.into_opt(),
+            target.into_opt(),
             src.uuid,
             src.topology.into_opt(),
             src.policy,

--- a/common/src/types/v0/transport/misc.rs
+++ b/common/src/types/v0/transport/misc.rs
@@ -86,6 +86,11 @@ macro_rules! rpc_impl_string_id_inner {
             }
         }
 
+        impl From<$Name> for Option<String> {
+            fn from(id: $Name) -> Option<String> {
+                Some(id.to_string())
+            }
+        }
         impl From<$Name> for String {
             fn from(id: $Name) -> String {
                 id.to_string()

--- a/common/src/types/v0/transport/volume.rs
+++ b/common/src/types/v0/transport/volume.rs
@@ -8,7 +8,7 @@ rpc_impl_string_uuid!(VolumeId, "UUID of a volume");
 
 /// Volumes
 ///
-/// Volume information
+/// Volume information.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Volume {
@@ -55,15 +55,15 @@ impl From<Volume> for models::Volume {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumeState {
-    /// name of the volume
+    /// Name of the volume.
     pub uuid: VolumeId,
-    /// size of the volume in bytes
+    /// Size of the volume in bytes.
     pub size: u64,
-    /// current status of the volume
+    /// The current status of the volume.
     pub status: VolumeStatus,
-    /// target nexus that connects to the children
+    /// The target nexus that connects to the children.
     pub target: Option<Nexus>,
-    /// replica topology information
+    /// The replica topology information.
     pub replica_topology: HashMap<ReplicaId, ReplicaTopology>,
 }
 
@@ -84,12 +84,12 @@ impl From<VolumeState> for models::VolumeState {
 }
 
 impl VolumeState {
-    /// Get the target node if the volume is published
+    /// Get the target node if the volume is published.
     pub fn target_node(&self) -> Option<Option<NodeId>> {
         self.target.as_ref()?;
         Some(self.target.clone().map(|n| n.node))
     }
-    /// Get the target protocol if the volume is published
+    /// Get the target protocol if the volume is published.
     pub fn target_protocol(&self) -> Option<VolumeShareProtocol> {
         match &self.target {
             None => None,
@@ -100,8 +100,8 @@ impl VolumeState {
     }
 }
 
-/// The protocol used to share the volume
-/// Currently it's the same as the nexus
+/// The protocol used to share the volume.
+/// Currently it's the same as the nexus.
 pub type VolumeShareProtocol = NexusShareProtocol;
 impl From<NexusShareProtocol> for models::VolumeShareProtocol {
     fn from(src: NexusShareProtocol) -> Self {
@@ -120,8 +120,8 @@ impl From<models::VolumeShareProtocol> for NexusShareProtocol {
     }
 }
 
-/// Volume State information
-/// Currently it's the same as the nexus
+/// Volume State information.
+/// Currently it's the same as the nexus.
 pub type VolumeStatus = NexusStatus;
 
 impl From<VolumeStatus> for models::VolumeStatus {
@@ -136,13 +136,13 @@ impl From<VolumeStatus> for models::VolumeStatus {
     }
 }
 
-/// Volume placement topology using resource labels
+/// Volume placement topology using resource labels.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 pub struct LabelledTopology {
-    /// exclusive labels
+    /// Exclusive labels.
     #[serde(default)]
     pub exclusion: ::std::collections::HashMap<String, String>,
-    /// inclusive labels
+    /// Inclusive labels.
     #[serde(default)]
     pub inclusion: ::std::collections::HashMap<String, String>,
 }
@@ -161,11 +161,13 @@ impl From<LabelledTopology> for models::LabelledTopology {
     }
 }
 
-/// Volume topology used to determine how to place/distribute the data
+/// Volume topology used to determine how to place/distribute the data.
 /// If no topology is used then the control plane will select from all available resources.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct Topology {
+    /// The node topology.
     pub node: Option<NodeTopology>,
+    /// The pool topology.
     pub pool: Option<PoolTopology>,
 }
 impl Topology {
@@ -206,17 +208,17 @@ pub type ExclusiveLabel = String;
 /// inclusive label key value in the form "NAME: VALUE"
 pub type InclusiveLabel = String;
 
-/// Node topology for volumes
+/// Node topology for volumes.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub enum NodeTopology {
-    /// using topology labels
+    /// Using topology labels.
     Labelled(LabelledTopology),
-    /// explicitly selected
+    /// Explicitly selected.
     Explicit(ExplicitNodeTopology),
 }
 
 impl NodeTopology {
-    /// Get a reference to the explicit topology
+    /// Get a reference to the explicit topology.
     pub fn explicit(&self) -> Option<&ExplicitNodeTopology> {
         match self {
             Self::Labelled(_) => None,
@@ -242,7 +244,7 @@ impl From<models::NodeTopology> for NodeTopology {
     }
 }
 
-/// Placement pool topology used by volume operations
+/// Placement pool topology used by volume operations.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub enum PoolTopology {
     Labelled(LabelledTopology),
@@ -262,13 +264,13 @@ impl From<PoolTopology> for models::PoolTopology {
     }
 }
 
-/// Explicit node placement Selection for a volume
+/// Explicit node placement Selection for a volume.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 pub struct ExplicitNodeTopology {
-    /// replicas can only be placed on these nodes
+    /// Replicas can only be placed on these nodes.
     #[serde(default)]
     pub allowed_nodes: Vec<NodeId>,
-    /// preferred nodes to place the replicas
+    /// Preferred nodes to place the replicas.
     #[serde(default)]
     pub preferred_nodes: Vec<NodeId>,
 }
@@ -287,11 +289,11 @@ impl From<ExplicitNodeTopology> for models::ExplicitNodeTopology {
     }
 }
 
-/// Volume policy used to determine if and how to replace a replica
+/// Volume policy used to determine if and how to replace a replica.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct VolumePolicy {
-    /// the server will attempt to heal the volume by itself
-    /// the client should not attempt to do the same if this is enabled
+    /// The server will attempt to heal the volume by itself.
+    /// The client should not attempt to do the same if this is enabled.
     pub self_heal: bool,
 }
 
@@ -314,15 +316,15 @@ impl From<VolumePolicy> for models::VolumePolicy {
     }
 }
 
-/// Get volumes
+/// Get volumes request.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GetVolumes {
-    /// filter volumes
+    /// Filter volumes.
     pub filter: Filter,
 }
 impl GetVolumes {
-    /// Return new `Self` to retrieve the specified volume
+    /// Return new `Self` to retrieve the specified volume.
     pub fn new(volume: &VolumeId) -> Self {
         Self {
             filter: Filter::Volume(volume.clone()),
@@ -330,31 +332,31 @@ impl GetVolumes {
     }
 }
 
-/// Create volume
+/// Create volume request.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateVolume {
-    /// uuid of the volume
+    /// The uuid of the volume.
     pub uuid: VolumeId,
-    /// size of the volume in bytes
+    /// The size of the volume in bytes.
     pub size: u64,
-    /// number of storage replicas
+    /// The number of storage replicas.
     pub replicas: u64,
-    /// volume policy
+    /// The volume policy.
     pub policy: VolumePolicy,
-    /// initial replica placement topology
+    /// The initial replica placement topology.
     pub topology: Option<Topology>,
-    /// volume labels
+    /// The volume labels.
     pub labels: Option<VolumeLabels>,
-    /// flag indicating whether the volume should be thin provisioned
+    /// The flag indicating whether the volume should be thin provisioned.
     pub thin: bool,
 }
 
-/// Volume label information
+/// Volume label information.
 pub type VolumeLabels = HashMap<String, String>;
 
 impl CreateVolume {
-    /// explicitly selected allowed_nodes
+    /// Explicitly selected allowed_nodes.
     pub fn allowed_nodes(&self) -> Vec<NodeId> {
         match &self.topology {
             None => vec![],
@@ -366,45 +368,44 @@ impl CreateVolume {
     }
 }
 
-/// Add ANA Nexus to volume
+/// Add ANA Nexus to volume.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddVolumeNexus {
-    /// uuid of the volume
+    /// The uuid of the volume.
     pub uuid: VolumeId,
-    /// preferred node id for the nexus
+    /// The preferred node id for the nexus.
     pub preferred_node: Option<NodeId>,
 }
 
-/// Add ANA Nexus to volume
+/// Add ANA Nexus to volume.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveVolumeNexus {
-    /// uuid of the volume
+    /// The uuid of the volume.
     pub uuid: VolumeId,
-    /// id of the node where the nexus lives
+    /// The id of the node where the nexus lives.
     pub node: Option<NodeId>,
 }
 
-/// Publish a volume on a node
-/// Unpublishes the nexus if it's published somewhere else and creates a nexus on the given node.
-/// Then, share the nexus via the provided share protocol.
+/// Publish a volume on a target node.
+/// If requested, it'll also share the nexus via the provided share protocol.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PublishVolume {
-    /// uuid of the volume
+    /// The uuid of the volume.
     pub uuid: VolumeId,
-    /// the node where front-end IO will be sent to
+    /// The node where front-end IO will be sent to.
     pub target_node: Option<NodeId>,
-    /// share protocol
+    /// Share protocol.
     pub share: Option<VolumeShareProtocol>,
-    /// Publish Context.
+    /// Opaque publish Context.
     pub publish_context: HashMap<String, String>,
-    /// Hosts allowed to access nexus
+    /// Hosts allowed to access nexus.
     pub frontend_nodes: Vec<String>,
 }
 impl PublishVolume {
-    /// Create new `PublishVolume` based on the provided arguments
+    /// Create new `PublishVolume` based on the provided arguments.
     pub fn new(
         uuid: VolumeId,
         target_node: Option<NodeId>,
@@ -422,8 +423,9 @@ impl PublishVolume {
     }
 }
 
-/// Republishes the nexus on a new node decided by the control-plane,
-/// by shutting down the older nexus.
+/// Republishes the target on a new node (pre-selected or determined by the control-plane).
+/// If online, the previous target nexus is first shutdown which may gives us enough time for the
+/// switchover as it'd be prevent from failing any IO outright.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RepublishVolume {
@@ -453,39 +455,39 @@ impl RepublishVolume {
     }
 }
 
-/// Unpublish a volume from any node where it may be published
+/// Unpublish a volume from any node where it may be published.
 /// Unshares the children nexuses from the volume and destroys them.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UnpublishVolume {
-    /// uuid of the volume
+    /// The uuid of the volume.
     pub uuid: VolumeId,
-    /// if the node where the nexus lives is offline then we can force unpublish, forgetting about
+    /// If the node where the nexus lives is offline then we can force unpublish, forgetting about
     /// the nexus. Note: this option should be used only when we know the node will not become
     /// accessible again and it is safe to do so.
     force: bool,
 }
 impl UnpublishVolume {
-    /// Create a new `UnpublishVolume` for the given uuid
+    /// Create a new `UnpublishVolume` for the given uuid.
     pub fn new(uuid: &VolumeId, force: bool) -> Self {
         Self {
             uuid: uuid.clone(),
             force,
         }
     }
-    /// It's a force `Self`
+    /// It's a force `Self`.
     pub fn force(&self) -> bool {
         self.force
     }
 }
 
-/// Share Volume request
+/// Share Volume request.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ShareVolume {
-    /// uuid of the volume
+    /// The uuid of the volume.
     pub uuid: VolumeId,
-    /// share protocol
+    /// Share protocol.
     pub protocol: VolumeShareProtocol,
     /// Hosts allowed to connect nexus.
     pub frontend_hosts: Vec<String>,
@@ -501,50 +503,50 @@ impl ShareVolume {
     }
 }
 
-/// Unshare Volume request
+/// Unshare Volume request.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UnshareVolume {
-    /// uuid of the volume
+    /// The uuid of the volume.
     pub uuid: VolumeId,
 }
 impl UnshareVolume {
-    /// Create a new `UnshareVolume` request
+    /// Create a new `UnshareVolume` request.
     pub fn new(uuid: VolumeId) -> Self {
         Self { uuid }
     }
 }
-/// Set the volume replica count
+/// Set the volume replica count.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SetVolumeReplica {
-    /// uuid of the volume
+    /// The uuid of the volume.
     pub uuid: VolumeId,
-    /// replica count
+    /// The replica count.
     pub replicas: u8,
 }
 impl SetVolumeReplica {
-    /// Create new `Self` based on the provided arguments
+    /// Create new `Self` based on the provided arguments.
     pub fn new(uuid: VolumeId, replicas: u8) -> Self {
         Self { uuid, replicas }
     }
 }
 
-/// Delete volume
+/// Delete volume request.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DestroyVolume {
-    /// uuid of the volume
+    /// The uuid of the volume.
     pub uuid: VolumeId,
 }
 impl DestroyVolume {
-    /// Create new `Self` to destroy the specified volume
+    /// Create new `Self` to destroy the specified volume.
     pub fn new(volume: &VolumeId) -> Self {
         Self {
             uuid: volume.clone(),
         }
     }
-    /// Get the volume's identification
+    /// Get the volume's identification.
     pub fn uuid(&self) -> &VolumeId {
         &self.uuid
     }
@@ -554,11 +556,11 @@ impl DestroyVolume {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ReplicaTopology {
-    /// id of the io-engine instance
+    /// The id of the io-engine instance.
     node: Option<NodeId>,
-    /// id of the pool
+    /// The id of the pool.
     pool: Option<PoolId>,
-    /// status of the replica
+    /// The status of the replica.
     status: ReplicaStatus,
 }
 

--- a/common/src/types/v0/transport/volume.rs
+++ b/common/src/types/v0/transport/volume.rs
@@ -433,6 +433,8 @@ pub struct RepublishVolume {
     pub uuid: VolumeId,
     /// The node where front-end IO will be sent to.
     pub target_node: Option<NodeId>,
+    /// The node where front-end IO will be sent from.
+    pub frontend_node: NodeId,
     /// Share protocol.
     pub share: VolumeShareProtocol,
     /// Allows reusing of the current target.
@@ -443,12 +445,14 @@ impl RepublishVolume {
     pub fn new(
         uuid: VolumeId,
         target_node: Option<NodeId>,
+        frontend_node: NodeId,
         share: VolumeShareProtocol,
         reuse_existing: bool,
     ) -> Self {
         Self {
             uuid,
             target_node,
+            frontend_node,
             share,
             reuse_existing,
         }

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
@@ -152,7 +152,7 @@ async fn disown_unused_nexuses(
     for nexus in context.specs().get_volume_nexuses(volume.uuid()) {
         let nexus_clone = nexus.lock().clone();
 
-        match &volume.as_ref().target {
+        match volume.as_ref().target() {
             Some(target) if target.nexus() == nexus.uid() || nexus_clone.is_shutdown() => continue,
             _ => {}
         };

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -26,6 +26,7 @@ use common_lib::{
         store::{
             definitions::{StorableObject, Store, StoreError, StoreKey},
             registry::{ControlPlaneService, CoreRegistryConfig, NodeRegistration},
+            volume::InitiatorAC,
         },
         transport::{HostNqn, NodeId},
     },
@@ -342,9 +343,14 @@ impl Registry {
         &self,
         req: HostAccessControl,
         nodes: &[String],
-    ) -> Vec<HostNqn> {
+    ) -> Vec<InitiatorAC> {
         match self.host_acl.contains(&req) {
-            true => HostNqn::from_nodenames(nodes),
+            true => nodes
+                .iter()
+                .map(|nodename| {
+                    InitiatorAC::new(nodename.clone(), HostNqn::from_nodename(nodename))
+                })
+                .collect(),
             false => vec![],
         }
     }

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -86,7 +86,7 @@ impl NodeFilters {
 
     /// Should only attempt to use node where current target is not present.
     pub(crate) fn current_target(request: &GetSuitableNodesContext, item: &NodeItem) -> bool {
-        if let Some(target) = &request.target {
+        if let Some(target) = request.target() {
             target.node() != item.node_wrapper().id()
         } else {
             true

--- a/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
@@ -314,7 +314,7 @@ async fn unused_reconcile(cluster: &Cluster) {
             PublishVolumeBody::new_all(
                 HashMap::new(),
                 None,
-                nexus_node.id.to_string(),
+                nexus_node.id.clone(),
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -50,7 +50,7 @@ async fn lazy_delete_shutdown_targets() {
                 share: None,
                 target_node: Some(cluster.node(0)),
                 publish_context: HashMap::new(),
-                frontend_nodes: vec![],
+                frontend_nodes: vec![cluster.node(1).to_string()],
             },
             None,
         )
@@ -71,6 +71,21 @@ async fn lazy_delete_shutdown_targets() {
                 target_node: Some(cluster.node(1)),
                 share: VolumeShareProtocol::Nvmf,
                 reuse_existing: true,
+                frontend_node: cluster.node(0),
+            },
+            None,
+        )
+        .await
+        .expect_err("Wrong frontend node");
+
+    vol_cli
+        .republish(
+            &RepublishVolume {
+                uuid: volume.uuid().clone(),
+                target_node: Some(cluster.node(1)),
+                share: VolumeShareProtocol::Nvmf,
+                reuse_existing: true,
+                frontend_node: cluster.node(1),
             },
             None,
         )
@@ -180,7 +195,7 @@ async fn volume_republish_nexus_recreation() {
                 share: Some(VolumeShareProtocol::Nvmf),
                 target_node: Some(replica_node.into()),
                 publish_context: HashMap::new(),
-                frontend_nodes: vec![],
+                frontend_nodes: vec![cluster.node(1).to_string()],
             },
             None,
         )
@@ -222,6 +237,7 @@ async fn volume_republish_nexus_recreation() {
                 share: VolumeShareProtocol::Nvmf,
                 target_node: None,
                 reuse_existing: true,
+                frontend_node: cluster.node(1),
             },
             None,
         )

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -295,16 +295,14 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
 
         let last_target = self.as_ref().health_info_id().cloned();
         let target_cfg = self.next_target_config(&nexus_node, &request.share).await;
+
         let operation = VolumeOperation::Publish(PublishOperation::new(
-            nexus_node.clone(),
-            target_cfg.uuid().clone(),
-            request.share,
-            Some(target_cfg.config().clone()),
+            target_cfg.clone(),
             request.publish_context.clone(),
         ));
         let spec_clone = self.start_update(registry, &state, operation).await?;
 
-        // Create a Nexus on the requested or auto-selected node
+        // Create a Nexus on the requested or auto-selected node.
         let result = specs
             .volume_create_nexus(registry, &target_cfg, &spec_clone)
             .await;
@@ -313,7 +311,7 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
             .validate_update_step(registry, result, &spec_clone)
             .await?;
 
-        // Share the Nexus if it was requested
+        // Share the Nexus if it was requested.
         let mut result = Ok(());
         if let Some(share) = request.share {
             let allowed_hosts =
@@ -369,7 +367,7 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
             .start_update(registry, &state, VolumeOperation::Unpublish)
             .await?;
 
-        let volume_target = spec_clone.target.as_ref().expect("already validated");
+        let volume_target = spec_clone.target().expect("already validated");
         let result = match specs.nexus_opt(volume_target.nexus()).await? {
             None => Ok(()),
             Some(mut nexus) => {
@@ -389,7 +387,7 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
                         };
                         if !node_online {
                             nexus_clone.warn_span(|| {
-                                tracing::warn!("Force unpublish. Forgetting about the target nexus because the node is not online and it was requested")
+                                tracing::warn!("Force unpublish. Forgetting about the target nexus because the node is not online and it was requested");
                             });
                             Ok(())
                         } else {
@@ -412,7 +410,7 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         let spec = self.as_ref().clone();
         let state = registry.get_volume_state(&request.uuid).await?;
         // If the volume is not published then it should issue publish call rather than republish.
-        let volume_target = match &spec.target {
+        let volume_target = match spec.target() {
             None => {
                 return Err(SvcError::VolumeNotPublished {
                     vol_id: request.uuid.to_string(),
@@ -422,7 +420,6 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         };
 
         let mut older_nexus = specs.nexus(volume_target.nexus()).await?;
-
         let mut move_nexus = true;
 
         match get_healthy_volume_replicas(&spec, &older_nexus.as_ref().node, registry).await {
@@ -442,36 +439,31 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         }
 
         if !move_nexus {
-            // older nexus is back again, so completing republish without modifications.
+            // The older nexus is back again, so completing republish without modifications.
             info!(nexus.uuid=%older_nexus.as_ref().uuid, "Current target is back online, not moving nexus");
             let volume = registry.get_volume(&request.uuid).await?;
             return Ok(volume);
         }
 
-        // get the newer target node for new nexus creation
+        // Get the newer target node for the new nexus creation.
         let nexus_node = get_volume_target_node(registry, &state, request, true).await?;
         let target_cfg = self
             .next_target_config(&nexus_node, &Some(request.share))
             .await;
-        let operation = VolumeOperation::Republish(RepublishOperation::new(
-            nexus_node.clone(),
-            target_cfg.uuid().clone(),
-            request.share,
-            target_cfg.config().clone(),
-        ));
+        let operation = VolumeOperation::Republish(RepublishOperation::new(target_cfg.clone()));
 
         let spec_clone = self.start_update(registry, &state, operation).await?;
 
         let older_nexus_id = older_nexus.uuid().clone();
 
-        // shutdown the older nexus before newer nexus creation.
+        // Shutdown the older nexus before newer nexus creation.
         let result = older_nexus
             .shutdown(registry, &ShutdownNexus::new(older_nexus_id, true))
             .await;
         self.validate_update_step(registry, result, &spec_clone)
             .await?;
 
-        // Create a Nexus on the requested or auto-selected node
+        // Create a Nexus on the requested or auto-selected node.
         let result = specs
             .volume_create_nexus(registry, &target_cfg, &spec_clone)
             .await;
@@ -479,7 +471,7 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
             .validate_update_step(registry, result, &spec_clone)
             .await?;
         let allowed_host = older_nexus.lock().allowed_hosts.clone();
-        // Share the Nexus
+        // Share the Nexus.
         let result = match nexus
             .share(
                 registry,
@@ -610,7 +602,7 @@ impl ResourceShutdownOperations for OperationGuardArc<VolumeSpec> {
 
 impl OperationGuardArc<VolumeSpec> {
     fn published(&self) -> bool {
-        self.as_ref().target.is_some()
+        self.as_ref().target().is_some()
     }
     /// Make the next target config.
     /// This essentially bumps up the controller id by 1 as otherwise the initiator cannot tell

--- a/control-plane/agents/src/bin/core/volume/registry.rs
+++ b/control-plane/agents/src/bin/core/volume/registry.rs
@@ -73,7 +73,7 @@ impl Registry {
             VolumeState {
                 uuid: volume_spec.uuid.to_owned(),
                 size: volume_spec.size,
-                status: if volume_spec.target.is_none() {
+                status: if volume_spec.target().is_none() {
                     if replica_specs.len() >= volume_spec.num_replicas as usize {
                         VolumeStatus::Online
                     } else if replica_specs.is_empty() {

--- a/control-plane/agents/src/bin/ha/cluster/main.rs
+++ b/control-plane/agents/src/bin/ha/cluster/main.rs
@@ -84,10 +84,10 @@ async fn main() -> anyhow::Result<()> {
     let store = etcd::EtcdStore::new(cli.store, cli.store_timeout.into()).await?;
     let node_list = nodes::NodeList::new();
 
-    // Node list has ref counted list internally.
-    let mover = volume::VolumeMover::new(store.clone(), node_list.clone());
-
     let entries = store.fetch_incomplete_requests().await?;
+
+    // Node list has ref counted list internally.
+    let mover = volume::VolumeMover::new(store, node_list.clone());
     mover.send_switchover_req(entries).await?;
 
     info!("starting cluster-agent server");

--- a/control-plane/agents/src/bin/ha/cluster/nodes.rs
+++ b/control-plane/agents/src/bin/ha/cluster/nodes.rs
@@ -5,34 +5,32 @@ use tokio::sync::Mutex;
 use tracing::info;
 
 /// Store node information and reported failed path.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct NodeList {
     list: Arc<Mutex<HashMap<NodeId, SocketAddr>>>,
     failed_path: Arc<Mutex<HashMap<String, SocketAddr>>>,
 }
 
 impl NodeList {
+    /// Get a new `Self`.
     pub fn new() -> Self {
-        NodeList {
-            list: Arc::new(Mutex::new(HashMap::new())),
-            failed_path: Arc::new(Mutex::new(HashMap::new())),
-        }
+        Self::default()
     }
 
     /// Register node and its endpoint.
-    /// If node is already registered then update it details.
+    /// If the node is already registered then update its details.
     pub async fn register_node(&self, name: NodeId, endpoint: SocketAddr) {
         let mut list = self.list.lock().await;
         list.insert(name, endpoint);
     }
 
+    /// Remove path from failed_path list.
     pub async fn remove_failed_path(&self, path: String) {
         let mut failed_path = self.failed_path.lock().await;
         failed_path.remove(&path);
     }
 
-    /// Send switchover request to switchover engine for the
-    /// reported node and path.
+    /// Send request to the switchover engine for the reported node and path.
     pub async fn report_failed_path(
         self,
         node: NodeId,
@@ -47,25 +45,16 @@ impl NodeList {
             .entry(node.clone())
             .or_insert(endpoint);
 
-        let uri = {
-            let list = self.list.lock().await;
-            list.get(&node).copied()
-        };
-
         let mut failed_path = self.failed_path.lock().await;
 
         if failed_path.get(&path).is_some() {
             anyhow::bail!("Path {} is already reported for switchover", path);
         };
 
-        info!(node.id=%node, %path, "Sending switchover for path");
+        info!(node.id=%node, %path, "Sending switchover");
 
-        if let Some(socket) = uri {
-            mover.switchover(node, socket, path.clone()).await?;
-            failed_path.insert(path, socket);
-            Ok(())
-        } else {
-            Err(anyhow::format_err!("Node {} is not registered", node))
-        }
+        mover.switchover(node, endpoint, path.clone()).await?;
+        failed_path.insert(path, endpoint);
+        Ok(())
     }
 }

--- a/control-plane/agents/src/bin/ha/cluster/nodes.rs
+++ b/control-plane/agents/src/bin/ha/cluster/nodes.rs
@@ -61,7 +61,7 @@ impl NodeList {
         info!(node.id=%node, %path, "Sending switchover for path");
 
         if let Some(socket) = uri {
-            mover.switchover(socket, path.clone()).await?;
+            mover.switchover(node, socket, path.clone()).await?;
             failed_path.insert(path, socket);
             Ok(())
         } else {

--- a/control-plane/agents/src/bin/ha/cluster/server.rs
+++ b/control-plane/agents/src/bin/ha/cluster/server.rs
@@ -26,10 +26,10 @@ impl ClusterAgent {
         }
     }
     /// Runs this server as a future until a shutdown signal is received.
-    pub(crate) async fn run(&self) -> Result<(), agents::ServiceError> {
+    pub(crate) async fn run(self) -> Result<(), agents::ServiceError> {
         let r = ClusterAgentServer::new(Arc::new(ClusterAgentSvc {
-            nodes: self.nodes.clone(),
-            mover: self.mover.clone(),
+            nodes: self.nodes,
+            mover: self.mover,
         }));
         agents::Service::builder()
             .with_service(r.into_grpc_server())

--- a/control-plane/agents/src/bin/ha/node/detector.rs
+++ b/control-plane/agents/src/bin/ha/node/detector.rs
@@ -60,7 +60,7 @@ impl PathRecord {
         self.epoch = epoch;
     }
 
-    // Trigger state transition based on 'connecting' state of the underlying NVMe controller.
+    /// Trigger state transition based on 'connecting' state of the underlying NVMe controller.
     fn report_connecting(&mut self) {
         match self.state {
             PathState::Good => {
@@ -136,14 +136,14 @@ enum NvmePathCacheCommandResponse {
     CachedNvmeController(NvmeController),
 }
 
-/// Messsage sent to NVMe cache from a cache client: client passes a channel
+/// Message sent to NVMe cache from a cache client: client passes a channel
 /// to receive a response from the cache.
 type NvmeCacheMessage = (NvmePathCacheCommand, Sender<NvmePathCacheCommandResponse>);
 
 /// Path failure detector for NVMe paths.
 /// All known NVMe paths on system are periodically checked for liveness and get classified
 /// as:
-///  Good  - path is fully functional.
+///  Good - path is fully functional.
 ///  Suspected - path experiences connectivity problems for the first time.
 ///  Failed - path has experienced connectivity problems two times in a row.
 /// Once a path is classified as Failed, it's reported to PathReporter and gets sent to
@@ -159,7 +159,8 @@ pub struct PathFailureDetector {
 }
 
 impl PathFailureDetector {
-    pub(crate) fn new(args: &Cli) -> anyhow::Result<Self> {
+    /// Return a new `Self`.
+    pub(crate) fn new(args: &Cli) -> Self {
         let reporter = PathReporter::new(
             args.node_name.clone(),
             *args.retransmission_period,
@@ -168,14 +169,14 @@ impl PathFailureDetector {
 
         let (tx, rx) = channel(64);
 
-        Ok(Self {
+        Self {
             epoch: 0,
             detection_period: *args.detection_period,
             suspected_paths: HashMap::new(),
             reporter: Rc::new(reporter),
             cache_channel_tx: Arc::new(tx),
             cache_channel_rx: rx,
-        })
+        }
     }
 
     fn rescan_paths(&mut self, path_collection: &mut NvmePathNameCollection) {
@@ -312,6 +313,7 @@ impl PathFailureDetector {
 }
 
 impl NvmePathCache {
+    /// Lookup a controller by its NVMe NQN.
     pub(crate) async fn lookup_controller(&self, nqn: String) -> anyhow::Result<NvmeController> {
         let (tx, mut rx) = channel(1);
 

--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -1,4 +1,3 @@
-use agents::errors::SvcError;
 use common_lib::{
     transport_api::TimeoutOptions, types::v0::transport::cluster_agent::NodeAgentInfo,
 };
@@ -65,7 +64,7 @@ struct Cli {
 
     /// The csi-node socket file for grpc over uds.
     #[structopt(long)]
-    csi_socket: String,
+    csi_socket: std::path::PathBuf,
 }
 
 static CLUSTER_AGENT_CLIENT: OnceCell<ClusterAgentClient> = OnceCell::new();
@@ -108,13 +107,10 @@ async fn main() {
         .expect("Expect to be initialized only once");
 
     CSI_NODE_NVME_CLIENT
-        .set(
-            get_nvme_connection_client(
-                cli_args.csi_socket.as_str(),
-                TimeoutOptions::new().with_connect_timeout(Duration::from_millis(500)),
-            )
-            .expect("Expect to get the csi node client"),
-        )
+        .set(get_nvme_connection_client(
+            &cli_args.csi_socket,
+            TimeoutOptions::new().with_connect_timeout(Duration::from_millis(500)),
+        ))
         .expect("Expect to be initialized only once");
 
     if let Err(error) = cluster_agent_client()
@@ -131,8 +127,7 @@ async fn main() {
     }
 
     // Instantiate path failure detector along with Nvme cache object.
-    let detector =
-        PathFailureDetector::new(&cli_args).expect("Failed to initialize path failure detector");
+    let detector = PathFailureDetector::new(&cli_args);
 
     let cache = detector.get_cache();
 
@@ -142,25 +137,25 @@ async fn main() {
     // Start gRPC server and path failure detection loop.
     tokio::select! {
         _ = detector.start() => {
-            tracing::info!("Path failure detector stopped.")
+            tracing::info!("Path failure detector stopped")
         },
         _ = server.serve() => {
-            tracing::info!("gRPC server stopped.");
+            tracing::info!("gRPC server stopped");
         },
     }
 }
 
 // helper function to connect to csi-node nvme operations svc over uds.
 fn get_nvme_connection_client(
-    socket_path: &str,
+    socket_path: &std::path::Path,
     timeout_options: TimeoutOptions,
-) -> Result<NvmeOperationsClient<Channel>, SvcError> {
-    let socket_path_cp = socket_path.to_string();
+) -> NvmeOperationsClient<Channel> {
+    let socket_path_cp = socket_path.to_path_buf();
     let channel = Endpoint::try_from("http://[::]:50051")
-        .map_err(|_| SvcError::InvalidArguments {})?
+        .expect("local endpoint should be valid")
         .connect_timeout(timeout_options.connect_timeout())
         .connect_with_connector_lazy(service_fn(move |_: Uri| {
-            UnixStream::connect(socket_path_cp.to_string())
+            UnixStream::connect(socket_path_cp.clone())
         }));
-    Ok(NvmeOperationsClient::new(channel))
+    NvmeOperationsClient::new(channel)
 }

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -100,6 +100,8 @@ pub enum SvcError {
     VolumeNotFound { vol_id: String },
     #[snafu(display("Volume '{}' not published", vol_id))]
     VolumeNotPublished { vol_id: String },
+    #[snafu(display("Node '{}' not allowed to access target for volume '{}'", node, vol_id))]
+    FrontendNodeNotAllowed { node: String, vol_id: String },
     #[snafu(display("{} {} cannot be shared over invalid protocol '{}'", kind.to_string(), id, share))]
     InvalidShareProtocol {
         kind: ResourceKind,
@@ -525,6 +527,12 @@ impl From<SvcError> for ReplyError {
             },
             SvcError::VolumeAlreadyPublished { .. } => ReplyError {
                 kind: ReplyErrorKind::AlreadyPublished,
+                resource: ResourceKind::Volume,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+            SvcError::FrontendNodeNotAllowed { .. } => ReplyError {
+                kind: ReplyErrorKind::PermissionDenied,
                 resource: ResourceKind::Volume,
                 source: desc.to_string(),
                 extra: error.full_string(),

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -196,6 +196,8 @@ message RepublishVolumeRequest {
   VolumeShareProtocol share = 3;
   // Allows reusing of the current target.
   bool reuse_existing = 4;
+  // the node where front-end IO will be sent from
+  string frontend_node = 5;
 }
 
 // Unpublish a volume from any node where it may be published

--- a/control-plane/grpc/src/operations/ha_node/client.rs
+++ b/control-plane/grpc/src/operations/ha_node/client.rs
@@ -65,10 +65,8 @@ impl ClusterAgentOperations for ClusterAgentClient {
         context: Option<Context>,
     ) -> Result<(), ReplyError> {
         let req = self.request(request, context, MessageIdVs::ReportFailedPaths);
-        match self.client().report_failed_nvme_paths(req).await {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e.into()),
-        }
+        self.client().report_failed_nvme_paths(req).await?;
+        Ok(())
     }
 }
 

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -17,10 +17,10 @@ use common_lib::{
         store::volume::{TargetConfig, VolumeSpec, VolumeTarget},
         transport::{
             CreateVolume, DestroyShutdownTargets, DestroyVolume, ExplicitNodeTopology, Filter,
-            LabelledTopology, Nexus, NexusId, NodeId, NodeTopology, PoolTopology, PublishVolume,
-            ReplicaId, ReplicaStatus, ReplicaTopology, RepublishVolume, SetVolumeReplica,
-            ShareVolume, Topology, UnpublishVolume, UnshareVolume, Volume, VolumeId, VolumeLabels,
-            VolumePolicy, VolumeShareProtocol, VolumeState,
+            LabelledTopology, Nexus, NexusId, NexusNvmfConfig, NodeId, NodeTopology, PoolTopology,
+            PublishVolume, ReplicaId, ReplicaStatus, ReplicaTopology, RepublishVolume,
+            SetVolumeReplica, ShareVolume, Topology, UnpublishVolume, UnshareVolume, Volume,
+            VolumeId, VolumeLabels, VolumePolicy, VolumeShareProtocol, VolumeState,
         },
     },
     IntoOption,
@@ -98,6 +98,8 @@ pub trait VolumeOperations: Send + Sync {
 impl From<VolumeSpec> for volume::VolumeDefinition {
     fn from(volume_spec: VolumeSpec) -> Self {
         let nexus_id = volume_spec.health_info_id().cloned();
+        let target = volume_spec.target().cloned();
+        let target_config = volume_spec.config().clone().into_opt();
         let spec_status: common::SpecStatus = volume_spec.status.into();
         Self {
             spec: Some(volume::VolumeSpec {
@@ -107,7 +109,7 @@ impl From<VolumeSpec> for volume::VolumeDefinition {
                     .labels
                     .map(|labels| crate::common::StringMapValue { value: labels }),
                 num_replicas: volume_spec.num_replicas.into(),
-                target: volume_spec.target.map(|target| target.into()),
+                target: target.map(|target| target.into()),
                 policy: Some(volume_spec.policy.into()),
                 topology: volume_spec.topology.map(|topology| topology.into()),
                 last_nexus_id: nexus_id.map(|id| id.to_string()),
@@ -115,7 +117,7 @@ impl From<VolumeSpec> for volume::VolumeDefinition {
             }),
             metadata: Some(volume::Metadata {
                 spec_status: spec_status as i32,
-                target_config: volume_spec.target_config.into_opt(),
+                target_config,
                 publish_context: volume_spec
                     .publish_context
                     .map(|map| common::MapWrapper { map }),
@@ -183,17 +185,17 @@ impl TryFrom<volume::VolumeDefinition> for VolumeSpec {
             },
             num_replicas: volume_spec.num_replicas as u8,
             status: volume_spec_status,
-            target: match volume_spec.target {
-                Some(target) => match VolumeTarget::try_from(target) {
-                    Ok(target) => Some(target),
-                    Err(err) => {
-                        return Err(ReplyError::invalid_argument(
+            target_config: match volume_spec.target {
+                Some(target) => {
+                    let target = VolumeTarget::try_from(target).map_err(|err| {
+                        ReplyError::invalid_argument(
                             ResourceKind::Volume,
                             "volume.definition.spec.target",
                             err.to_string(),
-                        ))
-                    }
-                },
+                        )
+                    })?;
+                    Some(TargetConfig::new(target, NexusNvmfConfig::default()))
+                }
                 None => None,
             },
             policy: match volume_spec.policy {
@@ -234,7 +236,6 @@ impl TryFrom<volume::VolumeDefinition> for VolumeSpec {
             },
             operation: None,
             thin: volume_spec.thin,
-            target_config: None,
             publish_context: volume_meta
                 .publish_context
                 .map(|map_wrapper| map_wrapper.map),
@@ -1126,9 +1127,9 @@ impl From<&dyn PublishVolumeInfo> for PublishVolumeRequest {
 
 /// Trait to be implemented for Republish operation.
 pub trait RepublishVolumeInfo: Send + Sync + std::fmt::Debug {
-    /// Uuid of the volume to be published
+    /// Uuid of the volume to be published.
     fn uuid(&self) -> VolumeId;
-    /// The node where front-end IO will be sent to
+    /// The node where front-end IO will be sent to.
     fn target_node(&self) -> Option<NodeId>;
     /// The protocol over which volume be published
     fn share(&self) -> VolumeShareProtocol;

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2096,8 +2096,8 @@ components:
           type: boolean
         node:
           description: |-
-            The node where the front-end workload resides.
-            If the workload moves then the volume must be republished.
+            The node where the target will reside in.
+            It may be moved elsewhere during volume republish.
           allOf:
             - $ref: '#/components/schemas/NodeId'
         protocol:
@@ -2109,12 +2109,13 @@ components:
             Allows republishing the volume on the node by shutting down the existing target first.
           type: boolean
         frontend_node:
-          description: The Node id from where the volume target will be accessed.
+          description: |-
+            The node where the front-end workload resides.
+            If the workload moves then the volume must be republished.
           type: string
       required:
         - publish_context
         - protocol
-        - frontend_node
     JsonGeneric:
       description: 'Generic JSON value eg: { "size": 1024 }'
       type: object

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -158,6 +158,7 @@ impl apis::actix_server::Volumes for RestApi {
                             target_node: publish_volume_body.node.map(|id| id.into()),
                             share: publish_volume_body.protocol.into(),
                             reuse_existing: publish_volume_body.reuse_existing.unwrap_or(true),
+                            frontend_node: publish_volume_body.frontend_node.unwrap().into(),
                         },
                         None,
                     )
@@ -171,11 +172,7 @@ impl apis::actix_server::Volumes for RestApi {
                             target_node: publish_volume_body.node.map(|id| id.into()),
                             share: Some(publish_volume_body.protocol.into()),
                             publish_context: publish_volume_body.publish_context,
-                            frontend_nodes: if !publish_volume_body.frontend_node.is_empty() {
-                                vec![publish_volume_body.frontend_node]
-                            } else {
-                                vec![]
-                            },
+                            frontend_nodes: publish_volume_body.frontend_node.into_iter().collect(),
                         },
                         None,
                     )

--- a/openapi/build.rs
+++ b/openapi/build.rs
@@ -15,6 +15,7 @@ fn main() {
 
     println!("cargo:rerun-if-changed=../nix/pkgs/openapi-generator");
     println!("cargo:rerun-if-changed=../control-plane/rest/openapi-specs");
+    println!("cargo:rerun-if-changed=version.txt");
     // seems the internal timestamp is taken before build.rs runs, so we can't set this
     // directive against files created during the build of build.rs??
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed

--- a/tests/bdd/features/ha/core-agent/test_target_switchover.py
+++ b/tests/bdd/features/ha/core-agent/test_target_switchover.py
@@ -112,7 +112,7 @@ def a_published_volume_with_two_replicas():
     volume = ApiClient.volumes_api().put_volume_target(
         VOLUME_UUID,
         publish_volume_body=PublishVolumeBody(
-            {}, Protocol("nvmf"), node=NODE_NAME_1, frontend_node=""
+            {}, Protocol("nvmf"), node=NODE_NAME_1, frontend_node="app-node-1"
         ),
     )
     pytest.older_target_uri = volume["state"]["target"]["deviceUri"]
@@ -182,7 +182,7 @@ def the_volume_republish_and_the_destroy_shutdown_target_call_has_succeeded_for_
                     Protocol("nvmf"),
                     republish=True,
                     reuse_existing=pytest.reuse_existing,
-                    frontend_node="",
+                    frontend_node="app-node-1",
                 ),
             )
         except grpc.RpcError:
@@ -205,7 +205,7 @@ def the_volume_republish_on_another_node_has_succeeded():
                 reuse_existing=pytest.reuse_existing,
                 node=NODE_NAME_2,
                 republish=True,
-                frontend_node="",
+                frontend_node="app-node-1",
             ),
         )
     except grpc.RpcError:

--- a/tests/bdd/features/ha/node-agent/test_path_replacement.py
+++ b/tests/bdd/features/ha/node-agent/test_path_replacement.py
@@ -124,7 +124,7 @@ def background():
     volume = ApiClient.volumes_api().put_volume_target(
         VOLUME_UUID,
         publish_volume_body=PublishVolumeBody(
-            {}, Protocol("nvmf"), node=TARGET_NODE_1, frontend_node=""
+            {}, Protocol("nvmf"), node=TARGET_NODE_1, frontend_node="app-node-1"
         ),
     )
     yield volume


### PR DESCRIPTION
feat(cluster-agent): cancel outdated switchover requests

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

refactor: tidy some some of the cluster agent code

Adds a few missing docs and refactors some of the code including removing
some unused code.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(core-agent): reject outdated republishes from cluster-agent

If the volume is unpublished/republished to another node we now reject republishes
related to the previous node.
The cluster agent will also forget about the rejects and stop retrying.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

refactor!: tidy up (re)publish operations

Since 2.0 got delayed we can modify the new (re)publish operation and make certain fields
mandtory if we split the old publish into a sperate operation since it won't really be used
if one upgrades from 1.0 to 2.0.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>