### PR TITLE
refactor(dsp-operator): refactor disk pool operator

### DIFF
--- a/k8s/operators/src/diskpool/crd.rs
+++ b/k8s/operators/src/diskpool/crd.rs
@@ -18,8 +18,8 @@ derive = "PartialEq",
 derive = "Default",
 shortname = "dsp",
 printcolumn = r#"{ "name":"node", "type":"string", "description":"node the pool is on", "jsonPath":".spec.node"}"#,
-printcolumn = r#"{ "name":"status", "type":"string", "description":"pool status", "jsonPath":".status.state"}"#,
-printcolumn = r#"{ "name":"poolstatus", "type":"string", "description":"control plane pool status", "jsonPath":".status.status"}"#,
+printcolumn = r#"{ "name":"state", "type":"string", "description":"dsp cr state", "jsonPath":".status.state"}"#,
+printcolumn = r#"{ "name":"pool_status", "type":"string", "description":"Control plane pool status", "jsonPath":".status.pool_status"}"#,
 printcolumn = r#"{ "name":"capacity", "type":"integer", "format": "int64", "minimum" : "0", "description":"total bytes", "jsonPath":".status.capacity"}"#,
 printcolumn = r#"{ "name":"used", "type":"integer", "format": "int64", "minimum" : "0", "description":"used bytes", "jsonPath":".status.used"}"#,
 printcolumn = r#"{ "name":"available", "type":"integer", "format": "int64", "minimum" : "0", "description":"available bytes", "jsonPath":".status.available"}"#
@@ -46,7 +46,6 @@ impl DiskPoolSpec {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
 #[non_exhaustive]
-/// PoolState represents operator specific states for DSP CR.
 pub enum PoolState {
     /// The pool is a new OR missing resource, and it has not been created or
     /// imported yet by the operator. The pool spec MAY be but DOES
@@ -58,8 +57,6 @@ pub enum PoolState {
     /// The resource is present, and the pool has been created. The schema MUST
     /// have a status and spec field.
     Online,
-    /// This state is set when we receive delete event on the dsp cr.
-    Terminating,
     /// The resource is present but the control plane did not return the pool state.
     Unknown,
     /// Trying to converge to the next state has exceeded the maximum retry
@@ -68,6 +65,22 @@ pub enum PoolState {
     /// reconciliation stops. Only external events (a new resource version)
     /// will trigger a new attempt.
     Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema, Default)]
+#[non_exhaustive]
+/// PoolState represents operator specific states for DSP CR.
+pub enum CrPoolState {
+    /// The pool is a new OR missing resource, and it has not been created or
+    /// imported yet by the operator. The pool spec MAY be but DOES
+    /// NOT have a status field.
+    #[default]
+    Creating,
+    /// The resource spec has been created, and the pool is getting created by
+    /// the control plane.
+    Created,
+    /// This state is set when we receive delete event on the dsp cr.
+    Terminating,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
@@ -87,10 +100,12 @@ pub enum PoolStatus {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
 /// Status of the pool which is driven and changed by the controller loop.
 pub struct DiskPoolStatus {
-    /// The state of the pool.
     pub state: PoolState,
+    /// The state of the pool.
+    #[serde(default)]
+    pub cr_state: CrPoolState,
     /// Pool status from respective control plane object.
-    pub status: Option<PoolStatus>,
+    pub pool_status: Option<PoolStatus>,
     /// Capacity as number of bytes.
     capacity: u64,
     /// Used number of bytes.
@@ -103,7 +118,8 @@ impl Default for DiskPoolStatus {
     fn default() -> Self {
         Self {
             state: PoolState::Creating,
-            status: None,
+            cr_state: CrPoolState::Creating,
+            pool_status: None,
             capacity: 0,
             used: 0,
             available: 0,
@@ -112,28 +128,15 @@ impl Default for DiskPoolStatus {
 }
 
 impl DiskPoolStatus {
-    /// Set when Pool creation fails for some reason.
-    pub fn error() -> Self {
-        Self {
-            state: PoolState::Error,
-            ..Default::default()
-        }
-    }
-    /// Set when create pool api call is successful.
-    pub fn created() -> Self {
+    /// Set when Pool is not found for some reason.
+    pub fn not_found() -> Self {
         Self {
             state: PoolState::Created,
+            pool_status: None,
             ..Default::default()
         }
     }
-    /// Set when we cant get the Pool from control plane.
-    pub fn unknown() -> Self {
-        Self {
-            state: PoolState::Unknown,
-            status: Some(PoolStatus::Unknown),
-            ..Default::default()
-        }
-    }
+
     /// Set when operator is attempting delete on pool.
     pub fn terminating(p: Pool) -> Self {
         let state = p.state.unwrap_or_default();
@@ -143,8 +146,9 @@ impl DiskPoolStatus {
             0
         };
         Self {
-            state: PoolState::Terminating,
-            status: Some(state.status.into()),
+            state: PoolState::Online,
+            cr_state: CrPoolState::Terminating,
+            pool_status: Some(state.status.into()),
             capacity: state.capacity,
             used: state.used,
             available: free,
@@ -154,8 +158,18 @@ impl DiskPoolStatus {
     /// Set when deleting a Pool which is not accessible.
     pub fn terminating_when_unknown() -> Self {
         Self {
-            state: PoolState::Terminating,
-            status: Some(PoolStatus::Unknown),
+            state: PoolState::Unknown,
+            cr_state: CrPoolState::Terminating,
+            pool_status: Some(PoolStatus::Unknown),
+            ..Default::default()
+        }
+    }
+
+    pub fn mark_unknown() -> Self {
+        Self {
+            state: PoolState::Unknown,
+            cr_state: CrPoolState::Created,
+            pool_status: Some(PoolStatus::Unknown),
             ..Default::default()
         }
     }
@@ -175,40 +189,26 @@ impl From<RestPoolStatus> for PoolStatus {
 /// Returns DiskPoolStatus from Control plane pool object.
 impl From<Pool> for DiskPoolStatus {
     fn from(p: Pool) -> Self {
-        let state = p.state.expect("pool does not have state");
-        // todo: Should we set the pool to some sort of error state?
-        let free = if state.capacity > state.used {
-            state.capacity - state.used
+        if let Some(state) = p.state {
+            let free = if state.capacity > state.used {
+                state.capacity - state.used
+            } else {
+                0
+            };
+            Self {
+                state: PoolState::Online,
+                cr_state: CrPoolState::Created,
+                pool_status: Some(state.status.into()),
+                capacity: state.capacity,
+                used: state.used,
+                available: free,
+            }
         } else {
-            0
-        };
-        Self {
-            state: PoolState::Online,
-            status: Some(state.status.into()),
-            capacity: state.capacity,
-            used: state.used,
-            available: free,
+            Self {
+                state: PoolState::Online,
+                cr_state: CrPoolState::Created,
+                ..Default::default()
+            }
         }
-    }
-}
-
-/// converts the pool state into a string
-impl ToString for PoolState {
-    fn to_string(&self) -> String {
-        match self {
-            PoolState::Creating => "Creating",
-            PoolState::Created => "Created",
-            PoolState::Online => "Online",
-            PoolState::Unknown => "Unknown",
-            PoolState::Error => "Error",
-            PoolState::Terminating => "Terminating",
-        }
-        .to_string()
-    }
-}
-/// Pool state into a string
-impl From<PoolState> for String {
-    fn from(p: PoolState) -> Self {
-        p.to_string()
     }
 }

--- a/k8s/operators/src/diskpool/main.rs
+++ b/k8s/operators/src/diskpool/main.rs
@@ -23,9 +23,16 @@ use openapi::{
     clients::{self, tower::Url},
     models::{CreatePoolBody, Pool, RestJsonError},
 };
+
+use crate::crd::CrPoolState;
 use serde_json::json;
 use snafu::Snafu;
-use std::{collections::HashMap, ops::Deref, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    ops::Deref,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use tracing::{debug, error, info, trace, warn};
 
 const WHO_AM_I: &str = "DiskPool Operator";
@@ -87,6 +94,7 @@ pub(crate) struct ResourceContext {
     num_retries: u32,
     /// Reference to the operator context
     ctx: Arc<OperatorContext>,
+    event_info: Arc<Mutex<Vec<String>>>,
 }
 
 impl Deref for ResourceContext {
@@ -107,8 +115,6 @@ pub(crate) struct OperatorContext {
     http: clients::tower::ApiClient,
     /// Interval
     interval: u64,
-    /// Disable device validation before attempting to create the pool
-    disable_device_validation: bool,
 }
 
 impl OperatorContext {
@@ -123,6 +129,7 @@ impl OperatorContext {
         let resource = ResourceContext {
             inner: dsp,
             num_retries: 0,
+            event_info: Default::default(),
             ctx,
         };
 
@@ -135,7 +142,7 @@ impl OperatorContext {
                     if matches!(
                         resource.status,
                         Some(DiskPoolStatus {
-                            state: PoolState::Online,
+                            state: PoolState::Created,
                             ..
                         })
                     ) {
@@ -185,11 +192,16 @@ impl ResourceContext {
         Ok(Action::await_change())
     }
 
-    /// Our notification that we should remove the pool and then the finalizer
+    /// Remove pool from control plane if exist, Then delete it from map.
     #[tracing::instrument(fields(name = ?resource.name_any()) skip(resource))]
-    pub(crate) async fn delete_finalizer(resource: ResourceContext) -> Result<Action, Error> {
+    pub(crate) async fn delete_finalizer(
+        resource: ResourceContext,
+        attempt_delete: bool,
+    ) -> Result<Action, Error> {
         let ctx = resource.ctx.clone();
-        resource.delete_pool().await?;
+        if attempt_delete {
+            resource.delete_pool().await?;
+        }
         ctx.remove(resource.name_any()).await;
         Ok(Action::await_change())
     }
@@ -204,18 +216,19 @@ impl ResourceContext {
         Api::namespaced(self.ctx.k8s.clone(), &self.namespace().unwrap())
     }
 
+    /// Control plane pool handler.
     fn pools_api(&self) -> &dyn openapi::apis::pools_api::tower::client::Pools {
         self.ctx.http.pools_api()
     }
 
+    /// Control plane block device handler.
     fn block_devices_api(
         &self,
     ) -> &dyn openapi::apis::block_devices_api::tower::client::BlockDevices {
         self.ctx.http.block_devices_api()
     }
 
-    /// Patch the given dsp status to the state provided. When not online the
-    /// size should be assumed to be zero.
+    /// Patch the given dsp status to the state provided.
     async fn patch_status(&self, status: DiskPoolStatus) -> Result<DiskPool, Error> {
         let status = json!({ "status": status });
 
@@ -228,7 +241,6 @@ impl ResourceContext {
             .map_err(|source| Error::Kube { source })?;
 
         debug!(name = ?o.name_any(), old = ?self.status, new =?o.status, "status changed");
-
         Ok(o)
     }
 
@@ -236,29 +248,22 @@ impl ResourceContext {
     /// this resource it implies that it does not exist yet and so we create
     /// it. We set the state of the of the object to Creating, such that we
     /// can track the its progress
-    async fn start(&self) -> Result<Action, Error> {
+    async fn init_cr(&self) -> Result<Action, Error> {
         let _ = self.patch_status(DiskPoolStatus::default()).await?;
         Ok(Action::await_change())
     }
 
-    /// Mark the resource as errored which is its final state. A pool in the
-    /// error state will not be deleted.
-    async fn mark_error(&self) -> Result<Action, Error> {
-        let _ = self.patch_status(DiskPoolStatus::error()).await?;
-
-        error!(name = ?self.name_any(),"status set to error");
-        Ok(Action::await_change())
+    /// Mark Pool state as None as couldnt find already provisioned pool in control plane.
+    async fn mark_pool_not_found(&self) -> Result<Action, Error> {
+        self.patch_status(DiskPoolStatus::not_found()).await?;
+        error!(name = ?self.name_any(), "Pool not found, clearing status");
+        Ok(Action::requeue(Duration::from_secs(30)))
     }
 
-    /// patch the resource state to creating.
+    /// Patch the resource state to creating.
     async fn is_missing(&self) -> Result<Action, Error> {
         self.patch_status(DiskPoolStatus::default()).await?;
         Ok(Action::await_change())
-    }
-    /// patch the resource state to unknown
-    async fn mark_unknown(&self) -> Result<Action, Error> {
-        self.patch_status(DiskPoolStatus::unknown()).await?;
-        Ok(Action::requeue(Duration::from_secs(self.ctx.interval)))
     }
 
     /// Patch the resource state to terminating.
@@ -268,67 +273,15 @@ impl ResourceContext {
         Ok(Action::requeue(Duration::from_secs(self.ctx.interval)))
     }
 
-    /// Create or import the pool, on failure try again. When we reach max error
-    /// count we fail the whole thing.
+    /// Used to patch control plane state as Unknown.
+    async fn mark_unknown(&self) -> Result<Action, Error> {
+        self.patch_status(DiskPoolStatus::mark_unknown()).await?;
+        Ok(Action::requeue(Duration::from_secs(self.ctx.interval)))
+    }
+
+    /// Create or import the pool, on failure try again.
     #[tracing::instrument(fields(name = ?self.name_any(), status = ?self.status) skip(self))]
     pub(crate) async fn create_or_import(self) -> Result<Action, Error> {
-        if !self.ctx.disable_device_validation {
-            match self
-                .block_devices_api()
-                .get_node_block_devices(&self.spec.node(), Some(true))
-                .await
-            {
-                Ok(response) => {
-                    if !response.into_body().into_iter().any(|b| {
-                        b.devname == normalize_disk(&self.spec.disks()[0])
-                            || b.devlinks
-                                .iter()
-                                .any(|d| *d == normalize_disk(&self.spec.disks()[0]))
-                    }) {
-                        self.k8s_notify(
-                            "Create or import",
-                            "Missing",
-                            &format!(
-                                "The block device(s): {} can not be found",
-                                &self.spec.disks()[0]
-                            ),
-                            "Warn",
-                        )
-                        .await;
-
-                        return Err(Error::SpecError {
-                            value: self.spec.disks()[0].clone(),
-                            timeout: u32::pow(2, self.num_retries),
-                        });
-                    }
-                }
-                // We would land here if some error occurred ex, precondition failed, i.e. node
-                // down, in that case we check for pool existence before setting a status.
-                Err(_) => match self.pools_api().get_pool(&self.name_any()).await {
-                    Ok(response) => {
-                        let pool = response.into_body();
-                        // As pool exists, set the status based on the presence of pool state.
-                        return self.set_status_or_unknown(pool).await;
-                    }
-                    Err(clients::tower::Error::Request(_)) => {
-                        // Probably grpc server is not yet up
-                        return self.mark_unknown().await;
-                    }
-                    Err(clients::tower::Error::Response(err)) => {
-                        if err.status() == clients::tower::StatusCode::SERVICE_UNAVAILABLE
-                            || err.status() == clients::tower::StatusCode::REQUEST_TIMEOUT
-                        {
-                            // Probably grpc server is not yet up
-                            return self.mark_unknown().await;
-                        } else {
-                            // If we don't find the pool, i.e. its not present or not yet created
-                            // so, set the status to Creating to retry creation.
-                            return self.mark_error().await;
-                        }
-                    }
-                },
-            }
-        }
         let mut labels: HashMap<String, String> = HashMap::new();
         labels.insert(
             String::from(utils::CREATED_BY_KEY),
@@ -346,22 +299,75 @@ impl ResourceContext {
                 if response.status() == clients::tower::StatusCode::UNPROCESSABLE_ENTITY =>
             {
                 // UNPROCESSABLE_ENTITY indicates that the pool spec already exists in the
-                // control plane. So we want to update the CRD to
-                // 'Created' to reflect this.
+                // control plane. Keeping it idempotent.
             }
-            Err(e) => {
-                if self.num_retries == 10 {
-                    self.k8s_notify(
-                        "Create or Import Failure",
-                        "Failure",
-                        format!("Unable to create or import pool {}", e).as_str(),
-                        "Critical",
-                    )
-                    .await;
-                }
-                return Err(e.into());
+            Err(error) => {
+                return match self
+                    .block_devices_api()
+                    .get_node_block_devices(&self.spec.node(), Some(true))
+                    .await
+                {
+                    Ok(response) => {
+                        if !response.into_body().into_iter().any(|b| {
+                            b.devname == normalize_disk(&self.spec.disks()[0])
+                                || b.devlinks
+                                    .iter()
+                                    .any(|d| *d == normalize_disk(&self.spec.disks()[0]))
+                        }) {
+                            self.k8s_notify(
+                                "Create or import",
+                                "Missing",
+                                &format!(
+                                    "The block device(s): {} can not be found",
+                                    &self.spec.disks()[0]
+                                ),
+                                "Warn",
+                            )
+                            .await;
+                            error!(
+                                "The block device(s): {} can not be found",
+                                &self.spec.disks()[0]
+                            );
+                            Err(error.into())
+                        } else {
+                            self.k8s_notify(
+                                "Create or Import Failure",
+                                "Failure",
+                                format!("Unable to create or import pool {error}").as_str(),
+                                "Critical",
+                            )
+                            .await;
+                            error!("Unable to create or import pool {}", error);
+                            Err(error.into())
+                        }
+                    }
+                    Err(clients::tower::Error::Response(response))
+                        if response.status() == StatusCode::NOT_FOUND =>
+                    {
+                        self.k8s_notify(
+                            "Create or Import Failure",
+                            "Failure",
+                            format!("Unable to find io-engine node {}", &self.spec.node()).as_str(),
+                            "Critical",
+                        )
+                        .await;
+                        error!("Unable to find io-engine node {}", &self.spec.node());
+                        Err(error.into())
+                    }
+                    _ => {
+                        self.k8s_notify(
+                            "Create or Import Failure",
+                            "Failure",
+                            format!("Unable to create or import pool {error}").as_str(),
+                            "Critical",
+                        )
+                        .await;
+                        error!("Unable to create or import pool {}", error);
+                        Err(error.into())
+                    }
+                };
             }
-        };
+        }
 
         self.k8s_notify(
             "Create or Import",
@@ -371,29 +377,12 @@ impl ResourceContext {
         )
         .await;
 
-        let _ = self.patch_status(DiskPoolStatus::created()).await?;
-
-        // We are done creating the pool, we patched to created which triggers a
-        // new loop. Any error in the loop will call our error handler where we
-        // decide what to do
-        Ok(Action::await_change())
+        self.pool_created().await
     }
 
     /// Delete the pool from the io-engine instance
     #[tracing::instrument(fields(name = ?self.name_any(), status = ?self.status) skip(self))]
     async fn delete_pool(&self) -> Result<Action, Error> {
-        // Do not delete pools which are in the error state. We have no way of
-        // knowing whats wrong with the physical pool. Simply discard the CRD.
-        if matches!(
-            self.status,
-            Some(DiskPoolStatus {
-                state: PoolState::Error,
-                ..
-            })
-        ) {
-            return Ok(Action::await_change());
-        }
-
         let res = self
             .pools_api()
             .del_node_pool(&self.spec.node(), &self.name_any())
@@ -426,11 +415,9 @@ impl ResourceContext {
         }
     }
 
-    /// Online the pool which is no-op from the data plane point of view. However
-    /// it does provide us feedback from the k8s side of things which is
-    /// useful when trouble shooting.
+    /// Gets pool from control plane and sets state as applicable.
     #[tracing::instrument(fields(name = ?self.name_any(), status = ?self.status) skip(self))]
-    async fn online_pool(self) -> Result<Action, Error> {
+    async fn pool_created(self) -> Result<Action, Error> {
         let pool = self
             .pools_api()
             .get_node_pool(&self.spec.node(), &self.name_any())
@@ -477,7 +464,7 @@ impl ResourceContext {
                     } else {
                         tracing::warn!(pool = ?self.name_any(), "deleted by external event NOT recreating");
                         self.k8s_notify(
-                            "Offline",
+                            "Notfound",
                             "Check",
                             "The pool has been deleted through an external API request",
                             "Warning",
@@ -485,12 +472,19 @@ impl ResourceContext {
                             .await;
 
                         // We expected the control plane to have a spec for this pool. It didn't so
-                        // set the CRD to the error state and don't try to recreate it.
-                        self.mark_error().await
+                        // set the pool_status in CRD to None.
+                        self.mark_pool_not_found().await
                     }
                 } else if response.status() == clients::tower::StatusCode::SERVICE_UNAVAILABLE || response.status() == clients::tower::StatusCode::REQUEST_TIMEOUT {
                     // Probably grpc server is not yet up
-                    self.mark_unknown().await
+                    self.k8s_notify(
+                        "Unreachable",
+                        "Check",
+                        "Could not reach Rest API service. Please check control plane health",
+                        "Warning",
+                    )
+                        .await;
+                    self.mark_pool_not_found().await
                 } else {
                     self.k8s_notify(
                         "Missing",
@@ -504,7 +498,7 @@ impl ResourceContext {
             }
             Err(clients::tower::Error::Request(_)) => {
                 // Probably grpc server is not yet up
-                return self.mark_unknown().await;
+                return self.mark_pool_not_found().await
             }
         }.into_body();
         // As pool exists, set the status based on the presence of pool state.
@@ -518,7 +512,7 @@ impl ResourceContext {
             if let Some(status) = &self.status {
                 let mut new_status = DiskPoolStatus::from(pool);
                 if self.metadata.deletion_timestamp.is_some() {
-                    new_status.state = PoolState::Terminating;
+                    new_status.cr_state = CrPoolState::Terminating;
                 }
                 if status != &new_status {
                     // update the usage state such that users can see the values changes
@@ -527,20 +521,6 @@ impl ResourceContext {
                 }
             }
         } else {
-            // There is no pool state, so we can't determine the health of the pool. Reflect this in
-            // the CRD as an 'Unknown' state.
-            if let Some(status) = &self.status {
-                if status.state != PoolState::Unknown {
-                    debug!("Missing pool state. Setting dsp state to 'Unknown'.");
-                    self.k8s_notify(
-                        "Unknown",
-                        "Check",
-                        "Missing pool state. Setting state to 'Unknown'.",
-                        "Warning",
-                    )
-                    .await;
-                }
-            }
             return if self.metadata.deletion_timestamp.is_some() {
                 self.mark_terminating_when_unknown().await
             } else {
@@ -573,36 +553,44 @@ impl ResourceContext {
         let e: Api<Event> = Api::namespaced(client.clone(), &ns);
         let pp = PostParams::default();
         let time = Utc::now();
-
-        let metadata = ObjectMeta {
-            // the name must be unique for all events we post
-            generate_name: Some(format!("{}.{:x}", self.name_any(), time.timestamp())),
-            namespace: Some(ns),
-            ..Default::default()
+        let contains = {
+            self.event_info
+                .lock()
+                .unwrap()
+                .contains(&message.to_string())
         };
+        if !contains {
+            self.event_info.lock().unwrap().push(message.to_string());
+            let metadata = ObjectMeta {
+                // the name must be unique for all events we post
+                generate_name: Some(format!("{}.{:x}", self.name_any(), time.timestamp())),
+                namespace: Some(ns),
+                ..Default::default()
+            };
 
-        let _ = e
-            .create(
-                &pp,
-                &Event {
-                    event_time: Some(MicroTime(time)),
-                    involved_object: self.object_ref(&()),
-                    action: Some(action.into()),
-                    reason: Some(reason.into()),
-                    type_: Some(type_.into()),
-                    metadata,
-                    reporting_component: Some(WHO_AM_I_SHORT.into()),
-                    reporting_instance: Some(
-                        std::env::var("MY_POD_NAME")
-                            .ok()
-                            .unwrap_or_else(|| WHO_AM_I_SHORT.into()),
-                    ),
-                    message: Some(message.into()),
-                    ..Default::default()
-                },
-            )
-            .await
-            .map_err(|e| error!(?e));
+            let _ = e
+                .create(
+                    &pp,
+                    &Event {
+                        event_time: Some(MicroTime(time)),
+                        involved_object: self.object_ref(&()),
+                        action: Some(action.into()),
+                        reason: Some(reason.into()),
+                        type_: Some(type_.into()),
+                        metadata,
+                        reporting_component: Some(WHO_AM_I_SHORT.into()),
+                        reporting_instance: Some(
+                            std::env::var("MY_POD_NAME")
+                                .ok()
+                                .unwrap_or_else(|| WHO_AM_I_SHORT.into()),
+                        ),
+                        message: Some(message.into()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .map_err(|error| error!(?error));
+        }
     }
 
     /// Callback hooks for the finalizers
@@ -615,18 +603,26 @@ impl ResourceContext {
                 match event {
                     finalizer::Event::Apply(dsp) => Self::put_finalizer(dsp).await,
                     finalizer::Event::Cleanup(dsp) => {
-                        if dsp.status.as_ref().unwrap().state != PoolState::Terminating {
-                            info!("set state as terminating");
-                            let pool = self
-                                .pools_api()
-                                .get_node_pool(&self.spec.node(), &self.name_any())
-                                .await?
-                                .into_body();
-                            let new_status = DiskPoolStatus::terminating(pool);
-                            let _ = self.patch_status(new_status).await?;
+                        match self
+                            .pools_api()
+                            .get_node_pool(&self.spec.node(), &self.name_any())
+                            .await
+                        {
+                            Ok(pool) => {
+                                if dsp.status.as_ref().unwrap().cr_state != CrPoolState::Terminating
+                                {
+                                    let new_status = DiskPoolStatus::terminating(pool.into_body());
+                                    let _ = self.patch_status(new_status).await?;
+                                }
+                                Self::delete_finalizer(self.clone(), true).await
+                            }
+                            Err(clients::tower::Error::Response(response))
+                                if response.status() == StatusCode::NOT_FOUND =>
+                            {
+                                Self::delete_finalizer(self.clone(), false).await
+                            }
+                            Err(error) => Err(error.into()),
                         }
-                        info!("Calling delete finalizer");
-                        Self::delete_finalizer(self.clone()).await
                     }
                 }
             },
@@ -650,28 +646,15 @@ async fn ensure_crd(k8s: Client) {
     // Create new if it doesnt exist.
     let mut crd = DiskPool::crd();
     let crd_name = crd.metadata.name.as_ref().unwrap().as_str();
-    if let Ok(exiting) = dsp.get(crd_name).await {
-        crd.metadata.resource_version = exiting.resource_version();
+    let result = if let Ok(existing) = dsp.get(crd_name).await {
+        crd.metadata.resource_version = existing.resource_version();
         info!(
-            "Creating CRD: {}",
+            "Replacing CRD: {}",
             serde_json::to_string_pretty(&crd).unwrap()
         );
 
         let pp = PostParams::default();
-        match dsp.replace(crd_name, &pp, &crd).await {
-            Ok(o) => {
-                info!(crd = ?o.name_any(), "created");
-                // let the CRD settle this purely to avoid errors messages in the console
-                // that are harmless but can cause some confusion maybe.
-                tokio::time::sleep(Duration::from_secs(5)).await;
-            }
-
-            Err(e) => {
-                error!("failed to create CRD error {}", e);
-                tokio::time::sleep(Duration::from_secs(1)).await;
-                std::process::exit(1);
-            }
-        }
+        dsp.replace(crd_name, &pp, &crd).await
     } else {
         info!(
             "Creating CRD: {}",
@@ -679,22 +662,25 @@ async fn ensure_crd(k8s: Client) {
         );
 
         let pp = PostParams::default();
-        match dsp.create(&pp, &crd).await {
-            Ok(o) => {
-                info!(crd = ?o.name_any(), "created");
-                // let the CRD settle this purely to avoid errors messages in the console
-                // that are harmless but can cause some confusion maybe.
-                tokio::time::sleep(Duration::from_secs(5)).await;
-            }
+        dsp.create(&pp, &crd).await
+    };
+    match result {
+        Ok(o) => {
+            info!(crd = ?o.name_any(), "created");
+            // let the CRD settle this purely to avoid errors messages in the console
+            // that are harmless but can cause some confusion maybe.
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
 
-            Err(e) => {
-                error!("failed to create CRD error {}", e);
-                tokio::time::sleep(Duration::from_secs(1)).await;
-                std::process::exit(1);
-            }
+        Err(e) => {
+            error!("failed to create CRD error {}", e);
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            std::process::exit(1);
         }
     }
 }
+
+const BACKOFF_PERIOD: u64 = 20;
 
 /// Determine what we want to do when dealing with errors from the
 /// reconciliation loop
@@ -705,7 +691,7 @@ fn error_policy(_object: Arc<DiskPool>, error: &Error, _ctx: Arc<OperatorContext
         Error::ReconcileError { .. } => {
             return Action::await_change();
         }
-        _ => 20,
+        _ => BACKOFF_PERIOD,
     });
 
     let when = Utc::now()
@@ -728,41 +714,21 @@ async fn reconcile(dsp: Arc<DiskPool>, ctx: Arc<OperatorContext>) -> Result<Acti
 
     match dsp.status {
         Some(DiskPoolStatus {
-            state: PoolState::Creating,
+            cr_state: CrPoolState::Creating,
             ..
         }) => dsp.create_or_import().await,
 
         Some(DiskPoolStatus {
-            state: PoolState::Created,
-            ..
-        }) => dsp.online_pool().await,
-
-        Some(DiskPoolStatus {
-            state: PoolState::Online,
+            cr_state: CrPoolState::Created,
             ..
         })
         | Some(DiskPoolStatus {
-            state: PoolState::Unknown,
-            ..
-        })
-        | Some(DiskPoolStatus {
-            state: PoolState::Terminating,
+            cr_state: CrPoolState::Terminating,
             ..
         }) => dsp.pool_check().await,
-
-        Some(DiskPoolStatus {
-            state: PoolState::Error,
-            ..
-        }) => {
-            error!(pool = ?dsp.name_any(), "entered error as final state");
-            Err(Error::ReconcileError {
-                name: dsp.name_any(),
-            })
-        }
-
         // We use this state to indicate its a new CRD however, we could (and
         // perhaps should) use the finalizer callback.
-        None => dsp.start().await,
+        None => dsp.init_cr().await,
     }
 }
 
@@ -803,7 +769,6 @@ async fn pool_controller(args: ArgMatches) -> anyhow::Result<()> {
             .parse::<humantime::Duration>()
             .expect("interval value is invalid")
             .as_secs(),
-        disable_device_validation: args.get_flag("disable-device-validation"),
     };
 
     info!(


### PR DESCRIPTION
### mark dsp as terminating before deleting it

Currently when dsp cr is deleted, cmd gets hung if for some reason pool deletion is failing. Pool status stays as Online evnthough operator is trying to delete pool as part of reconcilation.

Signed-off-by: Abhilash Shetty [abhilash.shetty@datacore.com](mailto:abhilash.shetty@datacore.com)

### add respective control plane pool status in dsp cr
adding control plane pool status in CR. This is as is representation of respective control plane Pool resource state.

Signed-off-by: Abhilash Shetty [abhilash.shetty@datacore.com](mailto:abhilash.shetty@datacore.com)

### added new cr states to align with control plane states
added new cr state field. Reconciling on new states.

Signed-off-by: Abhilash Shetty <abhilash.shetty@datacore.com>