### PR TITLE
Thin Provisioning Simple Policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "url",
  "utils",
  "uuid",
+ "weighted-scoring",
 ]
 
 [[package]]
@@ -4383,6 +4384,10 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "weighted-scoring"
+version = "0.1.0"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "utils/platform",
     "utils/pstor-usage",
     "utils/shutdown",
+    "utils/weighted-scoring",
     "utils/deployer-cluster",
     "tests/io-engine",
 ]

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -62,6 +62,7 @@ rpc =  { path = "../../rpc"}
 stor-port = { path = "../stor-port" }
 utils = { path = "../../utils/utils-lib" }
 nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
+weighted-scoring = { path = "../../utils/weighted-scoring" }
 
 [target.'cfg(target_os="linux")'.dependencies]
 tokio-udev = { version = "0.8.0" }

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -47,11 +47,13 @@ pub(crate) trait ResourceFilter: Sized {
     fn policy_async<P: ResourcePolicy<Self>>(self, policy: P) -> Self {
         policy.apply_async(self)
     }
-    fn filter_param<P, F>(self, _param: P, _filter: F) -> Self
+    fn filter_param<P, F>(mut self, param: &P, filter: F) -> Self
     where
-        F: FnMut(&P, &Self::Request, &Self::Item) -> bool,
+        F: Fn(&P, &Self::Request, &Self::Item) -> bool,
     {
-        unimplemented!()
+        let data = self.data();
+        data.list.retain(|v| filter(param, &data.context, v));
+        self
     }
     fn filter_iter(self, filter: fn(Self) -> Self) -> Self {
         filter(self)

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -21,7 +21,8 @@ pub(crate) struct PoolItem {
 }
 
 impl PoolItem {
-    fn new(node: NodeWrapper, pool: PoolWrapper) -> Self {
+    /// Create a new `Self`.
+    pub(crate) fn new(node: NodeWrapper, pool: PoolWrapper) -> Self {
         Self { node, pool }
     }
     /// Get the number of replicas in the pool.

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -24,6 +24,14 @@ impl PoolItem {
     fn new(node: NodeWrapper, pool: PoolWrapper) -> Self {
         Self { node, pool }
     }
+    /// Get the number of replicas in the pool.
+    pub(crate) fn len(&self) -> u64 {
+        self.pool.replicas().len() as u64
+    }
+    /// Get a reference to the inner `PoolWrapper`.
+    pub(crate) fn pool(&self) -> &PoolWrapper {
+        &self.pool
+    }
     /// Collect the item into a pool.
     pub(crate) fn collect(self) -> PoolWrapper {
         self.pool

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
@@ -2,8 +2,10 @@ use super::ResourceFilter;
 use crate::controller::scheduling::{volume::AddVolumeReplica, NodeFilters};
 
 pub(crate) mod pool;
+mod simple;
 mod thick;
 
+pub(super) use simple::SimplePolicy;
 pub(super) use thick::ThickPolicy;
 
 struct DefaultBasePolicy {}

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -1,0 +1,95 @@
+use crate::controller::scheduling::{
+    resources::PoolItem,
+    volume::{AddVolumeReplica, GetSuitablePoolsContext},
+    volume_policy::{pool::PoolBaseFilters, DefaultBasePolicy},
+    ResourceFilter, ResourcePolicy,
+};
+use weighted_scoring::{Criteria, Ranged, ValueGrading, WeightedScore};
+
+/// A very simple policy for pool replica placement that takes into account thin provisioning
+/// and currently allocated bytes.
+/// todo: make parameters configurable: eg they could be provided during volume creation?
+pub(crate) struct SimplePolicy {
+    /// Current volume replicas are not online.
+    /// Configure a minimum size that is a percentage of the volume size.
+    no_state_min_free_space_percent: u64,
+    /// When creating a volume replica, the chosen pool should have free space larger than
+    /// the current volume allocation plus some slack.
+    min_free_space_slack_percent: u64,
+}
+impl Default for SimplePolicy {
+    fn default() -> Self {
+        Self {
+            no_state_min_free_space_percent: 100,
+            min_free_space_slack_percent: 40,
+        }
+    }
+}
+impl SimplePolicy {
+    pub(crate) fn builder() -> Self {
+        Self::default()
+    }
+}
+#[async_trait::async_trait(?Send)]
+impl ResourcePolicy<AddVolumeReplica> for SimplePolicy {
+    fn apply(self, to: AddVolumeReplica) -> AddVolumeReplica {
+        DefaultBasePolicy::filter(to)
+            .filter(PoolBaseFilters::min_free_space)
+            .filter_param(&self, SimplePolicy::min_free_space)
+            // sort pools in order of preference (from least to most number of replicas)
+            .sort(SimplePolicy::sort_by_weights)
+    }
+}
+
+impl SimplePolicy {
+    /// Sort pools using weights between:
+    /// 1. number of replicas (N_REPL_WEIGHT %)
+    /// 2. free space         (FREE_SPACE_WEIGHT %)
+    /// 3. overcommitment     (OVER_COMMIT_WEIGHT %)
+    pub(crate) fn sort_by_weights(a: &PoolItem, b: &PoolItem) -> std::cmp::Ordering {
+        const N_REPL_WEIGHT: Ranged = Ranged::new_const(25);
+        const FREE_SPACE_WEIGHT: Ranged = Ranged::new_const(40);
+        const OVER_COMMIT_WEIGHT: Ranged = Ranged::new_const(35);
+
+        let n_replicas = Criteria::new("n_replicas", N_REPL_WEIGHT);
+        let free_space = Criteria::new("free_space", FREE_SPACE_WEIGHT);
+        let over_commit = Criteria::new("over_commit", OVER_COMMIT_WEIGHT);
+
+        let (score_a, score_b) = WeightedScore::dual_values()
+            .weigh(n_replicas, ValueGrading::Lower, a.len(), b.len())
+            .weigh(
+                free_space,
+                ValueGrading::Higher,
+                a.pool().free_space(),
+                b.pool().free_space(),
+            )
+            .weigh(
+                over_commit,
+                ValueGrading::Lower,
+                a.pool().over_commitment(),
+                b.pool().over_commitment(),
+            )
+            .score()
+            .unwrap();
+
+        score_a.cmp(&score_b)
+    }
+    /// Minimum free space is the currently allocated usage plus some percentage of volume size
+    /// slack.
+    fn min_free_space(&self, request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        if !request.thin {
+            return item.pool.free_space() > request.size;
+        }
+        match request.allocated_bytes() {
+            Some(bytes) => {
+                let size = (self.min_free_space_slack_percent * request.size) / 100;
+                let required_cap = (bytes + size).min(request.size);
+                item.pool.free_space() > required_cap
+            }
+            None => {
+                let min_size = (self.no_state_min_free_space_percent * request.size) / 100;
+                item.pool.free_space() > min_size
+            }
+        }
+    }
+}

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -94,6 +94,24 @@ impl NodeWrapper {
         }
     }
 
+    /// Create a stub `Self` for a `Node` with a given state.
+    #[allow(unused)]
+    pub(crate) fn new_stub(node: &NodeState) -> Self {
+        Self {
+            node_state: node.clone(),
+            watchdog: Watchdog::new(&node.id, std::time::Duration::from_secs(1)),
+            missed_deadline: false,
+            lock: Default::default(),
+            comms_timeouts: NodeCommsTimeout::new(
+                std::time::Duration::from_secs(1),
+                std::time::Duration::from_secs(1),
+                false,
+            ),
+            states: ResourceStatesLocked::new(),
+            num_rebuilds: Arc::new(RwLock::new(0)),
+        }
+    }
+
     /// Set the node state to the passed argument.
     fn set_state_inner(&mut self, mut node_state: NodeState, creation: bool) -> bool {
         // don't modify the status through the state.

--- a/control-plane/agents/src/bin/core/pool/service.rs
+++ b/control-plane/agents/src/bin/core/pool/service.rs
@@ -188,11 +188,11 @@ impl Service {
                     .pool_wrapper(&pool_id)
                     .await
                     .context(PoolNotFound { pool_id })?;
-                Ok(pool_wrapper.replicas())
+                Ok(pool_wrapper.replicas().clone())
             }
             Filter::Pool(pool_id) => {
                 let pool_wrapper = self.registry.get_node_pool_wrapper(pool_id).await?;
-                Ok(pool_wrapper.replicas())
+                Ok(pool_wrapper.replicas().clone())
             }
             Filter::NodePoolReplica(node_id, pool_id, replica_id) => {
                 let node = self.registry.node_wrapper(&node_id).await?;

--- a/utils/weighted-scoring/Cargo.toml
+++ b/utils/weighted-scoring/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "weighted-scoring"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/utils/weighted-scoring/src/criteria.rs
+++ b/utils/weighted-scoring/src/criteria.rs
@@ -1,0 +1,33 @@
+use crate::{range::Ranged, score::Score};
+
+/// A Criteria which carries a ranged weight (1..100).
+/// The higher the weight the more important the criteria is and the greater effect on the final
+/// weighted score it has.
+#[derive(Copy, Clone)]
+pub struct Criteria {
+    _name: Option<&'static str>,
+    weight: Ranged,
+}
+impl Criteria {
+    /// Create a new `Criteria` with the given names and weight.
+    pub fn new(name: impl Into<&'static str>, weight: Ranged) -> Self {
+        let _name = Some(name.into());
+        Self { _name, weight }
+    }
+    /// Weigh the given score according to this criteria's weight.
+    pub(crate) fn weigh(&self, entry: &Score) -> u64 {
+        self.weight.val() * entry.ranged_val().val()
+    }
+    /// Get the criteria weight.
+    pub fn weight(&self) -> &Ranged {
+        &self.weight
+    }
+}
+impl From<Ranged> for Criteria {
+    fn from(weight: Ranged) -> Self {
+        Self {
+            _name: None,
+            weight,
+        }
+    }
+}

--- a/utils/weighted-scoring/src/error.rs
+++ b/utils/weighted-scoring/src/error.rs
@@ -1,0 +1,26 @@
+impl std::error::Error for Error {}
+
+/// Errors associated with the weight scoring.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Error {
+    /// Invalid range - should be from 0 - 100.
+    Bounds {},
+    /// Sum of weights exceeds 100%.
+    Heavy {
+        /// The sum of weights encountered.
+        sum: u64,
+    },
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Bounds { .. } => {
+                write!(f, "Invalid range")
+            }
+            Error::Heavy { sum } => {
+                write!(f, "Sum of weights ({sum}%) exceeds 100%")
+            }
+        }
+    }
+}

--- a/utils/weighted-scoring/src/lib.rs
+++ b/utils/weighted-scoring/src/lib.rs
@@ -1,0 +1,118 @@
+//! A library for weighted scoring.
+
+#![deny(missing_docs)]
+
+mod criteria;
+mod error;
+mod range;
+mod score;
+mod value;
+mod weighted_score;
+
+/// Exports from the criteria module.
+pub use criteria::Criteria;
+/// Exports from the error module.
+pub use error::Error;
+/// Exports from the range module.
+pub use range::Ranged;
+/// Exports from the score module.
+pub use score::Score;
+/// Exports from the value module.
+pub use value::{Value, ValueGrading};
+/// Exports from the weighted_score module.
+pub use weighted_score::WeightedScore;
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        criteria::Criteria,
+        error::Error,
+        range::Ranged,
+        score::Score,
+        value::{Value, ValueGrading},
+        weighted_score::WeightedScore,
+    };
+
+    #[test]
+    fn value_to_score() {
+        let value1 = Value::new("pool1", 100);
+        let value2 = Value::new("pool2", 10);
+
+        let (score1, score2) = Value::dual_grade(value1, value2, ValueGrading::Higher);
+        assert_eq!(score1, Score::new_const("pool1", 90));
+        assert_eq!(score2, Score::new_const("pool2", 9));
+
+        let (score1, score2) = Value::dual_grade(value1, value2, ValueGrading::Lower);
+        assert_eq!(score1, Score::new_const("pool1", 9));
+        assert_eq!(score2, Score::new_const("pool2", 90));
+
+        let (score1, score2) = Value::dual_grade(value2, value1, ValueGrading::Higher);
+        assert_eq!(score1, Score::new_const("pool2", 9));
+        assert_eq!(score2, Score::new_const("pool1", 90));
+    }
+
+    #[test]
+    fn weighted_score() {
+        let n_replicas = Criteria::new("n_replicas", Ranged(25));
+        let free_space = Criteria::new("free_space", Ranged(40));
+        let over_commit = Criteria::new("over_commit", Ranged(35));
+
+        let score = WeightedScore::single()
+            .weigh(n_replicas, Score::new("pool1", Ranged(10)))
+            .weigh(free_space, Score::new("pool1", Ranged(30)))
+            .weigh(over_commit, Score::new("pool1", Ranged(50)))
+            .score()
+            .unwrap();
+        assert_eq!(score.val(), 32);
+
+        let score = WeightedScore::single()
+            .weigh(Ranged(25), Ranged(10))
+            .weigh(Ranged(40), Ranged(30))
+            .weigh(Ranged(35), Ranged(50))
+            .score()
+            .unwrap();
+        assert_eq!(score.val(), 32);
+    }
+
+    #[test]
+    fn weighted_values() {
+        let n_replicas = Criteria::new("n_replicas", Ranged(25));
+
+        let pool1_repl = Value::new("pool1", 100);
+        let pool2_repl = Value::new("pool2", 10);
+
+        let (score1, _) = Value::dual_grade(pool1_repl, pool2_repl, ValueGrading::Higher);
+
+        let score = WeightedScore::single()
+            .weigh(n_replicas, score1)
+            .score()
+            .unwrap();
+        assert_eq!(score.val(), 22);
+    }
+
+    #[test]
+    fn dual_weighted_values() {
+        let n_replicas = Criteria::new("n_replicas", Ranged(25));
+        let free_space = Criteria::new("free_space", Ranged(40));
+        let over_commit = Criteria::new("over_commit", Ranged(35));
+
+        let score = WeightedScore::dual_values()
+            .weigh(n_replicas, ValueGrading::Lower, 100, 100)
+            .weigh(free_space, ValueGrading::Higher, 100, 100)
+            .weigh(over_commit, ValueGrading::Lower, 100, 100)
+            .score()
+            .unwrap();
+        assert_eq!(score, (Ranged(50), Ranged(50)));
+    }
+
+    #[test]
+    fn heavy_weighted() {
+        let error = WeightedScore::single()
+            .weigh(Ranged(25), Ranged(10))
+            .weigh(Ranged(40), Ranged(30))
+            .weigh(Ranged(80), Ranged(50))
+            .score()
+            .expect_err("Too heavy!");
+        assert_eq!(error, Error::Heavy { sum: 145 });
+    }
+}

--- a/utils/weighted-scoring/src/range.rs
+++ b/utils/weighted-scoring/src/range.rs
@@ -1,0 +1,51 @@
+use crate::error::Error;
+
+/// A wrapper over a `u64` value which ensures that the inner value is within
+/// a the range: 0..100.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Ranged(pub(crate) u64);
+
+impl Ranged {
+    /// Create a new ranged `Self` which is used to ensure that the inner `val` is within
+    /// the range of 0 .. 100.
+    pub fn new(value: u64) -> Result<Self, Error> {
+        if (0 .. 100).contains(&value) {
+            Ok(Self(value))
+        } else {
+            Err(Error::Bounds {})
+        }
+    }
+    /// Create a new ranged `Self` which is used to ensure that the inner `val` is within
+    /// the range of 0 .. 100.
+    /// If the value is not is within range this will fail to compile.
+    pub const fn new_const(value: u64) -> Self {
+        if value <= 100 {
+            Self(value)
+        } else {
+            panic!("Not valid")
+        }
+    }
+    /// Create a new `Self` from the given value.
+    /// # Warning: the provided value must be within range, otherwise it will be bounded.
+    pub(crate) fn new_ranged(value: u64) -> Self {
+        Self(value.max(0).min(100))
+    }
+    /// Get the inner u64 value of this Ranged wrapper.
+    /// The value is guaranteed to be within 0 .. 100.
+    pub fn val(&self) -> u64 {
+        self.0
+    }
+}
+
+impl TryFrom<u8> for Ranged {
+    type Error = Error;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Self::new(value as u64)
+    }
+}
+impl TryFrom<u64> for Ranged {
+    type Error = Error;
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}

--- a/utils/weighted-scoring/src/score.rs
+++ b/utils/weighted-scoring/src/score.rs
@@ -1,0 +1,33 @@
+use crate::range::Ranged;
+
+/// A "balanced" entry score which as been balanced to a value of 0..100.
+#[derive(Debug, Clone, Eq, PartialEq, Copy)]
+pub struct Score {
+    name: Option<&'static str>,
+    value: Ranged,
+}
+impl Score {
+    /// Create a new `Self` const.
+    /// The value does not need to be validated because compilation will fail otherwise.
+    pub const fn new_const(name: &'static str, value: u64) -> Self {
+        Self {
+            name: Some(name),
+            value: Ranged::new_const(value),
+        }
+    }
+    /// Creates a new `Self`.
+    /// As opposed to `Self::new_const`, the provided value must be `Ranged`.
+    pub fn new(name: impl Into<Option<&'static str>>, value: Ranged) -> Self {
+        let name = name.into();
+        Self { name, value }
+    }
+    /// Get a reference to the inner range value.
+    pub fn ranged_val(&self) -> &Ranged {
+        &self.value
+    }
+}
+impl From<Ranged> for Score {
+    fn from(value: Ranged) -> Self {
+        Self { name: None, value }
+    }
+}

--- a/utils/weighted-scoring/src/value.rs
+++ b/utils/weighted-scoring/src/value.rs
@@ -1,0 +1,51 @@
+use crate::{range::Ranged, score::Score};
+
+/// Strategy used to grade values into scores.
+#[derive(Copy, Clone)]
+pub enum ValueGrading {
+    /// The Higher the value, the higher the score.
+    Higher,
+    /// The higher the value, the lower the score.
+    Lower,
+}
+
+/// An entry score which has not yet been scored.
+/// Before it may be weighted against other entries it must be scored from (0..100).
+#[derive(Debug, Copy, Clone)]
+pub struct Value {
+    name: Option<&'static str>,
+    value: u64,
+}
+impl Value {
+    /// Create a new `Self` using the given name and value.
+    pub fn new(name: impl Into<&'static str>, value: u64) -> Self {
+        let name = Some(name.into());
+        Self { name, value }
+    }
+    /// Scores 2 entries by balancing each other.
+    pub fn dual_grade(
+        a: impl Into<Self>,
+        b: impl Into<Self>,
+        strategy: ValueGrading,
+    ) -> (Score, Score) {
+        let (a, b) = (a.into(), b.into());
+        let total = a.value + b.value;
+        let percent = |v: &Self| -> u64 {
+            match strategy {
+                _ if total == 0 => 50,
+                ValueGrading::Higher => (v.value * 100) / total,
+                ValueGrading::Lower => ((total - v.value) * 100) / total,
+            }
+        };
+        let (score1, score2) = (percent(&a), percent(&b));
+        (
+            Score::new(a.name, Ranged::new_ranged(score1)),
+            Score::new(b.name, Ranged::new_ranged(score2)),
+        )
+    }
+}
+impl From<u64> for Value {
+    fn from(value: u64) -> Self {
+        Self { name: None, value }
+    }
+}

--- a/utils/weighted-scoring/src/weighted_score.rs
+++ b/utils/weighted-scoring/src/weighted_score.rs
@@ -1,0 +1,87 @@
+use crate::{
+    criteria::Criteria,
+    error::Error,
+    range::Ranged,
+    score::Score,
+    value::{Value, ValueGrading},
+};
+
+/// A weighted score is calculated by iterating over various criteria and multiplying each
+/// weight by the scored data point.
+#[derive(Default, Debug)]
+pub struct WeightedScore {}
+impl WeightedScore {
+    /// Builder like pattern for `WeightedScoreSingle`.
+    pub fn single() -> WeightedScoreSingle {
+        WeightedScoreSingle::default()
+    }
+    /// Builder like pattern for `DualValWeightedScore`.
+    pub fn dual_values() -> DualValWeightedScore {
+        DualValWeightedScore::default()
+    }
+}
+
+/// A weighted score is calculated by iterating over various criteria and multiplying each
+/// weight by the scored data point.
+#[derive(Default, Debug)]
+pub struct WeightedScoreSingle {
+    accrued_weights: u64,
+    accrued_score: u64,
+}
+impl WeightedScoreSingle {
+    /// Weigh the matching `criteria` and `score` by reference.
+    pub fn weigh_ref(mut self, criteria: &Criteria, score: &Score) -> Self {
+        self.accrued_score += criteria.weigh(score);
+        self.accrued_weights += criteria.weight().val();
+        self
+    }
+    /// Weigh the matching `criteria` and `score`.
+    pub fn weigh(self, criteria: impl Into<Criteria>, score: impl Into<Score>) -> Self {
+        self.weigh_ref(&criteria.into(), &score.into())
+    }
+    /// Returns the final score which is the sum of all criteria weighing.
+    pub fn score(self) -> Result<Ranged, Error> {
+        if self.accrued_weights > 100 {
+            return Err(Error::Heavy {
+                sum: self.accrued_weights,
+            });
+        }
+        Ok(Ranged(self.accrued_score / 100))
+    }
+}
+
+/// A weighted score is calculated by iterating over various criteria and multiplying each
+/// weight by the scored data point.
+/// Same principle as `WeightedScoreSingle` but it operates with "raw" values rather than scores.
+/// That means it has to grade each "raw" value into a `Score` in order to be able to calculate
+/// each weighted score.
+/// Once graded, each weighted score is then calculated using `WeightedScoreSingle`.
+#[derive(Default, Debug)]
+pub struct DualValWeightedScore {
+    accrued_score_1: WeightedScoreSingle,
+    accrued_score_2: WeightedScoreSingle,
+}
+impl DualValWeightedScore {
+    /// Weigh the matching `criteria` and scores by reference.
+    pub fn weigh_ref(mut self, criteria: &Criteria, score_1: &Score, score_2: &Score) -> Self {
+        self.accrued_score_1 = self.accrued_score_1.weigh_ref(criteria, score_1);
+        self.accrued_score_2 = self.accrued_score_2.weigh_ref(criteria, score_2);
+        self
+    }
+    /// Weigh the matching `criteria` and values. The values are graded using the given
+    /// `ValueGrading` strategy.
+    pub fn weigh(
+        self,
+        criteria: impl Into<Criteria>,
+        strategy: ValueGrading,
+        value_1: impl Into<Value>,
+        value_2: impl Into<Value>,
+    ) -> Self {
+        let (score_1, score_2) = Value::dual_grade(value_1, value_2, strategy);
+        self.weigh_ref(&criteria.into(), &score_1, &score_2)
+    }
+    /// Returns the final score which is the sum of all criteria weighing.
+    pub fn score(self) -> Result<(Ranged, Ranged), Error> {
+        Ok((self.accrued_score_1.score()?, self.accrued_score_2.score()?))
+    }
+}


### PR DESCRIPTION
feat(weighted-scoring): add new crate for weighted scores

This crate be used when for scoring a particular thing (eg: pool) according to particular criteria
with different weights.
Example, we may want to weight score a pool based on certain criteria: it's number of replicas,
free space and over commitment.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(thin/policy): adds an initial policy for thin provisioned volumes

Pool of that don't have at least a min free space are filtered out of the candidates.
This space is determined via two configurable min_free_space_slack_percent params.

Also use weights to determine which pools are the "best" candidates for replica placement.
Different weights are given to number of existing pool replicas, free space and over commitment.
The pool with the best weighted score is the candidate!

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

test(thin): add simple thin policy testing
    
Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
