### PR TITLE
fix(csi-node): wait until filesystem shutdown before disconnecting

### DIFF
--- a/control-plane/csi-driver/src/bin/node/mount.rs
+++ b/control-plane/csi-driver/src/bin/node/mount.rs
@@ -297,3 +297,56 @@ pub(crate) fn blockdevice_unmount(target: &str) -> Result<(), Error> {
     info!("block device at {} has been unmounted", target);
     Ok(())
 }
+
+/// Waits until a device's filesystem is shutdown.
+/// This is useful to know if it's safe to detach a device from a node or not as it seems that
+/// even after a umount completes the filesystem and more specifically the filesystem's journal
+/// might not be completely shutdown.
+/// Specifically, this waits for the filesystem (eg: ext4) shutdown and the filesystem's journal
+/// shutdown: jbd2.
+pub(crate) async fn wait_fs_shutdown(device: &str, fstype: Option<String>) -> Result<(), Error> {
+    let device_trim = device.replace("/dev/", "");
+
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(2);
+
+    if let Some(fstype) = fstype {
+        let proc_fs_str = format!("/proc/fs/{fstype}/{device_trim}");
+        let proc_fs = std::path::Path::new(&proc_fs_str);
+        wait_file_removal(proc_fs, start, timeout).await?;
+    }
+
+    let jbd2_pattern = format!("/proc/fs/jbd2/{device_trim}-*");
+    let proc_jbd2 = glob::glob(&jbd2_pattern)
+        .expect("valid pattern")
+        .next()
+        .and_then(|v| v.ok());
+    if let Some(proc_jbd2) = proc_jbd2 {
+        wait_file_removal(&proc_jbd2, start, timeout).await?;
+    }
+
+    Ok(())
+}
+
+/// Waits until a file is removed, up to a timeout.
+async fn wait_file_removal(
+    proc: &std::path::Path,
+    start: std::time::Instant,
+    timeout: std::time::Duration,
+) -> Result<(), Error> {
+    let check_interval = std::time::Duration::from_millis(200);
+    let proc_str = proc.to_string_lossy().to_string();
+    let mut exists = proc.exists();
+    while start.elapsed() < timeout && exists {
+        tracing::error!(proc = proc_str, "proc entry still exists");
+        tokio::time::sleep(check_interval).await;
+        exists = proc.exists();
+    }
+    match exists {
+        false => Ok(()),
+        true => Err(Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!("Timed out waiting for '{proc_str}' to be removed"),
+        )),
+    }
+}

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -154,6 +154,8 @@ async fn detach(uuid: &Uuid, errheader: String) -> Result<(), Status> {
             ));
         }
 
+        crate::mount::wait_fs_shutdown(&device_path, None).await?;
+
         if let Err(error) = device.detach().await {
             return Err(failure!(
                 Code::Internal,

--- a/scripts/python/test.sh
+++ b/scripts/python/test.sh
@@ -26,6 +26,7 @@ fi
 . "$ROOT_DIR"/tests/bdd/setup.sh
 
 trap cleanup_handler ERR INT QUIT TERM HUP
+cleanup_handler
 
 # Extra arguments will be provided directly to pytest, otherwise the bdd folder will be tested with default arguments
 if [ $# -eq 0 ]; then

--- a/scripts/python/test_residue_cleanup.sh
+++ b/scripts/python/test_residue_cleanup.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+echo "Cleaning leftover nvme devices..."
+sudo nvme disconnect-all
+
 echo "Cleaning all IPTABLE rules added by tests..."
 
 # First backup the iptables rules

--- a/scripts/rust/test.sh
+++ b/scripts/rust/test.sh
@@ -12,6 +12,7 @@ cleanup_handler() {
 }
 
 trap cleanup_handler ERR INT QUIT TERM HUP
+sudo nvme disconnect-all
 
 set -euxo pipefail
 # test dependencies


### PR DESCRIPTION
Sometimes after/during disconnect we get some page write errors, triggered by a journal update by the JBD2 worker task.
To get around these, wait until the filesystem&jbd2 is shutdown before disconnecting.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>