### PR TITLE
fix(ha_nexus): cleanup older unregistered shutdown targets

### DIFF
--- a/common/src/transport_api/v0.rs
+++ b/common/src/transport_api/v0.rs
@@ -30,6 +30,8 @@ impl_message!(DestroyPool);
 impl_vector_request!(Pools, Pool);
 impl_message!(GetPools);
 
+impl_vector_request!(NvmeSubsystems, NvmeSubsystem);
+
 impl_vector_request!(Replicas, Replica);
 impl_message!(GetReplicas);
 impl_message!(CreateReplica);

--- a/common/src/types/v0/transport/cluster_agent.rs
+++ b/common/src/types/v0/transport/cluster_agent.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, net::SocketAddr};
-
 use super::*;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, net::SocketAddr};
 
 #[derive(Debug)]
 pub struct NodeAgentInfo {
@@ -80,6 +80,44 @@ impl ReportFailedPaths {
     /// Get list of all failed paths in the request.
     pub fn failed_paths(&self) -> &Vec<FailedPath> {
         &self.failed_paths
+    }
+}
+
+/// Request struct to get Nvme subsystems registered for a given nqn.
+#[derive(Debug)]
+pub struct GetController {
+    /// nvme_path is the device uri of the target associated with volume.
+    nvme_path: String,
+}
+
+impl GetController {
+    /// Constructor to create instance of the struct.
+    pub fn new(nvme_path: String) -> Self {
+        Self { nvme_path }
+    }
+    /// Get nvme path.
+    pub fn nvme_path(&self) -> String {
+        self.nvme_path.clone()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Represents targets address of Nvme Subsystem.
+pub struct NvmeSubsystem {
+    /// Address is the IP address of the Nvme Subsystem.
+    address: String,
+}
+
+impl NvmeSubsystem {
+    /// Creates an instance of this struct.
+    pub fn new(target_addr: String) -> Self {
+        Self {
+            address: target_addr,
+        }
+    }
+    /// Get IP address of the Nvme Subsystem.
+    pub fn address(&self) -> &str {
+        self.address.as_str()
     }
 }
 

--- a/common/src/types/v0/transport/mod.rs
+++ b/common/src/types/v0/transport/mod.rs
@@ -141,6 +141,8 @@ pub enum MessageIdVs {
     ShutdownNexus,
     /// Replace Path
     ReplacePathInfo,
+    /// Get Nvme Subsystems.
+    GetNvmeSubsystems,
 }
 
 impl From<MessageIdVs> for MessageId {

--- a/common/src/types/v0/transport/volume.rs
+++ b/common/src/types/v0/transport/volume.rs
@@ -605,12 +605,25 @@ impl From<&ReplicaTopology> for models::ReplicaTopology {
 #[serde(rename_all = "camelCase")]
 pub struct DestroyShutdownTargets {
     /// The uuid of the owner, i.e the volume.
-    pub uuid: VolumeId,
+    uuid: VolumeId,
+    /// List of target address registered as Nvme Subsystems in the Frontend nodes.
+    registered_targets: Option<Vec<String>>,
 }
 
 impl DestroyShutdownTargets {
     /// Create new `Self` from the given volume id.
-    pub fn new(uuid: VolumeId) -> Self {
-        DestroyShutdownTargets { uuid }
+    pub fn new(uuid: VolumeId, registered_targets: Option<Vec<String>>) -> Self {
+        DestroyShutdownTargets {
+            uuid,
+            registered_targets,
+        }
+    }
+    /// Get volumeId.
+    pub fn uuid(&self) -> &VolumeId {
+        &self.uuid
+    }
+    /// Get registered_targets.
+    pub fn registered_targets(&self) -> Option<Vec<String>> {
+        self.registered_targets.clone()
     }
 }

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -101,14 +101,9 @@ async fn lazy_delete_shutdown_targets() {
         .node_service_liveness(None)
         .await
         .expect("Should have restarted by now");
-
+    let request = DestroyShutdownTargets::new(volume.uuid().clone(), None);
     vol_cli
-        .destroy_shutdown_target(
-            &DestroyShutdownTargets {
-                uuid: volume.uuid().clone(),
-            },
-            None,
-        )
+        .destroy_shutdown_target(&request, None)
         .await
         .expect("Should destroy old target even though the node is offline!");
 

--- a/control-plane/agents/src/bin/core/volume/service.rs
+++ b/control-plane/agents/src/bin/core/volume/service.rs
@@ -231,12 +231,12 @@ impl Service {
     }
 
     /// Destroy the shutdown targets associate with the volume.
-    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
+    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid()))]
     pub(super) async fn destroy_shutdown_target(
         &self,
         request: &DestroyShutdownTargets,
     ) -> Result<(), SvcError> {
-        let mut volume = self.specs().volume(&request.uuid).await?;
+        let mut volume = self.specs().volume(request.uuid()).await?;
         volume
             .remove_shutdown_targets(&self.registry, request)
             .await

--- a/control-plane/grpc/proto/v1/ha/node_agent.proto
+++ b/control-plane/grpc/proto/v1/ha/node_agent.proto
@@ -9,6 +9,7 @@ package v1.ha_node_agent;
 // Service for managing node-agent rpc calls
 service HaNodeRpc {
   rpc ReplacePath (ReplacePathRequest) returns (google.protobuf.Empty) {}
+  rpc GetNvmeController (GetNvmeControllerRequest) returns (GetNvmeControllerResponse){}
 }
 
 // Path replacement message.
@@ -21,4 +22,26 @@ message ReplacePathRequest {
 
   // Pubish context of the volume
   common.MapWrapper publish_context = 3;
+}
+
+// Get Controller request message.
+message GetNvmeControllerRequest {
+  // Nvme path containing nqn for the volume.
+  string nvme_path = 1;
+}
+
+// Get Controller response message.
+message GetNvmeControllerResponse {
+  oneof reply {
+    // List of target address registered as Nvme Subsystem.
+    NvmeControllers nvme_controllers = 1;
+    // Error incase No subsystem found.
+    common.ReplyError error = 2;
+  }
+}
+
+// Message to represent target's address in the rpc response.
+message NvmeControllers {
+ // Target address registered as Nvme Subsystem.
+  repeated string target_address = 1;
 }

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -321,6 +321,13 @@ message ProbeResponse {
 message DestroyShutdownTargetRequest {
   // uuid of the volume
   google.protobuf.StringValue volume_id = 1;
+  // List of Targets registered as subsystems for the volume.
+  optional RegisteredTargets registered_targets = 2;
+}
+
+message RegisteredTargets{
+  // Registered targets for the volume.
+  repeated string target_list = 1;
 }
 
 // Reply type for a DestroyShutdownTargetRequest request

--- a/control-plane/grpc/src/operations/ha_node/server.rs
+++ b/control-plane/grpc/src/operations/ha_node/server.rs
@@ -1,4 +1,4 @@
-use tonic::{Response, Status};
+use tonic::{Request, Response, Status};
 
 use crate::{
     ha_cluster_agent::{
@@ -6,8 +6,9 @@ use crate::{
         HaNodeInfo, ReportFailedNvmePathsRequest,
     },
     ha_node_agent::{
+        get_nvme_controller_response,
         ha_node_rpc_server::{HaNodeRpc, HaNodeRpcServer},
-        ReplacePathRequest,
+        GetNvmeControllerRequest, GetNvmeControllerResponse, ReplacePathRequest,
     },
     operations::ha_node::traits::{ClusterAgentOperations, NodeAgentOperations, NodeInfoConv},
 };
@@ -40,6 +41,21 @@ impl HaNodeRpc for NodeAgentServer {
 
         match self.service.replace_path(&msg, None).await {
             Ok(_) => Ok(Response::new(())),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    async fn get_nvme_controller(
+        &self,
+        request: Request<GetNvmeControllerRequest>,
+    ) -> Result<Response<GetNvmeControllerResponse>, Status> {
+        let msg = request.into_inner();
+        match self.service.get_nvme_controller(&msg, None).await {
+            Ok(val) => Ok(Response::new(GetNvmeControllerResponse {
+                reply: Some(get_nvme_controller_response::Reply::NvmeControllers(
+                    val.into(),
+                )),
+            })),
             Err(err) => Err(err.into()),
         }
     }

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -7,7 +7,7 @@ use crate::{
     replica, volume,
     volume::{
         get_volumes_request, CreateVolumeRequest, DestroyShutdownTargetRequest,
-        DestroyVolumeRequest, PublishVolumeRequest, RepublishVolumeRequest,
+        DestroyVolumeRequest, PublishVolumeRequest, RegisteredTargets, RepublishVolumeRequest,
         SetVolumeReplicaRequest, ShareVolumeRequest, UnpublishVolumeRequest, UnshareVolumeRequest,
     },
 };
@@ -25,7 +25,7 @@ use common_lib::{
     },
     IntoOption,
 };
-use std::{collections::HashMap, convert::TryFrom};
+use std::{borrow::Borrow, collections::HashMap, convert::TryFrom};
 
 /// All volume crud operations to be a part of the VolumeOperations trait.
 #[tonic::async_trait]
@@ -1424,12 +1424,17 @@ impl TryFrom<StringValue> for VolumeId {
 /// which want to use this operation.
 pub trait DestroyShutdownTargetsInfo: Send + Sync + std::fmt::Debug {
     /// uuid of the volume, i.e the owner
-    fn uuid(&self) -> VolumeId;
+    fn uuid(&self) -> &VolumeId;
+    /// List of all targets registered in the Application node for the volume.
+    fn registered_targets(&self) -> Option<Vec<String>>;
 }
 
 impl DestroyShutdownTargetsInfo for DestroyShutdownTargets {
-    fn uuid(&self) -> VolumeId {
-        self.uuid.clone()
+    fn uuid(&self) -> &VolumeId {
+        self.uuid()
+    }
+    fn registered_targets(&self) -> Option<Vec<String>> {
+        self.registered_targets()
     }
 }
 
@@ -1437,11 +1442,15 @@ impl DestroyShutdownTargetsInfo for DestroyShutdownTargets {
 #[derive(Debug)]
 pub struct ValidatedDestroyShutdownTargetRequest {
     uuid: VolumeId,
+    registered_targets: Option<Vec<String>>,
 }
 
 impl DestroyShutdownTargetsInfo for ValidatedDestroyShutdownTargetRequest {
-    fn uuid(&self) -> VolumeId {
-        self.uuid.clone()
+    fn uuid(&self) -> &VolumeId {
+        self.uuid.borrow()
+    }
+    fn registered_targets(&self) -> Option<Vec<String>> {
+        self.registered_targets.clone()
     }
 }
 
@@ -1450,6 +1459,10 @@ impl ValidateRequestTypes for DestroyShutdownTargetRequest {
     fn validated(self) -> Result<Self::Validated, ReplyError> {
         Ok(ValidatedDestroyShutdownTargetRequest {
             uuid: VolumeId::try_from(StringValue(self.volume_id))?,
+            registered_targets: match self.registered_targets {
+                Some(val) => Some(val.target_list),
+                None => None,
+            },
         })
     }
 }
@@ -1458,12 +1471,15 @@ impl From<&dyn DestroyShutdownTargetsInfo> for DestroyShutdownTargetRequest {
     fn from(data: &dyn DestroyShutdownTargetsInfo) -> Self {
         Self {
             volume_id: Some(data.uuid().to_string()),
+            registered_targets: data
+                .registered_targets()
+                .map(|val| RegisteredTargets { target_list: val }),
         }
     }
 }
 
 impl From<&dyn DestroyShutdownTargetsInfo> for DestroyShutdownTargets {
     fn from(data: &dyn DestroyShutdownTargetsInfo) -> Self {
-        Self::new(data.uuid())
+        Self::new(data.uuid().clone(), data.registered_targets())
     }
 }

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -41,14 +41,8 @@ impl apis::actix_server::Volumes for RestApi {
     async fn del_volume_shutdown_targets(
         Path(volume_id): Path<Uuid>,
     ) -> Result<(), RestError<RestJsonError>> {
-        client()
-            .destroy_shutdown_target(
-                &DestroyShutdownTargets {
-                    uuid: volume_id.into(),
-                },
-                None,
-            )
-            .await?;
+        let destroy = DestroyShutdownTargets::new(volume_id.into(), None);
+        client().destroy_shutdown_target(&destroy, None).await?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR allows cluster agents to cleanup shutdown targets of the volume which are not registered as Subsystems in the Frontend node. Cleanup starts when we exhaust all nodes during target republish.

Signed-off-by: Abhilash Shetty <abhilash.shetty@datacore.com>