### PR TITLE
fix(v1/concurrency): enable openapi client concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -137,7 +137,7 @@ dependencies = [
  "http",
  "log",
  "tokio-rustls 0.23.1",
- "tokio-util",
+ "tokio-util 0.6.9",
  "webpki-roots",
 ]
 
@@ -618,7 +618,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "url",
  "winapi",
 ]
@@ -1623,7 +1623,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -1952,7 +1952,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower",
  "tower-http",
  "tracing",
@@ -2005,7 +2005,7 @@ dependencies = [
  "smallvec",
  "snafu",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -3972,6 +3972,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tonic"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3994,7 +4007,7 @@ dependencies = [
  "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4016,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4028,8 +4041,7 @@ dependencies = [
  "rand 0.8.4",
  "slab",
  "tokio",
- "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.2",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/control-plane/msp-operator/src/main.rs
+++ b/control-plane/msp-operator/src/main.rs
@@ -912,13 +912,14 @@ async fn pool_controller(args: ArgMatches<'_>) -> anyhow::Result<()> {
     let msp: Api<MayastorPool> = Api::namespaced(k8s.clone(), namespace);
     let lp = ListParams::default();
     let url = Url::parse(args.value_of("endpoint").unwrap()).expect("endpoint is not a valid URL");
-    let cfg = clients::tower::Configuration::new(url, Duration::from_secs(5), None, None, true)
-        .map_err(|error| {
-            anyhow::anyhow!(
-                "Failed to create openapi configuration, Error: '{:?}'",
-                error
-            )
-        })?;
+    let cfg =
+        clients::tower::Configuration::new(url, Duration::from_secs(5), None, None, true, None)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "Failed to create openapi configuration, Error: '{:?}'",
+                    error
+                )
+            })?;
 
     let context = Context::new(OperatorContext {
         k8s,

--- a/control-plane/rest/src/lib.rs
+++ b/control-plane/rest/src/lib.rs
@@ -59,7 +59,7 @@ impl RestClient {
         let cert_file = &std::include_bytes!("../certs/rsa/ca.cert")[..];
 
         let openapi_client_config =
-            client::Configuration::new(url, timeout, bearer_token, Some(cert_file), trace)
+            client::Configuration::new(url, timeout, bearer_token, Some(cert_file), trace, None)
                 .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{:?}'", e))?;
         let openapi_client = client::direct::ApiClient::new(openapi_client_config);
 
@@ -76,7 +76,7 @@ impl RestClient {
         trace: bool,
     ) -> anyhow::Result<Self> {
         let openapi_client_config =
-            client::Configuration::new(url, timeout, bearer_token, None, trace)
+            client::Configuration::new(url, timeout, bearer_token, None, trace, None)
                 .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{:?}'", e))?;
         let openapi_client = client::direct::ApiClient::new(openapi_client_config);
         Ok(Self {

--- a/kubectl-plugin/src/rest_wrapper.rs
+++ b/kubectl-plugin/src/rest_wrapper.rs
@@ -15,7 +15,7 @@ impl RestClient {
             url.set_port(Some(30011))
                 .map_err(|_| anyhow::anyhow!("Failed to set REST client port"))?;
         }
-        let cfg = Configuration::new(url, timeout, None, None, true).map_err(|error| {
+        let cfg = Configuration::new(url, timeout, None, None, true, None).map_err(|error| {
             anyhow::anyhow!(
                 "Failed to create openapi configuration, Error: '{:?}'",
                 error

--- a/nix/pkgs/openapi-generator/default.nix
+++ b/nix/pkgs/openapi-generator/default.nix
@@ -1,7 +1,8 @@
 { pkgs, lib, stdenv, fetchFromGitHub, maven, jdk, jre, makeWrapper }:
+
 let
   src = fetchFromGitHub (lib.importJSON ./source.json);
-  version = "5.2.1-${src.rev}";
+  version = "6.1.0-${src.rev}";
 
   # perform fake build to make a fixed-output derivation out of the files downloaded from maven central
   deps = stdenv.mkDerivation {
@@ -19,10 +20,11 @@ let
       runHook postBuild
     '';
     # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
-    installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
+    installPhase =
+      "find $out/.m2 -type f -regex '.+\\(\\.lastUpdated\\|resolver-status\\.properties\\|_remote\\.repositories\\)' -delete";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "0f30vfvqrwa4gdgid9c94kvv83yfrgpx6ii1npjxspdawqr3whrj";
+    outputHash = if stdenv.hostPlatform.isDarwin then "sha256-9Li0uSD39ZwptIRgOXeBkLeZvfy/9w69faNDm75zdws=" else "sha256-MieSA5Y8u35H1xdP27A+YDekyyQ6CThNXOjQ82ArM7U=";
   };
 in
 stdenv.mkDerivation rec {
@@ -56,7 +58,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
+    description =
+      "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
     homepage = "https://github.com/openebs/openapi-generator";
     license = licenses.asl20;
     maintainers = [ maintainers.tiagolobocastro ];

--- a/nix/pkgs/openapi-generator/source.json
+++ b/nix/pkgs/openapi-generator/source.json
@@ -1,6 +1,6 @@
 {
   "owner": "openebs",
   "repo": "openapi-generator",
-  "rev": "27b71d9cc49bc24c8af83e4fb2b693c5350c397f",
-  "sha256": "00axipm0nkhp05dqiyzvgflwdfdwj4kw9q22g39mb061piwm9zqc"
+  "rev": "c40274969da7ed4f04686ac0224f47b157ae0284",
+  "hash": "sha256-Vcre5OoCcut7jIIH8eijZ2tnVezEvHxjFdYrsV5BdFw="
 }

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -43,7 +43,7 @@ awc = { version = "3.0.0-beta.7", optional = true }
 
 # tower and hyper dependencies
 hyper = { version = "0.14.13", features = [ "client", "http1", "http2", "tcp", "stream" ], optional = true }
-tower = { version = "0.4.8", features = [ "timeout", "util" ], optional = true }
+tower = { version = "0.4.13", features = [ "timeout", "util", "limit" ], optional = true }
 tower-http = { version = "0.1.1", features = [ "trace", "map-response-body", "auth" ], optional = true }
 bytes = {version = "1.1.0", optional = true }
 tokio = { version = "1.12.0", features = ["full"], optional = true }

--- a/scripts/generate-openapi-bindings.sh
+++ b/scripts/generate-openapi-bindings.sh
@@ -46,7 +46,7 @@ fi
 tmpd=$(mktemp -d /tmp/openapi-gen-XXXXXXX)
 
 # Generate a new openapi crate
-openapi-generator-cli generate -i "$SPEC" -g rust-mayastor -o "$tmpd" --additional-properties actixWebVersion="4.0.0-beta.8" --additional-properties actixWebTelemetryVersion='"0.11.0-beta.4"'
+openapi-generator-cli generate -i "$SPEC" -g rust-mayastor -o "$tmpd" --additional-properties actixWeb4Beta="True"
 
 if [[ $default_toml = "no" ]]; then
   cp "$CARGO_TOML" "$tmpd"

--- a/tests/tests-mayastor/src/rest_client.rs
+++ b/tests/tests-mayastor/src/rest_client.rs
@@ -41,7 +41,7 @@ impl RestClient {
         let cert_file = &std::include_bytes!("../../../control-plane/rest/certs/rsa/ca.cert")[..];
 
         let openapi_client_config =
-            client::Configuration::new(url, timeout, bearer_token, Some(cert_file), trace)
+            client::Configuration::new(url, timeout, bearer_token, Some(cert_file), trace, None)
                 .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{:?}'", e))?;
         let openapi_client = client::direct::ApiClient::new(openapi_client_config);
 
@@ -58,7 +58,7 @@ impl RestClient {
         trace: bool,
     ) -> anyhow::Result<Self> {
         let openapi_client_config =
-            client::Configuration::new(url, timeout, bearer_token, None, trace)
+            client::Configuration::new(url, timeout, bearer_token, None, trace, None)
                 .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{:?}'", e))?;
         let openapi_client = client::direct::ApiClient::new(openapi_client_config);
         Ok(Self {


### PR DESCRIPTION
Upgrade openapi-generator which includes a new concurrency_limit option. Added env var "MAX_CONCURRENCY_RPC" to both csi-controller and core agent, with defaults of 10 and 3, respectively.
On develop there is no limit for core, but we haven't tested this before on v1 and that's why we're setting it conservatively to 3.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>