### PR TITLE
fix(ha): nvme path replacement timeout

### DIFF
--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -15,7 +15,8 @@ use tower::service_fn;
 use utils::{
     package_description, tracing_telemetry::KeyValue, version_info_str,
     DEFAULT_CLUSTER_AGENT_CLIENT_ADDR, DEFAULT_NODE_AGENT_SERVER_ADDR,
-    NVME_PATH_AGGREGATION_PERIOD, NVME_PATH_CHECK_PERIOD, NVME_PATH_RETRANSMISSION_PERIOD,
+    NVME_PATH_AGGREGATION_PERIOD, NVME_PATH_CHECK_PERIOD, NVME_PATH_CONNECTION_PERIOD,
+    NVME_PATH_RETRANSMISSION_PERIOD,
 };
 mod detector;
 mod path_provider;
@@ -56,6 +57,10 @@ struct Cli {
     /// Period for aggregating multiple failed paths before reporting them.
     #[clap(short, long, env = "AGGREGATION_PERIOD", default_value = NVME_PATH_AGGREGATION_PERIOD)]
     aggregation_period: humantime::Duration,
+
+    /// Connection timeout for path replacement operation.
+    #[clap(short, long, env = "PATH_CONNECTION_TIMEOUT", default_value = NVME_PATH_CONNECTION_PERIOD)]
+    path_connection_timeout: humantime::Duration,
 
     /// Sends opentelemetry spans to the Jaeger endpoint agent.
     #[clap(long, short)]
@@ -131,7 +136,7 @@ async fn main() {
     let cache = detector.get_cache();
 
     // Instantiate gRPC server.
-    let server = NodeAgentApiServer::new(cli_args.grpc_endpoint, cache);
+    let server = NodeAgentApiServer::new(&cli_args, cache);
 
     // Start gRPC server and path failure detection loop.
     tokio::select! {

--- a/control-plane/agents/src/bin/ha/node/server.rs
+++ b/control-plane/agents/src/bin/ha/node/server.rs
@@ -2,6 +2,7 @@ use crate::{
     csi_node_nvme_client,
     detector::{NvmeController, NvmePathCache},
     path_provider::get_nvme_path_entry,
+    Cli,
 };
 use agents::errors::{SvcError, SvcError::SubsystemNotFound};
 use grpc::{
@@ -24,7 +25,7 @@ use stor_port::{
 
 use http::Uri;
 use nvmeadm::nvmf_subsystem::Subsystem;
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Instant};
 use tokio::time::{sleep, Duration};
 use utils::NVME_TARGET_NQN_PREFIX;
 
@@ -38,21 +39,30 @@ const SUBSYSTEM_STATE_REFRESH_INTERVAL_MS: u64 = 500;
 pub(crate) struct NodeAgentApiServer {
     endpoint: SocketAddr,
     path_cache: NvmePathCache,
+    path_connection_timeout: Duration,
 }
 
 impl NodeAgentApiServer {
     /// Returns a new `Self` with the given parameters.
-    pub(crate) fn new(endpoint: SocketAddr, path_cache: NvmePathCache) -> Self {
+    pub(crate) fn new(args: &Cli, path_cache: NvmePathCache) -> Self {
         Self {
-            endpoint,
+            endpoint: args.grpc_endpoint,
             path_cache,
+            path_connection_timeout: *args.path_connection_timeout,
         }
     }
 
     /// Runs this server as a future until a shutdown signal is received.
     pub(crate) async fn serve(&self) -> Result<(), agents::ServiceError> {
-        let r = NodeAgentServer::new(Arc::new(NodeAgentSvc::new(self.path_cache.clone())));
-        tracing::info!("Starting gRPC server at {:?}", self.endpoint);
+        let r = NodeAgentServer::new(Arc::new(NodeAgentSvc::new(
+            self.path_cache.clone(),
+            self.path_connection_timeout,
+        )));
+        tracing::info!(
+            endpoint=?self.endpoint,
+            path_connection_timeout=?self.path_connection_timeout,
+            "Starting gRPC server"
+        );
         agents::Service::builder()
             .with_service(r.into_grpc_server())
             .run_err(self.endpoint)
@@ -63,12 +73,16 @@ impl NodeAgentApiServer {
 /// The gRPC server implementation for the HA Node agent.
 struct NodeAgentSvc {
     path_cache: NvmePathCache,
+    path_connection_timeout: Duration,
 }
 
 impl NodeAgentSvc {
     /// Returns a new `Self` with the given parameters.
-    pub(crate) fn new(path_cache: NvmePathCache) -> Self {
-        Self { path_cache }
+    pub(crate) fn new(path_cache: NvmePathCache, path_connection_timeout: Duration) -> Self {
+        Self {
+            path_cache,
+            path_connection_timeout,
+        }
     }
 }
 
@@ -140,6 +154,15 @@ impl NodeAgentSvc {
 
         tracing::info!(new_path, "Connecting to NVMe target");
 
+        // Check if the NVMe subsystem already exists to not
+        // delete it in case of unsuccessful path replacement.
+        let preexisted_subsystem = Subsystem::get(
+            parsed_uri.host().as_str(),
+            &parsed_uri.port(),
+            parsed_uri.nqn().as_str(),
+        )
+        .is_ok();
+
         // Open connection to the new nexus: ANA will automatically create
         // the second path and add it as an alternative for the first broken one,
         // which immediately resumes all stalled I/O
@@ -182,6 +205,8 @@ impl NodeAgentSvc {
             }
         };
 
+        let now = Instant::now();
+        let timeout = self.path_connection_timeout;
         // Wait till new controller is fully connected before completing the call.
         // Straight after connection subsystem transitions into 'new' state, then
         // proceeds to 'connecting' till the connection is fully established,
@@ -228,6 +253,54 @@ impl NodeAgentSvc {
                         ),
                     });
                 }
+            }
+
+            // Check if path reconnection timeout has elapsed.
+            if now.elapsed() >= timeout {
+                tracing::error!(
+                    new_path,
+                    nqn,
+                    "Timeout while connecting NVMe path, disconnecting NVMe subsystem"
+                );
+
+                let nvme_err = format!(
+                    "Timeout while connecting to new NVMe target: new path: {new_path}, nqn: {nqn}"
+                );
+
+                // Delete the subsystem in case it is not pre-existed.
+                // Re-read the subsystem to get the most recent data on raw device path.
+                if !preexisted_subsystem {
+                    let curr_subsystem = match Subsystem::get(
+                        parsed_uri.host().as_str(),
+                        &parsed_uri.port(),
+                        parsed_uri.nqn().as_str(),
+                    ) {
+                        Ok(s) => s,
+                        Err(error) => {
+                            tracing::warn!(
+                                new_path,
+                                ?error,
+                                "Can't lookup NVMe subsystem, skipping removal"
+                            );
+                            return Err(SvcError::NvmeConnectError { details: nvme_err });
+                        }
+                    };
+
+                    // Remove the subsystem.
+                    if let Err(error) = curr_subsystem.disconnect() {
+                        tracing::error!(
+                            ?curr_subsystem,
+                            ?error,
+                            "Failed to disconnect NVMe subsystem"
+                        );
+                    } else {
+                        tracing::info!(?curr_subsystem, "NVMe subsystem successfully disconnected");
+                    }
+                } else {
+                    tracing::info!(?subsystem, "Keeping NVMe subsystem after connect timeout");
+                }
+
+                return Err(SvcError::NvmeConnectError { details: nvme_err });
             }
         }
 

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -107,6 +107,9 @@ pub const NVME_INITIATOR_NQN_PREFIX: &str = "nqn.2019-05.io.openebs:node-name:";
 /// NVMe path check period.
 pub const NVME_PATH_CHECK_PERIOD: &str = "3s";
 
+/// NVMe path connection timeout for path replacement operation.
+pub const NVME_PATH_CONNECTION_PERIOD: &str = "11s";
+
 /// The default retransmission interval for reporting failed paths in case of network issues.
 pub const NVME_PATH_RETRANSMISSION_PERIOD: &str = "10s";
 


### PR DESCRIPTION
Currently HA node agent waits indefinitely till new path is connected while replacing a broken NVMe path, which can lead to gRPC timeouts on HA Cluster agent and may leave dangling NVMe controllers in the system. The fix introduces a tuneable timeout with the default value of 11 seconds.