### PR TITLE
Capacity - remove largest enospc replica and online enospc child

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
@@ -188,7 +188,13 @@ impl crate::controller::io_engine::NexusShareApi<Nexus, Nexus> for super::RpcCli
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::RpcClient {
-    #[tracing::instrument(name = "rpc::v1::nexus::add_child", level = "debug", skip(self), err)]
+    #[tracing::instrument(
+        name = "rpc::v1::nexus::add_child",
+        level = "debug",
+        skip(self),
+        fields(rpc.io_engine = true),
+        err
+    )]
     async fn add_child(&self, request: &AddNexusChild) -> Result<Nexus, SvcError> {
         let rpc_nexus = self
             .nexus()
@@ -213,6 +219,7 @@ impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::Rp
         name = "rpc::v1::nexus::remove_child",
         level = "debug",
         skip(self),
+        fields(rpc.io_engine = true),
         err
     )]
     async fn remove_child(&self, request: &RemoveNexusChild) -> Result<Nexus, SvcError> {
@@ -248,7 +255,7 @@ impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::Rp
         }
     }
 
-    #[tracing::instrument(name = "rpc::v1::nexus::fault_child", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "rpc::v1::nexus::fault_child", level = "debug", skip(self), fields(rpc.io_engine = true), err)]
     async fn fault_child(&self, request: &FaultNexusChild) -> Result<(), SvcError> {
         let _ = self
             .nexus()
@@ -264,6 +271,7 @@ impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::Rp
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::NexusChildActionApi for super::RpcClient {
+    #[tracing::instrument(name = "rpc::v1::nexus::child_action", level = "debug", skip(self), fields(rpc.io_engine = true), err)]
     async fn child_action(&self, request: &NexusChildAction) -> Result<Nexus, SvcError> {
         let response = self
             .nexus()

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
@@ -1,0 +1,30 @@
+use crate::controller::{
+    resources::{OperationGuardArc, TraceSpan},
+    task_poller::{PollContext, PollResult, PollerState},
+};
+
+use stor_port::types::v0::{store::nexus::NexusSpec, transport::NexusStatus};
+
+/// Find thin-provisioned Nexus children which are degraded due to ENOSPC and try to online them
+/// if sufficient pool space has been freed.
+#[tracing::instrument(skip(nexus, context), level = "trace", fields(nexus.uuid = %nexus.uuid(), request.reconcile = true))]
+pub(crate) async fn enospc_children_onliner(
+    nexus: &mut OperationGuardArc<NexusSpec>,
+    context: &PollContext,
+) -> PollResult {
+    let nexus_uuid = nexus.uuid();
+    let nexus_state = context.registry().nexus(nexus_uuid).await?;
+    let child_count = nexus_state.children.len();
+
+    if nexus_state.status == NexusStatus::Degraded && child_count > 1 {
+        for child in nexus_state.children.iter().filter(|c| c.enospc()) {
+            nexus.warn_span(|| {
+                tracing::info!(child.uri = child.uri.as_str(), "Found child with enospc")
+            });
+
+            // todo: online child
+        }
+    }
+
+    PollResult::Ok(PollerState::Idle)
+}

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
@@ -1,9 +1,15 @@
 use crate::controller::{
+    io_engine::NexusChildActionApi,
+    registry::Registry,
     resources::{OperationGuardArc, TraceSpan},
     task_poller::{PollContext, PollResult, PollerState},
 };
+use agents::errors::SvcError;
 
-use stor_port::types::v0::{store::nexus::NexusSpec, transport::NexusStatus};
+use stor_port::types::v0::{
+    store::nexus::NexusSpec,
+    transport::{Child, NexusChildActionContext, NexusStatus},
+};
 
 /// Find thin-provisioned Nexus children which are degraded due to ENOSPC and try to online them
 /// if sufficient pool space has been freed.
@@ -22,9 +28,119 @@ pub(crate) async fn enospc_children_onliner(
                 tracing::info!(child.uri = child.uri.as_str(), "Found child with enospc")
             });
 
-            // todo: online child
+            if let Err(error) = online_enospc(nexus, child, context.registry()).await {
+                nexus.warn_span(|| {
+                    tracing::error!(child.uri = child.uri.as_str(), %error, "Failed to online child");
+                });
+            }
         }
     }
 
     PollResult::Ok(PollerState::Idle)
+}
+
+async fn online_enospc(
+    nexus: &mut OperationGuardArc<NexusSpec>,
+    child: &Child,
+    registry: &Registry,
+) -> Result<(), SvcError> {
+    let replica_uri = nexus
+        .as_ref()
+        .replica_uri(&child.uri)
+        .ok_or(SvcError::Internal {
+            // this should never happen for managed nexus..
+            details: "Just a plain old uri, nothing we can do here..".into(),
+        })?;
+    let replica_spec = registry.specs().replica(replica_uri.uuid()).await?;
+    let replica_state = registry.get_replica(replica_uri.uuid()).await?;
+
+    let pool_name = replica_spec.as_ref().pool_name().clone();
+    let pool_wrapper = registry.get_node_pool_wrapper(pool_name).await?;
+
+    // todo: Should we list pools to check for latest free space?
+    tracing::debug!(
+        pool.id = pool_wrapper.id.as_str(),
+        pool.free_space = pool_wrapper.free_space(),
+        "Reporting free space in pool"
+    );
+
+    // Don't bother proceeding if we don't have at least this much free space...
+    let slack = 16 * 1024 * 1024;
+    if pool_wrapper.free_space() < slack {
+        nexus.info_span(|| {
+            tracing::warn!(
+                child.uri = %child.uri.as_str(),
+                pool.free_space = pool_wrapper.free_space(),
+                slack,
+                "Not enough free_space slack to online enospc child",
+            )
+        });
+        return Err(SvcError::NoCapacityToOnline {
+            pool_id: pool_wrapper.id.to_string(),
+            child: child.uri.to_string(),
+            free_space: pool_wrapper.free_space(),
+            required: slack,
+        });
+    }
+
+    // must have enough space for the current volume size!
+    let children = nexus.as_ref().children.iter();
+    let mut replicas = Vec::with_capacity(children.len());
+    for r in children.flat_map(|c| c.as_replica()) {
+        replicas.push(registry.get_replica(r.uuid()).await?);
+    }
+
+    let repl_allocated_bytes = replica_state
+        .space
+        .as_ref()
+        .map(|s| s.allocated_bytes)
+        .unwrap_or_default();
+    let allocated_bytes = replicas
+        .into_iter()
+        .flat_map(|r| r.space)
+        .map(|r| r.allocated_bytes)
+        .max()
+        .unwrap_or_else(|| nexus.as_ref().size);
+    // we've already allocated some bytes, so take those into account
+    let bytes_needed = allocated_bytes - repl_allocated_bytes;
+
+    // We need sufficient free space for at least the current allocation of other replicas, but
+    // just this capacity may not be enough as applications may carry on issuing new writes.
+    // So add some slack to ensure we have a little wiggle room.
+    // todo: how to figure out which slack to add, probably pool allocation rate?
+    let slack = 16 * 1024 * 1024;
+    let required_free_space = bytes_needed + slack;
+    if pool_wrapper.free_space() < required_free_space {
+        nexus.info_span(|| {
+            tracing::warn!(
+                child.uri = %child.uri.as_str(),
+                pool.free_space = pool_wrapper.free_space(),
+                required_free_space,
+                "Not enough free_space to online enospc child",
+            )
+        });
+        return Err(SvcError::NoCapacityToOnline {
+            pool_id: pool_wrapper.id.to_string(),
+            child: child.uri.to_string(),
+            free_space: pool_wrapper.free_space(),
+            required: required_free_space,
+        });
+    }
+
+    let nexus_node = &nexus.as_ref().node;
+    let node = registry.node_wrapper(nexus_node).await?;
+    node.online_child(&NexusChildActionContext::new(
+        nexus_node,
+        nexus.uuid(),
+        &child.uri,
+    ))
+    .await?;
+    nexus.info_span(|| {
+        tracing::info!(
+            child.uri = %child.uri.as_str(),
+            "Successfully onlined enospc child",
+        )
+    });
+
+    Ok(())
 }

--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/capacity.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/capacity.rs
@@ -1,0 +1,88 @@
+use crate::{
+    controller::{
+        registry::Registry,
+        resources::{operations_helper::OperationSequenceGuard, ResourceMutex},
+        scheduling::pool::ENoSpcReplica,
+        wrapper::{GetterOps, PoolWrapper},
+    },
+    pool::scheduling::unfiltered_enospc_pools,
+};
+use agents::errors::{PoolNotFound, SvcError};
+use snafu::OptionExt;
+use stor_port::types::v0::store::{pool::PoolSpec, replica::ReplicaSpec};
+
+/// When a pool is exhausted multiple thin-provisioned replicas may fail with ENOSPC.
+/// In this situation we'll currently adopt the simplistic strategy of faulting the largest replica
+/// on the pool, or more specifically the replica with largest actual allocation.
+/// A pre-condition for the replica faulting is that the volume to which the replica belongs to
+/// should retain "enough" remaining healthy replicas! For example, we can't fault the last replica
+/// of a volume as we can't rebuild from "thin" air.
+pub(crate) async fn remove_larger_replicas(registry: &Registry) {
+    let pools = unfiltered_enospc_pools(registry).await;
+
+    if !pools.is_empty() {
+        tracing::warn!("Found {} pools with ENOSPACE replicas", pools.len());
+    }
+
+    for pool in pools {
+        let (pool, replicas) = pool.into_parts();
+        if let Ok(pool_wrapper) = node_pool_wrapper(&pool, registry).await {
+            let largest_replica = pool_wrapper
+                .move_replicas()
+                .into_iter()
+                .filter_map(|r| {
+                    replicas
+                        .iter()
+                        .find(|rs| rs.replica().uuid == r.uuid)
+                        .map(|rs| (r, rs))
+                })
+                .max_by(|(a, _), (b, _)| match (&a.space, &b.space) {
+                    (Some(space_a), Some(space_b)) => {
+                        space_a.allocated_bytes.cmp(&space_b.allocated_bytes)
+                    }
+                    // If we're running a thin volume on io-engine v1, this should not happen.
+                    _ => std::cmp::Ordering::Equal,
+                })
+                .and_then(|(r, rs)| registry.specs().replica_rsc(&r.uuid).map(|r| (r, rs)));
+
+            // If the node is online/flaky we might not be able to get the current replica
+            // information, and in this case there's not much we can do.
+            if let Some(largest_replica) = largest_replica {
+                let _ = remove_larger_replica(largest_replica, registry).await;
+            }
+        }
+    }
+}
+
+async fn remove_larger_replica(
+    (replica, eno_replica): (ResourceMutex<ReplicaSpec>, &ENoSpcReplica),
+    registry: &Registry,
+) -> Result<bool, SvcError> {
+    let volume_owner = replica.lock().owners.volume().cloned();
+    match volume_owner {
+        Some(volume) => {
+            let mut volume = registry.specs().volume(&volume).await?;
+            volume.remove_replica(eno_replica, registry).await?;
+            Ok(true)
+        }
+        None => {
+            // The replica is not part of a volume, and not managed by us, NMP.
+            if !replica.lock().managed {
+                return Ok(false);
+            }
+
+            let nexus = eno_replica.nexus().operation_guard()?;
+            let mut replica = replica.operation_guard()?;
+            replica.fault(nexus, eno_replica, registry).await?;
+            Ok(true)
+        }
+    }
+}
+
+async fn node_pool_wrapper(pool: &PoolSpec, registry: &Registry) -> Result<PoolWrapper, SvcError> {
+    let node = registry.node_wrapper(&pool.node).await?;
+    let pool_wrapper = node.pool_wrapper(&pool.id).await.context(PoolNotFound {
+        pool_id: pool.id.clone(),
+    })?;
+    Ok(pool_wrapper)
+}

--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
@@ -1,3 +1,5 @@
+mod capacity;
+
 use crate::controller::{
     reconciler::{GarbageCollect, ReCreate},
     resources::{
@@ -53,6 +55,7 @@ impl TaskPoller for PoolReconciler {
                 pool.recreate_state(context).await,
             ]))
         }
+        capacity::remove_larger_replicas(context.registry()).await;
         Self::squash_results(results)
     }
 

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
@@ -296,7 +296,7 @@ async fn disown_non_reservable_replicas(
 
     // Remove the local child from the shutdown pending nexuses as they are
     // non reservable.
-    for mut nexus in shutdown_failed_nexuses {
+    for nexus in shutdown_failed_nexuses {
         let children = nexus.lock().clone().children;
         for child in children {
             if let Some(replica_uri) = child.as_replica() {

--- a/control-plane/agents/src/bin/core/controller/resources/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/nexus/mod.rs
@@ -6,7 +6,7 @@ use stor_port::types::v0::{
 
 impl ResourceMutex<NexusSpec> {
     /// Get the resource uuid.
-    pub fn uuid(&mut self) -> &NexusId {
+    pub fn uuid(&self) -> &NexusId {
         &self.immutable_ref().uuid
     }
 }

--- a/control-plane/agents/src/bin/core/controller/resources/operations.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations.rs
@@ -89,6 +89,7 @@ pub(crate) trait ResourceOffspring {
     type Add: Sync + Send;
     type AddOutput: Sync + Send;
     type Remove: Sync + Send;
+    type Fault: Sync + Send;
 
     /// Add a child to the resource.
     async fn add_child(

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod nexus;
+pub(crate) mod pool;
 pub(crate) mod resources;
 pub(crate) mod volume;
 mod volume_policy;

--- a/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
@@ -12,7 +12,7 @@ use agents::errors::SvcError;
 use std::ops::Deref;
 use stor_port::types::v0::{
     store::{nexus::NexusSpec, nexus_persistence::NexusInfo, volume::VolumeSpec},
-    transport::{ChildUri, NexusId, NodeId, VolumeId},
+    transport::{NexusId, NodeId, VolumeId},
 };
 
 /// Request to retrieve a list of healthy nexus children which is used for nexus creation
@@ -143,7 +143,7 @@ impl GetPersistedNexusChildrenCtx {
                 let child_info = self.nexus_info.as_ref().and_then(|n| {
                     n.children.iter().find(|c| {
                         if let Some(replica_state) = replica_state {
-                            ChildUri::from(&replica_state.uri).uuid_str().as_ref() == Some(&c.uuid)
+                            replica_state.uuid == c.uuid
                         } else {
                             false
                         }

--- a/control-plane/agents/src/bin/core/controller/scheduling/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/pool.rs
@@ -1,0 +1,177 @@
+use crate::controller::{
+    registry::Registry,
+    resources::{ResourceMutex, ResourceUid},
+    scheduling::{ResourceData, ResourceFilter},
+};
+use agents::errors::SvcError;
+use stor_port::types::v0::{
+    store::{
+        nexus::{NexusSpec, ReplicaUri},
+        pool::PoolSpec,
+        replica::ReplicaSpec,
+    },
+    transport::{Child, NexusId, NexusStatus, NodeId},
+};
+
+#[derive(Clone)]
+pub(crate) struct NexusChildrenENoSpcPoolsCtx {
+    #[allow(unused)]
+    registry: Registry,
+}
+
+/// ResourceData context for getting pools with failed ENOSPC NexusChildren's replicas.
+#[derive(Clone)]
+pub(crate) struct NexusChildrenENoSpcPools {
+    data: ResourceData<NexusChildrenENoSpcPoolsCtx, ENoSpcPool>,
+}
+
+#[async_trait::async_trait(?Send)]
+impl ResourceFilter for NexusChildrenENoSpcPools {
+    type Request = NexusChildrenENoSpcPoolsCtx;
+    type Item = ENoSpcPool;
+
+    fn data(&mut self) -> &mut ResourceData<Self::Request, Self::Item> {
+        &mut self.data
+    }
+
+    fn collect(self) -> Vec<Self::Item> {
+        self.data.list
+    }
+}
+
+impl NexusChildrenENoSpcPools {
+    async fn builder(registry: &Registry) -> Self {
+        let list = nexus_enospc_pools(registry).await;
+        Self {
+            data: ResourceData::new(
+                NexusChildrenENoSpcPoolsCtx {
+                    registry: registry.clone(),
+                },
+                list,
+            ),
+        }
+    }
+
+    /// Builder used to retrieve a list of pools with their respective ENOSPC replicas.
+    /// No filtering is done yet until we decide on what the best strategy is.
+    pub(crate) async fn builder_with_defaults(registry: &Registry) -> Self {
+        Self::builder(registry).await
+    }
+}
+
+/// A pool spec with a list of its failed ENOSPC replicas.
+/// # Note
+/// The replica itself is not flagged as ENOSPC, rather it's via the `NexusChild`
+/// that we find this information.
+#[derive(Debug, Clone)]
+pub(crate) struct ENoSpcPool {
+    pool: PoolSpec,
+    repl: Vec<ENoSpcReplica>,
+}
+/// A replica whose equivalent `NexusChild` has hit ENOSPC.
+#[derive(Debug, Clone)]
+pub(crate) struct ENoSpcReplica {
+    nexus: ResourceMutex<NexusSpec>,
+    replica: ReplicaSpec,
+    child: ReplicaUri,
+    repl_node: NodeId,
+}
+impl ENoSpcPool {
+    /// Collect the spec and replicas.
+    pub(crate) fn into_parts(self) -> (PoolSpec, Vec<ENoSpcReplica>) {
+        (self.pool, self.repl)
+    }
+}
+impl ENoSpcReplica {
+    /// Get a reference to the replica.
+    pub(crate) fn replica(&self) -> &ReplicaSpec {
+        &self.replica
+    }
+    /// Get a reference to the nexus.
+    pub(crate) fn nexus(&self) -> &ResourceMutex<NexusSpec> {
+        &self.nexus
+    }
+    /// Get a reference to the replica node.
+    pub(crate) fn repl_node(&self) -> &NodeId {
+        &self.repl_node
+    }
+    /// Get a reference to the child.
+    pub(crate) fn child(&self) -> &ReplicaUri {
+        &self.child
+    }
+}
+
+async fn nexus_enospc_pools(registry: &Registry) -> Vec<ENoSpcPool> {
+    let mut enospc_children = Vec::new();
+
+    for nexus in registry.specs().nexuses() {
+        if let Ok(raw_children) = enospc_nexus_children(&nexus, registry).await {
+            enospc_children.extend(raw_children.into_iter().map(|c| (nexus.clone(), c)));
+        }
+    }
+
+    let mut pools = Vec::<ENoSpcPool>::new();
+    for (nexus, child) in enospc_children {
+        if let Ok(repl) = registry.specs().replica(child.uuid()).await {
+            let pool = repl.as_ref().pool.pool_name();
+            if let Ok(pool) = registry.specs().pool(pool) {
+                let node = pool.node.clone();
+                match pools.iter_mut().find(|p| p.pool.uid() == pool.uid()) {
+                    None => {
+                        pools.push(ENoSpcPool {
+                            pool,
+                            repl: vec![ENoSpcReplica {
+                                nexus: nexus.clone(),
+                                replica: repl.lock().clone(),
+                                child,
+                                repl_node: node,
+                            }],
+                        });
+                    }
+                    Some(pool) => {
+                        pool.repl.push(ENoSpcReplica {
+                            nexus: nexus.clone(),
+                            replica: repl.lock().clone(),
+                            child,
+                            repl_node: node,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    pools
+}
+
+async fn enospc_nexus_children(
+    nexus: &ResourceMutex<NexusSpec>,
+    registry: &Registry,
+) -> Result<Vec<ReplicaUri>, SvcError> {
+    let children_states = enospc_children(nexus.uuid(), registry).await?;
+    let children_specs = {
+        let nexus = nexus.lock();
+        children_states
+            .into_iter()
+            .flat_map(|state| nexus.replica_uri(&state.uri))
+            .collect::<Vec<_>>()
+    };
+
+    Ok(children_specs)
+}
+
+async fn enospc_children(
+    nexus_uuid: &NexusId,
+    registry: &Registry,
+) -> Result<Vec<Child>, SvcError> {
+    let nexus_state = registry.nexus(nexus_uuid).await?;
+    if nexus_state.status == NexusStatus::Degraded {
+        let enospc = nexus_state
+            .children
+            .into_iter()
+            .filter(|c| c.enospc())
+            .collect::<Vec<_>>();
+        return Ok(enospc);
+    }
+    Ok(vec![])
+}

--- a/control-plane/agents/src/bin/core/controller/scheduling/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/pool.rs
@@ -154,6 +154,7 @@ async fn enospc_nexus_children(
         children_states
             .into_iter()
             .flat_map(|state| nexus.replica_uri(&state.uri))
+            .cloned()
             .collect::<Vec<_>>()
     };
 

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
@@ -11,7 +11,7 @@ use crate::controller::{
 use agents::errors::SvcError;
 use stor_port::types::v0::{
     store::{nexus::NexusSpec, nexus_persistence::NexusInfo, volume::VolumeSpec},
-    transport::{ChildUri, VolumeState},
+    transport::VolumeState,
 };
 
 use std::ops::Deref;
@@ -438,7 +438,7 @@ impl VolumeReplicasForNexusCtx {
                 let child_info = self.nexus_info.as_ref().and_then(|n| {
                     n.children.iter().find(|c| {
                         if let Some(replica_state) = replica_state {
-                            ChildUri::from(&replica_state.uri).uuid_str().as_ref() == Some(&c.uuid)
+                            replica_state.uuid == c.uuid
                         } else {
                             false
                         }

--- a/control-plane/agents/src/bin/core/nexus/operations.rs
+++ b/control-plane/agents/src/bin/core/nexus/operations.rs
@@ -29,11 +29,6 @@ use stor_port::types::v0::{
     },
 };
 
-// pub(crate) struct FaultNexusChild {
-//     pub(crate) uri: ChildUri,
-// }
-//pub(crate) type FaultNexusChild = ChildUri;
-
 #[async_trait::async_trait]
 impl ResourceLifecycle for OperationGuardArc<NexusSpec> {
     type Create = CreateNexus;

--- a/control-plane/agents/src/bin/core/nexus/operations.rs
+++ b/control-plane/agents/src/bin/core/nexus/operations.rs
@@ -25,9 +25,14 @@ use stor_port::types::v0::{
     transport::{
         child::Child,
         nexus::{CreateNexus, DestroyNexus, Nexus, ShareNexus, UnshareNexus},
-        AddNexusChild, NodeStatus, RemoveNexusChild, ShutdownNexus,
+        AddNexusChild, FaultNexusChild, NodeStatus, RemoveNexusChild, ShutdownNexus,
     },
 };
+
+// pub(crate) struct FaultNexusChild {
+//     pub(crate) uri: ChildUri,
+// }
+//pub(crate) type FaultNexusChild = ChildUri;
 
 #[async_trait::async_trait]
 impl ResourceLifecycle for OperationGuardArc<NexusSpec> {
@@ -195,6 +200,7 @@ impl ResourceOffspring for OperationGuardArc<NexusSpec> {
     type Add = AddNexusChild;
     type AddOutput = Child;
     type Remove = RemoveNexusChild;
+    type Fault = FaultNexusChild;
 
     async fn add_child(
         &mut self,
@@ -218,6 +224,7 @@ impl ResourceOffspring for Option<&mut OperationGuardArc<NexusSpec>> {
     type Add = AddNexusChild;
     type AddOutput = Child;
     type Remove = RemoveNexusChild;
+    type Fault = FaultNexusChild;
 
     async fn add_child(
         &mut self,

--- a/control-plane/agents/src/bin/core/nexus/registry.rs
+++ b/control-plane/agents/src/bin/core/nexus/registry.rs
@@ -95,7 +95,7 @@ impl Registry {
                         info.uuid = nexus_uuid.clone();
                         Ok(Some(info))
                     }
-                    Err(SvcError::StoreMissingEntry { .. }) if missing_key_is_error => Ok(None),
+                    Err(SvcError::StoreMissingEntry { .. }) if !missing_key_is_error => Ok(None),
                     Err(error) => Err(error),
                 }
             }

--- a/control-plane/agents/src/bin/core/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/pool/mod.rs
@@ -1,6 +1,7 @@
 mod pool_operations;
 mod registry;
 mod replica_operations;
+pub(crate) mod scheduling;
 mod service;
 mod specs;
 pub(crate) mod wrapper;

--- a/control-plane/agents/src/bin/core/pool/replica_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/replica_operations.rs
@@ -2,16 +2,21 @@ use crate::controller::{
     io_engine::ReplicaApi,
     registry::Registry,
     resources::{
-        operations::{ResourceLifecycle, ResourceOwnerUpdate, ResourceSharing},
+        operations::{ResourceLifecycle, ResourceOffspring, ResourceOwnerUpdate, ResourceSharing},
         operations_helper::{GuardedOperationsHelper, OnCreateFail, OperationSequenceGuard},
         OperationGuardArc, UpdateInnerValue,
     },
+    scheduling::pool::ENoSpcReplica,
 };
 use agents::errors::{SvcError, SvcError::CordonedNode};
 use stor_port::types::v0::{
-    store::replica::{ReplicaOperation, ReplicaSpec},
+    store::{
+        nexus::NexusSpec,
+        replica::{PoolRef, ReplicaOperation, ReplicaSpec},
+    },
     transport::{
-        CreateReplica, DestroyReplica, Replica, ReplicaOwners, ShareReplica, UnshareReplica,
+        CreateReplica, DestroyReplica, NodeId, RemoveNexusChild, Replica, ReplicaOwners,
+        ShareReplica, UnshareReplica,
     },
 };
 
@@ -187,5 +192,58 @@ impl ResourceOwnerUpdate for OperationGuardArc<ReplicaSpec> {
             }
             Err(error) => Err(error),
         }
+    }
+}
+
+impl OperationGuardArc<ReplicaSpec> {
+    /// Faults this replica.
+    /// The replica is first removed from the nexus, which will let us know if it's safe to destroy
+    /// it.
+    /// Then we can destroy the replica knowing it's not integral part of a volume.
+    #[tracing::instrument(level = "debug", skip(self, nexus, info, registry), fields(volume.uuid = %self.uuid(), replica.uuid = %info.child().uuid()))]
+    pub(crate) async fn fault(
+        &mut self,
+        mut nexus: OperationGuardArc<NexusSpec>,
+        info: &ENoSpcReplica,
+        registry: &Registry,
+    ) -> Result<(), SvcError> {
+        // First we must remove the child from thus nexus, thus rendering it a "non-healthy" child.
+        // The nexus should fail removal if there are no other healthy children.
+        let nexus_node = nexus.as_ref().node.clone();
+        nexus
+            .remove_child(
+                registry,
+                &RemoveNexusChild {
+                    node: nexus_node,
+                    nexus: info.nexus().uuid().clone(),
+                    uri: info.child().uri().clone(),
+                },
+            )
+            .await?;
+
+        // Now it's safe to delete the replica.
+        let request = destroy_replica_request(info.replica(), info.repl_node());
+        self.destroy(registry, &request).await?;
+
+        Ok(())
+    }
+}
+
+fn destroy_replica_request(spec: &ReplicaSpec, node: &NodeId) -> DestroyReplica {
+    let pool_id = match spec.pool.clone() {
+        PoolRef::Named(id) => id,
+        PoolRef::Uuid(id, _) => id,
+    };
+    let pool_uuid = match spec.pool.clone() {
+        PoolRef::Named(_) => None,
+        PoolRef::Uuid(_, uuid) => Some(uuid),
+    };
+    DestroyReplica {
+        node: node.clone(),
+        pool_id,
+        pool_uuid,
+        uuid: spec.uuid.clone(),
+        name: spec.name.clone().into(),
+        disowners: ReplicaOwners::new_disown_all(),
     }
 }

--- a/control-plane/agents/src/bin/core/pool/scheduling.rs
+++ b/control-plane/agents/src/bin/core/pool/scheduling.rs
@@ -1,0 +1,18 @@
+use crate::controller::{
+    registry::Registry,
+    scheduling::{
+        pool::{ENoSpcPool, NexusChildrenENoSpcPools},
+        ResourceFilter,
+    },
+};
+
+/// Get all the pools that have seen replicas hit with ENoSpcPool and their respective replicas
+/// whose "NexusChild" have failed due to ENOSPC error.
+/// They are currently "unfiltered" as we're still not sure what the best way to pick replicas
+/// to move is.
+pub(crate) async fn unfiltered_enospc_pools(registry: &Registry) -> Vec<ENoSpcPool> {
+    let candidates: Vec<ENoSpcPool> = NexusChildrenENoSpcPools::builder_with_defaults(registry)
+        .await
+        .collect();
+    candidates
+}

--- a/control-plane/agents/src/bin/core/pool/wrapper.rs
+++ b/control-plane/agents/src/bin/core/pool/wrapper.rs
@@ -37,6 +37,10 @@ impl PoolWrapper {
     pub(crate) fn replicas(&self) -> &Vec<Replica> {
         &self.replicas
     }
+    /// Get all the replicas.
+    pub(crate) fn move_replicas(self) -> Vec<Replica> {
+        self.replicas
+    }
     /// Get the specified replica.
     pub(crate) fn replica(&self, replica: &ReplicaId) -> Option<&Replica> {
         self.replicas.iter().find(|r| &r.uuid == replica)

--- a/control-plane/agents/src/bin/core/tests/volume/capacity.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/capacity.rs
@@ -1,24 +1,26 @@
 #![cfg(test)]
 
-use crate::volume::helpers::wait_till_volume_children;
-use deployer_cluster::{ClusterBuilder, FindVolumeRequest};
+use crate::volume::RECONCILE_TIMEOUT_SECS;
+use deployer_cluster::{Cluster, ClusterBuilder, FindVolumeRequest};
+use grpc::operations::volume::traits::VolumeOperations;
 use std::{collections::HashMap, convert::TryFrom, time::Duration};
 use stor_port::types::v0::{
     openapi::{models, models::PublishVolumeBody},
-    transport::ReplicaId,
+    transport::{ChildState, Filter, VolumeStatus},
 };
 
-/// Re-enable after onliner...
 #[tokio::test]
-async fn fault_enospc_child() {
+async fn online_enospc_child() {
+    let cache_period = Duration::from_millis(250);
     let cluster = ClusterBuilder::builder()
         .with_rest(true)
-        .with_io_engines(3)
-        .with_pools(1)
+        .with_io_engines(2)
+        .with_pool(0, "malloc:///p1?size_mb=300")
+        .with_pool(1, "malloc:///p1?size_mb=100")
         .with_csi(false, true)
         .with_options(|o| o.with_isolated_io_engine(true))
-        .with_cache_period("250ms")
-        .with_reconcile_period(Duration::from_millis(250), Duration::from_millis(250))
+        .with_cache_period(&humantime::Duration::from(cache_period).to_string())
+        .with_reconcile_period(Duration::from_millis(3000), Duration::from_millis(3000))
         .build()
         .await
         .unwrap();
@@ -28,11 +30,11 @@ async fn fault_enospc_child() {
     let pools_api = api_client.pools_api();
     let replica_api = api_client.replicas_api();
 
-    let volume_1_size = 10u64 * 1024 * 1024;
+    let volume_size = 80u64 * 1024 * 1024;
     let mut volume_1 = volumes_api
         .put_volume(
             &"ec4e66fd-3b33-4439-b504-d49aba53da26".parse().unwrap(),
-            models::CreateVolumeBody::new(models::VolumePolicy::new(true), 3, volume_1_size, true),
+            models::CreateVolumeBody::new(models::VolumePolicy::new(true), 2, volume_size, true),
         )
         .await
         .unwrap();
@@ -53,38 +55,32 @@ async fn fault_enospc_child() {
     let uri = volume_1.state.target.as_ref().unwrap().device_uri.as_str();
     let _drop_target = DeviceDisconnect(nvmeadm::NvmeTarget::try_from(uri).unwrap());
 
-    replica_api
-        .put_pool_replica(
-            cluster.pool(0, 0).as_str(),
-            &ReplicaId::new(),
-            models::CreateReplicaBody {
-                share: None,
-                size: 85u64 * 1024 * 1024,
-                thin: false,
-                allowed_hosts: None,
-            },
+    let mut volume_2 = volumes_api
+        .put_volume(
+            &"ec4e66fd-3b33-4439-b504-d49aba53da27".parse().unwrap(),
+            models::CreateVolumeBody::new(models::VolumePolicy::new(true), 2, volume_size, true),
         )
         .await
         .unwrap();
-    replica_api
-        .put_pool_replica(
-            cluster.pool(1, 0).as_str(),
-            &ReplicaId::new(),
-            models::CreateReplicaBody {
-                share: None,
-                size: 85u64 * 1024 * 1024,
-                thin: false,
-                allowed_hosts: None,
-            },
+    volume_2 = volumes_api
+        .put_volume_target(
+            &volume_2.spec.uuid,
+            PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                cluster.node(0).to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+            ),
         )
         .await
         .unwrap();
-    let pool = pools_api
-        .get_pool(cluster.pool(0, 0).as_str())
-        .await
-        .unwrap();
-    let pool = pool.state.unwrap();
-    tracing::info!(?pool, "Here's the pool");
+    let uri = volume_2.state.target.as_ref().unwrap().device_uri.as_str();
+    let _drop_target2 = DeviceDisconnect(nvmeadm::NvmeTarget::try_from(uri).unwrap());
+
+    let pools = pools_api.get_pools().await.unwrap();
+    tracing::info!(?pools, "Here's the pools");
 
     let replicas = replica_api.get_replicas().await.unwrap();
     tracing::info!(?replicas, "Here's the replicas");
@@ -99,20 +95,70 @@ async fn fault_enospc_child() {
         .await
         .unwrap();
     tracing::info!(?response);
+    let device_path_1 = response.into_inner().device_path;
 
-    let device_path = response.into_inner().device_path;
-    let output = cluster
-        .composer()
-        .exec(
-            cluster.csi_container(0).as_str(),
-            vec![
-                "dd",
-                "if=/dev/zero",
-                format!("of={device_path}").as_str(),
-                "bs=64k",
-            ],
+    node.node_stage_volume(&volume_2).await.unwrap();
+    let response = node
+        .internal()
+        .find_volume(FindVolumeRequest {
+            volume_id: volume_2.spec.uuid.to_string(),
+        })
+        .await
+        .unwrap();
+    tracing::info!(?response);
+    let device_path_2 = response.into_inner().device_path;
+
+    let name = cluster.csi_container(0);
+    let dev_path_1 = format!("of={device_path_1}");
+
+    let dd_1 = cluster.composer().exec(
+        name.as_str(),
+        vec![
+            "dd",
+            "if=/dev/urandom",
+            dev_path_1.as_str(),
+            "bs=64k",
+            "count=640",
+        ],
+    );
+    let dev_path_2 = format!("of={device_path_2}");
+    let dd_2 = cluster.composer().exec(
+        name.as_str(),
+        vec![
+            "dd",
+            "if=/dev/urandom",
+            dev_path_2.as_str(),
+            "bs=64k",
+            "count=640",
+        ],
+    );
+
+    let output = futures::future::join(dd_1, dd_2).await;
+    tracing::info!("\n{:?}", output);
+
+    // 1. really need a way to by pass the cache!
+    // for now simply wait for the cache period!
+    tokio::time::sleep(cache_period * 2).await;
+    log_thin(&cluster).await;
+
+    pools_api
+        .put_node_pool(
+            cluster.node(1).as_str(),
+            cluster.pool(1, 1).as_str(),
+            models::CreatePoolBody::new(vec!["malloc:///disk?size_mb=200"]),
         )
-        .await;
+        .await
+        .unwrap();
+
+    let dd_1 = cluster.composer().exec(
+        name.as_str(),
+        vec!["dd", "if=/dev/urandom", dev_path_1.as_str(), "bs=64k"],
+    );
+    let dd_2 = cluster.composer().exec(
+        name.as_str(),
+        vec!["dd", "if=/dev/urandom", dev_path_2.as_str(), "bs=64k"],
+    );
+    let output = futures::future::join(dd_1, dd_2).await;
 
     cluster
         .composer()
@@ -123,10 +169,46 @@ async fn fault_enospc_child() {
         .await
         .unwrap();
 
-    tracing::info!("\n{:?}", output.unwrap());
+    tracing::info!("\n{:?}", output);
+
+    tokio::time::sleep(cache_period * 2).await;
+    log_thin(&cluster).await;
 
     let volume_client = cluster.grpc_client().volume();
-    let _ = wait_till_volume_children(&volume_1.spec.uuid.into(), 2, &volume_client).await;
+    wait_till_1_volume_healthy(&volume_client).await;
+}
+
+async fn log_thin(cluster: &Cluster) {
+    let api_client = cluster.rest_v00();
+    let volumes_api = api_client.volumes_api();
+    let pools_api = api_client.pools_api();
+    let replica_api = api_client.replicas_api();
+
+    let volumes = volumes_api.get_volumes(0, None, None).await.unwrap();
+
+    for volume in volumes.entries {
+        let target = volume.state.target.as_ref().unwrap();
+        tracing::info!("VolumeStatus: {} => {target:#?}", volume.spec.uuid);
+    }
+
+    let pools = pools_api.get_pools().await.unwrap();
+    let pools = pools
+        .into_iter()
+        .map(|p| p.state.unwrap())
+        .collect::<Vec<_>>();
+    tracing::info!("Here's the pools: {pools:#?}");
+    for replica in replica_api.get_replicas().await.unwrap() {
+        let space = replica.space.as_ref().unwrap();
+        let free = (space.capacity_bytes - space.allocated_bytes) / (1024 * 1024);
+        let cap = space.capacity_bytes / (1024 * 1024);
+        tracing::info!(
+            "Replica {}/{} => {}MB free out of {}MB",
+            replica.uuid,
+            replica.node,
+            free,
+            cap
+        );
+    }
 }
 
 struct DeviceDisconnect(nvmeadm::NvmeTarget);
@@ -138,5 +220,31 @@ impl Drop for DeviceDisconnect {
                 .status()
                 .unwrap();
         }
+    }
+}
+
+async fn wait_till_1_volume_healthy(volume_client: &dyn VolumeOperations) {
+    let timeout = Duration::from_secs(RECONCILE_TIMEOUT_SECS);
+    let start = std::time::Instant::now();
+    loop {
+        let volumes = volume_client
+            .get(Filter::None, false, None, None)
+            .await
+            .unwrap()
+            .entries;
+
+        for volume in &volumes {
+            if volume.status().as_ref().unwrap() == &VolumeStatus::Online {
+                let children = volume.state().target.unwrap().children;
+                if children.iter().all(|c| c.state == ChildState::Online) {
+                    return;
+                }
+            }
+        }
+
+        if std::time::Instant::now() > (start + timeout) {
+            panic!("Timeout waiting for a volume to be healthy! Current: {volumes:#?}");
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
     }
 }

--- a/control-plane/agents/src/bin/core/tests/volume/helpers.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/helpers.rs
@@ -113,6 +113,7 @@ async fn existing_replicas(volume_id: &VolumeId, client: &dyn VolumeOperations) 
 }
 
 /// Wait for the published volume target to have the specified number of children.
+#[allow(dead_code)]
 pub(crate) async fn wait_till_volume_children(
     volume: &VolumeId,
     children: usize,

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -170,7 +170,7 @@ async fn nexus_persistence_test_iteration(
     let mark_child_unhealthy = |c: &Child, ni: &mut NexusInfo| {
         let uri = url::Url::from_str(c.uri.as_str()).unwrap();
         let uuid = uri.query_pairs().find(|(q, _)| q == "uuid").unwrap().1;
-        let child_info = ni.children.iter_mut().find(|c| c.uuid == uuid);
+        let child_info = ni.children.iter_mut().find(|c| c.uuid.as_str() == uuid);
         child_info.unwrap().healthy = false;
     };
     match fault {

--- a/control-plane/stor-port/src/types/v0/store/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus.rs
@@ -132,9 +132,9 @@ impl NexusSpec {
         &self.status_info
     }
     /// Get the matching `ReplicaUri`.
-    pub fn replica_uri(&self, uri: &ChildUri) -> Option<ReplicaUri> {
+    pub fn replica_uri(&self, uri: &ChildUri) -> Option<&ReplicaUri> {
         self.children.iter().find_map(|c| match c {
-            NexusChild::Replica(replica) if &replica.share_uri == uri => Some(replica.clone()),
+            NexusChild::Replica(replica) if &replica.share_uri == uri => Some(replica),
             _ => None,
         })
     }
@@ -384,7 +384,7 @@ impl From<&NexusSpec> for DestroyNexus {
 /// Additional information about the nexus status.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct NexusStatusInfo {
-    pub shutdown_failed: bool,
+    shutdown_failed: bool,
 }
 
 impl NexusStatusInfo {

--- a/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
@@ -24,11 +24,12 @@ pub struct NexusInfo {
 impl NexusInfo {
     /// Check if the provided replica is healthy or not
     pub fn is_replica_healthy(&self, replica: &ReplicaId) -> bool {
-        match self.children.iter().find(|c| c.uuid == replica.as_str()) {
+        match self.children.iter().find(|c| &c.uuid == replica) {
             Some(info) => info.healthy,
             None => false,
         }
     }
+
     /// Check if no replica is healthy
     pub fn no_healthy_replicas(&self) -> bool {
         self.children.iter().all(|c| !c.healthy) || self.children.is_empty()
@@ -40,7 +41,7 @@ impl NexusInfo {
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct ChildInfo {
     /// UUID of the child.
-    pub uuid: String,
+    pub uuid: ReplicaId,
     /// Child's state of health.
     pub healthy: bool,
 }

--- a/control-plane/stor-port/src/types/v0/store/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/replica.rs
@@ -96,6 +96,13 @@ pub struct ReplicaSpec {
     pub allowed_hosts: Vec<HostNqn>,
 }
 
+impl ReplicaSpec {
+    /// Get the pool name.
+    pub fn pool_name(&self) -> &PoolId {
+        self.pool.pool_name()
+    }
+}
+
 /// Reference of a pool.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(untagged)]

--- a/control-plane/stor-port/src/types/v0/transport/child.rs
+++ b/control-plane/stor-port/src/types/v0/transport/child.rs
@@ -3,6 +3,7 @@ use super::*;
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt::Debug, str::FromStr};
+use strum_macros::Display;
 
 /// Child information
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
@@ -70,7 +71,7 @@ impl PartialEq<String> for ChildUri {
 }
 
 /// Child State information
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Display)]
 pub enum ChildState {
     /// Default Unknown state
     Unknown,


### PR DESCRIPTION
feat(capacity): remove largest enospc replicas

When a pool is exhausted multiple thin-provisioned replicas may fail with ENOSPC.
In this situation we'll currently adopt the simplistic strategy of faulting the largest replica
on the pool, or more specifically the replica with largest actual allocation.
A pre-condition for the replica faulting is that the volume to which the replica belongs to
should retain "enough" remaining healthy replicas! For example, we can't fault the last replica
of a volume as we can't rebuild from "thin" air.

todo: online nexus children if their respective pools have sufficient capacity.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

feat(capacity): online enospc children if there is enough capacity in the pool

It's not trivial to find out if we should online a child as the pool allocation can be forever
changing.
For capacity v1 start with a kiss approach of simply onlining children if we have *some* space.
We take into account the current replica and volume allocation.
Example, if the failed child's replica has been allocated up to 90% of the volume full capacity,
then we don't need free space for the whole volume capacity.
At the same time, if the volume current allocation is 90% then we need to make sure we have free
space to reach 90% of the volume allocation.
A dummy slack is added on top, which is mostly a placeholder for a future replacement that would
take into account pool allocation growth.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>