### PR TITLE
Fix stuck container creating error

### DIFF
--- a/common/src/types/v0/store/mod.rs
+++ b/common/src/types/v0/store/mod.rs
@@ -79,6 +79,10 @@ pub trait SpecTransaction<Operation> {
     fn start_op(&mut self, operation: Operation);
     /// Sets the result of the operation
     fn set_op_result(&mut self, result: bool);
+    /// Allow this operation while deleting a spec.
+    fn allow_op_deleting(&mut self, _operation: &Operation) -> bool {
+        false
+    }
 }
 
 /// Sequence operations for a resource without locking it

--- a/common/src/types/v0/store/replica.rs
+++ b/common/src/types/v0/store/replica.rs
@@ -269,6 +269,10 @@ impl SpecTransaction<ReplicaOperation> for ReplicaSpec {
             op.result = Some(result);
         }
     }
+
+    fn allow_op_deleting(&mut self, operation: &ReplicaOperation) -> bool {
+        matches!(operation, ReplicaOperation::OwnerUpdate(_))
+    }
 }
 
 /// Available Replica Operations

--- a/common/src/types/v0/transport/nexus.rs
+++ b/common/src/types/v0/transport/nexus.rs
@@ -397,6 +397,12 @@ impl CreateNexus {
         let name = self.owner.as_ref().map(|i| i.to_string());
         name.unwrap_or_else(|| self.uuid.to_string())
     }
+    /// Name of the nexus as uuid.
+    /// When part of a volume, it's set to its `VolumeId`. Otherwise it's set to its `NexusId`.
+    pub fn name_uuid(&self) -> uuid::Uuid {
+        let name = self.owner.as_ref().map(|i| *i.uuid());
+        name.unwrap_or_else(|| *self.uuid.uuid())
+    }
 
     /// Return the key that should be used by the Io-Engine to persist the NexusInfo.
     pub fn nexus_info_key(&self) -> String {

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/garbage_collector.rs
@@ -47,7 +47,9 @@ impl TaskPoller for GarbageCollector {
 
     async fn poll_event(&mut self, context: &PollContext) -> bool {
         match context.event() {
-            PollEvent::TimedRun | PollEvent::Triggered(PollTriggerEvent::Start) => true,
+            PollEvent::TimedRun
+            | PollEvent::Triggered(PollTriggerEvent::Start)
+            | PollEvent::Triggered(PollTriggerEvent::ResourceCreatingToDeleting) => true,
             PollEvent::Shutdown | PollEvent::Triggered(_) => false,
         }
     }

--- a/control-plane/agents/src/bin/core/controller/reconciler/poller.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/poller.rs
@@ -27,10 +27,10 @@ impl ReconcilerWorker {
     /// Create a new `Self` with the provided communication channels
     pub(super) fn new() -> Self {
         let poll_targets: Vec<Box<dyn TaskPoller>> = vec![
+            Box::new(PersistentStoreReconciler::new()),
             Box::new(pool::PoolReconciler::new()),
             Box::new(nexus::NexusReconciler::new()),
             Box::new(volume::VolumeReconciler::new()),
-            Box::new(PersistentStoreReconciler::new()),
             Box::new(replica::ReplicaReconciler::new()),
             Box::new(node::NodeReconciler::new()),
         ];

--- a/control-plane/agents/src/bin/core/controller/reconciler/replica/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/replica/mod.rs
@@ -146,7 +146,7 @@ async fn destroy_orphaned_replica(
 ) -> PollResult {
     let destroy_owned = {
         let replica = replica.as_ref();
-        replica.managed && !replica.owned()
+        replica.managed && !replica.owned() && !replica.status().deleted()
     };
 
     if destroy_owned {

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
@@ -57,6 +57,7 @@ impl TaskPoller for GarbageCollector {
         match context.event() {
             PollEvent::TimedRun
             | PollEvent::Triggered(PollTriggerEvent::VolumeDegraded)
+            | PollEvent::Triggered(PollTriggerEvent::ResourceCreatingToDeleting)
             | PollEvent::Triggered(PollTriggerEvent::Start) => true,
             PollEvent::Shutdown | PollEvent::Triggered(_) => false,
         }

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -21,6 +21,7 @@ use common_lib::{
 };
 
 use super::{OperationGuardArc, ResourceMutex, ResourceUid, UpdateInnerValue};
+use crate::controller::task_poller::PollTriggerEvent;
 use async_trait::async_trait;
 use parking_lot::RwLock;
 use serde::de::DeserializeOwned;
@@ -42,6 +43,17 @@ enum SpecError {
     /// Failed to get entries from the persistent store.
     #[snafu(display("Key does not contain UUID"))]
     KeyUuid {},
+}
+
+/// What to do when creation fails.
+pub(crate) enum OnCreateFail {
+    /// Leave object as `Creating`, could allow for frontend retries.
+    #[allow(unused)]
+    LeaveAsIs,
+    /// When frontend retries don't make sense, set it to deleting so we can clean-up.
+    SetDeleting,
+    /// When there's no need to garbage collect, simply delete it.
+    Delete,
 }
 
 /// This trait is used to encapsulate common behaviour for all different types of resources,
@@ -100,12 +112,14 @@ pub(crate) trait GuardedOperationsHelper:
     /// Completes a create operation by trying to update the spec in the persistent store.
     /// If the persistent store operation fails then the spec is marked accordingly and the dirty
     /// spec reconciler will attempt to update the store when the store is back online.
-    /// todo: The state of the object is left as Creating for now. Determine whether to set it to
-    /// Deleted or let the reconciler clean it up.
+    /// # Note:
+    /// `on_err_destroy` is used to determine if the resource spec should be deleted on error.
+    /// On most cases we don't want to destroy as that will prevent garbage collection.
     async fn complete_create<O, R: Send>(
         &self,
         result: Result<R, SvcError>,
         registry: &Registry,
+        on_fail: OnCreateFail,
     ) -> Result<R, SvcError>
     where
         Self::Inner: SpecTransaction<O>,
@@ -127,17 +141,12 @@ pub(crate) trait GuardedOperationsHelper:
                     }
                 }
             }
-            Err(error) => {
-                // The create failed so delete the spec.
-                self.delete_spec(registry).await.ok();
-                Err(error)
-            }
+            Err(error) => Err(self.handle_create_failed(registry, error, on_fail).await),
         }
     }
 
     /// Validates the outcome of a create step.
-    /// In case of an error, an attempt is made to delete the spec in the persistent store and
-    /// registry.
+    /// In case of an error, the object is set to deleting.
     async fn validate_create_step<R: Send, O>(
         &self,
         registry: &Registry,
@@ -147,11 +156,54 @@ pub(crate) trait GuardedOperationsHelper:
         Self::Inner: SpecTransaction<O>,
         Self::Inner: StorableObject,
     {
+        self.validate_create_step_ext(registry, result, OnCreateFail::SetDeleting)
+            .await
+    }
+
+    /// Validates the outcome of a create step.
+    /// In case of an error, it is handled as per the `OnCreateFail` policy.
+    async fn validate_create_step_ext<R: Send, O>(
+        &self,
+        registry: &Registry,
+        result: Result<R, SvcError>,
+        on_fail: OnCreateFail,
+    ) -> Result<R, SvcError>
+    where
+        Self::Inner: SpecTransaction<O>,
+        Self::Inner: StorableObject,
+    {
         match result {
             Ok(val) => Ok(val),
-            Err(error) => {
+            Err(error) => Err(self.handle_create_failed(registry, error, on_fail).await),
+        }
+    }
+
+    /// Handles a failed creation according to the `OnCreateFail` policy.
+    async fn handle_create_failed<O>(
+        &self,
+        registry: &Registry,
+        error: SvcError,
+        on_fail: OnCreateFail,
+    ) -> SvcError
+    where
+        Self::Inner: SpecTransaction<O>,
+        Self::Inner: StorableObject,
+    {
+        match on_fail {
+            OnCreateFail::LeaveAsIs => error,
+            OnCreateFail::SetDeleting => {
+                // Let the garbage collector delete the spec gracefully.
+                // This will ensure we'll delete previously created resources.
+                let spec = self.lock().fail_creating_to_deleting();
+                registry.store_obj(&spec).await.ok();
+                registry
+                    .notify(PollTriggerEvent::ResourceCreatingToDeleting)
+                    .await;
+                error
+            }
+            OnCreateFail::Delete => {
                 self.delete_spec(registry).await.ok();
-                Err(error)
+                error
             }
         }
     }
@@ -423,7 +475,12 @@ pub(crate) trait GuardedOperationsHelper:
     {
         let spec_status = self.lock().status();
         match spec_status {
-            SpecStatus::Creating | SpecStatus::Deleted => {
+            SpecStatus::Creating => {
+                // Go to deleting stage to make sure we clean-up previously allocated resources.
+                self.lock().set_status(SpecStatus::Deleting);
+                true
+            }
+            SpecStatus::Deleted => {
                 self.delete_spec(registry).await.ok();
                 true
             }
@@ -626,6 +683,15 @@ pub(crate) trait SpecOperationsHelper:
     fn status(&self) -> SpecStatus<Self::Status>;
     /// Set the state of the object
     fn set_status(&mut self, state: SpecStatus<Self::Status>);
+    /// When creating fails we might want to transition spec to deleting and clear the create op.
+    fn fail_creating_to_deleting<O>(&mut self) -> Self
+    where
+        Self: SpecTransaction<O>,
+    {
+        self.set_status(SpecStatus::Deleting);
+        self.clear_op();
+        self.clone()
+    }
     /// Check if the object is owned by another
     fn owned(&self) -> bool {
         false

--- a/control-plane/agents/src/bin/core/controller/states.rs
+++ b/control-plane/agents/src/bin/core/controller/states.rs
@@ -53,6 +53,11 @@ impl ResourceStates {
         self.nexuses.populate(nexuses);
     }
 
+    /// Update nexus state.
+    pub(crate) fn update_nexus(&mut self, nexus: Nexus) {
+        self.nexuses.insert(nexus.into());
+    }
+
     /// Returns a vector of cloned nexus states.
     pub(crate) fn nexus_states_cloned(&self) -> Vec<NexusState> {
         Self::cloned_inner_states(self.nexuses.values())

--- a/control-plane/agents/src/bin/core/controller/task_poller.rs
+++ b/control-plane/agents/src/bin/core/controller/task_poller.rs
@@ -22,6 +22,8 @@ pub(crate) enum PollTriggerEvent {
     /// A volume has been published in a Degraded state
     /// eg: may need replicas to be carved and/or added
     VolumeDegraded,
+    /// Resource Set to Deleting from Creating, garbage collection required.
+    ResourceCreatingToDeleting,
     /// The Agent is starting up
     Start,
 }

--- a/control-plane/agents/src/bin/core/nexus/operations.rs
+++ b/control-plane/agents/src/bin/core/nexus/operations.rs
@@ -5,11 +5,13 @@ use crate::{
             operations::{
                 ResourceLifecycle, ResourceOffspring, ResourceSharing, ResourceShutdownOperations,
             },
-            operations_helper::{GuardedOperationsHelper, OnCreateFail, OperationSequenceGuard},
+            operations_helper::{
+                GuardedOperationsHelper, OnCreateFail, OperationSequenceGuard, SpecOperationsHelper,
+            },
             OperationGuardArc, TraceSpan,
         },
         scheduling::resources::HealthyChildItems,
-        wrapper::{ClientOps, GetterOps},
+        wrapper::{ClientOps, GetterOps, NodeWrapper},
     },
     nexus::scheduling::healthy_nexus_children,
 };
@@ -52,7 +54,7 @@ impl ResourceLifecycle for OperationGuardArc<NexusSpec> {
             .await?;
         let _ = nexus.start_create(registry, request).await?;
 
-        let result = node.create_nexus(request).await;
+        let result = nexus.create_nexus(registry, node, request).await;
         specs.on_create_set_owners(request, &nexus, &result);
 
         let nexus_state = nexus
@@ -342,6 +344,47 @@ impl ResourceShutdownOperations for OperationGuardArc<NexusSpec> {
 }
 
 impl OperationGuardArc<NexusSpec> {
+    async fn create_nexus(
+        &self,
+        registry: &Registry,
+        node: std::sync::Arc<tokio::sync::RwLock<NodeWrapper>>,
+        request: &CreateNexus,
+    ) -> Result<Nexus, SvcError> {
+        let error = match node.create_nexus(request).await {
+            Err(error @ SvcError::AlreadyExists { .. }) => error,
+            other => return other,
+        };
+
+        let retry = match node.volume_nexus(&request.name_uuid().into()).await {
+            Some(existing_nexus) => match registry.specs().nexus_rsc(&existing_nexus.uuid) {
+                Some(nexus) => {
+                    tracing::error!(volume.uuid=%existing_nexus.name, nexus.uuid=%existing_nexus.uuid, "A NexusSpec already exists for the given volume");
+                    match nexus.operation_guard() {
+                        Ok(mut nexus) if nexus.lock().status().deleting() => nexus
+                            .destroy(
+                                registry,
+                                &DestroyNexus::from(existing_nexus).with_disown_all(),
+                            )
+                            .await
+                            .is_ok(),
+                        _ => false,
+                    }
+                }
+                None => {
+                    tracing::warn!(volume.uuid=%existing_nexus.name, nexus.uuid=%existing_nexus.uuid, "Removing nexus for unknown NexusSpec");
+                    // Node spec exists for this nexus, let's delete it and try once more..
+                    node.destroy_nexus(&DestroyNexus::from(existing_nexus).with_disown_all())
+                        .await
+                        .is_ok()
+                }
+            },
+            None => false,
+        };
+        match retry {
+            true => node.create_nexus(request).await,
+            false => Err(error),
+        }
+    }
     /// Recreate the nexus as a part of the republish call.
     pub(crate) async fn missing_nexus_recreate(
         &mut self,

--- a/control-plane/agents/src/bin/core/nexus/operations.rs
+++ b/control-plane/agents/src/bin/core/nexus/operations.rs
@@ -5,7 +5,7 @@ use crate::{
             operations::{
                 ResourceLifecycle, ResourceOffspring, ResourceSharing, ResourceShutdownOperations,
             },
-            operations_helper::{GuardedOperationsHelper, OperationSequenceGuard},
+            operations_helper::{GuardedOperationsHelper, OnCreateFail, OperationSequenceGuard},
             OperationGuardArc, TraceSpan,
         },
         scheduling::resources::HealthyChildItems,
@@ -55,7 +55,9 @@ impl ResourceLifecycle for OperationGuardArc<NexusSpec> {
         let result = node.create_nexus(request).await;
         specs.on_create_set_owners(request, &nexus, &result);
 
-        let nexus_state = nexus.complete_create(result, registry).await?;
+        let nexus_state = nexus
+            .complete_create(result, registry, OnCreateFail::SetDeleting)
+            .await?;
         Ok((nexus, nexus_state))
     }
 

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -2,7 +2,7 @@ use crate::controller::{
     registry::Registry,
     resources::{
         operations::ResourceLifecycle,
-        operations_helper::{GuardedOperationsHelper, OperationSequenceGuard},
+        operations_helper::{GuardedOperationsHelper, OnCreateFail, OperationSequenceGuard},
         OperationGuardArc,
     },
     wrapper::ClientOps,
@@ -45,7 +45,9 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
 
         let result = node.create_pool(request).await;
 
-        let pool_state = pool.complete_create(result, registry).await?;
+        let pool_state = pool
+            .complete_create(result, registry, OnCreateFail::SetDeleting)
+            .await?;
         let spec = pool.lock().clone();
         Ok(Pool::new(spec, pool_state))
     }

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -44,10 +44,9 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
         let _ = pool.start_create(registry, request).await?;
 
         let result = node.create_pool(request).await;
+        let on_fail = OnCreateFail::eeinval_delete(&result);
 
-        let pool_state = pool
-            .complete_create(result, registry, OnCreateFail::SetDeleting)
-            .await?;
+        let pool_state = pool.complete_create(result, registry, on_fail).await?;
         let spec = pool.lock().clone();
         Ok(Pool::new(spec, pool_state))
     }

--- a/control-plane/agents/src/bin/core/pool/replica_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/replica_operations.rs
@@ -2,7 +2,7 @@ use crate::controller::{
     registry::Registry,
     resources::{
         operations::{ResourceLifecycle, ResourceOwnerUpdate, ResourceSharing},
-        operations_helper::{GuardedOperationsHelper, OperationSequenceGuard},
+        operations_helper::{GuardedOperationsHelper, OnCreateFail, OperationSequenceGuard},
         OperationGuardArc, UpdateInnerValue,
     },
     wrapper::ClientOps,
@@ -42,7 +42,9 @@ impl ResourceLifecycle for OperationGuardArc<ReplicaSpec> {
         let _ = replica.start_create(registry, request).await?;
 
         let result = node.create_replica(request).await;
-        replica.complete_create(result, registry).await
+        replica
+            .complete_create(result, registry, OnCreateFail::SetDeleting)
+            .await
     }
 
     async fn destroy(

--- a/control-plane/agents/src/bin/core/pool/replica_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/replica_operations.rs
@@ -42,9 +42,9 @@ impl ResourceLifecycle for OperationGuardArc<ReplicaSpec> {
         let _ = replica.start_create(registry, request).await?;
 
         let result = node.create_replica(request).await;
-        replica
-            .complete_create(result, registry, OnCreateFail::SetDeleting)
-            .await
+        let on_fail = OnCreateFail::eeinval_delete(&result);
+
+        replica.complete_create(result, registry, on_fail).await
     }
 
     async fn destroy(

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -62,7 +62,9 @@ impl ResourceLifecycle for OperationGuardArc<VolumeSpec> {
         // todo: pick nodes and pools using the Node&Pool Topology
         // todo: virtually increase the pool usage to avoid a race for space with concurrent calls
         let result = create_volume_replicas(registry, request).await;
-        let create_replicas = volume.validate_create_step(registry, result).await?;
+        let create_replicas = volume
+            .validate_create_step_ext(registry, result, OnCreateFail::Delete)
+            .await?;
 
         let mut replicas = Vec::<Replica>::new();
         for replica in &create_replicas {


### PR DESCRIPTION
    fix(nexus/create): destroy unused nexuses on creation
    
    When creation fails due to an unused nexus (no equivalent spec), or deleting nexus,
    simply destroy said nexus and retry the creation attempt once.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(volume/publish): clean up nexus/spec on failure
    
    For some weird reasons, after each nexus creation we check if the nexus is listed by the io=engine.
    This is due to the new v1 idempotency where if already exists an error is returned.
    
    When creating the first time we don't need this listing because we already have the nexus returned.
    The listing was actually creating a weird bug where it was timing out after a successful creation.
    To fix this properly, a new enum `OnCreateFail` was introduced which allows us to control the
    behaviour when create fails. By default it will be set to `SetDeleting` which means we'll set the
    spec to Deleting on a failed creation allowing the garbage collector to clean up..
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
