### PR TITLE
chore(yaml): prepare release v1.0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,10 @@
 /openapi/*
 !/openapi/Cargo.toml
 !/openapi/build.rs
-/tests/bdd/common/__pycache__
+/.rust-toolchain
+/rust-toolchain.toml
+/terraform
+/rpc/api
+/utils
+/tests/bdd/autogen
+__pycache__

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -3004,6 +3004,7 @@ dependencies = [
  "http",
  "humantime",
  "jsonwebtoken",
+ "num_cpus",
  "opentelemetry",
  "opentelemetry-jaeger",
  "rpc",

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -29,3 +29,6 @@ pub const OPENEBS_CREATED_BY_KEY: &str = "openebs.io/created-by";
 
 /// The value to mark the creation source of a pool to be msp-operator in labels
 pub const MSP_OPERATOR: &str = "msp-operator";
+
+/// The default worker threads cap for the api-rest service.
+pub const DEFAULT_REST_MAX_WORKER_THREADS: &str = "8";

--- a/control-plane/agents/core/src/volume/tests.rs
+++ b/control-plane/agents/core/src/volume/tests.rs
@@ -887,6 +887,7 @@ async fn wait_till_volume(volume: &VolumeId, replicas: usize) {
             .replicas
             .iter()
             .filter(|r| r.owners.owned_by(volume))
+            .filter(|r| r.status.created())
             .collect::<Vec<_>>();
 
         if replica_specs.len() == replicas {

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -42,6 +42,7 @@ jsonwebtoken = "7.2.0"
 common-lib = { path = "../../common" }
 humantime = "2.1.0"
 git-version = "0.3.5"
+num_cpus = "1.13.1"
 
 [dev-dependencies]
 rpc = { path = "../../rpc" }

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -61,11 +61,26 @@ pub(crate) struct CliArgs {
     /// Don't use minimum timeouts for specific requests
     #[structopt(long)]
     no_min_timeouts: bool,
+
+    /// Set number of workers to start.
+    /// The value 0 means the number of available physical CPUs is used.
+    #[structopt(long, short, default_value = physical())]
+    workers: usize,
+
+    /// Set the max number of workers to start.
+    /// The value 0 means the number of available physical CPUs is used.
+    #[structopt(long, short, default_value = common_lib::DEFAULT_REST_MAX_WORKER_THREADS)]
+    max_workers: usize,
 }
 impl CliArgs {
     fn args() -> Self {
         CliArgs::from_args()
     }
+}
+
+/// Return the number of physical cpus.
+fn physical() -> &'static str {
+    Box::leak(num_cpus::get_physical().to_string().into_boxed_str())
 }
 
 /// default timeout options for every bus request
@@ -201,6 +216,20 @@ fn get_jwk_path() -> Option<String> {
     }
 }
 
+fn workers(args: &CliArgs) -> usize {
+    let max_workers = match args.max_workers {
+        0 => num_cpus::get_physical(),
+        max => max,
+    };
+
+    let workers = match args.workers {
+        0 => num_cpus::get_physical(),
+        workers => workers,
+    };
+
+    workers.clamp(1, max_workers)
+}
+
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
     // need to keep the jaeger pipeline tracer alive, if enabled
@@ -226,6 +255,7 @@ async fn main() -> anyhow::Result<()> {
     } else {
         server
     }
+    .workers(workers(&CliArgs::args()))
     .run()
     .await
     .map_err(|e| e.into());

--- a/deploy/core-agents-deployment.yaml
+++ b/deploy/core-agents-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             requests:
               cpu: 500m
               memory: 16Mi
-          image: mayadata/mcp-core:v1.0.4
+          image: mayadata/mcp-core:v1.0.5
           imagePullPolicy: IfNotPresent
           args:
             - "-smayastor-etcd"

--- a/deploy/csi-deployment.yaml
+++ b/deploy/csi-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             requests:
               cpu: 16m
               memory: 64Mi
-          image: mayadata/mcp-csi-controller:v1.0.4
+          image: mayadata/mcp-csi-controller:v1.0.5
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock"

--- a/deploy/msp-deployment.yaml
+++ b/deploy/msp-deployment.yaml
@@ -44,7 +44,7 @@ spec:
             requests:
               cpu: 50m
               memory: 16Mi
-          image: mayadata/mcp-msp-operator:v1.0.4
+          image: mayadata/mcp-msp-operator:v1.0.5
           imagePullPolicy: IfNotPresent
           args:
             - "-e http://rest:8081"

--- a/deploy/rest-deployment.yaml
+++ b/deploy/rest-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             requests:
               cpu: 50m
               memory: 32Mi
-          image: mayadata/mcp-rest:v1.0.4
+          image: mayadata/mcp-rest:v1.0.5
           imagePullPolicy: IfNotPresent
           args:
             - "--dummy-certificates"

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -43,7 +43,7 @@ pub struct ListOptions {
     pub no_docker: bool,
 
     /// Format the docker output
-    #[structopt(short, long, conflicts_with = "no_docker")]
+    #[structopt(short, long, conflicts_with = "no-docker")]
     pub format: Option<String>,
 
     /// Label for the cluster

--- a/scripts/check-deploy-yamls.sh
+++ b/scripts/check-deploy-yamls.sh
@@ -7,7 +7,7 @@ ROOTDIR="$SCRIPTDIR"/../
 DEPLOYDIR="$ROOTDIR"/deploy
 
 PROFILE=release
-TAG=v1.0.4
+TAG=v1.0.5
 
 "$SCRIPTDIR"/generate-deploy-yamls.sh -t "$TAG" "$PROFILE"
 


### PR DESCRIPTION
chore: update gitignore

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

chore(cherry-pick): add worker thread knobs to the api-rest service

By default set the max number of worker threads is set to 8.
This will unblock running on servers with large numbers of cpus and using more memory
than what our defaults in the helm charts are prepared to dish out.

Adds 2 new args to the api-rest, workers and max workers.
By default workers is the number of physical cpus and the default max is 8.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

chore(yaml): prepare release v1.0.5

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>