### PR TITLE
Destroy pools even when they are not loaded

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
@@ -12,9 +12,9 @@ use stor_port::{
     transport_api::v0::BlockDevices,
     types::v0::transport::{
         AddNexusChild, CreateNexus, CreatePool, CreateReplica, DestroyNexus, DestroyPool,
-        DestroyReplica, FaultNexusChild, GetBlockDevices, Nexus, NexusId, NodeId, PoolState,
-        Register, RemoveNexusChild, Replica, ShareNexus, ShareReplica, ShutdownNexus, UnshareNexus,
-        UnshareReplica,
+        DestroyReplica, FaultNexusChild, GetBlockDevices, ImportPool, Nexus, NexusId, NodeId,
+        PoolState, Register, RemoveNexusChild, Replica, ShareNexus, ShareReplica, ShutdownNexus,
+        UnshareNexus, UnshareReplica,
     },
 };
 
@@ -48,6 +48,8 @@ pub(crate) trait PoolApi {
     async fn create_pool(&self, request: &CreatePool) -> Result<PoolState, SvcError>;
     /// Destroy a pool on the node via gRPC.
     async fn destroy_pool(&self, request: &DestroyPool) -> Result<(), SvcError>;
+    /// Import a pool on the node via gRPC.
+    async fn import_pool(&self, request: &ImportPool) -> Result<PoolState, SvcError>;
 }
 
 #[async_trait]

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/pool.rs
@@ -3,7 +3,7 @@ use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::io_engine::Null;
 use stor_port::{
     transport_api::ResourceKind,
-    types::v0::transport::{CreatePool, DestroyPool, NodeId, PoolState},
+    types::v0::transport::{CreatePool, DestroyPool, ImportPool, NodeId, PoolState},
 };
 
 use snafu::ResultExt;
@@ -56,5 +56,13 @@ impl crate::controller::io_engine::PoolApi for super::RpcClient {
                 request: "destroy_pool",
             })?;
         Ok(())
+    }
+
+    async fn import_pool(&self, _request: &ImportPool) -> Result<PoolState, SvcError> {
+        Err(SvcError::GrpcRequestError {
+            resource: ResourceKind::Pool,
+            request: "import_pool".to_string(),
+            source: tonic::Status::unimplemented(""),
+        })
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
@@ -78,6 +78,7 @@ impl crate::controller::io_engine::NexusListApi for super::RpcClient {
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::NexusApi<()> for super::RpcClient {
+    #[tracing::instrument(name = "rpc::v1::nexus::create", level = "debug", skip(self), err)]
     async fn create_nexus(&self, request: &CreateNexus) -> Result<Nexus, SvcError> {
         let response =
             self.nexus()
@@ -90,6 +91,7 @@ impl crate::controller::io_engine::NexusApi<()> for super::RpcClient {
         Self::nexus_opt(response.into_inner().nexus, &request.node, "create_nexus")
     }
 
+    #[tracing::instrument(name = "rpc::v1::nexus::destroy", level = "debug", skip(self), err)]
     async fn destroy_nexus(&self, request: &DestroyNexus) -> Result<(), SvcError> {
         let result = self.nexus().destroy_nexus(request.to_rpc()).await;
         match result {
@@ -108,6 +110,7 @@ impl crate::controller::io_engine::NexusApi<()> for super::RpcClient {
         }
     }
 
+    #[tracing::instrument(name = "rpc::v1::nexus::shutdown", level = "debug", skip(self), err)]
     async fn shutdown_nexus(&self, request: &ShutdownNexus) -> Result<(), SvcError> {
         let _ = self
             .nexus()
@@ -185,6 +188,7 @@ impl crate::controller::io_engine::NexusShareApi<Nexus, Nexus> for super::RpcCli
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::RpcClient {
+    #[tracing::instrument(name = "rpc::v1::nexus::add_child", level = "debug", skip(self), err)]
     async fn add_child(&self, request: &AddNexusChild) -> Result<Nexus, SvcError> {
         let rpc_nexus = self
             .nexus()
@@ -205,6 +209,12 @@ impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::Rp
         }
     }
 
+    #[tracing::instrument(
+        name = "rpc::v1::nexus::remove_child",
+        level = "debug",
+        skip(self),
+        err
+    )]
     async fn remove_child(&self, request: &RemoveNexusChild) -> Result<Nexus, SvcError> {
         let result = self
             .nexus()
@@ -238,6 +248,7 @@ impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::Rp
         }
     }
 
+    #[tracing::instrument(name = "rpc::v1::nexus::fault_child", level = "debug", skip(self), err)]
     async fn fault_child(&self, request: &FaultNexusChild) -> Result<(), SvcError> {
         let _ = self
             .nexus()

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
@@ -29,16 +29,30 @@ impl crate::controller::io_engine::PoolListApi for super::RpcClient {
 impl crate::controller::io_engine::PoolApi for super::RpcClient {
     #[tracing::instrument(name = "rpc::v1::pool::create", level = "debug", skip(self), err)]
     async fn create_pool(&self, request: &CreatePool) -> Result<PoolState, SvcError> {
-        let rpc_pool =
-            self.pool()
-                .create_pool(request.to_rpc())
-                .await
-                .context(GrpcRequestError {
+        match self.pool().create_pool(request.to_rpc()).await {
+            Ok(rpc_pool) => {
+                let pool = rpc_pool_to_agent(&rpc_pool.into_inner(), &request.node);
+                Ok(pool)
+            }
+            Err(error)
+                if error.code() == tonic::Code::Internal
+                    && error.message()
+                        == format!(
+                            "Failed to create a BDEV '{}'",
+                            request.disks.first().cloned().unwrap_or_default()
+                        ) =>
+            {
+                Err(SvcError::GrpcRequestError {
                     resource: ResourceKind::Pool,
-                    request: "create_pool",
-                })?;
-        let pool = rpc_pool_to_agent(&rpc_pool.into_inner(), &request.node);
-        Ok(pool)
+                    request: "create_pool".to_string(),
+                    source: tonic::Status::not_found(error.message()),
+                })
+            }
+            Err(error) => Err(error).context(GrpcRequestError {
+                resource: ResourceKind::Pool,
+                request: "create_pool",
+            }),
+        }
     }
 
     #[tracing::instrument(name = "rpc::v1::pool::destroy", level = "debug", skip(self), err)]

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
@@ -3,7 +3,7 @@ use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::v1::pool::ListPoolOptions;
 use stor_port::{
     transport_api::ResourceKind,
-    types::v0::transport::{CreatePool, DestroyPool, NodeId, PoolState},
+    types::v0::transport::{CreatePool, DestroyPool, ImportPool, NodeId, PoolState},
 };
 
 use snafu::ResultExt;
@@ -27,6 +27,7 @@ impl crate::controller::io_engine::PoolListApi for super::RpcClient {
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::PoolApi for super::RpcClient {
+    #[tracing::instrument(name = "rpc::v1::pool::create", level = "debug", skip(self), err)]
     async fn create_pool(&self, request: &CreatePool) -> Result<PoolState, SvcError> {
         let rpc_pool =
             self.pool()
@@ -40,6 +41,7 @@ impl crate::controller::io_engine::PoolApi for super::RpcClient {
         Ok(pool)
     }
 
+    #[tracing::instrument(name = "rpc::v1::pool::destroy", level = "debug", skip(self), err)]
     async fn destroy_pool(&self, request: &DestroyPool) -> Result<(), SvcError> {
         let _ = self
             .pool()
@@ -50,5 +52,19 @@ impl crate::controller::io_engine::PoolApi for super::RpcClient {
                 request: "destroy_pool",
             })?;
         Ok(())
+    }
+
+    #[tracing::instrument(name = "rpc::v1::pool::import", level = "debug", skip(self), err)]
+    async fn import_pool(&self, request: &ImportPool) -> Result<PoolState, SvcError> {
+        let rpc_pool =
+            self.pool()
+                .import_pool(request.to_rpc())
+                .await
+                .context(GrpcRequestError {
+                    resource: ResourceKind::Pool,
+                    request: "import_pool",
+                })?;
+        let pool = rpc_pool_to_agent(&rpc_pool.into_inner(), &request.node);
+        Ok(pool)
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -418,6 +418,18 @@ impl AgentToIoEngine for transport::DestroyPool {
     }
 }
 
+impl AgentToIoEngine for transport::ImportPool {
+    type IoEngineMessage = v1::pb::ImportPoolRequest;
+    fn to_rpc(&self) -> Self::IoEngineMessage {
+        v1::pb::ImportPoolRequest {
+            name: self.id.clone().into(),
+            uuid: None,
+            disks: self.disks.clone().into_vec(),
+            pooltype: v1::pool::PoolType::Lvs as i32,
+        }
+    }
+}
+
 /// Converts rpc pool to a agent pool.
 pub(super) fn rpc_pool_to_agent(rpc_pool: &rpc::v1::pool::Pool, id: &NodeId) -> PoolState {
     let mut pool = rpc_pool.to_agent();

--- a/control-plane/agents/src/bin/core/controller/reconciler/poller.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/poller.rs
@@ -96,7 +96,7 @@ impl ReconcilerWorker {
         }
     }
 
-    #[tracing::instrument(skip(context), level = "trace", err)]
+    #[tracing::instrument(skip(context), level = "trace")]
     async fn poller_work(&mut self, context: PollContext) -> PollResult {
         tracing::trace!("Entering the reconcile loop...");
         let mut results = vec![];

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -65,6 +65,7 @@ impl OnCreateFail {
     pub(crate) fn eeinval_delete<O>(result: &Result<O, SvcError>) -> Self {
         match result {
             Err(error) if error.tonic_code() == tonic::Code::InvalidArgument => Self::Delete,
+            Err(error) if error.tonic_code() == tonic::Code::NotFound => Self::Delete,
             _ => Self::SetDeleting,
         }
     }

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -129,7 +129,7 @@ pub(crate) trait GuardedOperationsHelper:
     /// # Note:
     /// `on_err_destroy` is used to determine if the resource spec should be deleted on error.
     /// On most cases we don't want to destroy as that will prevent garbage collection.
-    async fn complete_create<O, R: Send>(
+    async fn complete_create<O, R: Send + Debug>(
         &self,
         result: Result<R, SvcError>,
         registry: &Registry,
@@ -140,6 +140,8 @@ pub(crate) trait GuardedOperationsHelper:
     {
         match result {
             Ok(val) => {
+                tracing::info!(?val, "complete_create");
+
                 let mut spec_clone = self.lock().clone();
                 spec_clone.commit_op();
                 let stored = registry.store_obj(&spec_clone).await;
@@ -327,7 +329,7 @@ pub(crate) trait GuardedOperationsHelper:
     /// Completes a destroy operation by trying to delete the spec from the persistent store.
     /// If the persistent store operation fails then the spec is marked accordingly and the dirty
     /// spec reconciler will attempt to update the store when the store is back online.
-    async fn complete_destroy<O, R: Send>(
+    async fn complete_destroy<O, R: Send + Debug>(
         &mut self,
         result: Result<R, SvcError>,
         registry: &Registry,
@@ -339,6 +341,8 @@ pub(crate) trait GuardedOperationsHelper:
         let key = self.lock().key();
         match result {
             Ok(val) => {
+                tracing::info!(?val, "complete_destroy");
+
                 let mut spec_clone = self.lock().clone();
                 spec_clone.commit_op();
                 let deleted = registry.delete_kv(&key.key()).await;
@@ -402,7 +406,7 @@ pub(crate) trait GuardedOperationsHelper:
     /// Completes an update operation by trying to update the spec in the persistent store.
     /// If the persistent store operation fails then the spec is marked accordingly and the dirty
     /// spec reconciler will attempt to update the store when the store is back online.
-    async fn complete_update<R: Send, O>(
+    async fn complete_update<R: Send + Debug, O>(
         &mut self,
         registry: &Registry,
         result: Result<R, SvcError>,
@@ -414,6 +418,8 @@ pub(crate) trait GuardedOperationsHelper:
     {
         match result {
             Ok(val) => {
+                tracing::info!(?val, "complete_update");
+
                 spec_clone.commit_op();
                 let stored = registry.store_obj(&spec_clone).await;
                 match stored {
@@ -765,7 +771,7 @@ impl<T: AsOperationSequencer + SpecOperationsHelper> OperationSequenceGuard<T>
             Ok(guard) => Ok(guard),
             Err((error, log)) => {
                 if log {
-                    tracing::debug!("Resource '{}' is busy: {}", self.lock().uuid_str(), error);
+                    tracing::trace!("Resource '{}' is busy: {}", self.lock().uuid_str(), error);
                 }
                 Err(SvcError::Conflict {})
             }

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -245,7 +245,7 @@ impl Service {
     }
 
     /// Deregister a node through the deregister information
-    #[tracing::instrument(level = "trace", skip(self), fields(node.id = %node.id))]
+    #[tracing::instrument(level = "debug", skip(self), fields(node.id = %node.id))]
     pub(super) async fn deregister(&self, node: &Deregister) {
         let nodes = self.registry.nodes().read().await;
         match nodes.get(&node.id) {

--- a/control-plane/agents/src/bin/core/pool/service.rs
+++ b/control-plane/agents/src/bin/core/pool/service.rs
@@ -260,7 +260,7 @@ impl Service {
     }
 
     /// Create a pool using the given parameters.
-    #[tracing::instrument(level = "debug", skip(self), err, fields(pool.id = %request.id))]
+    #[tracing::instrument(level = "info", skip(self), err, fields(pool.id = %request.id))]
     pub(super) async fn create_pool(&self, request: &CreatePool) -> Result<Pool, SvcError> {
         OperationGuardArc::<PoolSpec>::create(&self.registry, request).await
     }

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -573,11 +573,14 @@ async fn wait_till_pool_state(cluster: &Cluster, pool: (u32, u32), has_state: bo
 /// that pools with same spec can be created.
 #[tokio::test]
 async fn reconciler_deleting_pool_on_node_down() {
+    const POOL_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+
     let cluster = ClusterBuilder::builder()
         .with_rest(true)
         .with_agents(vec!["core"])
         .with_io_engines(2)
-        .with_pools(2)
+        .with_tmpfs_pool(POOL_SIZE_BYTES)
+        .with_tmpfs_pool(POOL_SIZE_BYTES)
         .with_reconcile_period(Duration::from_secs(1), Duration::from_secs(1))
         .build()
         .await
@@ -888,4 +891,50 @@ async fn test_disown_missing_replica_owners() {
         .expect("Failed to get replicas.")
         .len();
     assert_eq!(num_replicas, 0);
+}
+
+#[tokio::test]
+async fn destroy_after_restart() {
+    const POOL_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+
+    let cluster = ClusterBuilder::builder()
+        .with_io_engines(1)
+        .with_tmpfs_pool(POOL_SIZE_BYTES)
+        .with_reconcile_period(Duration::from_secs(10), Duration::from_secs(10))
+        .build()
+        .await
+        .unwrap();
+
+    let client = cluster.grpc_client();
+
+    let pools = client
+        .pool()
+        .get(Filter::Pool(cluster.pool(0, 0)), None)
+        .await
+        .unwrap();
+    let pool = pools.into_inner().first().cloned().unwrap();
+
+    cluster
+        .composer()
+        .restart(cluster.node(0).as_str())
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let destroy = DestroyPool {
+        node: cluster.node(0),
+        id: cluster.pool(0, 0),
+    };
+    let create = CreatePool {
+        node: cluster.node(0),
+        id: "bob".into(),
+        disks: pool.state().unwrap().disks,
+        labels: None,
+    };
+
+    client.pool().destroy(&destroy, None).await.unwrap();
+    let pool = client.pool().create(&create, None).await.unwrap();
+
+    assert_eq!(pool.state().unwrap().id, create.id);
 }

--- a/control-plane/agents/src/lib.rs
+++ b/control-plane/agents/src/lib.rs
@@ -62,7 +62,12 @@ impl Service {
     pub fn builder() -> Service<tonic::transport::Server<LayerStack>> {
         Service::<tonic::transport::Server<LayerStack>> {
             shared_state: Arc::new(<Container![Send + Sync]>::new()),
-            tonic_server: tonic::transport::Server::builder().layer(OpenTelServer::new()),
+            tonic_server: tonic::transport::Server::builder().layer(OpenTelServer::new(vec![
+                // This is a bit of hack, but tonic doesn't seem to provide access to this uri
+                // path in any way.
+                // todo: add ignored routes via shared state
+                "/mayastor.v1.Registration/Register",
+            ])),
         }
     }
 

--- a/control-plane/grpc/src/operations/registration/traits.rs
+++ b/control-plane/grpc/src/operations/registration/traits.rs
@@ -13,7 +13,7 @@ use stor_port::{
 /// New type to wrap grpc ApiVersion type.
 pub struct ApiVersion(pub rpc::v1::registration::ApiVersion);
 
-/// Operations to be supportes by the Registration Service.
+/// Operations to be supported by the Registration Service.
 #[tonic::async_trait]
 pub trait RegistrationOperations: Send + Sync {
     /// Register a dataplane node to controlplane.

--- a/control-plane/stor-port/src/transport_api/v0.rs
+++ b/control-plane/stor-port/src/transport_api/v0.rs
@@ -27,6 +27,7 @@ impl_message!(GetNodes);
 
 impl_message!(CreatePool);
 impl_message!(DestroyPool);
+impl_message!(ImportPool);
 impl_vector_request!(Pools, Pool);
 impl_message!(GetPools);
 

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -12,6 +12,7 @@ use crate::types::v0::{
 // PoolLabel is the type for the labels
 pub type PoolLabel = std::collections::HashMap<String, String>;
 
+use crate::types::v0::transport::ImportPool;
 use serde::{Deserialize, Serialize};
 use std::{convert::From, fmt::Debug};
 
@@ -81,6 +82,17 @@ pub struct PoolSpec {
     pub sequencer: OperationSequence,
     /// Record of the operation in progress
     pub operation: Option<PoolOperationState>,
+}
+
+impl From<&PoolSpec> for ImportPool {
+    fn from(value: &PoolSpec) -> Self {
+        Self {
+            node: value.node.clone(),
+            id: value.id.clone(),
+            disks: value.disks.clone(),
+            uuid: None,
+        }
+    }
 }
 
 impl AsOperationSequencer for PoolSpec {

--- a/control-plane/stor-port/src/types/v0/transport/mod.rs
+++ b/control-plane/stor-port/src/types/v0/transport/mod.rs
@@ -69,6 +69,8 @@ pub enum MessageIdVs {
     CreatePool,
     /// Destroy Pool.
     DestroyPool,
+    /// Import Pool.
+    ImportPool,
     /// Get replicas with filter.
     GetReplicas,
     /// Create Replica.

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -272,6 +272,32 @@ impl CreatePool {
     }
 }
 
+/// Create Pool Request
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportPool {
+    /// id of the io-engine instance
+    pub node: NodeId,
+    /// id of the pool
+    pub id: PoolId,
+    /// disk device paths or URIs to be claimed by the pool
+    pub disks: Vec<PoolDeviceUri>,
+    /// the pool uuid if specified
+    pub uuid: Option<PoolUuid>,
+}
+
+impl ImportPool {
+    /// Create new `Self` from the given parameters
+    pub fn new(node: &NodeId, id: &PoolId, disks: &[PoolDeviceUri]) -> Self {
+        Self {
+            node: node.clone(),
+            id: id.clone(),
+            disks: disks.to_vec(),
+            uuid: None,
+        }
+    }
+}
+
 /// Destroy Pool Request
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -230,9 +230,9 @@ impl From<String> for PoolDeviceUri {
         Self(device)
     }
 }
-impl ToString for PoolDeviceUri {
-    fn to_string(&self) -> String {
-        self.deref().to_string()
+impl std::fmt::Display for PoolDeviceUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 impl From<PoolDeviceUri> for String {

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -9,23 +9,23 @@ use std::{cmp::Ordering, fmt::Debug, ops::Deref};
 use strum_macros::{Display, EnumString};
 
 /// Pool Service
-/// Get all the pools from specific node or None for all nodes
+/// Get all the pools from specific node or None for all nodes.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct GetPools {
     /// Filter request
     pub filter: Filter,
 }
 
-/// Status of the Pool
+/// Status of the Pool.
 #[derive(Serialize, Deserialize, Debug, Clone, EnumString, Display, Eq, PartialEq)]
 pub enum PoolStatus {
-    /// unknown state
+    /// Unknown state.
     Unknown = 0,
-    /// the pool is in normal working order
+    /// The pool is in normal working order.
     Online = 1,
-    /// the pool has experienced a failure but can still function
+    /// The pool has experienced a failure but can still function.
     Degraded = 2,
-    /// the pool is completely inaccessible
+    /// The pool is completely inaccessible.
     Faulted = 3,
 }
 
@@ -55,21 +55,21 @@ impl From<PoolStatus> for models::PoolStatus {
     }
 }
 
-/// Pool information
+/// Pool state information.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PoolState {
-    /// id of the io-engine instance
+    /// Id of the io-engine instance.
     pub node: NodeId,
-    /// id of the pool
+    /// Id of the pool.
     pub id: PoolId,
-    /// absolute disk paths claimed by the pool
+    /// Absolute disk paths claimed by the pool.
     pub disks: Vec<PoolDeviceUri>,
-    /// current state of the pool
+    /// Current state of the pool.
     pub status: PoolStatus,
-    /// size of the pool in bytes
+    /// Size of the pool in bytes.
     pub capacity: u64,
-    /// used bytes from the pool
+    /// Used bytes from the pool.
     pub used: u64,
 }
 
@@ -121,13 +121,13 @@ impl PartialOrd for PoolStatus {
     }
 }
 
-/// A Storage Pool
-/// It may have a spec which is the specification provided by the creator
-/// It may have a state if such state is retrieved from a storage node
+/// A Storage Pool.
+/// It may have a spec which is the specification provided by the creator.
+/// It may have a state if such state is retrieved from a storage node.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Pool {
-    /// pool identification
+    /// Pool identification.
     id: PoolId,
     /// Desired specification of the pool.
     spec: Option<PoolSpec>,
@@ -136,7 +136,7 @@ pub struct Pool {
 }
 
 impl Pool {
-    /// Construct a new pool with spec and state
+    /// Construct a new pool with spec and state.
     pub fn new(spec: PoolSpec, state: PoolState) -> Self {
         Self {
             id: spec.id.clone(),
@@ -144,7 +144,7 @@ impl Pool {
             state: Some(state),
         }
     }
-    /// Construct a new pool with spec but no state
+    /// Construct a new pool with spec but no state.
     pub fn from_spec(spec: PoolSpec) -> Self {
         Self {
             id: spec.id.clone(),
@@ -152,7 +152,7 @@ impl Pool {
             state: None,
         }
     }
-    /// Construct a new pool with optional spec and state
+    /// Construct a new pool with optional spec and state.
     pub fn from_state(state: PoolState, spec: Option<PoolSpec>) -> Self {
         Self {
             id: state.id.clone(),
@@ -160,7 +160,7 @@ impl Pool {
             state: Some(state),
         }
     }
-    /// Try to construct a new pool from spec and state
+    /// Try to construct a new pool from spec and state.
     pub fn try_new(spec: Option<PoolSpec>, state: Option<PoolState>) -> Option<Self> {
         match (spec, state) {
             (Some(spec), Some(state)) => Some(Self::new(spec, state)),
@@ -181,7 +181,7 @@ impl Pool {
     pub fn state(&self) -> Option<PoolState> {
         self.state.clone()
     }
-    /// Get the node identification
+    /// Get the node identification.
     pub fn node(&self) -> NodeId {
         match &self.spec {
             // guaranteed that at either spec or state are defined
@@ -198,9 +198,9 @@ impl From<Pool> for models::Pool {
     }
 }
 
-/// Pool device URI
-/// Can be specified in the form of a file path or a URI
-/// eg: /dev/sda, aio:///dev/sda, malloc:///disk?size_mb=100
+/// Pool device URI.
+/// Can be specified in the form of a file path or a URI.
+/// eg: /dev/sda, aio:///dev/sda, malloc:///disk?size_mb=100.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct PoolDeviceUri(String);
 impl Deref for PoolDeviceUri {
@@ -241,22 +241,22 @@ impl From<PoolDeviceUri> for String {
     }
 }
 
-/// Create Pool Request
+/// Create Pool Request.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatePool {
-    /// id of the io-engine instance
+    /// Id of the io-engine instance.
     pub node: NodeId,
-    /// id of the pool
+    /// Id of the pool.
     pub id: PoolId,
-    /// disk device paths or URIs to be claimed by the pool
+    /// Disk device paths or URIs to be claimed by the pool.
     pub disks: Vec<PoolDeviceUri>,
-    /// labels to be set on the pool
+    /// Labels to be set on the pool.
     pub labels: Option<PoolLabel>,
 }
 
 impl CreatePool {
-    /// Create new `Self` from the given parameters
+    /// Create new `Self` from the given parameters.
     pub fn new(
         node: &NodeId,
         id: &PoolId,
@@ -272,22 +272,22 @@ impl CreatePool {
     }
 }
 
-/// Create Pool Request
+/// Create Pool Request.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ImportPool {
-    /// id of the io-engine instance
+    /// Id of the io-engine instance.
     pub node: NodeId,
-    /// id of the pool
+    /// Id of the pool.
     pub id: PoolId,
-    /// disk device paths or URIs to be claimed by the pool
+    /// Disk device paths or URIs to be claimed by the pool.
     pub disks: Vec<PoolDeviceUri>,
-    /// the pool uuid if specified
+    /// The pool uuid if specified.
     pub uuid: Option<PoolUuid>,
 }
 
 impl ImportPool {
-    /// Create new `Self` from the given parameters
+    /// Create new `Self` from the given parameters.
     pub fn new(node: &NodeId, id: &PoolId, disks: &[PoolDeviceUri]) -> Self {
         Self {
             node: node.clone(),
@@ -298,12 +298,12 @@ impl ImportPool {
     }
 }
 
-/// Destroy Pool Request
+/// Destroy Pool Request.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DestroyPool {
-    /// id of the io-engine instance
+    /// Id of the io-engine instance.
     pub node: NodeId,
-    /// id of the pool
+    /// Id of the pool.
     pub id: PoolId,
 }

--- a/tests/bdd/common/operations.py
+++ b/tests/bdd/common/operations.py
@@ -1,4 +1,5 @@
 from common.apiclient import ApiClient
+from openapi.exceptions import NotFoundException
 
 
 class Pool(object):
@@ -10,7 +11,10 @@ class Pool(object):
     @staticmethod
     def delete_all():
         for pool in Pool.__pools_api().get_pools():
-            Pool.__pools_api().del_pool(pool.id)
+            try:
+                Pool.__pools_api().del_pool(pool.id)
+            except NotFoundException:
+                pass
 
 
 class Volume(object):
@@ -22,4 +26,7 @@ class Volume(object):
     @staticmethod
     def delete_all():
         for volume in Volume.__api().get_volumes().entries:
-            Volume.__api().del_volume(volume.spec.uuid)
+            try:
+                Volume.__api().del_volume(volume.spec.uuid)
+            except NotFoundException:
+                pass

--- a/tests/bdd/features/pool/create/disks.feature
+++ b/tests/bdd/features/pool/create/disks.feature
@@ -6,7 +6,7 @@ Feature: Pool creation
 
   Scenario: creating a pool with a non-existent disk
     When the user attempts to create a pool with a non-existent disk
-    Then the pool creation should fail with error kind "Internal"
+    Then the pool creation should fail with error kind "NotFound"
 
   Scenario: creating a pool with multiple disks
     When the user attempts to create a pool specifying multiple disks

--- a/tests/bdd/features/pool/create/test_disks.py
+++ b/tests/bdd/features/pool/create/test_disks.py
@@ -71,11 +71,11 @@ def the_user_attempts_to_create_a_pool_with_a_nonexistent_disk(
     """the user attempts to create a pool with a non-existent disk."""
 
 
-@then('the pool creation should fail with error kind "Internal"')
+@then('the pool creation should fail with error kind "NotFound"')
 def the_pool_creation_should_fail_with_error_internal(pool_attempt):
-    """the pool creation should fail with error kind "Internal"."""
-    assert pool_attempt.status == http.HTTPStatus.INTERNAL_SERVER_ERROR
-    assert ApiClient.exception_to_error(pool_attempt).kind == "Internal"
+    """the pool creation should fail with error kind "NotFound"."""
+    assert pool_attempt.status == http.HTTPStatus.NOT_FOUND
+    assert ApiClient.exception_to_error(pool_attempt).kind == "NotFound"
 
 
 @then('the pool creation should fail with error kind "InvalidArgument"')


### PR DESCRIPTION
chore: disable tracing for registration

This is too verbose as they are sent every x seconds.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix: import pool when destroying

When a node is restarted, we may issue a pool destroy before the reconciler imports it.
Note: the reconciler will never attempt to import it after this as the pool will now be in
the Destroying phase.
To address this, if pool destroy fails with status NotFound, we then attempt to import it
and then retry the destruction.

Added a test case for this.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

refactor: tidy-up docs comments for pool definitions

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

fix(pool/operator): make delete idempotent

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

chore: add info traces for completed operations

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

 fix: attempt to decrypt not found errors for pool creation

Really the dataplane should return proper status codes rather than internal, this is
an interim step..

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
