### PR TITLE
fix(io-engine/pools): committed bytes is now exposed by the dataplane

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -93,6 +93,7 @@ impl IoEngineToAgent for v0::Pool {
             status: self.state.into(),
             capacity: self.capacity,
             used: self.used,
+            committed: None,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -380,7 +380,7 @@ impl AgentToIoEngine for transport::NexusChildActionKind {
         match self {
             transport::NexusChildActionKind::Offline => v1::nexus::ChildAction::Offline,
             transport::NexusChildActionKind::Online => v1::nexus::ChildAction::Online,
-            transport::NexusChildActionKind::Retire => v1::nexus::ChildAction::Retire,
+            transport::NexusChildActionKind::Retire => v1::nexus::ChildAction::FaultIoError,
         }
     }
 }
@@ -415,6 +415,11 @@ impl IoEngineToAgent for v1::pool::Pool {
             capacity: self.capacity,
             used: self.used,
             status: self.state.into(),
+            committed: if self.used > 0 && self.committed == 0 {
+                None
+            } else {
+                Some(self.committed)
+            },
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -135,6 +135,7 @@ mod tests {
             status: PoolStatus::Online,
             capacity,
             used,
+            committed: None,
         };
         let replica = Replica::default();
         let pool = PoolWrapper::new(

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -55,10 +55,7 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
 
         let state = pool.complete_create(result, registry, on_fail).await?;
         let spec = pool.lock().clone();
-        Ok(Pool::new(
-            spec,
-            CtrlPoolState::new(state, Default::default()),
-        ))
+        Ok(Pool::new(spec, CtrlPoolState::new(state)))
     }
 
     async fn destroy(

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -13,8 +13,6 @@ message Pool {
   optional PoolDefinition definition = 1;
   // Runtime state of the pool as seen by the dataplane.
   optional PoolState state = 2;
-  /// State metadata information added by the control plane.
-  optional PoolStateMetadata state_meta = 3;
 }
 
 // Multiple pools
@@ -64,12 +62,8 @@ message PoolState {
   uint64 capacity = 5;
   // used bytes from the pool
   uint64 used = 6;
-}
-
-// Pool information
-message PoolStateMetadata {
   // total size of pool replicas
-  uint64 committed = 1;
+  optional uint64 committed = 7;
 }
 
 // status of the pool

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -212,6 +212,7 @@ impl From<&PoolSpec> for transport::PoolState {
             status: transport::PoolStatus::Unknown,
             capacity: 0,
             used: 0,
+            committed: None,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -61,21 +61,15 @@ impl From<PoolStatus> for models::PoolStatus {
 pub struct CtrlPoolState {
     /// The state, mostly as returned by the data-plane.
     state: PoolState,
-    /// Additional metadata added by the control-plane.
-    metadata: PoolStateMetadata,
 }
 impl CtrlPoolState {
     /// Construct a new pool with spec and state.
-    pub fn new(state: PoolState, metadata: PoolStateMetadata) -> Self {
-        Self { state, metadata }
+    pub fn new(state: PoolState) -> Self {
+        Self { state }
     }
     /// Get the pool state.
     pub fn state(&self) -> &PoolState {
         &self.state
-    }
-    /// Get the pool state metadata.
-    pub fn metadata(&self) -> &PoolStateMetadata {
-        &self.metadata
     }
 }
 impl Deref for CtrlPoolState {
@@ -102,25 +96,12 @@ pub struct PoolState {
     pub capacity: u64,
     /// Used bytes from the pool.
     pub used: u64,
-}
-
-/// Pool state metadata information.
-#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct PoolStateMetadata {
     /// Total pool commitment (in bytes) which is basically the accrued size of pool replicas.
-    pub committed: u64,
-}
-impl PoolStateMetadata {
-    /// Returns a new `Self` from the given parameters.
-    pub fn new(committed: u64) -> Self {
-        Self { committed }
-    }
+    pub committed: Option<u64>,
 }
 
 impl From<CtrlPoolState> for models::PoolState {
     fn from(src: CtrlPoolState) -> Self {
-        let metadata = src.metadata;
         let src = src.state;
         Self::new_all(
             src.capacity,
@@ -129,7 +110,7 @@ impl From<CtrlPoolState> for models::PoolState {
             src.node,
             src.status,
             src.used,
-            Some(metadata.committed),
+            src.committed,
         )
     }
 }


### PR DESCRIPTION
Revert control-plane specific metadata changes.