### PR TITLE
test(capacity/bdd): add thin volume rebuild bdd feature and test

### DIFF
--- a/deployer/src/infra/fio_spdk.rs
+++ b/deployer/src/infra/fio_spdk.rs
@@ -9,11 +9,11 @@ impl ComponentAction for FioSpdk {
         Ok(if options.fio_spdk {
             cfg.add_container_spec(
                 ContainerSpec::from_image("fio-spdk", &utils::fio_spdk_image())
-                    .with_entrypoint("sleep")
+                    .with_entrypoint("tini")
                     .with_bind("/var/run/dpdk", "/var/run/dpdk")
                     .with_bind("/dev/vfio/vfio", "/dev/vfio/vfio")
                     .with_privileged(Some(true))
-                    .with_arg("infinity"),
+                    .with_args(vec!["--", "sleep", "infinity"]),
             )
         } else {
             cfg

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -23,6 +23,7 @@ class StartOptions:
     ha_node_agent: bool = False
     ha_cluster_agent: bool = False
     fio_spdk: bool = False
+    io_engine_coreisol: bool = False
 
     def args(self):
         args = [
@@ -58,6 +59,8 @@ class StartOptions:
             args.append(f"--max-rebuilds={self.max_rebuilds}")
         if self.fio_spdk:
             args.append("--fio-spdk")
+        if self.io_engine_coreisol:
+            args.append("--io-engine-isolate")
 
         agent_arg = "--agents=Core"
         if self.ha_node_agent:
@@ -88,6 +91,7 @@ class Deployer(object):
         cluster_agent=False,
         node_agent=False,
         fio_spdk=False,
+        io_engine_coreisol=False,
     ):
         options = StartOptions(
             io_engines,
@@ -105,6 +109,7 @@ class Deployer(object):
             ha_node_agent=node_agent,
             ha_cluster_agent=cluster_agent,
             fio_spdk=fio_spdk,
+            io_engine_coreisol=io_engine_coreisol,
         )
         Deployer.start_with_opts(options)
 
@@ -117,7 +122,8 @@ class Deployer(object):
     # Stop containers
     @staticmethod
     def stop():
-        if os.getenv("CLEAN") == "false":
+        clean = os.getenv("CLEAN")
+        if clean is not None and clean.lower() in ("no", "false", "f", "0"):
             return
         deployer_path = os.environ["ROOT_DIR"] + "/target/debug/deployer"
         subprocess.run([deployer_path, "stop"])

--- a/tests/bdd/common/fio.py
+++ b/tests/bdd/common/fio.py
@@ -2,55 +2,115 @@ import shutil
 from typing import Optional
 from urllib.parse import parse_qs, ParseResult
 
+import os
+import subprocess
+
 
 class Fio(object):
     def __init__(
         self,
         name,
         rw,
-        device="",
-        runtime=15,
-        optstr="",
+        device=None,
+        runtime=None,
         uri: Optional[ParseResult] = None,
+        bs="4k",
+        io_depth=64,
+        direct=True,
+        size=None,
+        extra_args="",
     ):
         self.name = name
         self.rw = rw
-        self.device = device
-        self.cmd = shutil.which("fio")
+        self.fio_exec = shutil.which("fio")
         self.output = {}
         self.success = {}
+        self.extra_args = extra_args
         self.runtime = runtime
-        self.optstr = optstr
-        self.uri = uri
+        self.size = size
+        self.bs = bs
+        self.direct = direct
+        self.io_depth = io_depth
+
+        if device is None == uri is None:
+            raise "Device and Uri as exclusive!"
+        if device is not None:
+            self.device = device
+            self.userspace = False
+        if uri is not None:
+            self.uri = uri
+            self.userspace = True
 
     def build(self):
+        if self.userspace:
+            return self.build_for_userspace()
+        else:
+            return self.build_for_kernel()
+
+    def build_common_args(self):
+        args = f"--name={self.name}"
+        if self.runtime is not None:
+            args = f"{args} --time_based=1 --runtime={self.runtime}"
+        if self.size is not None:
+            args = f"{args} --size={self.size}"
+        if self.direct:
+            args = f"{args} --direct=1"
+        args = (
+            f"{args} --bs={self.bs} --rw={self.rw} --group_reporting=1 --norandommap=1"
+        )
+        args = f"{args} --iodepth={self.io_depth} {self.extra_args}"
+        return args
+
+    def build_for_kernel(self):
+        args = self.build_common_args()
         devs = [self.device] if isinstance(self.device, str) else self.device
+        filename = ":".join(map(str, devs))
 
         command = (
-            "sudo fio --ioengine=linuxaio --direct=1 --bs=4k "
-            "--time_based=1 {} --rw={} "
-            "--group_reporting=1 --norandommap=1 --iodepth=64 "
-            "--runtime={} --name={} --filename={}"
-        ).format(
-            self.optstr, self.rw, self.runtime, self.name, ":".join(map(str, devs))
+            f"sudo fio --ioengine=linuxaio --filename={filename} "
+            f"--numjobs=1 --thread=1 {args} "
         )
 
         return command
 
     def build_for_userspace(self):
+        args = self.build_common_args()
+
         uri_query = parse_qs(self.uri.query)
         traddr = self.uri.hostname
-        subnqn = self.uri.path[1:]
+        subnqn = self.uri.path[1:].replace(":", "\\:")
         hostnqn = ""
 
         if uri_query.keys().__contains__("hostnqn"):
-            hostnqn = "--hostnqn={}".format(uri_query["hostnqn"][0])
+            args = "--hostnqn={} {}".format(uri_query["hostnqn"][0], args)
 
         command = (
-            "docker exec -i fio-spdk fio --name={} --filename='trtype=tcp adrfam=IPv4 traddr={} trsvcid=8420 "
-            "subnqn={} ns=1' --direct=1 --rw={} --ioengine=spdk --bs=4k --iodepth=64 --numjobs=1 --thread=1 "
-            "--size=50M --norandommap=1 {}".format(
-                self.name, traddr, subnqn.replace(":", "\\:"), self.rw, hostnqn
-            )
+            "docker exec -i fio-spdk fio --ioengine=spdk "
+            f"--filename='trtype=tcp adrfam=IPv4 traddr={traddr} trsvcid=8420 subnqn={subnqn} ns=1' "
+            f"--numjobs=1 --thread=1 {args} "
         )
         return command
+
+    def open(self):
+        print(f"{self.build()}")
+        return subprocess.Popen(self.build(), shell=True)
+
+    def run(self):
+        print(f"{self.build()}")
+        try:
+            return subprocess.run(self.build(), shell=True, check=True)
+        except subprocess.CalledProcessError:
+            if self.userspace:
+                self.remove_stale_files_on_error()
+            raise
+
+    def remove_stale_files_on_error(self):
+        ip = self.uri.hostname
+        nqn = self.uri.path[1:]
+        root = os.environ["ROOT_DIR"]
+
+        try:
+            command = f"rm -f {root}/'trtype=tcp adrfam=IPv4 traddr={ip} trsvcid=8420 subnqn={nqn} ns=1'"
+            subprocess.run(command, shell=True, check=True)
+        except subprocess.CalledProcessError:
+            assert False, "Could not clean up the stale files, needs manual cleanup"

--- a/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
+++ b/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
@@ -146,8 +146,8 @@ def run_fio_to_first_path(connect_to_first_path):
     assert len(subsystem["Paths"]) == 1, "Must be exactly one I/O path to target nexus"
     assert subsystem["Paths"][0]["State"] == "live", "I/O path is not healthy"
     # Launch fio in background and let it always run along with the test.
-    fio = Fio("job", "randread", device, runtime=FIO_RUNTIME).build()
-    return subprocess.Popen(fio, shell=True)
+    fio = Fio("job", "randread", device, runtime=FIO_RUNTIME)
+    return fio.open()
 
 
 @pytest.fixture

--- a/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
+++ b/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
@@ -109,6 +109,7 @@ def background():
         cache_period="1s",
         io_engine_env="NEXUS_NVMF_ANA_ENABLE=1,NEXUS_NVMF_RESV_ENABLE=1",
         agents_env="TEST_NEXUS_NVMF_ANA_ENABLE=1",
+        io_engine_coreisol=True,
     )
 
     ApiClient.pools_api().put_node_pool(

--- a/tests/bdd/features/capacity/thin/volume/rebuild.feature
+++ b/tests/bdd/features/capacity/thin/volume/rebuild.feature
@@ -1,0 +1,24 @@
+Feature: Thin Provisioning - Volume Rebuild
+  Background:
+    Given a control plane, Io-Engine instances and pools
+
+  # Thin replication.
+  Scenario: Replicating a thin volume
+    Given a thin provisioned volume with 1 replica
+    When data is written to the volume
+    And the number of replicas is increased
+    When the new replica is fully rebuilt
+    Then the new replica allocation equals the volume allocation
+
+  # Out-of-space condition for a thin multi-replica volume.
+  # No different from any other I/O failure.
+  Scenario: Resolving out-of-space condition for a thin multi-replica volume
+    Given a thin provisioned volume with 2 replicas
+    When data is written to the volume which exceeds the free space on one of the pools
+    Then a replica is reported as faulted due to out-of-space
+    And the total number of healthy replicas of the volume decreases by one
+    But the client app is not affected because other healthy replicas exists
+    And the faulted replica is relocated to another pool with sufficient free space
+    When the new replica is fully rebuilt
+    Then the new replica allocation equals the volume allocation
+    And the total number of healthy replicas is restored

--- a/tests/bdd/features/capacity/thin/volume/test_rebuild.py
+++ b/tests/bdd/features/capacity/thin/volume/test_rebuild.py
@@ -1,0 +1,268 @@
+"""Thin Provisioning - Volume Rebuild feature tests."""
+from retrying import retry
+from urllib.parse import urlparse
+import pytest
+import subprocess
+
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+)
+
+from common.deployer import Deployer
+from common.apiclient import ApiClient
+from common.fio import Fio
+
+from openapi.model.create_pool_body import CreatePoolBody
+from openapi.model.create_volume_body import CreateVolumeBody
+from openapi.model.publish_volume_body import PublishVolumeBody
+from openapi.model.protocol import Protocol
+from openapi.model.volume_status import VolumeStatus
+from openapi.model.volume_policy import VolumePolicy
+from openapi.model.create_replica_body import CreateReplicaBody
+
+VOLUME_UUID = "ec4e66fd-3b33-4439-b504-d49aba53da26"
+VOLUME_SIZE = 20 * 1024 * 1024
+POOL_SIZE = VOLUME_SIZE + 8 * 1024 * 1024
+NUM_VOLUME_REPLICAS = 1
+CREATE_REQUEST_KEY = "create_request"
+POOL_UUID_1 = "4cc6ee64-7232-497d-a26f-38284a444980"
+POOL_UUID_2 = "4cc6ee64-7232-497d-a26f-38284a444981"
+POOL_UUID_3 = "4cc6ee64-7232-497d-a26f-38284a444982"
+REPL_UUID = "4cc6ee64-7232-497d-a26f-38284a444981"
+NODE_NAME_1 = "io-engine-1"
+NODE_NAME_2 = "io-engine-2"
+NODE_NAME_3 = "io-engine-3"
+
+
+# This fixture will be automatically used by all tests.
+# It starts the deployer which launches all the necessary containers.
+# A pool is created for convenience such that it is available for use by the tests.
+@pytest.fixture(autouse=True)
+def init():
+    Deployer.start(
+        io_engines=2,
+        cache_period="250ms",
+        reconcile_period="500ms",
+        fio_spdk=True,
+        io_engine_coreisol=True,
+    )
+    pool_size_mb = int(POOL_SIZE / (1024 * 1024))
+    ApiClient.pools_api().put_node_pool(
+        NODE_NAME_1,
+        POOL_UUID_1,
+        CreatePoolBody([f"malloc:///disk1?size_mb={pool_size_mb}"]),
+    )
+    ApiClient.pools_api().put_node_pool(
+        NODE_NAME_2,
+        POOL_UUID_2,
+        CreatePoolBody([f"malloc:///disk2?size_mb={pool_size_mb}"]),
+    )
+
+    yield
+    Deployer.stop()
+
+
+@scenario("rebuild.feature", "Replicating a thin volume")
+def test_replicating_a_thin_volume():
+    """Replicating a thin volume."""
+
+
+@scenario(
+    "rebuild.feature",
+    "Resolving out-of-space condition for a thin multi-replica volume",
+)
+def test_resolving_outofspace_condition_for_a_thin_multireplica_volume():
+    """Resolving out-of-space condition for a thin multi-replica volume."""
+
+
+@given("a control plane, Io-Engine instances and pools")
+def a_control_plane_ioengine_instances_and_pools(init):
+    """a control plane, Io-Engine instances and pools."""
+
+
+@given("a thin provisioned volume with 1 replica")
+def a_thin_provisioned_volume_with_1_replica():
+    """a thin provisioned volume with 1 replica."""
+    volume = ApiClient.volumes_api().put_volume(
+        VOLUME_UUID,
+        create_volume_body=CreateVolumeBody(VolumePolicy(True), 1, VOLUME_SIZE, True),
+    )
+    volume = ApiClient.volumes_api().put_volume_target(
+        volume.spec.uuid,
+        publish_volume_body=PublishVolumeBody({}, Protocol("nvmf")),
+    )
+    assert hasattr(volume.spec, "target")
+    assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))
+    pytest.volume = volume
+
+
+@given("a thin provisioned volume with 2 replicas")
+def a_thin_provisioned_volume_with_2_replicas():
+    """a thin provisioned volume with 2 replicas."""
+    volume = ApiClient.volumes_api().put_volume(
+        VOLUME_UUID,
+        create_volume_body=CreateVolumeBody(VolumePolicy(True), 2, VOLUME_SIZE, True),
+    )
+
+    # Ensure it's the first replica that gets faulted with enospc to work around a datapath bug: GTM-609.
+    # Once fixed we can set it to None.
+    node = NODE_NAME_1
+    volume = ApiClient.volumes_api().put_volume_target(
+        volume.spec.uuid,
+        publish_volume_body=PublishVolumeBody({}, Protocol("nvmf"), node=node),
+    )
+    assert hasattr(volume.spec, "target")
+    assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))
+    pytest.volume = volume
+
+
+@when("data is written to the volume")
+def data_is_written_to_the_volume():
+    """data is written to the volume."""
+    volume = pytest.volume
+    uri = urlparse(volume.state.target["deviceUri"])
+
+    fio = Fio(name="job", rw="write", uri=uri, size="10M")
+
+    code = fio.run().returncode
+    assert code == 0, "Fio is expected to execute successfully"
+
+
+@when("data is written to the volume which exceeds the free space on one of the pools")
+def data_is_written_to_the_volume_which_exceeds_the_free_space_on_one_of_the_pools():
+    """data is written to the volume which exceeds the free space on one of the pools."""
+
+    # Fill up a pool with other data
+    ApiClient.replicas_api().put_pool_replica(
+        POOL_UUID_1, REPL_UUID, CreateReplicaBody(size=int(VOLUME_SIZE / 2), thin=False)
+    )
+
+    volume = pytest.volume
+    uri = urlparse(volume.state.target["deviceUri"])
+
+    fio = Fio(name="job", rw="write", uri=uri)
+    pytest.fio = fio.open()
+
+
+@when("the new replica is fully rebuilt")
+def the_new_replica_is_fully_rebuilt():
+    """the new replica is fully rebuilt."""
+    wait_volume_rebuild(pytest.volume)
+
+
+@when("the number of replicas is increased")
+def the_number_of_replicas_is_increased():
+    """the number of replicas is increased."""
+    ApiClient.volumes_api().put_volume_replica_count(
+        VOLUME_UUID, NUM_VOLUME_REPLICAS + 1
+    )
+
+
+@then("a replica is reported as faulted due to out-of-space")
+def a_replica_is_reported_as_faulted_due_to_outofspace():
+    """a replica is reported as faulted due to out-of-space."""
+    volume = ApiClient.volumes_api().get_volume(pytest.volume.spec.uuid)
+    wait_volume_enospc(volume)
+
+
+@then("the client app is not affected because other healthy replicas exists")
+def the_client_app_is_not_affected_because_other_healthy_replicas_exists():
+    """the client app is not affected because other healthy replicas exists."""
+    fio = pytest.fio
+
+    try:
+        code = fio.wait(timeout=30)
+        assert code == 0, "FIO failed, exit code: %d" % code
+    except subprocess.TimeoutExpired:
+        assert False, "FIO timed out"
+
+
+@then("the faulted replica is relocated to another pool with sufficient free space")
+def the_faulted_replica_is_relocated_to_another_pool_with_sufficient_free_space():
+    """the faulted replica is relocated to another pool with sufficient free space."""
+
+    volume = pytest.volume
+    replicas = volume.state.replica_topology.keys()
+
+    # Make free capacity available on another pool
+    pool_size_mb = int(POOL_SIZE / (1024 * 1024))
+    ApiClient.pools_api().put_node_pool(
+        NODE_NAME_1,
+        POOL_UUID_3,
+        CreatePoolBody([f"malloc:///disk22?size_mb={pool_size_mb}"]),
+    )
+
+    wait_volume_new_replica(volume, replicas)
+
+
+@then("the new replica allocation equals the volume allocation")
+def the_new_replica_allocation_equals_the_volume_allocation():
+    """the new replica allocation equals the volume allocation."""
+    volume = ApiClient.volumes_api().get_volume(pytest.volume.spec.uuid)
+    total_allocated = 0
+
+    for replica in volume.state.replica_topology.values():
+        assert replica.usage.capacity == volume.state.usage.capacity
+        assert replica.usage.allocated == volume.state.usage.allocated
+        total_allocated += replica.usage.allocated
+
+    assert volume.state.usage.total_allocated == total_allocated
+    assert volume.state.usage.allocated > 10 * 1024 * 1024 + 4 * 1024 * 1024
+
+
+@then("the total number of healthy replicas is restored")
+def the_total_number_of_healthy_replicas_is_restored():
+    """the total number of healthy replicas is restored."""
+    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
+    assert volume.state.status == VolumeStatus("Online")
+    assert len(volume.state.target["children"]) == 2
+
+
+@then("the total number of healthy replicas of the volume decreases by one")
+def the_total_number_of_healthy_replicas_of_the_volume_decreases_by_one():
+    """the total number of healthy replicas of the volume decreases by one."""
+    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
+    wait_volume_degraded(volume)
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=20)
+def wait_volume_rebuild(volume):
+    volume = ApiClient.volumes_api().get_volume(volume.spec.uuid)
+    assert volume.state.status == VolumeStatus("Online")
+    assert len(volume.state.target["children"]) == 2
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=20)
+def wait_volume_enospc(volume):
+    volume = ApiClient.volumes_api().get_volume(volume.spec.uuid)
+    assert volume.state.status == VolumeStatus("Degraded")
+    assert len(volume.state.target["children"]) == 2
+
+    enospcs = list(
+        filter(
+            lambda child: child.get("state_reason") == "OutOfSpace",
+            list(volume.state.target["children"]),
+        )
+    )
+    assert len(enospcs) == 1
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=20)
+def wait_volume_degraded(volume):
+    volume = ApiClient.volumes_api().get_volume(volume.spec.uuid)
+    assert volume.state.status == VolumeStatus("Degraded")
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=20)
+def wait_volume_new_replica(volume, prev_replicas):
+    volume = ApiClient.volumes_api().get_volume(volume.spec.uuid)
+    new_replicas = list(
+        filter(
+            lambda uuid: uuid not in prev_replicas,
+            list(volume.state.replica_topology),
+        )
+    )
+    assert len(new_replicas) == 1

--- a/tests/bdd/features/ha/node-agent/test_path_replacement.py
+++ b/tests/bdd/features/ha/node-agent/test_path_replacement.py
@@ -150,8 +150,8 @@ def run_fio_to_first_path(connect_to_first_path):
     assert len(subsystem["Paths"]) == 1, "Must be exactly one I/O path to target nexus"
     assert subsystem["Paths"][0]["State"] == "live", "I/O path is not healthy"
     # Launch fio in background and let it always run along with the test.
-    fio = Fio("job", "randread", device, runtime=FIO_RUNTIME).build()
-    return subprocess.Popen(fio, shell=True)
+    fio = Fio("job", "randread", device, runtime=FIO_RUNTIME)
+    return fio.open()
 
 
 @pytest.fixture

--- a/tests/bdd/features/ha/node-agent/test_path_replacement.py
+++ b/tests/bdd/features/ha/node-agent/test_path_replacement.py
@@ -113,6 +113,7 @@ def background():
         cluster_agent=True,
         csi_node=True,
         cache_period="1s",
+        io_engine_coreisol=True,
     )
 
     ApiClient.pools_api().put_node_pool(


### PR DESCRIPTION
    test(capacity/bdd): add thin volume rebuild bdd feature and test
    
    The node where we place the volume target is currently hardcoded to avoid a bug that was
    encountered during this test: gtm-609.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(fio-spdk): use tini for graceful shutdown
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(bdd/fio): make fio-spdk a bit easier to use in bdd
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

Bonus: sped up bdd tests by using core isolation for IO bound tests.