### PR TITLE
chore: don't rebuild when git HEAD and index changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,22 +1573,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
-name = "git-version"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
-dependencies = [
- "git-version-macro",
- "proc-macro-hack",
-]
-
-[[package]]
 name = "git-version-macro"
 version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -2823,12 +2810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3071,7 +3052,6 @@ dependencies = [
  "composer",
  "deployer-cluster",
  "futures",
- "git-version",
  "grpc",
  "http",
  "humantime",
@@ -4323,7 +4303,7 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 name = "utils"
 version = "0.1.0"
 dependencies = [
- "git-version",
+ "git-version-macro",
  "opentelemetry",
  "opentelemetry-jaeger",
  "tracing",
@@ -4364,7 +4344,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 name = "version-info"
 version = "0.1.0"
 dependencies = [
- "git-version",
+ "git-version-macro",
  "regex",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,9 @@ members = [
     "utils/utils-lib",
     "utils/pstor-usage",
     "utils/shutdown",
-    "utils/dependencies/composer",
-    "utils/dependencies/devinfo",
-    "utils/dependencies/nvmeadm",
-    "utils/dependencies/sysfs",
-    "utils/dependencies/version-info",
     "utils/deployer-cluster",
-    # Test io-engine through the rest api
     "tests/io-engine",
+]
+exclude = [
+    "utils/dependencies/*",
 ]

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -42,7 +42,6 @@ jsonwebtoken = "8.1.1"
 common-lib = { path = "../../common" }
 utils = { path = "../../utils/utils-lib" }
 humantime = "2.1.0"
-git-version = "0.3.5"
 grpc = { path = "../grpc" }
 num_cpus = "1.13.1"
 

--- a/scripts/nix/git-submodule-init.sh
+++ b/scripts/nix/git-submodule-init.sh
@@ -6,7 +6,7 @@ FORCE=
 while [ "$#" -gt 0 ]; do
   case $1 in
     -f|--force)
-      FORCE="true"
+      FORCE="--force"
       shift
       ;;
     *)
@@ -16,9 +16,15 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-for mod in `git config --file .gitmodules --get-regexp path | awk '{ print $2 }'`; do
+submodule_init() {
+  for mod in `git config --file .gitmodules --get-regexp path | awk '{ print $2 }'`; do
     if [ -n "$FORCE" ] || [ ! -f $mod/.git ]; then
-       git submodule update --init --recursive $mod
+      git submodule update $FORCE --init --recursive $mod
     fi
+    pushd $mod 1>/dev/null
+    submodule_init
+    popd 1>/dev/null
 done
+}
 
+submodule_init

--- a/utils/utils-lib/Cargo.toml
+++ b/utils/utils-lib/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "utils"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-git-version = "0.3.5"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.15", features = [ "env-filter" ] }
 tracing-opentelemetry = "0.17.4"
 opentelemetry = { version = "0.17.0", features = ["rt-tokio-current-thread"] }
 opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio-current-thread"] }
-version-info = { path = "../dependencies/version-info" }
+version-info = { path = "../dependencies/version-info", default-features = false }
+git-version-macro = { path = "../dependencies/rust-git-version/git-version-macro" }

--- a/utils/utils-lib/src/lib.rs
+++ b/utils/utils-lib/src/lib.rs
@@ -5,7 +5,7 @@ pub mod tracing_telemetry;
 
 pub(crate) mod test_constants;
 
-pub use version_info::{
-    package_description, print_package_info, raw_version_str, raw_version_string, version_info,
-    version_info_str, VersionInfo,
-};
+pub mod version;
+
+pub use version::{long_raw_version_str, raw_version_str, raw_version_string};
+pub use version_info::{version_info as version_info_inner, VersionInfo};

--- a/utils/utils-lib/src/version.rs
+++ b/utils/utils-lib/src/version.rs
@@ -1,0 +1,88 @@
+pub mod macros {
+    /// Makes a version info instance.
+    #[macro_export]
+    macro_rules! version_info {
+        () => {{
+            $crate::version_info_inner!($crate::long_raw_version_str())
+        }};
+    }
+
+    /// Returns a version info instance.
+    #[macro_export]
+    macro_rules! package_description {
+        () => {
+            $crate::version_info!().fmt_description()
+        };
+    }
+
+    /// Gets package's version info as a String.
+    #[macro_export]
+    macro_rules! version_info_string {
+        () => {
+            String::from($crate::version_info!())
+        };
+    }
+
+    /// Gets package's version info as a static str.
+    /// Each call to this macro leaks a string.
+    #[macro_export]
+    macro_rules! version_info_str {
+        () => {
+            Box::leak(Box::new(String::from($crate::version_info!()))) as &'static str
+        };
+    }
+
+    /// Formats package related information.
+    /// This includes the package name and version, and commit info.
+    #[macro_export]
+    macro_rules! fmt_package_info {
+        () => {{
+            let vi = $crate::version_info!();
+            format!("{} {}", vi.fmt_description(), vi)
+        }};
+    }
+
+    /// Prints package related information.
+    /// This includes the package name and version, and commit info.
+    #[macro_export]
+    macro_rules! print_package_info {
+        () => {
+            println!("{}", $crate::fmt_package_info!());
+        };
+    }
+}
+
+/// Analogous to `version_info::raw_version_string`.
+pub fn raw_version_string() -> String {
+    String::from(raw_version_str())
+}
+
+/// Analogous to `version_info::raw_version_str`.
+pub fn raw_version_str() -> &'static str {
+    // to keep clippy happy
+    #[allow(dead_code)]
+    fn fallback() -> &'static str {
+        option_env!("GIT_VERSION").expect("git version fallback")
+    }
+
+    git_version_macro::git_version!(
+        args = ["--abbrev=12", "--always"],
+        fallback = fallback(),
+        git_deps = []
+    )
+}
+
+/// Analogous to `version_info::long_raw_version_str`.
+pub fn long_raw_version_str() -> &'static str {
+    // to keep clippy happy
+    #[allow(dead_code)]
+    fn fallback() -> &'static str {
+        option_env!("GIT_VERSION_LONG").expect("git version fallback")
+    }
+
+    git_version_macro::git_version!(
+        args = ["--abbrev=12", "--always", "--long"],
+        fallback = fallback(),
+        git_deps = []
+    )
+}


### PR DESCRIPTION
Container images are built with the version provided by nix so we don't necesserily need to keep local builds with the right version.
This makes development a lot faster as otherwise for every git stage change or commit we have to rebuild everything.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>