### PR TITLE
fix(capacity/thin): don't add children for rebuild if there's no space

### DIFF
--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -9,6 +9,7 @@ use crate::controller::scheduling::{
     resources::{ChildItem, NodeItem, PoolItem, ReplicaItem},
     volume::{GetSuitablePoolsContext, VolumeReplicasForNexusCtx},
 };
+
 use std::{cmp::Ordering, collections::HashMap, future::Future};
 
 #[async_trait::async_trait(?Send)]

--- a/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
@@ -155,7 +155,7 @@ impl GetPersistedNexusChildrenCtx {
                     .find(|p| p.id == pool_id)
                     .and_then(|pool| {
                         replica_state.map(|replica_state| {
-                            ChildItem::new(&replica_spec, replica_state, child_info, pool)
+                            ChildItem::new(&replica_spec, replica_state, child_info, pool, None)
                         })
                     })
             })

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -132,6 +132,7 @@ pub(crate) struct ChildItem {
     replica_state: Replica,
     pool_state: PoolWrapper,
     child_info: Option<ChildInfo>,
+    rebuildable: Option<bool>,
 }
 
 // todo: keep original Debug and use valuable trait from tracing instead
@@ -186,12 +187,14 @@ impl ChildItem {
         replica_state: &Replica,
         child_info: Option<&ChildInfo>,
         pool_state: &PoolWrapper,
+        rebuildable: Option<bool>,
     ) -> Self {
         Self {
             replica_spec: replica_spec.clone(),
             replica_state: replica_state.clone(),
             child_info: child_info.cloned(),
             pool_state: pool_state.clone(),
+            rebuildable,
         }
     }
     /// Get the replica spec.
@@ -209,6 +212,10 @@ impl ChildItem {
     /// Get the pool wrapper.
     pub(crate) fn pool(&self) -> &PoolWrapper {
         &self.pool_state
+    }
+    /// Check if we can rebuild this child.
+    pub(crate) fn rebuildable(&self) -> &Option<bool> {
+        &self.rebuildable
     }
 }
 

--- a/tests/bdd/features/capacity/thin/volume/rebuild.feature
+++ b/tests/bdd/features/capacity/thin/volume/rebuild.feature
@@ -22,3 +22,14 @@ Feature: Thin Provisioning - Volume Rebuild
     When the new replica is fully rebuilt
     Then the new replica allocation equals the volume allocation
     And the total number of healthy replicas is restored
+
+  # Child should not be added if it cannot be rebuilt.
+  Scenario: Rebuild is not started if there's no space in the pool
+    Given a thin provisioned volume with 2 replicas
+    When data is written to the volume which exceeds the free space on one of the pools
+    Then a replica is reported as faulted due to out-of-space
+    And the total number of healthy replicas of the volume decreases by one
+    But the client app is not affected because other healthy replicas exists
+    And if the volume is republished again
+    Then the faulted replica should not be rebuilt as there's no free space in the pool
+    And the faulted replica should be deleted


### PR DESCRIPTION
Don't attempt to add replicas to a nexus for rebuild if the replicas has no space to grow. This ensures we follow the same logic for add and online. Also, delete these replicas otherwise we're keeping them around even though we can't use them.