### PR TITLE
Capacity - add storage usage to agents rpc and openapi

### DIFF
--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -502,6 +502,7 @@ async fn publishing_test(cluster: &Cluster) {
         .await
         .unwrap();
     wait_for_node_online(cluster, &target_node).await;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     volume_client
         .destroy(

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -140,6 +140,22 @@ message VolumeState {
   optional nexus.Nexus target = 4;
   // replica topology information
   map<string, ReplicaTopology> replica_topology = 5;
+  // volume usage information
+  optional VolumeUsage usage = 6;
+}
+
+// Volume usage information
+message VolumeUsage {
+  // Capacity of the volume in bytes.
+  uint64 capacity = 1;
+  // Allocated size in bytes, related to a single healthy replica.
+  // For example, if a volume has 2 replicas, each with 1MiB allocated space, then
+  // this field will be 1MiB.
+  uint64 allocated = 2;
+  // Allocated size in bytes, accrued from all the replica.
+  // For example, if a volume has 2 replicas, each with 1MiB allocated space, then
+  // this field will be 2MiB.
+  uint64 total_allocated = 3;
 }
 
 message ReplicaTopology {
@@ -149,6 +165,16 @@ message ReplicaTopology {
   optional string pool = 2;
   // status of the replica
   replica.ReplicaStatus status = 3;
+  // Volume Replica usage information
+  optional ReplicaUsage usage = 4;
+}
+
+// Volume Replica usage information
+message ReplicaUsage {
+  // Capacity of the replica in bytes.
+  uint64 capacity = 1;
+  // Allocated size in bytes.
+  uint64 allocated = 2;
 }
 
 message GetVolumesRequest {

--- a/control-plane/plugin/Cargo.toml
+++ b/control-plane/plugin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rest-plugin"
 description = "Rest Plugin"
 version = "1.0.0"
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "rest-plugin"

--- a/control-plane/plugin/src/resources/blockdevice.rs
+++ b/control-plane/plugin/src/resources/blockdevice.rs
@@ -49,20 +49,21 @@ impl BlockDeviceArgs {
 
 impl CreateRow for BlockDeviceAll {
     fn row(&self) -> Row {
+        let device = self.0.clone();
         row![
-            self.0.devname.clone(),
-            self.0.devtype.clone(),
-            self.0.size.to_string(),
-            String::from(if self.0.available { "yes" } else { "no" }),
-            self.0.model.clone(),
-            self.0.devpath.clone(),
-            self.0.devmajor.to_string(),
-            self.0.devminor.to_string(),
-            self.0.filesystem.fstype.clone(),
-            self.0.filesystem.uuid.clone(),
-            self.0.filesystem.mountpoint.clone(),
-            get_partition_type(&self.0.partition),
-            self.0
+            device.devname,
+            device.devtype,
+            ::utils::bytes::into_human(device.size * 512),
+            String::from(if device.available { "yes" } else { "no" }),
+            device.model,
+            device.devpath,
+            device.devmajor,
+            device.devminor,
+            device.filesystem.fstype,
+            device.filesystem.uuid,
+            device.filesystem.mountpoint,
+            get_partition_type(&device.partition),
+            device
                 .devlinks
                 .iter()
                 .map(|s| format!("\"{s}\""))
@@ -76,16 +77,17 @@ impl CreateRow for BlockDeviceAll {
 // BD returned from REST call with all set to false.
 impl CreateRow for BlockDeviceUsable {
     fn row(&self) -> Row {
+        let device = self.0.clone();
         row![
-            self.0.devname.clone(),
-            self.0.devtype.clone(),
-            self.0.size.to_string(),
-            String::from(if self.0.available { "yes" } else { "no" }),
-            self.0.model.clone(),
-            self.0.devpath.clone(),
-            self.0.devmajor.to_string(),
-            self.0.devminor.to_string(),
-            self.0
+            device.devname,
+            device.devtype,
+            ::utils::bytes::into_human(device.size * 512),
+            String::from(if device.available { "yes" } else { "no" }),
+            device.model,
+            device.devpath,
+            device.devmajor,
+            device.devminor,
+            device
                 .devlinks
                 .iter()
                 .map(|s| format!("\"{s}\""))

--- a/control-plane/plugin/src/resources/blockdevice.rs
+++ b/control-plane/plugin/src/resources/blockdevice.rs
@@ -2,7 +2,7 @@ use crate::{
     operations::GetBlockDevices,
     resources::{
         utils::{
-            print_table, CreateRows, GetHeaderRow, OutputFormat, BLOCKDEVICE_HEADERS_ALL,
+            print_table, CreateRow, GetHeaderRow, OutputFormat, BLOCKDEVICE_HEADERS_ALL,
             BLOCKDEVICE_HEADERS_USABLE,
         },
         NodeId,
@@ -47,11 +47,9 @@ impl BlockDeviceArgs {
     }
 }
 
-// CreateRows trait for BlockDeviceAll would create the row from the
-// BD returned from REST call with all set to true.
-impl CreateRows for BlockDeviceAll {
-    fn create_rows(&self) -> Vec<Row> {
-        vec![row![
+impl CreateRow for BlockDeviceAll {
+    fn row(&self) -> Row {
+        row![
             self.0.devname.clone(),
             self.0.devtype.clone(),
             self.0.size.to_string(),
@@ -70,15 +68,15 @@ impl CreateRows for BlockDeviceAll {
                 .map(|s| format!("\"{s}\""))
                 .collect::<Vec<String>>()
                 .join(", "),
-        ]]
+        ]
     }
 }
 
-// CreateRows trait for BlockDeviceUsable would create row from the
+// CreateRow trait for BlockDeviceUsable would create row from the
 // BD returned from REST call with all set to false.
-impl CreateRows for BlockDeviceUsable {
-    fn create_rows(&self) -> Vec<Row> {
-        vec![row![
+impl CreateRow for BlockDeviceUsable {
+    fn row(&self) -> Row {
+        row![
             self.0.devname.clone(),
             self.0.devtype.clone(),
             self.0.size.to_string(),
@@ -93,7 +91,7 @@ impl CreateRows for BlockDeviceUsable {
                 .map(|s| format!("\"{s}\""))
                 .collect::<Vec<String>>()
                 .join(", "),
-        ]]
+        ]
     }
 }
 

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -42,9 +42,9 @@ impl CreateRow for openapi::models::Pool {
             managed,
             state.node,
             state.status,
-            state.capacity,
-            state.used,
-            free,
+            ::utils::bytes::into_human(state.capacity),
+            ::utils::bytes::into_human(state.used),
+            ::utils::bytes::into_human(free),
         ]
     }
 }

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -2,7 +2,7 @@ use crate::{
     operations::{Get, List},
     resources::{
         utils,
-        utils::{CreateRows, GetHeaderRow},
+        utils::{CreateRow, GetHeaderRow},
         PoolId,
     },
     rest_wrapper::RestClient,
@@ -14,10 +14,8 @@ use prettytable::Row;
 #[derive(clap::Args, Debug)]
 pub struct Pools {}
 
-// CreateRows being trait for Pool would create the rows from the list of
-// Pools returned from REST call.
-impl CreateRows for openapi::models::Pool {
-    fn create_rows(&self) -> Vec<Row> {
+impl CreateRow for openapi::models::Pool {
+    fn row(&self) -> Row {
         // The spec would be empty if it was not created using
         // control plane.
         let managed = self.spec.is_some();
@@ -38,7 +36,7 @@ impl CreateRows for openapi::models::Pool {
             0
         };
         let disks = state.disks.join(", ");
-        let rows = vec![row![
+        row![
             self.id,
             disks,
             managed,
@@ -47,8 +45,7 @@ impl CreateRows for openapi::models::Pool {
             state.capacity,
             state.used,
             free,
-        ]];
-        rows
+        ]
     }
 }
 

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -63,8 +63,8 @@ lazy_static! {
     ];
 }
 
-// table_printer takes the above defined headers and the rows created at execution,
-// to create a Tabular output and prints to the stdout.
+/// table_printer takes the above defined headers and the rows created at execution,
+/// to create a Tabular output and prints to the stdout.
 pub fn table_printer(titles: Row, rows: Vec<Row>) {
     let mut table = Table::new();
     // FORMAT_CLEAN has been set to remove table borders
@@ -76,12 +76,16 @@ pub fn table_printer(titles: Row, rows: Vec<Row>) {
     table.printstd();
 }
 
-// CreateRows trait to be implemented by Vec<`resource`> to create the rows.
+/// CreateRows trait to be implemented by Vec<`resource`> to create the rows.
 pub trait CreateRows {
     fn create_rows(&self) -> Vec<Row>;
 }
+/// CreateRows trait to be implemented by `resource` to create a row.
+pub trait CreateRow {
+    fn row(&self) -> Row;
+}
 
-// GetHeaderRow trait to be implemented by Vec<`resource`> to fetch the corresponding headers.
+/// GetHeaderRow trait to be implemented by Vec<`resource`> to fetch the corresponding headers.
 pub trait GetHeaderRow {
     fn get_header_row(&self) -> Row;
 }
@@ -97,14 +101,21 @@ pub enum OutputFormat {
 
 impl<T> CreateRows for Vec<T>
 where
-    T: CreateRows,
+    T: CreateRow,
 {
     fn create_rows(&self) -> Vec<Row> {
-        self.iter().flat_map(|i| i.create_rows()).collect()
+        self.iter().map(|i| i.row()).collect()
+    }
+}
+impl<T> CreateRows for T
+where
+    T: CreateRow,
+{
+    fn create_rows(&self) -> Vec<Row> {
+        vec![self.row()]
     }
 }
 
-// GetHeaderRow trait to be implemented by Volume/Pool to fetch the corresponding headers.
 impl<T> GetHeaderRow for Vec<T>
 where
     T: GetHeaderRow,

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -19,19 +19,22 @@ lazy_static! {
         "ACCESSIBILITY",
         "STATUS",
         "SIZE",
-        "THIN-PROVISIONED"
+        "THIN-PROVISIONED",
+        "ALLOCATED"
     ];
     pub static ref POOLS_HEADERS: Row = row![
         "ID",
-        "TOTAL CAPACITY",
-        "USED CAPACITY",
         "DISKS",
+        "MANAGED",
         "NODE",
         "STATUS",
-        "MANAGED"
+        "CAPACITY",
+        "ALLOCATED",
+        "AVAILABLE"
     ];
     pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS", "CORDONED"];
-    pub static ref REPLICA_TOPOLOGY_HEADERS: Row = row!["ID", "NODE", "POOL", "STATUS"];
+    pub static ref REPLICA_TOPOLOGY_HEADERS: Row =
+        row!["ID", "NODE", "POOL", "STATUS", "CAPACITY", "ALLOCATED"];
     pub static ref BLOCKDEVICE_HEADERS_ALL: Row = row![
         "DEVNAME",
         "DEVTYPE",

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 
 use crate::{
     operations::ReplicaTopology,
-    resources::utils::{optional_cell, CreateRows, GetHeaderRow, OutputFormat},
+    resources::utils::{optional_cell, CreateRow, CreateRows, GetHeaderRow, OutputFormat},
 };
 use prettytable::Row;
 use std::collections::HashMap;
@@ -16,21 +16,19 @@ use std::collections::HashMap;
 #[derive(clap::Args, Debug)]
 pub struct Volumes {}
 
-// CreateRows being trait for Vec<Volume> would create the rows from the list of
-// Volumes returned from REST call.
-impl CreateRows for openapi::models::Volume {
-    fn create_rows(&self) -> Vec<Row> {
-        let state = self.state.clone();
-        vec![row![
+impl CreateRow for openapi::models::Volume {
+    fn row(&self) -> Row {
+        let state = &self.state;
+        row![
             state.uuid,
             self.spec.num_replicas,
             optional_cell(state.target.clone().map(|t| t.node)),
             optional_cell(state.target.as_ref().and_then(target_protocol)),
-            state.status,
+            state.status.clone(),
             state.size,
             self.spec.thin,
-            optional_cell(state.usage.map(|u| u.allocated))
-        ]]
+            optional_cell(state.usage.as_ref().map(|u| u.allocated))
+        ]
     }
 }
 
@@ -42,8 +40,6 @@ fn target_protocol(target: &openapi::models::Nexus) -> Option<openapi::models::P
     }
 }
 
-// GetHeaderRow being trait for Volume would return the Header Row for
-// Volume.
 impl GetHeaderRow for openapi::models::Volume {
     fn get_header_row(&self) -> Row {
         (*utils::VOLUME_HEADERS).clone()

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -21,16 +21,16 @@ pub struct Volumes {}
 impl CreateRows for openapi::models::Volume {
     fn create_rows(&self) -> Vec<Row> {
         let state = self.state.clone();
-        let rows = vec![row![
+        vec![row![
             state.uuid,
             self.spec.num_replicas,
             optional_cell(state.target.clone().map(|t| t.node)),
             optional_cell(state.target.as_ref().and_then(target_protocol)),
             state.status,
             state.size,
-            self.spec.thin
-        ]];
-        rows
+            self.spec.thin,
+            optional_cell(state.usage.map(|u| u.allocated))
+        ]]
     }
 }
 
@@ -161,15 +161,17 @@ impl GetHeaderRow for HashMap<String, openapi::models::ReplicaTopology> {
 
 impl CreateRows for HashMap<String, openapi::models::ReplicaTopology> {
     fn create_rows(&self) -> Vec<Row> {
-        let mut rows = vec![];
-        self.iter().for_each(|(id, topology)| {
-            rows.push(row![
-                id,
-                optional_cell(topology.node.as_ref()),
-                optional_cell(topology.pool.as_ref()),
-                topology.state,
-            ])
-        });
-        rows
+        self.iter()
+            .map(|(id, topology)| {
+                row![
+                    id,
+                    optional_cell(topology.node.as_ref()),
+                    optional_cell(topology.pool.as_ref()),
+                    topology.state,
+                    optional_cell(topology.usage.as_ref().map(|u| u.capacity)),
+                    optional_cell(topology.usage.as_ref().map(|u| u.allocated))
+                ]
+            })
+            .collect()
     }
 }

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -25,9 +25,14 @@ impl CreateRow for openapi::models::Volume {
             optional_cell(state.target.clone().map(|t| t.node)),
             optional_cell(state.target.as_ref().and_then(target_protocol)),
             state.status.clone(),
-            state.size,
+            ::utils::bytes::into_human(state.size),
             self.spec.thin,
-            optional_cell(state.usage.as_ref().map(|u| u.allocated))
+            optional_cell(
+                state
+                    .usage
+                    .as_ref()
+                    .map(|u| ::utils::bytes::into_human(u.allocated))
+            )
         ]
     }
 }
@@ -164,8 +169,18 @@ impl CreateRows for HashMap<String, openapi::models::ReplicaTopology> {
                     optional_cell(topology.node.as_ref()),
                     optional_cell(topology.pool.as_ref()),
                     topology.state,
-                    optional_cell(topology.usage.as_ref().map(|u| u.capacity)),
-                    optional_cell(topology.usage.as_ref().map(|u| u.allocated))
+                    optional_cell(
+                        topology
+                            .usage
+                            .as_ref()
+                            .map(|u| ::utils::bytes::into_human(u.capacity))
+                    ),
+                    optional_cell(
+                        topology
+                            .usage
+                            .as_ref()
+                            .map(|u| ::utils::bytes::into_human(u.allocated))
+                    )
                 ]
             })
             .collect()

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1801,6 +1801,7 @@ components:
           description: size of device in (512 byte) blocks
           type: integer
           format: int64
+          minimum: 0
       required:
         - available
         - devlinks

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2894,15 +2894,50 @@ components:
           type: string
           format: uuid
         replica_topology:
-          description: replica location information
+          description: replica topology information
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ReplicaTopology'
+        usage:
+          $ref: '#/components/schemas/VolumeUsage'
       required:
         - size
         - uuid
         - status
         - replica_topology
+    VolumeUsage:
+      example:
+      description: Volume space usage
+      type: object
+      properties:
+        capacity:
+          description: Capacity of the volume in bytes.
+          type: integer
+          example: 80241024
+          format: int64
+          minimum: 0
+        allocated:
+          description: -|
+             Allocated size in bytes, related to a single healthy replica.
+             For example, if a volume has 2 replicas, each with 1MiB allocated space, then
+             this field will be 1MiB.
+          example: 80241024
+          type: integer
+          format: int64
+          minimum: 0
+        total_allocated:
+          description: -|
+            Allocated size in bytes, accrued from all the replica.
+            For example, if a volume has 2 replicas, each with 1MiB allocated space, then
+            this field will be 2MiB.
+          example: 80241024
+          type: integer
+          format: int64
+          minimum: 0
+      required:
+        - capacity
+        - allocated
+        - total_allocated
     Volumes:
       description: |-
         Array of volumes plus the next token for subsequent get requests when using pagination
@@ -2930,7 +2965,7 @@ components:
         - spec
         - state
     ReplicaTopology:
-      description: Location of replicas (nodes and pools)
+      description: Volume Replica information.
       type: object
       properties:
         node:
@@ -2939,8 +2974,31 @@ components:
           $ref: '#/components/schemas/PoolId'
         state:
           $ref: '#/components/schemas/ReplicaState'
+        usage:
+          $ref: '#/components/schemas/ReplicaUsage'
       required:
         - state
+    ReplicaUsage:
+      description: |
+        Replica space usage information.
+        Useful for capacity management, eg: figure out how much of a thin-provisioned replica is allocated.
+      type: object
+      properties:
+        capacity:
+          description: Replica capacity in bytes.
+          example: 80241024
+          type: integer
+          format: int64
+          minimum: 0
+        allocated:
+          description: Amount of actually allocated disk space for this replica in bytes.
+          example: 80241024
+          type: integer
+          format: int64
+          minimum: 0
+      required:
+        - capacity
+        - allocated
     CordonDrainState:
       description: The drain state
       type: object

--- a/control-plane/stor-port/src/types/v0/mod.rs
+++ b/control-plane/stor-port/src/types/v0/mod.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::derive_partial_eq_without_eq)]
-
 /// All the control-plane resources which are persisted in the persistent store.
 pub mod store;
 /// All the "transport" types which allow control-plane components to interact with each other

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -575,6 +575,7 @@ impl From<&VolumeSpec> for transport::VolumeState {
         Self {
             uuid: spec.uuid.clone(),
             size: spec.size,
+            usage: None,
             status: transport::VolumeStatus::Unknown,
             target: None,
             replica_topology: HashMap::new(),

--- a/control-plane/stor-port/src/types/v0/transport/blockdevice.rs
+++ b/control-plane/stor-port/src/types/v0/transport/blockdevice.rs
@@ -92,7 +92,7 @@ impl From<BlockDevice> for models::BlockDevice {
             src.filesystem,
             src.model,
             src.partition,
-            src.size as i64,
+            src.size,
         )
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -124,7 +124,13 @@ impl From<VolumeState> for models::VolumeState {
                 .iter()
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
+            usage: volume.usage.into_opt(),
         }
+    }
+}
+impl From<VolumeUsage> for models::VolumeUsage {
+    fn from(value: VolumeUsage) -> Self {
+        Self::new(value.capacity, value.allocated, value.total_allocated)
     }
 }
 
@@ -723,7 +729,13 @@ impl From<&ReplicaTopology> for models::ReplicaTopology {
             replica_topology.node.clone().map(Into::into),
             replica_topology.pool.clone().map(Into::into),
             replica_topology.status.clone(),
+            replica_topology.usage.as_ref().into_opt(),
         )
+    }
+}
+impl From<&ReplicaUsage> for models::ReplicaUsage {
+    fn from(value: &ReplicaUsage) -> Self {
+        Self::new(value.capacity, value.allocated)
     }
 }
 

--- a/tests/bdd/features/volume/create/test_feature.py
+++ b/tests/bdd/features/volume/create/test_feature.py
@@ -258,12 +258,16 @@ def volume_creation_should_succeed_with_a_returned_volume_object(create_request)
     expected_replica_toplogy = {}
     for key, value in volume.state.replica_topology.items():
         expected_replica_toplogy[key] = ReplicaTopology(
-            ReplicaState("Online"), node="io-engine-1", pool=POOL_UUID
+            ReplicaState("Online"),
+            node="io-engine-1",
+            pool=POOL_UUID,
+            usage=volume.state.replica_topology[key].usage,
         )
     expected_state = VolumeState(
         VOLUME_SIZE,
         VolumeStatus("Online"),
         VOLUME_UUID,
         expected_replica_toplogy,
+        usage=volume.state.usage,
     )
     assert str(volume.state) == str(expected_state)

--- a/tests/bdd/features/volume/observability/test_feature.py
+++ b/tests/bdd/features/volume/observability/test_feature.py
@@ -91,12 +91,16 @@ def a_volume_object_representing_the_volume_should_be_returned(volume_ctx):
     expected_replica_toplogy = {}
     for key, value in volume.state.replica_topology.items():
         expected_replica_toplogy[key] = ReplicaTopology(
-            ReplicaState("Online"), node="io-engine-1", pool=POOL_UUID
+            ReplicaState("Online"),
+            node="io-engine-1",
+            pool=POOL_UUID,
+            usage=volume.state.replica_topology[key].usage,
         )
     expected_state = VolumeState(
         VOLUME_SIZE,
         VolumeStatus("Online"),
         VOLUME_UUID,
         expected_replica_toplogy,
+        usage=volume.state.usage,
     )
     assert str(volume.state) == str(expected_state)

--- a/utils/utils-lib/src/bytes.rs
+++ b/utils/utils-lib/src/bytes.rs
@@ -1,0 +1,22 @@
+/// Converts bytes to human-readable values.
+/// Based of the human_bytes crate.
+pub fn into_human(bytes: u64) -> String {
+    const SUFFIX: [&str; 9] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
+    const UNIT: f64 = 1024.0;
+
+    let size = bytes as f64;
+
+    if size <= 0.0 {
+        return "0 B".to_string();
+    }
+    let base = size.log10() / UNIT.log10();
+
+    let human_size_prefix = format!("{:.1}", UNIT.powf(base - base.floor()));
+    let human_size_prefix = human_size_prefix.trim_end_matches(".0");
+
+    let floor = base.floor() as usize;
+    match SUFFIX.get(floor) {
+        Some(units) => format!("{human_size_prefix}{units}"),
+        None => format!("{bytes} B"),
+    }
+}

--- a/utils/utils-lib/src/lib.rs
+++ b/utils/utils-lib/src/lib.rs
@@ -9,3 +9,6 @@ pub mod version;
 
 pub use version::{long_raw_version_str, raw_version_str, raw_version_string};
 pub use version_info::{version_info as version_info_inner, VersionInfo};
+
+/// Byte conversion helpers.
+pub mod bytes;


### PR DESCRIPTION
    feat(plugin): format byte size into appropriate unit
    
    Used the human read crate to format it.
    Also convert block size in blocks to a size.
    The doc mention that the size is in 512 blocks, is this really always true? Even
    if the device is 4k?
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(plugin): add new row trait to simplify single row resources
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(capacity/thin/plugin): add usage to rest plugin
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(capacity/thin/openapi): add volume and replica usage the openapi
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(capacity/thin/rpc): add volume and replica usage to the agents rpc
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
