### PR TITLE
fix(ha): invalid nqn in mayastor-agent-ha-node logs

### DIFF
--- a/control-plane/agents/src/bin/ha/node/detector.rs
+++ b/control-plane/agents/src/bin/ha/node/detector.rs
@@ -197,7 +197,7 @@ impl PathFailureDetector {
                             self.suspected_paths.insert(
                                 subsystem.nqn.clone(),
                                 PathRecord::new(
-                                    subsystem.nqn.clone(),
+                                    ctrlr.nqn().to_owned(),
                                     self.epoch,
                                     path,
                                     self.reporter.clone(),

--- a/control-plane/agents/src/bin/ha/node/server.rs
+++ b/control-plane/agents/src/bin/ha/node/server.rs
@@ -1,7 +1,7 @@
 use crate::{
     csi_node_nvme_client,
     detector::{NvmeController, NvmePathCache},
-    path_provider::get_nvme_path_buf,
+    path_provider::get_nvme_path_entry,
 };
 use agents::errors::SvcError;
 use common_lib::transport_api::{ErrorChain, ReplyError, ResourceKind};
@@ -69,9 +69,9 @@ impl NodeAgentSvc {
 fn disconnect_controller(ctrlr: &NvmeController, new_path: String) -> Result<(), SvcError> {
     let parsed_path = parse_uri(new_path.as_str())?;
 
-    match get_nvme_path_buf(&ctrlr.path) {
+    match get_nvme_path_entry(&ctrlr.path) {
         Some(pbuf) => {
-            let subsystem = Subsystem::new(pbuf.as_path()).map_err(|_| SvcError::Internal {
+            let subsystem = Subsystem::new(pbuf.path()).map_err(|_| SvcError::Internal {
                 details: "Failed to get NVMe subsystem for controller".to_string(),
             })?;
 


### PR DESCRIPTION
In current implementation NQNs for suspected NVMe paths are obtained from a Subsystem instance constructed from a platform NVMe subsystem which is in “connecting” state. Sometimes platform reports “(efault)” as NQNs for such disconnected subsystems.
As a fix, NQN is now obtained at the moment when NVMe path appears in the system for the first time.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>