### PR TITLE
Capacity - mixed&cluster bdd and enhance cli for replica topologies

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
@@ -60,6 +60,7 @@ async fn online_enospc(
     // todo: Should we list pools to check for latest free space?
     tracing::debug!(
         pool.id = pool_wrapper.id.as_str(),
+        pool.node = pool_wrapper.node.as_str(),
         pool.free_space = pool_wrapper.free_space(),
         "Reporting free space in pool"
     );
@@ -70,6 +71,8 @@ async fn online_enospc(
         nexus.info_span(|| {
             tracing::warn!(
                 child.uri = %child.uri.as_str(),
+                pool.id = pool_wrapper.id.as_str(),
+                pool.node = pool_wrapper.node.as_str(),
                 pool.free_space = pool_wrapper.free_space(),
                 slack,
                 "Not enough free_space slack to online enospc child",

--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/capacity.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/capacity.rs
@@ -78,6 +78,7 @@ async fn move_largest_replica(
                     replica.uuid = eno_replica.replica().uid().as_str(),
                     replica.old_pool = eno_replica.replica().pool_name().as_str(),
                     replica.pool = replica.pool_id.as_str(),
+                    replica.size = replica.size,
                     "Successfully moved enospc replica"
                 )
             });

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -167,6 +167,12 @@ message ReplicaTopology {
   replica.ReplicaStatus status = 3;
   // Volume Replica usage information
   optional ReplicaUsage usage = 4;
+  // status of the replica as seen by the volume target
+  optional nexus.ChildState child_status = 5;
+  // reason for the status of the replica as seen by the volume target
+  optional nexus.ChildStateReason child_status_reason = 6;
+  // current rebuild progress (%)
+  optional uint32 rebuild_progress = 7;
 }
 
 // Volume Replica usage information

--- a/control-plane/grpc/src/operations/nexus/traits.rs
+++ b/control-plane/grpc/src/operations/nexus/traits.rs
@@ -203,6 +203,11 @@ impl From<nexus::ChildState> for ChildState {
 }
 impl From<ChildState> for nexus::ChildState {
     fn from(src: ChildState) -> Self {
+        Self::from(&src)
+    }
+}
+impl From<&ChildState> for nexus::ChildState {
+    fn from(src: &ChildState) -> Self {
         match src {
             ChildState::Unknown => Self::ChildUnknown,
             ChildState::Online => Self::ChildOnline,
@@ -232,6 +237,11 @@ impl From<nexus::ChildStateReason> for ChildStateReason {
 }
 impl From<ChildStateReason> for nexus::ChildStateReason {
     fn from(src: ChildStateReason) -> Self {
+        Self::from(&src)
+    }
+}
+impl From<&ChildStateReason> for nexus::ChildStateReason {
+    fn from(src: &ChildStateReason) -> Self {
         match src {
             ChildStateReason::Unknown => Self::None,
             ChildStateReason::Init => Self::Init,

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -380,6 +380,13 @@ impl TryFrom<volume::ReplicaTopology> for ReplicaTopology {
             pool,
             status,
             topology.usage.into_opt(),
+            topology
+                .child_status
+                .and_then(|s| nexus::ChildState::from_i32(s).into_opt()),
+            topology
+                .child_status_reason
+                .and_then(|s| nexus::ChildStateReason::from_i32(s).into_opt()),
+            topology.rebuild_progress.and_then(|r| u8::try_from(r).ok()),
         ))
     }
 }
@@ -399,6 +406,13 @@ impl From<ReplicaTopology> for volume::ReplicaTopology {
             pool,
             status: status as i32,
             usage: replica_topology.usage().into_opt(),
+            child_status: replica_topology
+                .child_status()
+                .map(|s| crate::nexus::ChildState::from(s).into()),
+            child_status_reason: replica_topology
+                .child_status_reason()
+                .map(|s| crate::nexus::ChildStateReason::from(s).into()),
+            rebuild_progress: replica_topology.rebuild_progress().map(|r| r as u32),
         }
     }
 }

--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -84,6 +84,9 @@ async fn execute(cli_args: CliArgs) {
             },
             GetResources::Volumes => volume::Volumes::list(&cli_args.output).await,
             GetResources::Volume { id } => volume::Volume::get(id, &cli_args.output).await,
+            GetResources::VolumeReplicaTopologies => {
+                volume::Volume::topologies(&cli_args.output).await
+            }
             GetResources::VolumeReplicaTopology { id } => {
                 volume::Volume::topology(id, &cli_args.output).await
             }

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -62,6 +62,7 @@ pub trait Scale {
 #[async_trait(?Send)]
 pub trait ReplicaTopology {
     type ID;
+    async fn topologies(output: &utils::OutputFormat);
     async fn topology(id: &Self::ID, output: &utils::OutputFormat);
 }
 

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -29,7 +29,9 @@ pub enum GetResources {
     Volumes,
     /// Get volume with the given ID.
     Volume { id: VolumeId },
-    /// Get the replica topology for the volume with the given ID
+    /// Get the replica topology for all volumes.
+    VolumeReplicaTopologies,
+    /// Get the replica topology for the volume with the given ID.
     VolumeReplicaTopology { id: VolumeId },
     /// Get all pools.
     Pools,

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -33,8 +33,18 @@ lazy_static! {
         "AVAILABLE"
     ];
     pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS", "CORDONED"];
-    pub static ref REPLICA_TOPOLOGY_HEADERS: Row =
-        row!["ID", "NODE", "POOL", "STATUS", "CAPACITY", "ALLOCATED"];
+    pub static ref REPLICA_TOPOLOGIES_PREFIX: Row = row!["VOLUME-ID"];
+    pub static ref REPLICA_TOPOLOGY_HEADERS: Row = row![
+        "ID",
+        "NODE",
+        "POOL",
+        "STATUS",
+        "CAPACITY",
+        "ALLOCATED",
+        "CHILD-STATUS",
+        "CHILD-STATUS-REASON",
+        "REBUILD"
+    ];
     pub static ref BLOCKDEVICE_HEADERS_ALL: Row = row![
         "DEVNAME",
         "DEVTYPE",

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2981,8 +2981,17 @@ components:
           $ref: '#/components/schemas/PoolId'
         state:
           $ref: '#/components/schemas/ReplicaState'
+        child-status:
+          $ref: '#/components/schemas/ChildState'
+        child-status-reason:
+          $ref: '#/components/schemas/ChildStateReason'
         usage:
           $ref: '#/components/schemas/ReplicaUsage'
+        rebuild-progress:
+          description: current rebuild progress (%)
+          type: integer
+          minimum: 0
+          maximum: 100
       required:
         - state
     ReplicaUsage:

--- a/control-plane/stor-port/src/types/v0/transport/child.rs
+++ b/control-plane/stor-port/src/types/v0/transport/child.rs
@@ -33,10 +33,7 @@ impl From<Child> for models::Child {
         Self {
             rebuild_progress: src.rebuild_progress,
             state: src.state.into(),
-            state_reason: match src.state_reason {
-                ChildStateReason::NoSpace => Some(models::ChildStateReason::OutOfSpace),
-                _ => None,
-            },
+            state_reason: (&src.state_reason).into(),
             uri: src.uri.into(),
         }
     }
@@ -164,6 +161,15 @@ pub enum ChildStateReason {
     ByClient,
     /// Admin command failure.
     AdminCommandFailed,
+}
+
+impl From<&ChildStateReason> for Option<models::ChildStateReason> {
+    fn from(state_reason: &ChildStateReason) -> Self {
+        match state_reason {
+            ChildStateReason::NoSpace => Some(models::ChildStateReason::OutOfSpace),
+            _ => None,
+        }
+    }
 }
 
 impl Default for ChildState {

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -51,6 +51,10 @@ impl Nexus {
     pub fn contains_child(&self, uri: &ChildUri) -> bool {
         self.children.iter().any(|c| &c.uri == uri)
     }
+    /// Check if the nexus contains the provided `ChildUri`
+    pub fn child(&self, uri: &str) -> Option<&Child> {
+        self.children.iter().find(|c| c.uri.as_str() == uri)
+    }
     /// Add query parameter to the Uri.
     pub fn with_query(mut self, name: &str, value: &str) -> Self {
         self.device_uri = add_query(self.device_uri, name, value);

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -682,8 +682,14 @@ pub struct ReplicaTopology {
     pool: Option<PoolId>,
     /// The status of the replica.
     status: ReplicaStatus,
+    /// The status of the replica's child.
+    child_status: Option<ChildState>,
+    /// The reason for the status of the replica's child.
+    child_status_reason: Option<ChildStateReason>,
     /// The replica usage.
     usage: Option<ReplicaUsage>,
+    /// Current replica's child rebuild progress (%).
+    rebuild_progress: Option<u8>,
 }
 
 impl ReplicaTopology {
@@ -693,12 +699,18 @@ impl ReplicaTopology {
         pool: Option<PoolId>,
         status: ReplicaStatus,
         usage: Option<ReplicaUsage>,
+        child_status: Option<ChildState>,
+        child_status_reason: Option<ChildStateReason>,
+        rebuild_progress: Option<u8>,
     ) -> Self {
         Self {
             node,
             pool,
             status,
             usage,
+            child_status,
+            child_status_reason,
+            rebuild_progress,
         }
     }
 
@@ -712,9 +724,24 @@ impl ReplicaTopology {
         &self.pool
     }
 
-    /// Get the status of the replica
+    /// Get the status of the replica.
     pub fn status(&self) -> &ReplicaStatus {
         &self.status
+    }
+
+    /// Get the status of the replica as a target child.
+    pub fn child_status(&self) -> Option<&ChildState> {
+        self.child_status.as_ref()
+    }
+
+    /// Get the status reason of the replica as a target child.
+    pub fn child_status_reason(&self) -> Option<&ChildStateReason> {
+        self.child_status_reason.as_ref()
+    }
+
+    /// Get the rebuild progress of the replica as a target child.
+    pub fn rebuild_progress(&self) -> Option<u8> {
+        self.rebuild_progress
     }
 
     /// Get the storage usage of the replica.
@@ -729,7 +756,13 @@ impl From<&ReplicaTopology> for models::ReplicaTopology {
             replica_topology.node.clone().map(Into::into),
             replica_topology.pool.clone().map(Into::into),
             replica_topology.status.clone(),
+            replica_topology.child_status.clone().into_opt(),
+            replica_topology
+                .child_status_reason
+                .as_ref()
+                .and_then(Into::into),
             replica_topology.usage.as_ref().into_opt(),
+            replica_topology.rebuild_progress.into_opt(),
         )
     }
 }

--- a/scripts/python/venv-setup-prep.sh
+++ b/scripts/python/venv-setup-prep.sh
@@ -5,7 +5,7 @@
 set -e
 
 SCRIPTDIR="$(dirname "$(realpath "${BASH_SOURCE[0]:-"$0"}")")"
-ROOTDIR="$SCRIPTDIR"/../../
+ROOTDIR="$SCRIPTDIR"/../..
 
 CSI_PROTO=
 CSI_OUT=

--- a/tests/bdd/common/fio.py
+++ b/tests/bdd/common/fio.py
@@ -18,6 +18,7 @@ class Fio(object):
         io_depth=64,
         direct=True,
         size=None,
+        offset=0,
         extra_args="",
     ):
         self.name = name
@@ -31,6 +32,7 @@ class Fio(object):
         self.bs = bs
         self.direct = direct
         self.io_depth = io_depth
+        self.offset = offset
 
         if device is None == uri is None:
             raise "Device and Uri as exclusive!"
@@ -55,9 +57,7 @@ class Fio(object):
             args = f"{args} --size={self.size}"
         if self.direct:
             args = f"{args} --direct=1"
-        args = (
-            f"{args} --bs={self.bs} --rw={self.rw} --group_reporting=1 --norandommap=1"
-        )
+        args = f"{args} --offset={self.offset} --bs={self.bs} --rw={self.rw} --group_reporting=1 --norandommap=1"
         args = f"{args} --iodepth={self.io_depth} {self.extra_args}"
         return args
 

--- a/tests/bdd/features/capacity/thin/cluster.feature
+++ b/tests/bdd/features/capacity/thin/cluster.feature
@@ -1,0 +1,31 @@
+Feature: Thin Provisioning - Cluster Wide
+  Background:
+    Given a control plane, Io-Engine instances and pools
+
+  # Simultaneous out-of-space condition on several thin multi-replica volumes.
+  # This is a scenario when multiple volumes get out-of-space on some replicas
+  # at the same moment and some of them can be quickly recovered by
+  # freeing space of pool(s).
+  Scenario: Resolving out-of-space condition for several thin multi-replica volumes
+    Given there are 4 overcommitted thin volumes
+    And they share the same pools
+    When filling up the volumes with data
+    Then several replicas on the same pool are reported as faulted due to out-of-space
+    And if other pools with sufficient free space exist on the cluster
+    Then the largest of the failed replicas is relocated to another pool with sufficient free space
+    And the other faulted replicas start to rebuild in-place
+    And all volumes become healthy
+    And the data transfer to all volumes completes with success
+
+  # Reaching capacity of a whole cluster.
+  # This is a situation where the storage cluster is exhausted and we cannot relocated
+  # replicas because no free pools exist on the cluster.
+  Scenario: Reaching physical capacity of a cluster
+    Given there are 4 overcommitted thin volumes
+    And no other pools with sufficient free space exist on the cluster
+    When filling up the volumes with data
+    Then several replicas are reported as faulted due to out-of-space
+    And since no other pool can accommodate the out-of-space replicas
+    Then the out-of-space replicas stay permanently faulted
+    And the affected volumes remain degraded
+    But the data transfer to all volumes completes with success

--- a/tests/bdd/features/capacity/thin/test_cluster.py
+++ b/tests/bdd/features/capacity/thin/test_cluster.py
@@ -1,0 +1,325 @@
+"""Thin Provisioning - Cluster Wide feature tests."""
+
+from urllib.parse import urlparse
+import pytest
+import subprocess
+import uuid
+
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+)
+from retrying import retry
+
+from common.deployer import Deployer
+from common.apiclient import ApiClient
+from common.operations import Volume
+from common.fio import Fio
+
+from openapi.model.create_pool_body import CreatePoolBody
+from openapi.model.create_volume_body import CreateVolumeBody
+from openapi.model.publish_volume_body import PublishVolumeBody
+from openapi.model.protocol import Protocol
+from openapi.model.volume_status import VolumeStatus
+from openapi.model.volume_policy import VolumePolicy
+from openapi.exceptions import NotFoundException
+
+THIN_VOLUME_UUID = "ec4e66fd-3b33-4439-b504-d49aba53da26"
+THICK_VOLUME_UUID = "ec4e66fd-3b33-4439-b504-d49aba53da27"
+VOLUME_COUNT = 4
+SMALL_VOLUME_SIZE = 20
+REPLICA_OVERHEAD = 8
+LARGE_VOLUME_SIZE = SMALL_VOLUME_SIZE * 3
+POOL_SIZE = (SMALL_VOLUME_SIZE + REPLICA_OVERHEAD) * 3 + 4
+POOL_UUID_1 = "4cc6ee64-7232-497d-a26f-38284a444980"
+NODE_NAME_1 = "io-engine-1"
+POOL_UUID_2 = "4cc6ee64-7232-497d-a26f-38284a444981"
+NODE_NAME_2 = "io-engine-2"
+POOL_UUID_3 = "4cc6ee64-7232-497d-a26f-38284a444982"
+
+
+@pytest.fixture(autouse=True)
+def init():
+    Deployer.start(
+        io_engines=2,
+        cache_period="250ms",
+        reconcile_period="300ms",
+        fio_spdk=True,
+        io_engine_coreisol=True,
+    )
+    ApiClient.pools_api().put_node_pool(
+        NODE_NAME_1,
+        POOL_UUID_1,
+        CreatePoolBody([f"malloc:///disk1?size_mb={POOL_SIZE}"]),
+    )
+    ApiClient.pools_api().put_node_pool(
+        NODE_NAME_2,
+        POOL_UUID_2,
+        CreatePoolBody(
+            [f"malloc:///disk1?size_mb={POOL_SIZE + LARGE_VOLUME_SIZE + 8}"]
+        ),
+    )
+
+    yield
+    Deployer.stop()
+
+
+@scenario("cluster.feature", "Reaching physical capacity of a cluster")
+def test_reaching_physical_capacity_of_a_cluster():
+    """Reaching physical capacity of a cluster."""
+
+
+@scenario(
+    "cluster.feature",
+    "Resolving out-of-space condition for several thin multi-replica volumes",
+)
+def test_resolving_outofspace_condition_for_several_thin_multireplica_volumes():
+    """Resolving out-of-space condition for several thin multi-replica volumes."""
+
+
+@given("a control plane, Io-Engine instances and pools")
+def a_control_plane_ioengine_instances_and_pools():
+    """a control plane, Io-Engine instances and pools."""
+
+
+@given("no other pools with sufficient free space exist on the cluster")
+def no_other_pools_with_sufficient_free_space_exist_on_the_cluster():
+    """no other pools with sufficient free space exist on the cluster."""
+    assert len(ApiClient.pools_api().get_pools()) == 2
+
+
+@given("there are 4 overcommitted thin volumes")
+def there_are_4_overcommitted_thin_volumes():
+    """there are 4 overcommitted thin volumes."""
+    assert VOLUME_COUNT is 4
+    volumes = list()
+    # Ensure it's the first replica that gets faulted with enospc to work around a datapath bug: GTM-609.
+    # Once fixed we can set it to None.
+    node = NODE_NAME_1
+    for i in range(VOLUME_COUNT):
+        size = SMALL_VOLUME_SIZE
+        if i == 0:
+            size = LARGE_VOLUME_SIZE
+
+        volume = ApiClient.volumes_api().put_volume(
+            str(uuid.uuid4()),
+            create_volume_body=CreateVolumeBody(
+                VolumePolicy(True), 2, size * 1024 * 1024, True
+            ),
+        )
+        volume = ApiClient.volumes_api().put_volume_target(
+            volume.spec.uuid,
+            publish_volume_body=PublishVolumeBody({}, Protocol("nvmf"), node=node),
+        )
+        assert hasattr(volume.spec, "target")
+        assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))
+        volumes.append(volume)
+    pytest.volumes = volumes
+
+    pool = ApiClient.pools_api().get_pool(POOL_UUID_1)
+
+    assert pool.state.used == (REPLICA_OVERHEAD * VOLUME_COUNT) * 1024 * 1024
+
+    # Pre-fill the volumes no one volume can ever be fully allocated
+    fios = list()
+    for i in range(4):
+        fio_size = SMALL_VOLUME_SIZE / 2
+        if i == 0:
+            fio_size = LARGE_VOLUME_SIZE / 2
+        fio_size = f"{int(fio_size)}M"
+        volumes[i].fio_offset = fio_size
+
+        uri = urlparse(volumes[i].state.target["deviceUri"])
+        fio = Fio(name="job", rw="write", uri=uri, size=fio_size)
+        fios.append(fio.open())
+
+    for fio in fios:
+        try:
+            code = fio.wait(timeout=30)
+            assert code == 0, "FIO should have not failed!"
+        except subprocess.TimeoutExpired:
+            assert False, "FIO timed out"
+
+    # ensure no free space is left
+    no_free_space(POOL_UUID_1)
+    yield
+    Volume.delete_all()
+    try:
+        ApiClient.pools_api().del_pool(POOL_UUID_3)
+    except NotFoundException:
+        pass
+
+
+@given("they share the same pools")
+def they_share_the_same_pools():
+    """they share the same pools."""
+    volumes = pytest.volumes
+
+    pools = list()
+    for volume in volumes:
+        replicas = volume.state.replica_topology.values()
+        these_pools = list(map(lambda repl: repl.pool, list(replicas)))
+        these_pools.sort()
+        if not pools.__contains__(these_pools):
+            pools.append(these_pools)
+
+    # the first list gets in and the others should be the same
+    assert len(pools) == 1
+
+
+@when("filling up the volumes with data")
+def filling_up_the_volumes_with_data():
+    """filling up the volumes with data."""
+    volumes = pytest.volumes
+    fios = list()
+
+    for volume in volumes:
+        uri = urlparse(volume.state.target["deviceUri"])
+        fio = Fio(name="job", rw="write", uri=uri, offset=volume.fio_offset)
+        fios.append(fio.open())
+    pytest.fios = fios
+
+
+@then("all volumes become healthy")
+def all_volumes_become_healthy():
+    """all volumes become healthy."""
+    for volume in ApiClient.volumes_api().get_volumes().entries:
+        assert volume.state.status == VolumeStatus("Online")
+
+
+@then("if other pools with sufficient free space exist on the cluster")
+def if_other_pools_with_sufficient_free_space_exist_on_the_cluster():
+    """if other pools with sufficient free space exist on the cluster."""
+    # Make free capacity available on another pool to relocate the largest replica
+    ApiClient.pools_api().put_node_pool(
+        NODE_NAME_1,
+        POOL_UUID_3,
+        CreatePoolBody([f"malloc:///disk11?size_mb={LARGE_VOLUME_SIZE + 8}"]),
+    )
+
+
+@then("several replicas are reported as faulted due to out-of-space")
+def several_replicas_are_reported_as_faulted_due_to_outofspace():
+    """several replicas are reported as faulted due to out-of-space."""
+    volumes = pytest.volumes
+    wait_volumes_enospc(volumes)
+
+
+@then("several replicas on the same pool are reported as faulted due to out-of-space")
+def several_replicas_on_the_same_pool_are_reported_as_faulted_due_to_outofspace():
+    """several replicas on the same pool are reported as faulted due to out-of-space."""
+    volumes = pytest.volumes
+    wait_volumes_enospc(volumes)
+
+
+@then("since no other pool can accommodate the out-of-space replicas")
+def since_no_other_pool_can_accommodate_the_outofspace_replicas():
+    """since no other pool can accommodate the out-of-space replicas."""
+    assert len(ApiClient.pools_api().get_pools()) == 2
+
+
+@then("the affected volumes remain degraded")
+def the_affected_volumes_remain_degraded():
+    """the affected volumes remain degraded."""
+    volumes = pytest.volumes
+    wait_volumes_enospc(volumes)
+
+
+@then("the data transfer to all volumes completes with success")
+def the_data_transfer_to_all_volumes_completes_with_success():
+    """the data transfer to all volumes completes with success."""
+    fios = pytest.fios
+    for fio in fios:
+        try:
+            code = fio.wait(timeout=20)
+            # todo: should pass after gtm-609 is resolved.
+            # assert code == 0, "FIO should have not failed!"
+        except subprocess.TimeoutExpired:
+            assert False, "FIO timed out"
+
+
+@then(
+    "the largest of the failed replicas is relocated to another pool with sufficient free space"
+)
+def the_largest_of_the_failed_replicas_is_relocated_to_another_pool_with_sufficient_free_space():
+    """the largest of the failed replicas is relocated to another pool with sufficient free space."""
+    largest_volume = pytest.volumes[0]
+    largest_replica_relocated(largest_volume, POOL_UUID_3)
+
+
+@then("the other faulted replicas start to rebuild in-place")
+def the_other_faulted_replicas_start_to_rebuild_inplace():
+    """the other faulted replicas start to rebuild in-place."""
+    volumes = pytest.volumes
+    wait_volumes_rebuild_or_online(volumes)
+    for i in range(1, VOLUME_COUNT):
+        volume = ApiClient.volumes_api().get_volume(volumes[i].spec.uuid)
+        org_replicas = list(volumes[i].state.replica_topology.keys())
+        org_replicas.sort()
+        replicas = list(volume.state.replica_topology.keys())
+        replicas.sort()
+
+        assert (
+            org_replicas == replicas
+        ), "All but the larger replica should rebuild in-place"
+
+
+@then("the out-of-space replicas stay permanently faulted")
+def the_outofspace_replicas_stay_permanently_faulted():
+    """the out-of-space replicas stay permanently faulted."""
+    volumes = pytest.volumes
+    wait_volumes_enospc(volumes)
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=20)
+def wait_volumes_enospc(volumes):
+    for volume in volumes:
+        volume = ApiClient.volumes_api().get_volume(volume.spec.uuid)
+        assert volume.state.status == VolumeStatus("Degraded")
+        assert len(volume.state.target["children"]) == 2
+
+        replicas = list(volume.state.replica_topology.values())
+        enospcs = list(
+            filter(
+                lambda replica: str(replica.get("child_status_reason")) == "OutOfSpace",
+                replicas,
+            )
+        )
+        assert len(enospcs) == 1
+        assert enospcs[0].pool == POOL_UUID_1
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=20)
+def wait_volumes_rebuild_or_online(volumes):
+    for volume in volumes:
+        volume = ApiClient.volumes_api().get_volume(volume.spec.uuid)
+        assert volume.state.status == VolumeStatus(
+            "Online"
+        ) or volume.state.status == VolumeStatus("Degraded")
+        if volume.state.status == VolumeStatus("Degraded"):
+            assert volume.state.target.rebuilds == 1
+            assert len(volume.state.target["children"]) == 2
+            children = list(volume.state.target["children"])
+            degraded = list(
+                filter(lambda child: child.get("state") == "Degraded", children)
+            )
+            assert len(degraded) == 1
+
+
+@retry(wait_fixed=100, stop_max_attempt_number=5)
+def no_free_space(pool_id):
+    pool = ApiClient.pools_api().get_pool(pool_id)
+    assert pool.state.capacity - pool.state.used == 0
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=40)
+def largest_replica_relocated(largest_volume, to_pool):
+    volume = ApiClient.volumes_api().get_volume(largest_volume.spec.uuid)
+    replicas = list(volume.state.replica_topology.values())
+    assert len(replicas) is 2
+    moved = list(filter(lambda replica: replica.pool == to_pool, replicas))
+    assert len(moved) is 1
+    retained = list(filter(lambda replica: replica.pool == POOL_UUID_2, replicas))
+    assert len(retained) is 1

--- a/tests/bdd/features/capacity/thin/volume/create.feature
+++ b/tests/bdd/features/capacity/thin/volume/create.feature
@@ -4,14 +4,14 @@ Feature: Thin Provisioning - Volume Creation
 
   # Thick volume creation.
   Scenario: Creating a thick provisioned volume
-    Given a request for a tick provisioned volume
+    Given a request for a thick provisioned volume
     When a volume is successfully created
     Then its replicas are reported to be thick provisioned
     And the pools usage increases by volume size
 
   # Thick volume space limit.
   Scenario: Creating an oversized thick provisioned volume
-    Given a request for a tick provisioned volume
+    Given a request for a thick provisioned volume
     When the request size exceeds available pools free space
     Then volume creation fails due to insufficient space
 

--- a/tests/bdd/features/capacity/thin/volume/mixed.feature
+++ b/tests/bdd/features/capacity/thin/volume/mixed.feature
@@ -1,0 +1,14 @@
+Feature: Thin Provisioning
+  Background:
+    Given a control plane, Io-Engine instances and pools
+
+  # Mixing thin and thick volumes: thick volumes must not be affected by ENOSPC.
+  Scenario: Out-of-space condition does not affect thick volumes on mixed pools
+    Given a single replica thick volume
+    And a single replica overcommitted thin volume
+    And both volumes share the same pool
+    When data is being written to the thick volume
+    And data is being written to the thin volume which exceeds the free space on the pool
+    Then a write failure with ENOSPC error is reported on the thin volume
+    But the thick volume is not affected and remains healthy
+    And the app using the thick volume continues to run unaffected

--- a/tests/bdd/features/capacity/thin/volume/test_create.py
+++ b/tests/bdd/features/capacity/thin/volume/test_create.py
@@ -116,9 +116,9 @@ def a_request_for_a_thin_provisioned_volume(create_request):
     create_request[CREATE_REQUEST_KEY] = request
 
 
-@given("a request for a tick provisioned volume")
-def a_request_for_a_tick_provisioned_volume(create_request):
-    """a request for a tick provisioned volume."""
+@given("a request for a thick provisioned volume")
+def a_request_for_a_thick_provisioned_volume(create_request):
+    """a request for a thick provisioned volume."""
     request = CreateVolumeBody(
         VolumePolicy(False), NUM_VOLUME_REPLICAS, VOLUME_SIZE, False
     )

--- a/tests/bdd/features/capacity/thin/volume/test_mixed.py
+++ b/tests/bdd/features/capacity/thin/volume/test_mixed.py
@@ -1,0 +1,164 @@
+"""Thin Provisioning feature tests."""
+
+from urllib.parse import urlparse
+import pytest
+import subprocess
+
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+)
+
+from common.deployer import Deployer
+from common.apiclient import ApiClient
+from common.fio import Fio
+
+from openapi.model.create_pool_body import CreatePoolBody
+from openapi.model.create_volume_body import CreateVolumeBody
+from openapi.model.publish_volume_body import PublishVolumeBody
+from openapi.model.protocol import Protocol
+from openapi.model.volume_status import VolumeStatus
+from openapi.model.volume_policy import VolumePolicy
+
+THIN_VOLUME_UUID = "ec4e66fd-3b33-4439-b504-d49aba53da26"
+THICK_VOLUME_UUID = "ec4e66fd-3b33-4439-b504-d49aba53da27"
+VOLUME_SIZE = 20 * 1024 * 1024
+POOL_SIZE = VOLUME_SIZE + 16 * 1024 * 1024
+POOL_UUID_1 = "4cc6ee64-7232-497d-a26f-38284a444980"
+NODE_NAME_1 = "io-engine-1"
+
+
+@pytest.fixture(autouse=True)
+def init():
+    Deployer.start(
+        io_engines=2,
+        cache_period="250ms",
+        reconcile_period="500ms",
+        fio_spdk=True,
+        io_engine_coreisol=True,
+    )
+    pool_size_mb = int(POOL_SIZE / (1024 * 1024))
+    ApiClient.pools_api().put_node_pool(
+        NODE_NAME_1,
+        POOL_UUID_1,
+        CreatePoolBody([f"malloc:///disk1?size_mb={pool_size_mb}"]),
+    )
+
+    yield
+    Deployer.stop()
+
+
+@scenario(
+    "mixed.feature",
+    "Out-of-space condition does not affect thick volumes on mixed pools",
+)
+def test_outofspace_condition_does_not_affect_thick_volumes_on_mixed_pools():
+    """Out-of-space condition does not affect thick volumes on mixed pools."""
+
+
+@given("a control plane, Io-Engine instances and pools")
+def a_control_plane_ioengine_instances_and_pools():
+    """a control plane, Io-Engine instances and pools."""
+
+
+@given("a single replica overcommitted thin volume")
+def a_single_replica_overcommitted_thin_volume():
+    """a single replica overcommitted thin volume."""
+    volume = ApiClient.volumes_api().put_volume(
+        THIN_VOLUME_UUID,
+        create_volume_body=CreateVolumeBody(VolumePolicy(True), 1, VOLUME_SIZE, True),
+    )
+    volume = ApiClient.volumes_api().put_volume_target(
+        volume.spec.uuid,
+        publish_volume_body=PublishVolumeBody({}, Protocol("nvmf")),
+    )
+    assert hasattr(volume.spec, "target")
+    assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))
+    pytest.thin_volume = volume
+
+
+@given("a single replica thick volume")
+def a_single_replica_thick_volume():
+    """a single replica thick volume."""
+    volume = ApiClient.volumes_api().put_volume(
+        THICK_VOLUME_UUID,
+        create_volume_body=CreateVolumeBody(VolumePolicy(True), 1, VOLUME_SIZE, True),
+    )
+    volume = ApiClient.volumes_api().put_volume_target(
+        volume.spec.uuid,
+        publish_volume_body=PublishVolumeBody({}, Protocol("nvmf")),
+    )
+    assert hasattr(volume.spec, "target")
+    assert str(volume.spec.target.protocol) == str(Protocol("nvmf"))
+    pytest.thick_volume = volume
+
+
+@given("both volumes share the same pool")
+def both_volumes_share_the_same_pool():
+    """both volumes share the same pool."""
+    thin_volume = pytest.thin_volume
+    thick_volume = pytest.thick_volume
+
+    thin_replica = list(thin_volume.state.replica_topology.values())[0]
+    thick_replica = list(thick_volume.state.replica_topology.values())[0]
+
+    assert thin_replica.pool == thick_replica.pool
+
+
+@when("data is being written to the thick volume")
+def data_is_being_written_to_the_thick_volume():
+    """data is being written to the thick volume."""
+    volume = pytest.thick_volume
+    uri = urlparse(volume.state.target["deviceUri"])
+
+    fio = Fio(name="job", rw="write", uri=uri)
+    pytest.thick_fio = fio.open()
+
+
+@when(
+    "data is being written to the thin volume which exceeds the free space on the pool"
+)
+def data_is_being_written_to_the_thin_volume_which_exceeds_the_free_space_on_the_pool():
+    """data is being written to the thin volume which exceeds the free space on the pool."""
+    volume = pytest.thin_volume
+    thin_replica = list(volume.state.replica_topology.values())[0]
+    pool = ApiClient.pools_api().get_pool(thin_replica.pool)
+
+    pool_size_mb = int((pool.state.capacity - pool.state.used) / 1024 / 1024)
+
+    uri = urlparse(volume.state.target["deviceUri"])
+
+    fio = Fio(name="job", rw="write", uri=uri, size=f"{pool_size_mb}M")
+    pytest.thin_fio = fio.open()
+
+
+@then("a write failure with ENOSPC error is reported on the thin volume")
+def a_write_failure_with_enospc_error_is_reported_on_the_thin_volume():
+    """a write failure with ENOSPC error is reported on the thin volume."""
+    fio = pytest.thin_fio
+    try:
+        code = fio.wait(timeout=30)
+        assert code != 0, "FIO should have failed!"
+    except subprocess.TimeoutExpired:
+        assert False, "FIO timed out"
+
+
+@then("the app using the thick volume continues to run unaffected")
+def the_app_using_the_thick_volume_continues_to_run_unaffected():
+    """the app using the thick volume continues to run unaffected."""
+    fio = pytest.thick_fio
+    try:
+        code = fio.wait(timeout=30)
+        assert code == 0, "FIO failed, exit code: %d" % code
+    except subprocess.TimeoutExpired:
+        assert False, "FIO timed out"
+
+
+@then("the thick volume is not affected and remains healthy")
+def the_thick_volume_is_not_affected_and_remains_healthy():
+    """the thick volume is not affected and remains healthy."""
+    volume = pytest.thick_volume
+    volume = ApiClient.volumes_api().get_volume(volume.spec.uuid)
+    assert volume.state.status == VolumeStatus("Online")

--- a/tests/bdd/features/volume/topology/test_feature.py
+++ b/tests/bdd/features/volume/topology/test_feature.py
@@ -1,4 +1,4 @@
-"""Volume Topology feature feature tests."""
+"""Volume Topology feature tests."""
 
 import docker
 import pytest


### PR DESCRIPTION
    feat(capacity/thin/plugin): add replica topologies subcommand
    
```
Allows us to quickly inspect all the volume topologies, example:
VOLUME-ID                              ID                                    NODE         POOL                                  STATUS  CAPACITY  ALLOCATED  CHILD-STATUS  CHILD-STATUS-REASON  REBUILD
 c05ef923-a320-468c-b426-a260c1d84107  b58e1975-633f-4b34-9611-b648babf76a8  io-engine-1  4cc6ee64-7232-497d-a26f-38284a444980  Online  60MiB     36MiB      Degraded      OutOfSpace           <none>
 ├─                                    67a6ec31-5923-490f-84b7-0be1df3bfb53  io-engine-2  4cc6ee64-7232-497d-a26f-38284a444981  Online  60MiB     60MiB      Online        <none>               <none>
 └─                                    553aeb7c-4be4-4391-a403-ad241d96711f  io-engine-3  4cc6ee64-7232-497d-a26f-38284a444982  Online  60MiB     60MiB      Online        <none>               <none>
 83241cc8-5dca-4bf1-b55a-c427c3e9b4a1  d70aa822-8dd4-41e7-a810-30950e3e2972  io-engine-1  4cc6ee64-7232-497d-a26f-38284a444980  Online  20MiB     16MiB      Degraded      OutOfSpace           <none>
 ├─                                    67a6ec31-5923-490f-84b7-0be1df3bfb53  io-engine-2  4cc6ee64-7232-497d-a26f-38284a444981  Online  60MiB     60MiB      Online        <none>               <none>
 └─                                    a5059250-2e79-4c4a-a451-46f551d3d0bd  io-engine-3  4cc6ee64-7232-497d-a26f-38284a444982  Online  60MiB     60MiB      Online        <none>               <none>
 83241cc8-5dca-4bf1-b55a-c427c3e9b4a1  adde358f-70cd-4a2d-9dfb-f40d6663ecbc  io-engine-1  4cc6ee64-7232-497d-a26f-38284a444980  Online  20MiB     16MiB      Degraded      <none>               51%
 ├─                                    b5ff41b8-1a0a-4bc7-84bb-5bfdfe72a71e  io-engine-2  4cc6ee64-7232-497d-a26f-38284a444981  Online  60MiB     60MiB      Online        <none>               <none>
 └─                                    39431c11-0eea-48e7-970f-a2359ebbb9d1  io-engine-3  4cc6ee64-7232-497d-a26f-38284a444982  Online  60MiB     60MiB      Online        <none>               <none>
```
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(capacity/bdd): add thin volume mixed&cluster bdd feature and test
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(openapi/replica-topology): add child status and status reason to replica topology
    
    This can be used to inspect the status of a replica volume target (child) without having to
    parse the children URI's to fetch the UUID which we can compare against the replica.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
