### PR TITLE
feat(rebuild/policy): add policies for rebuild orchestration

### DIFF
--- a/control-plane/agents/src/bin/core/controller/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/mod.rs
@@ -1,6 +1,8 @@
 //! Common modules used by the different core services
 
 pub(crate) mod io_engine;
+/// Various policies' definitions(e.g. rebuild policy)
+pub(crate) mod policies;
 /// reconciliation logic
 pub(crate) mod reconciler;
 /// registry with node and all its resources

--- a/control-plane/agents/src/bin/core/controller/policies/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/policies/mod.rs
@@ -1,0 +1,1 @@
+pub mod rebuild_policies;

--- a/control-plane/agents/src/bin/core/controller/policies/rebuild_policies.rs
+++ b/control-plane/agents/src/bin/core/controller/policies/rebuild_policies.rs
@@ -1,0 +1,107 @@
+#![allow(unused)]
+use stor_port::types::v0::transport::Nexus;
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/*
+    This file defines the policies that control plane uses to make
+    decisions about rebuild workflow behaviour in case of a child
+    becoming faulted. We can logically provide multiple different policies.
+    These policies are represented as an enum, since only one of the policy
+    can be applied to a given volume/nexus at a time. Once applied, the
+    behaviour of the policy can vary depending on runtime state of the nexus.
+    Any new policy introduced in future will have to implement Policy trait
+    for defining the policy behaviour.
+*/
+
+// time constants, in seconds
+const TWAIT_SPERF: std::time::Duration = Duration::new(600, 0);
+const TWAIT_SAVAIL: std::time::Duration = Duration::new(300, 0);
+const TWAIT_ZERO: std::time::Duration = Duration::new(0, 0);
+// 100GiB = 100 * 1024 * 1024 * 1024 bytes
+const VOL_SIZE_100GIB: u64 = 107374182400;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq)]
+/// SystemPerf policy, optimized for rebuild performance.
+pub struct SystemPerf {}
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq)]
+/// SystemAvail policy, optimized to maintain replica redundancy.
+pub struct SystemAvail {}
+
+/// Set of policies that internally define their rules regarding
+/// partial rebuild feasibility.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+pub enum RuleSet {
+    SystemPerf(SystemPerf),
+    SystemAvail(SystemAvail),
+}
+
+impl RuleSet {
+    /// Returns a duration value. The caller can use this duration
+    /// to timeout between two time Instants, particularly to wait
+    /// upon a faulted child to possibly be healthy again.
+    pub fn faulted_child_wait(nexus: &Nexus) -> Duration {
+        let _pol = Self::assign(nexus.size);
+        Self::default_faulted_child_timewait()
+
+        // TODO: Enable when policies are dynamic
+        /* match pol {
+            RuleSet::SystemAvail(pol) => pol.faulted_child_wait_duration(nexus),
+            RuleSet::SystemPerf(pol) => pol.faulted_child_wait_duration(nexus),
+        } */
+    }
+
+    /// Assign a rebuild policy to the nexus.
+    fn assign(size: u64) -> Self {
+        match size > VOL_SIZE_100GIB {
+            true => RuleSet::SystemPerf(SystemPerf {}),
+            false => RuleSet::default(),
+        }
+    }
+
+    fn default_faulted_child_timewait() -> Duration {
+        tracing::info!("default timed-wait TWAIT_SPERF(10 mins)");
+        TWAIT_SPERF
+    }
+}
+
+impl Default for RuleSet {
+    fn default() -> Self {
+        RuleSet::SystemAvail(SystemAvail {})
+    }
+}
+
+trait Policy {
+    fn faulted_child_wait_duration(&self, nexus: &Nexus) -> Duration;
+    fn faulted_child_state_allows_wait(&self, nexus: &Nexus) -> bool;
+}
+
+impl Policy for SystemPerf {
+    fn faulted_child_wait_duration(&self, _nexus: &Nexus) -> Duration {
+        TWAIT_SPERF
+    }
+
+    fn faulted_child_state_allows_wait(&self, _nexus: &Nexus) -> bool {
+        todo!()
+    }
+}
+
+impl Policy for SystemAvail {
+    fn faulted_child_wait_duration(&self, nexus: &Nexus) -> Duration {
+        let mut online_child_cnt = 0;
+        for _ in nexus.children.iter().filter(|c| c.state.online()) {
+            online_child_cnt += 1;
+        }
+        if online_child_cnt <= 1 {
+            // immediate full rebuild
+            return TWAIT_ZERO;
+        }
+
+        TWAIT_SAVAIL
+    }
+
+    fn faulted_child_state_allows_wait(&self, _nexus: &Nexus) -> bool {
+        todo!()
+    }
+}


### PR DESCRIPTION
Adding policies to orchestrate the behaviour of rebuilds. Based on these policies the control-plane decides whether to online the existing faulted child, in effect doing partial rebuild, OR immediately remove faulted child and add new one, in effect doing full rebuild.