### PR TITLE
chore(test/rebuild_policy): add component test for policy api

### DIFF
--- a/control-plane/agents/src/bin/core/controller/policies/rebuild_policies.rs
+++ b/control-plane/agents/src/bin/core/controller/policies/rebuild_policies.rs
@@ -1,8 +1,8 @@
-#![allow(unused)]
-use stor_port::types::v0::transport::Nexus;
-
+#[allow(unused)]
 use serde::{Deserialize, Serialize};
+
 use std::time::Duration;
+use stor_port::types::v0::transport::Nexus;
 
 /*
     This file defines the policies that control plane uses to make
@@ -16,11 +16,12 @@ use std::time::Duration;
 */
 
 // time constants, in seconds
-const TWAIT_SPERF: std::time::Duration = Duration::new(600, 0);
-const TWAIT_SAVAIL: std::time::Duration = Duration::new(300, 0);
-const TWAIT_ZERO: std::time::Duration = Duration::new(0, 0);
+pub const TWAIT_SPERF: std::time::Duration = Duration::new(600, 0);
+pub const TWAIT_SAVAIL: std::time::Duration = Duration::new(300, 0);
+pub const TWAIT_ZERO: std::time::Duration = Duration::new(0, 0);
 // 100GiB = 100 * 1024 * 1024 * 1024 bytes
-const VOL_SIZE_100GIB: u64 = 107374182400;
+#[allow(unused)]
+pub const VOL_SIZE_100GIB: u64 = 107374182400;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq)]
 /// SystemPerf policy, optimized for rebuild performance.
@@ -41,6 +42,7 @@ impl RuleSet {
     /// Returns a duration value. The caller can use this duration
     /// to timeout between two time Instants, particularly to wait
     /// upon a faulted child to possibly be healthy again.
+    #[allow(dead_code)]
     pub fn faulted_child_wait(nexus: &Nexus) -> Duration {
         let _pol = Self::assign(nexus.size);
         Self::default_faulted_child_timewait()
@@ -53,6 +55,7 @@ impl RuleSet {
     }
 
     /// Assign a rebuild policy to the nexus.
+    #[allow(dead_code)]
     fn assign(size: u64) -> Self {
         match size > VOL_SIZE_100GIB {
             true => RuleSet::SystemPerf(SystemPerf {}),
@@ -60,6 +63,7 @@ impl RuleSet {
         }
     }
 
+    #[allow(dead_code)]
     fn default_faulted_child_timewait() -> Duration {
         tracing::info!("default timed-wait TWAIT_SPERF(10 mins)");
         TWAIT_SPERF

--- a/control-plane/agents/src/bin/core/tests/policies/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/policies/mod.rs
@@ -1,0 +1,61 @@
+#![allow(unused)]
+
+/**
+This file contains tests for any policies that are present
+in the control plane.
+*/
+use deployer_cluster::{Cluster, ClusterBuilder};
+use grpc::operations::{nexus::traits::NexusOperations, node::traits::NodeOperations};
+
+use stor_port::types::v0::transport::{CreateNexus, Filter, Nexus, NexusId};
+
+mod pmodule {
+    include!("../../controller/policies/rebuild_policies.rs");
+}
+
+async fn build_cluster(num_ioe: u32, num_pools: u32) -> Cluster {
+    ClusterBuilder::builder()
+        .with_rest(false)
+        .with_agents(vec!["core"])
+        .with_io_engines(num_ioe)
+        .with_pools(num_pools)
+        .build()
+        .await
+        .unwrap()
+}
+
+/// Test that rebuild policy assignment based on volume size works correctly
+#[tokio::test]
+async fn assign_policy() {
+    let cluster = build_cluster(1, 2).await;
+
+    let io_engine = cluster.node(0);
+    let node_client = cluster.grpc_client().node();
+    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    tracing::info!("Nodes: {:?}", nodes);
+
+    let nexus_client = cluster.grpc_client().nexus();
+    let local = "malloc:///local?size_mb=12&uuid=4a7b0566-8ec6-49e0-a8b2-1d9a292cf59b".into();
+    let nexus = nexus_client
+        .create(
+            &CreateNexus {
+                node: io_engine.clone(),
+                uuid: NexusId::try_from("f086f12c-1728-449e-be32-9415051090d6").unwrap(),
+                size: 5242880,
+                children: vec![local],
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(!nexus.children.is_empty());
+
+    // Test if the policy is returning expected duration value.
+    // Validations need to become more elaborate as we expand the
+    // purview of policies.
+    let twait = pmodule::RuleSet::faulted_child_wait(&nexus);
+    assert!(!twait.is_zero());
+    assert!(twait.cmp(&pmodule::TWAIT_SPERF).is_eq() || twait.cmp(&pmodule::TWAIT_SAVAIL).is_eq());
+}

--- a/control-plane/agents/src/bin/core/tests/test.rs
+++ b/control-plane/agents/src/bin/core/tests/test.rs
@@ -1,6 +1,7 @@
 mod controller;
 mod nexus;
 mod node;
+mod policies;
 mod pool;
 mod volume;
 mod watch;


### PR DESCRIPTION
Simple cargo test for policy API. Will be enhanced as the policies are enriched.