### PR TITLE
Refactor resource scheduling

### DIFF
--- a/control-plane/agents/src/bin/core/controller/resources/replica/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/replica/mod.rs
@@ -6,7 +6,7 @@ use stor_port::types::v0::{
 
 impl ResourceMutex<ReplicaSpec> {
     /// Get the resource uuid.
-    pub fn uuid(&mut self) -> &ReplicaId {
+    pub fn uuid(&self) -> &ReplicaId {
         &self.immutable_ref().uuid
     }
 }

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod nexus;
 pub(crate) mod resources;
 pub(crate) mod volume;
+mod volume_policy;
 
 use crate::controller::scheduling::{
     nexus::{GetPersistedNexusChildrenCtx, GetSuitableNodesContext},
@@ -8,13 +9,32 @@ use crate::controller::scheduling::{
     volume::{GetSuitablePoolsContext, VolumeReplicasForNexusCtx},
 };
 use std::{cmp::Ordering, collections::HashMap, future::Future};
-use stor_port::types::v0::transport::{PoolStatus, PoolTopology};
+
+#[async_trait::async_trait(?Send)]
+pub(crate) trait ResourcePolicy<Request: ResourceFilter>: Sized {
+    fn apply(self, to: Request) -> Request;
+    fn apply_async(self, to: Request) -> Request {
+        self.apply(to)
+    }
+}
 
 #[async_trait::async_trait(?Send)]
 pub(crate) trait ResourceFilter: Sized {
     type Request;
     type Item;
 
+    fn policy<P: ResourcePolicy<Self>>(self, policy: P) -> Self {
+        policy.apply(self)
+    }
+    fn policy_async<P: ResourcePolicy<Self>>(self, policy: P) -> Self {
+        policy.apply_async(self)
+    }
+    fn filter_param<P, F>(self, _param: P, _filter: F) -> Self
+    where
+        F: FnMut(&P, &Self::Request, &Self::Item) -> bool,
+    {
+        todo!()
+    }
     fn filter_iter(self, filter: fn(Self) -> Self) -> Self {
         filter(self)
     }
@@ -98,82 +118,6 @@ impl NodeFilters {
         !volume_targets
             .into_iter()
             .any(|n| &n.lock().node == item.node_wrapper().id())
-    }
-}
-
-/// Filter pools used for replica creation.
-pub(crate) struct PoolFilters {}
-impl PoolFilters {
-    /// The minimum free space in a pool for it to be eligible for thin provisioned replicas.
-    fn free_space_watermark() -> u64 {
-        16 * 1024 * 1024
-    }
-    /// Should only attempt to use pools with capacity bigger than the requested replica size.
-    pub(crate) fn capacity(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
-        item.pool.capacity > request.size
-    }
-    /// Should only attempt to use pools with sufficient free space.
-    pub(crate) fn free_space(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
-        match request.thin {
-            true => item.pool.free_space() > Self::free_space_watermark(),
-            false => item.pool.free_space() > request.size,
-        }
-    }
-    /// Should only attempt to use pools with sufficient free space for a full rebuild.
-    /// Currently the data-plane fully rebuilds a volume, meaning a thin provisioned volume
-    /// becomes fully allocated.
-    pub(crate) fn free_space_full_rebuild(
-        request: &GetSuitablePoolsContext,
-        item: &PoolItem,
-    ) -> bool {
-        match request.thin && request.config().is_none() {
-            true => item.pool.free_space() > Self::free_space_watermark(),
-            false => item.pool.free_space() > request.size,
-        }
-    }
-    /// Should only attempt to use usable (not faulted) pools.
-    pub(crate) fn usable(_: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
-        item.pool.status != PoolStatus::Faulted && item.pool.status != PoolStatus::Unknown
-    }
-    /// Should only attempt to use pools having specific creation label if topology has it.
-    pub(crate) fn topology(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
-        let volume_pool_topology_labels: HashMap<String, String>;
-        match request.topology.clone() {
-            None => return true,
-            Some(topology) => match topology.pool {
-                None => return true,
-                Some(pool_topology) => match pool_topology {
-                    PoolTopology::Labelled(labelled_topology) => {
-                        // The labels in Volume Pool Topology should match the pool labels if
-                        // present, otherwise selection of any pool is allowed.
-                        if !labelled_topology.inclusion.is_empty() {
-                            volume_pool_topology_labels = labelled_topology.inclusion
-                        } else {
-                            return true;
-                        }
-                    }
-                },
-            },
-        };
-        // We will reach this part of code only if the volume has pool topology labels.
-        match request.registry().specs().pool(&item.pool.id) {
-            Ok(spec) => match spec.labels {
-                None => false,
-                Some(label) => volume_pool_topology_labels.keys().all(|k| {
-                    label.contains_key(k) && (volume_pool_topology_labels.get(k) == label.get(k))
-                }),
-            },
-            Err(_) => false,
-        }
-    }
-}
-
-/// Sort the pools used for replica creation
-pub(crate) struct PoolSorters {}
-impl PoolSorters {
-    /// Sort pools by their number of allocated replicas
-    pub(crate) fn sort_by_replica_count(a: &PoolItem, b: &PoolItem) -> std::cmp::Ordering {
-        a.pool.cmp(&b.pool)
     }
 }
 

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
@@ -1,0 +1,28 @@
+use super::ResourceFilter;
+use crate::controller::scheduling::{volume::AddVolumeReplica, NodeFilters};
+
+pub(crate) mod pool;
+mod thick;
+
+pub(super) use thick::ThickPolicy;
+
+struct DefaultBasePolicy {}
+impl DefaultBasePolicy {
+    fn filter(request: AddVolumeReplica) -> AddVolumeReplica {
+        Self::filter_pools(Self::filter_nodes(request))
+    }
+    fn filter_nodes(request: AddVolumeReplica) -> AddVolumeReplica {
+        request
+            .filter(NodeFilters::cordoned_for_pool)
+            .filter(NodeFilters::online_for_pool)
+            .filter(NodeFilters::allowed)
+            .filter(NodeFilters::unused)
+    }
+    fn filter_pools(request: AddVolumeReplica) -> AddVolumeReplica {
+        request
+            .filter(pool::PoolBaseFilters::usable)
+            .filter(pool::PoolBaseFilters::capacity)
+            .filter(pool::PoolBaseFilters::min_free_space)
+            .filter(pool::PoolBaseFilters::topology)
+    }
+}

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
@@ -1,0 +1,79 @@
+use crate::controller::scheduling::{resources::PoolItem, volume::GetSuitablePoolsContext};
+use std::collections::HashMap;
+use stor_port::types::v0::transport::{PoolStatus, PoolTopology};
+
+/// Filter pools used for replica creation.
+pub(crate) struct PoolBaseFilters {}
+impl PoolBaseFilters {
+    /// The minimum free space in a pool for it to be eligible for thin provisioned replicas.
+    fn free_space_watermark() -> u64 {
+        16 * 1024 * 1024
+    }
+    /// Should only attempt to use pools with capacity bigger than the requested replica size.
+    pub(crate) fn capacity(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        item.pool.capacity > request.size
+    }
+    /// Should only attempt to use pools with sufficient free space.
+    pub(crate) fn min_free_space(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        match request.thin {
+            true => item.pool.free_space() > Self::free_space_watermark(),
+            false => item.pool.free_space() > request.size,
+        }
+    }
+    /// Should only attempt to use pools with sufficient free space for a full rebuild.
+    /// Currently the data-plane fully rebuilds a volume, meaning a thin provisioned volume
+    /// becomes fully allocated.
+    pub(crate) fn min_free_space_full_rebuild(
+        request: &GetSuitablePoolsContext,
+        item: &PoolItem,
+    ) -> bool {
+        match request.thin && request.config().is_none() {
+            true => item.pool.free_space() > Self::free_space_watermark(),
+            false => item.pool.free_space() > request.size,
+        }
+    }
+    /// Should only attempt to use usable (not faulted) pools.
+    pub(crate) fn usable(_: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        item.pool.status != PoolStatus::Faulted && item.pool.status != PoolStatus::Unknown
+    }
+    /// Should only attempt to use pools having specific creation label if topology has it.
+    pub(crate) fn topology(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        let volume_pool_topology_labels: HashMap<String, String>;
+        match request.topology.clone() {
+            None => return true,
+            Some(topology) => match topology.pool {
+                None => return true,
+                Some(pool_topology) => match pool_topology {
+                    PoolTopology::Labelled(labelled_topology) => {
+                        // The labels in Volume Pool Topology should match the pool labels if
+                        // present, otherwise selection of any pool is allowed.
+                        if !labelled_topology.inclusion.is_empty() {
+                            volume_pool_topology_labels = labelled_topology.inclusion
+                        } else {
+                            return true;
+                        }
+                    }
+                },
+            },
+        };
+        // We will reach this part of code only if the volume has pool topology labels.
+        match request.registry().specs().pool(&item.pool.id) {
+            Ok(spec) => match spec.labels {
+                None => false,
+                Some(label) => volume_pool_topology_labels.keys().all(|k| {
+                    label.contains_key(k) && (volume_pool_topology_labels.get(k) == label.get(k))
+                }),
+            },
+            Err(_) => false,
+        }
+    }
+}
+
+/// Sort the pools used for replica creation.
+pub(crate) struct PoolBaseSorters {}
+impl PoolBaseSorters {
+    /// Sort pools by their number of allocated replicas.
+    pub(crate) fn sort_by_replica_count(a: &PoolItem, b: &PoolItem) -> std::cmp::Ordering {
+        a.pool.cmp(&b.pool)
+    }
+}

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/thick.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/thick.rs
@@ -1,0 +1,25 @@
+use crate::controller::scheduling::{
+    volume::AddVolumeReplica,
+    volume_policy::{
+        pool::{PoolBaseFilters, PoolBaseSorters},
+        DefaultBasePolicy,
+    },
+    ResourceFilter, ResourcePolicy,
+};
+
+pub(crate) struct ThickPolicy {}
+impl ThickPolicy {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ResourcePolicy<AddVolumeReplica> for ThickPolicy {
+    fn apply(self, to: AddVolumeReplica) -> AddVolumeReplica {
+        DefaultBasePolicy::filter(to)
+            .filter(PoolBaseFilters::min_free_space_full_rebuild)
+            // sort pools in order of preference (from least to most number of replicas)
+            .sort(PoolBaseSorters::sort_by_replica_count)
+    }
+}

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -61,7 +61,7 @@ impl ResourceLifecycle for OperationGuardArc<VolumeSpec> {
 
         // todo: pick nodes and pools using the Node&Pool Topology
         // todo: virtually increase the pool usage to avoid a race for space with concurrent calls
-        let result = create_volume_replicas(registry, request).await;
+        let result = create_volume_replicas(registry, request, &volume_clone).await;
         let create_replicas = volume
             .validate_create_step_ext(registry, result, OnCreateFail::Delete)
             .await?;

--- a/control-plane/agents/src/bin/core/volume/scheduling.rs
+++ b/control-plane/agents/src/bin/core/volume/scheduling.rs
@@ -18,7 +18,7 @@ pub(crate) async fn volume_pool_candidates(
     request: impl Into<GetSuitablePools>,
     registry: &Registry,
 ) -> Vec<PoolWrapper> {
-    volume::AddVolumeReplica::builder_with_defaults(request, registry)
+    volume::AddVolumeReplica::builder_with_defaults(request.into(), registry)
         .await
         .collect()
         .into_iter()


### PR DESCRIPTION

    refactor: simplify resource filter interface
    
    Adds most used logic in the default impl.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(scheduling): make default behaviour a thick policy
    
    This prepares the existing scheduling to be able to support multiple policies.
    Adds a bunch of default filters which should be common for most policies.
    Adds a thick policy which will not be that useful for thin volumes.
    todo: add thin policy
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: don't create local toolchain copy if using rustup
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
