### PR TITLE
chore: change child fault timestamp type to systemtime from datatime

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -271,8 +271,7 @@ impl IoEngineToAgent for v1::nexus::Child {
             faulted_at: self
                 .fault_timestamp
                 .clone()
-                .and_then(|t| std::time::SystemTime::try_from(t).ok())
-                .map(chrono::DateTime::from),
+                .and_then(|t| std::time::SystemTime::try_from(t).ok()),
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/child.rs
+++ b/control-plane/stor-port/src/types/v0/transport/child.rs
@@ -1,9 +1,7 @@
 use super::*;
-
-use chrono::{DateTime, Utc};
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
-use std::{cmp::Ordering, fmt::Debug, str::FromStr};
+use std::{cmp::Ordering, fmt::Debug, str::FromStr, time::SystemTime};
 use strum_macros::Display;
 
 /// Child information
@@ -19,7 +17,7 @@ pub struct Child {
     /// Reason for the child state.
     pub state_reason: ChildStateReason,
     /// Last faulted timestamp of this child.
-    pub faulted_at: Option<DateTime<Utc>>,
+    pub faulted_at: Option<SystemTime>,
 }
 impl Child {
     /// If if the state reason is lack of space.


### PR DESCRIPTION
SystemTime has elapsed() fn implemented. This allows us to determine end of wait period.