### PR TITLE
feat(upgrade): revert changes for get upgrade-status

### DIFF
--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -100,7 +100,6 @@ async fn execute(cli_args: CliArgs) {
                 )
                 .await
             }
-            GetResources::UpgradeStatus => {}
         },
         Operations::Scale(resource) => match resource {
             ScaleResources::Volume { id, replica_count } => {

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -43,8 +43,6 @@ pub enum GetResources {
     /// Currently disks having blobstore pools not created by control-plane are also shown as
     /// usable.
     BlockDevices(BlockDeviceArgs),
-    /// Get the status of upgrade.
-    UpgradeStatus,
 }
 
 /// The types of resources that support the 'scale' operation.
@@ -95,9 +93,3 @@ pub enum GetDrainArgs {
 /// Tabular Output Tests
 #[cfg(test)]
 mod tests;
-
-#[derive(clap::Subcommand, Debug)]
-pub enum UpgradeStatus {
-    /// Get the upgrade status.
-    UpgradeStatus,
-}


### PR DESCRIPTION
As suggested by @tiagolobocastro  this change is not needed in control plane , So i have reverted the change. 
The upgrade status change is incorporated in extensions repo itself and is present in the PR https://github.com/openebs/mayastor-extensions/pull/76


Refer https://github.com/openebs/mayastor-control-plane/pull/404

Signed-off-by: sinhaashish <ashi.sinha.87@gmail.com>