### PR TITLE
fix(republish): filter out nodes with existing volume targets

### DIFF
--- a/common/src/transport_api/mod.rs
+++ b/common/src/transport_api/mod.rs
@@ -108,7 +108,7 @@ pub trait Message {
 }
 
 /// All the different variants of Resources
-#[derive(Serialize, Deserialize, Debug, Clone, AsRefStr, ToString)]
+#[derive(Serialize, Deserialize, Debug, Clone, AsRefStr, ToString, Eq, PartialEq)]
 pub enum ResourceKind {
     /// Unknown or unspecified resource
     Unknown,

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -92,6 +92,13 @@ impl NodeFilters {
             true
         }
     }
+    /// Should only attempt to use node where there are no targets for the current volume.
+    pub(crate) fn no_targets(request: &GetSuitableNodesContext, item: &NodeItem) -> bool {
+        let volume_targets = request.registry().specs().get_volume_nexuses(&request.uuid);
+        !volume_targets
+            .into_iter()
+            .any(|n| &n.lock().node == item.node_wrapper().id())
+    }
 }
 
 /// Filter pools used for replica creation.

--- a/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
@@ -363,6 +363,7 @@ impl NexusTargetNode {
             .filter(NodeFilters::online)
             .filter(NodeFilters::cordoned)
             .filter(NodeFilters::current_target)
+            .filter(NodeFilters::no_targets)
             .sort(NodeSorters::number_targets)
     }
 }

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -215,7 +215,11 @@ impl NodeItem {
         Self { node_wrapper }
     }
     /// Get the internal `node_wrapper` from `NodeItem`.
-    pub(crate) fn node_wrapper(&self) -> NodeWrapper {
-        self.node_wrapper.clone()
+    pub(crate) fn node_wrapper(&self) -> &NodeWrapper {
+        &self.node_wrapper
+    }
+    /// Convert into internal `node_wrapper` from `NodeItem`.
+    pub(crate) fn into_node_wrapper(self) -> NodeWrapper {
+        self.node_wrapper
     }
 }

--- a/control-plane/agents/src/bin/core/nexus/scheduling.rs
+++ b/control-plane/agents/src/bin/core/nexus/scheduling.rs
@@ -60,7 +60,7 @@ pub(crate) async fn get_target_node_candidate(
             .await
             .collect()
             .into_iter()
-            .map(|i| i.node_wrapper())
+            .map(|i| i.into_node_wrapper())
             .collect();
     match candidates.first() {
         None => Err(SvcError::NotEnoughResources {

--- a/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
@@ -108,7 +108,7 @@ async fn wait_till_volume_deleted(cluster: &Cluster) {
     let client = cluster.grpc_client().volume();
     let start = std::time::Instant::now();
     loop {
-        let volumes = client.get(Filter::None, None, None).await.unwrap();
+        let volumes = client.get(Filter::None, false, None, None).await.unwrap();
         if volumes.entries.is_empty() {
             return;
         }

--- a/control-plane/agents/src/bin/core/tests/volume/helpers.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/helpers.rs
@@ -16,7 +16,7 @@ pub(crate) async fn wait_till_volume_nexus(
     let start = std::time::Instant::now();
     loop {
         let volume = volume_client
-            .get(GetVolumes::new(volume).filter, None, None)
+            .get(GetVolumes::new(volume).filter, false, None, None)
             .await
             .unwrap();
         let volume_state = volume.entries.clone().first().unwrap().state();
@@ -46,7 +46,7 @@ pub(crate) async fn volume_children(
     client: &dyn VolumeOperations,
 ) -> Vec<Child> {
     let volume = client
-        .get(GetVolumes::new(volume).filter, None, None)
+        .get(GetVolumes::new(volume).filter, false, None, None)
         .await
         .unwrap();
     let volume_state = volume.entries.first().unwrap().state();
@@ -89,7 +89,7 @@ pub(crate) async fn wait_till_volume(
 /// Return the number of replicas that exist and have a state.
 async fn existing_replicas(volume_id: &VolumeId, client: &dyn VolumeOperations) -> usize {
     let volumes = client
-        .get(GetVolumes::new(volume_id).filter, None, None)
+        .get(GetVolumes::new(volume_id).filter, false, None, None)
         .await
         .unwrap();
 
@@ -123,7 +123,7 @@ pub(crate) async fn wait_till_volume_children(
     let start = std::time::Instant::now();
     loop {
         let volume = volume_client
-            .get(GetVolumes::new(volume).filter, None, None)
+            .get(GetVolumes::new(volume).filter, false, None, None)
             .await
             .unwrap();
         let volume_state = volume.entries.clone().first().unwrap().state();

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -251,7 +251,7 @@ async fn nexus_persistence_test_iteration(
         .expect("Should be able to destroy the volume");
 
     assert!(volume_client
-        .get(GetVolumes::default().filter, None, None)
+        .get(GetVolumes::default().filter, false, None, None)
         .await
         .unwrap()
         .entries
@@ -288,7 +288,7 @@ async fn publishing_test(cluster: &Cluster) {
         .await
         .unwrap();
     let volumes = volume_client
-        .get(GetVolumes::default().filter, None, None)
+        .get(GetVolumes::default().filter, false, None, None)
         .await
         .unwrap()
         .entries;
@@ -402,7 +402,7 @@ async fn publishing_test(cluster: &Cluster) {
     tracing::info!("Published on '{}' with share '{}'", nx.node, nx.device_uri);
 
     let volumes = volume_client
-        .get(Filter::Volume(volume_state.uuid.clone()), None, None)
+        .get(Filter::Volume(volume_state.uuid.clone()), false, None, None)
         .await
         .unwrap();
 
@@ -470,7 +470,7 @@ async fn publishing_test(cluster: &Cluster) {
     );
 
     let volumes = volume_client
-        .get(Filter::Volume(volume_state.uuid.clone()), None, None)
+        .get(Filter::Volume(volume_state.uuid.clone()), false, None, None)
         .await
         .unwrap();
 
@@ -516,7 +516,7 @@ async fn publishing_test(cluster: &Cluster) {
         .expect("Should be able to destroy the volume");
 
     assert!(volume_client
-        .get(GetVolumes::default().filter, None, None)
+        .get(GetVolumes::default().filter, false, None, None)
         .await
         .unwrap()
         .entries
@@ -537,7 +537,7 @@ async fn publishing_test(cluster: &Cluster) {
 
 async fn get_volume(volume: &VolumeState, client: &dyn VolumeOperations) -> Volume {
     let request = client
-        .get(Filter::Volume(volume.uuid.clone()), None, None)
+        .get(Filter::Volume(volume.uuid.clone()), false, None, None)
         .await
         .unwrap();
     request.entries.first().cloned().unwrap()
@@ -601,7 +601,7 @@ async fn replica_count_test(cluster: &Cluster) {
         .unwrap();
 
     let volumes = volume_client
-        .get(GetVolumes::default().filter, None, None)
+        .get(GetVolumes::default().filter, false, None, None)
         .await
         .unwrap()
         .entries;
@@ -771,7 +771,7 @@ async fn replica_count_test(cluster: &Cluster) {
         .expect("Should be able to destroy the volume");
 
     assert!(volume_client
-        .get(GetVolumes::default().filter, None, None)
+        .get(GetVolumes::default().filter, false, None, None)
         .await
         .unwrap()
         .entries
@@ -803,7 +803,7 @@ async fn smoke_test(cluster: &Cluster) {
 
     let volume = volume_client.create(&create_volume, None).await.unwrap();
     let volumes = volume_client
-        .get(GetVolumes::default().filter, None, None)
+        .get(GetVolumes::default().filter, false, None, None)
         .await
         .unwrap()
         .entries;
@@ -822,7 +822,7 @@ async fn smoke_test(cluster: &Cluster) {
         .expect("Should be able to destroy the volume");
 
     assert!(volume_client
-        .get(GetVolumes::default().filter, None, None)
+        .get(GetVolumes::default().filter, false, None, None)
         .await
         .unwrap()
         .entries

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -1178,7 +1178,7 @@ pub(crate) async fn get_volume_target_node(
             // determine a suitable node for the same.
             let volume_spec = registry.specs().get_volume(&status.uuid)?;
             let candidate = get_target_node_candidate(&volume_spec, registry).await?;
-            tracing::debug!(node.id=%candidate.id(), "node selected for volume publish by control-plane");
+            tracing::debug!(node.id=%candidate.id(), "Node selected for volume publish by the core-agent");
             Ok(candidate.id().clone())
         }
         Some(node) => {

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -200,7 +200,10 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         };
 
         // First check if the volume already exists.
-        match IoEngineApiClient::get_client().get_volume(&u).await {
+        match IoEngineApiClient::get_client()
+            .get_volume_for_create(&u)
+            .await
+        {
             Ok(volume) => {
                 check_existing_volume(&volume, replica_count, size, thin)?;
                 debug!(

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -150,6 +150,8 @@ message GetVolumesRequest {
   }
   // pagination to allow for multiple requests to get all volumes
   common.Pagination pagination = 2;
+  // ignore 404 not found errors
+  bool ignore_notfound = 3;
 }
 
 // volume creation request

--- a/control-plane/grpc/src/operations/volume/client.rs
+++ b/control-plane/grpc/src/operations/volume/client.rs
@@ -69,6 +69,7 @@ impl VolumeOperations for VolumeClient {
     async fn get(
         &self,
         filter: Filter,
+        ignore_notfound: bool,
         pagination: Option<Pagination>,
         ctx: Option<Context>,
     ) -> Result<Volumes, ReplyError> {
@@ -78,10 +79,12 @@ impl VolumeOperations for VolumeClient {
                     volume_id: volume_id.to_string(),
                 })),
                 pagination: pagination.map(|p| p.into()),
+                ignore_notfound,
             },
             _ => GetVolumesRequest {
                 filter: None,
                 pagination: pagination.map(|p| p.into()),
+                ignore_notfound,
             },
         };
         let req = self.request(req, ctx, MessageIdVs::GetVolumes);

--- a/control-plane/grpc/src/operations/volume/server.rs
+++ b/control-plane/grpc/src/operations/volume/server.rs
@@ -96,7 +96,11 @@ impl VolumeGrpc for VolumeServer {
         };
 
         let pagination: Option<Pagination> = req.pagination.map(|p| p.into());
-        match self.service.get(filter, pagination, None).await {
+        match self
+            .service
+            .get(filter, req.ignore_notfound, pagination, None)
+            .await
+        {
             Ok(volumes) => Ok(Response::new(GetVolumesReply {
                 reply: Some(get_volumes_reply::Reply::Volumes(volumes.into())),
             })),

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -40,6 +40,7 @@ pub trait VolumeOperations: Send + Sync {
     async fn get(
         &self,
         filter: Filter,
+        ignore_notfound: bool,
         pagination: Option<Pagination>,
         ctx: Option<Context>,
     ) -> Result<Volumes, ReplyError>;
@@ -314,7 +315,7 @@ impl TryFrom<volume::Volume> for Volume {
 impl TryFrom<volume::Volumes> for Volumes {
     type Error = ReplyError;
     fn try_from(grpc_volumes: volume::Volumes) -> Result<Self, Self::Error> {
-        let mut volumes: Vec<Volume> = vec![];
+        let mut volumes: Vec<Volume> = Vec::with_capacity(grpc_volumes.entries.len());
         for volume in grpc_volumes.entries {
             volumes.push(Volume::try_from(volume)?)
         }

--- a/control-plane/plugin/src/resources/tests.rs
+++ b/control-plane/plugin/src/resources/tests.rs
@@ -74,7 +74,7 @@ async fn get_volumes() {
         .await
         .rest_v00()
         .volumes_api()
-        .get_volumes(0, None)
+        .get_volumes(0, None, None)
         .await
         .unwrap();
     let volume_state = volumes.entries[0].state.clone();
@@ -116,7 +116,7 @@ async fn get_volumes_paginated() {
         .await
         .rest_v00()
         .volumes_api()
-        .get_volumes(0, None)
+        .get_volumes(0, None, None)
         .await
         .unwrap()
         .entries
@@ -133,7 +133,7 @@ async fn get_volumes_paginated() {
             .await
             .rest_v00()
             .volumes_api()
-            .get_volumes(max_entries, starting_token)
+            .get_volumes(max_entries, None, starting_token)
             .await
             .unwrap();
         // The number of returned volumes should be equal to the number of specified max entries.

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -73,7 +73,7 @@ async fn get_paginated_volumes() -> Option<Vec<openapi::models::Volume>> {
     while starting_token.is_some() {
         match RestClient::client()
             .volumes_api()
-            .get_volumes(max_entries, starting_token)
+            .get_volumes(max_entries, None, starting_token)
             .await
         {
             Ok(vols) => {

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1298,6 +1298,14 @@ paths:
       operationId: get_volumes
       parameters:
         - in: query
+          name: volume_id
+          description: |-
+            The uuid of a volume to retrieve.
+            This can be used to "bypass" the 404 error when a volume does not exist.
+          schema:
+            $ref: '#/components/schemas/VolumeId'
+          required: false
+        - in: query
           name: max_entries
           description: the maximum number of results to return
           schema:

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -367,7 +367,11 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
 
     client.volumes_api().del_volume(&volume_uuid).await.unwrap();
 
-    let volumes = client.volumes_api().get_volumes(0, None).await.unwrap();
+    let volumes = client
+        .volumes_api()
+        .get_volumes(0, None, None)
+        .await
+        .unwrap();
     assert!(volumes.entries.is_empty());
 
     client

--- a/scripts/rust/env-setup.sh
+++ b/scripts/rust/env-setup.sh
@@ -42,6 +42,8 @@ EOF
       # priority: https://github.com/rust-lang/cargo/pull/11023
       export PATH=$RUST_TOOLCHAIN/bin:$PATH:~/.cargo/bin
     else
+      # Expose this we can fmt files out of tree, eg: when we rustfmt the openapi in /tmp
+      export RUSTUP_TOOLCHAIN="$rustup_channel"
       cat <<EOF >rust-toolchain.toml
 [toolchain]
 channel = "$rustup_channel"

--- a/scripts/rust/generate-openapi-bindings.sh
+++ b/scripts/rust/generate-openapi-bindings.sh
@@ -88,7 +88,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [[ $check_spec = "yes" ]]; then
-  ( cd "$ROOTDIR"; git diff --cached --exit-code "$REAL_SPEC" 1>/dev/null && exit 0 )
+  ( cd "$ROOTDIR"; set +e; git diff --cached --exit-code "$REAL_SPEC" 1>/dev/null && exit 0; set -e )
 fi
 
 tmpd=$(mktemp -d /tmp/openapi-gen-XXXXXXX)

--- a/shell.nix
+++ b/shell.nix
@@ -59,7 +59,7 @@ mkShell {
   USE_NIX_RUST = "${toString (!norust)}";
   # copy the rust toolchain to a writable directory, see: https://github.com/rust-lang/cargo/issues/10096
   # the whole toolchain is copied to allow the src to be retrievable through "rustc --print sysroot"
-  RUST_TOOLCHAIN = "/tmp/rust-toolchain/${rust.version}";
+  RUST_TOOLCHAIN = ".rust-toolchain/${rust.version}";
   RUST_TOOLCHAIN_NIX = "${rust}";
 
   NODE_PATH = "${nodePackages."@commitlint/config-conventional"}/lib/node_modules";

--- a/tests/io-engine/tests/rebuild.rs
+++ b/tests/io-engine/tests/rebuild.rs
@@ -109,7 +109,7 @@ async fn concurrent_rebuilds() {
         let mut added_slack = false;
         let check_interval = std::time::Duration::from_secs(5);
         loop {
-            let curr_volumes = vol_cli.get_volumes(0, None).await.unwrap().entries;
+            let curr_volumes = vol_cli.get_volumes(0, None, None).await.unwrap().entries;
             assert_eq!(volumes.len(), curr_volumes.len());
             // volumes should either be online or degraded (while rebuilding)
             let not_expected = curr_volumes


### PR DESCRIPTION
Ensures we don't attempt to create nexus on a node which already has a nexus for a given volume.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>