### PR TITLE
Several Switchover fixes

### DIFF
--- a/control-plane/agents/src/bin/ha/cluster/nodes.rs
+++ b/control-plane/agents/src/bin/ha/cluster/nodes.rs
@@ -1,43 +1,74 @@
-use crate::volume::VolumeMover;
+use crate::{
+    switchover::{Stage, SwitchOverRequest, SwitchOverStage},
+    volume::VolumeMover,
+};
+use stor_port::{
+    transport_api::{ReplyError, ResourceKind},
+    types::v0::transport::NodeId,
+};
+
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
-use stor_port::types::v0::transport::NodeId;
 use tokio::sync::Mutex;
 use tracing::info;
 
+/// A record about a failed path reported by the ha node agent.
+#[derive(Debug)]
+struct PathRecord {
+    _socket: SocketAddr,
+    stage: SwitchOverStage,
+}
+impl PathRecord {
+    fn stage(&self) -> Stage {
+        self.stage.read()
+    }
+}
+
 /// Store node information and reported failed path.
 #[derive(Debug, Default, Clone)]
-pub struct NodeList {
+pub(crate) struct NodeList {
     list: Arc<Mutex<HashMap<NodeId, SocketAddr>>>,
-    failed_path: Arc<Mutex<HashMap<String, SocketAddr>>>,
+    failed_path: Arc<Mutex<HashMap<String, PathRecord>>>,
 }
 
 impl NodeList {
     /// Get a new `Self`.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
     /// Register node and its endpoint.
     /// If the node is already registered then update its details.
-    pub async fn register_node(&self, name: NodeId, endpoint: SocketAddr) {
+    pub(crate) async fn register_node(&self, name: NodeId, endpoint: SocketAddr) {
         let mut list = self.list.lock().await;
         list.insert(name, endpoint);
     }
 
     /// Remove path from failed_path list.
-    pub async fn remove_failed_path(&self, path: String) {
+    pub(crate) async fn remove_failed_path(&self, path: &str) {
         let mut failed_path = self.failed_path.lock().await;
-        failed_path.remove(&path);
+        failed_path.remove(path);
+    }
+    /// Add a failed switchover request to the failed paths.
+    /// Useful when reloading from the pstor after a crash/restart.
+    pub(crate) async fn insert_failed_request(&self, request: &SwitchOverRequest) {
+        let record = PathRecord {
+            _socket: request.socket(),
+            stage: request.stage_arc(),
+        };
+        self.failed_path
+            .lock()
+            .await
+            .insert(request.nqn().into(), record);
     }
 
     /// Send request to the switchover engine for the reported node and path.
-    pub async fn report_failed_path(
+    pub(crate) async fn report_failed_path(
         self,
         node: NodeId,
         path: String,
         mover: VolumeMover,
         endpoint: SocketAddr,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), ReplyError> {
         // Check if node is registered in the hashmap. Register if not.
         self.list
             .lock()
@@ -47,14 +78,31 @@ impl NodeList {
 
         let mut failed_path = self.failed_path.lock().await;
 
-        if failed_path.get(&path).is_some() {
-            anyhow::bail!("Path {} is already reported for switchover", path);
-        };
+        if let Some(record) = failed_path.get(&path) {
+            return match record.stage() {
+                Stage::ReplacePath | Stage::DeleteTarget | Stage::Successful | Stage::Errored => {
+                    Err(ReplyError::failed_precondition(
+                        ResourceKind::NvmePath,
+                        path,
+                        "Path is already reported for switchover".to_owned(),
+                    ))
+                }
+                Stage::Init | Stage::RepublishVolume => Err(ReplyError::already_exist(
+                    ResourceKind::NvmePath,
+                    path,
+                    "Path is already reported for switchover".to_owned(),
+                )),
+            };
+        }
 
         info!(node.id=%node, %path, "Sending switchover");
 
-        mover.switchover(node, endpoint, path.clone()).await?;
-        failed_path.insert(path, endpoint);
+        let stage = mover.switchover(node, endpoint, path.clone()).await?;
+        let record = PathRecord {
+            _socket: endpoint,
+            stage,
+        };
+        failed_path.insert(path, record);
         Ok(())
     }
 }

--- a/control-plane/agents/src/bin/ha/cluster/switchover.rs
+++ b/control-plane/agents/src/bin/ha/cluster/switchover.rs
@@ -15,8 +15,8 @@ use stor_port::{
             SpecTransaction,
         },
         transport::{
-            DestroyShutdownTargets, GetController, NodeId, ReplacePath, RepublishVolume, VolumeId,
-            VolumeShareProtocol,
+            DestroyShutdownTargets, GetController, NodeId, NvmeSubsystem, ReplacePath,
+            RepublishVolume, VolumeId, VolumeShareProtocol,
         },
     },
 };
@@ -25,8 +25,7 @@ use tokio::sync::{
     Mutex,
 };
 use tonic::transport::Uri;
-use tracing::{error, info};
-use utils::NVME_TARGET_NQN_PREFIX;
+use tracing::{error, info, warn};
 
 fn client() -> impl VolumeOperations {
     core_grpc().volume()
@@ -34,7 +33,7 @@ fn client() -> impl VolumeOperations {
 
 /// Stage represents the steps for switchover request.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone, Ord, PartialOrd)]
-pub enum Stage {
+pub(crate) enum Stage {
     /// Initialize switchover request.
     Init,
     /// Shutdown original/old volume target. Create new nexus for existing vol obj.
@@ -49,12 +48,33 @@ pub enum Stage {
     Errored,
 }
 
+/// A ref counted switchover stage which can be used to share stage information.
+#[derive(Debug, Clone)]
+pub(crate) struct SwitchOverStage(Arc<parking_lot::RwLock<Stage>>);
+impl SwitchOverStage {
+    /// Create a new `Self` for the given stage.
+    pub(crate) fn new(stage: Stage) -> Self {
+        SwitchOverStage(Arc::new(parking_lot::RwLock::new(stage)))
+    }
+    /// Read the stage value.
+    pub(crate) fn read(&self) -> Stage {
+        *self.0.read()
+    }
+}
+
+impl PartialEq for SwitchOverStage {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0.read() == *other.0.read()
+    }
+}
+impl Eq for SwitchOverStage {}
+
 /// SwitchOverRequest defines spec for switchover.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
-pub struct SwitchOverRequest {
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub(crate) struct SwitchOverRequest {
     callback_uri: SocketAddr,
-    pub volume_id: VolumeId,
-    stage: Stage,
+    volume_id: VolumeId,
+    stage: SwitchOverStage,
     /// The nodename of the request's originator node.
     node_name: NodeId,
     /// Timestamp when switchover request was initialized.
@@ -69,11 +89,13 @@ pub struct SwitchOverRequest {
     reuse_existing: bool,
     /// Publish context.
     publish_context: Option<HashMap<String, String>>,
+    /// The first time we handle exhaustion, retry right away.
+    fast_exhaustion_retry: bool,
 }
 
 impl Ord for SwitchOverRequest {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.stage.cmp(&other.stage) {
+        match self.stage().cmp(&other.stage()) {
             Ordering::Equal => self.timestamp.cmp(&other.timestamp),
             other => other,
         }
@@ -88,7 +110,7 @@ impl PartialOrd for SwitchOverRequest {
 
 impl SwitchOverRequest {
     /// Create a new switchover request for every failed Nvme path.
-    pub fn new(
+    pub(crate) fn new(
         callback_uri: SocketAddr,
         volume: VolumeId,
         node_name: NodeId,
@@ -97,7 +119,7 @@ impl SwitchOverRequest {
         SwitchOverRequest {
             callback_uri,
             volume_id: volume,
-            stage: Stage::Init,
+            stage: SwitchOverStage::new(Stage::Init),
             node_name,
             timestamp: Utc::now(),
             existing_nqn: existing_path,
@@ -105,18 +127,33 @@ impl SwitchOverRequest {
             retry_count: 0,
             reuse_existing: true,
             publish_context: None,
+            fast_exhaustion_retry: true,
         }
     }
 
+    /// Get a ref-counted switchover stage.
+    pub(crate) fn stage_arc(&self) -> SwitchOverStage {
+        self.stage.clone()
+    }
+
     /// Set the reuse_existing flag.
-    pub fn set_reuse_existing(&mut self, reuse_existing: bool) {
+    pub(crate) fn set_reuse_existing(&mut self, reuse_existing: bool) {
         self.reuse_existing = reuse_existing;
+    }
+
+    /// Get the node agent socket address.
+    pub(crate) fn socket(&self) -> SocketAddr {
+        self.callback_uri
+    }
+    /// Get the nqn of this path.
+    pub(crate) fn nqn(&self) -> &str {
+        &self.existing_nqn
     }
 
     /// Update stage with next stage.
     /// If a stage is PublishPath or Errored then it will not be updated.
-    pub fn update_next_stage(&mut self) {
-        self.stage = match self.stage {
+    pub(crate) fn update_next_stage(&mut self) {
+        self.set_stage(match self.stage() {
             Stage::Init => Stage::RepublishVolume,
             Stage::RepublishVolume => Stage::ReplacePath,
             Stage::ReplacePath => Stage::DeleteTarget,
@@ -124,12 +161,46 @@ impl SwitchOverRequest {
             // Successful and Errored stage mark request as complete, so no need to update
             Stage::Successful => Stage::Successful,
             Stage::Errored => Stage::Errored,
-        };
+        });
+    }
+
+    fn node_uri(&self) -> Result<Uri, http::Error> {
+        Uri::builder()
+            .scheme("http")
+            .authority(self.callback_uri.to_string())
+            .path_and_query("")
+            .build()
+    }
+    fn build_node_uri(&mut self) -> Result<Uri, anyhow::Error> {
+        match self.node_uri() {
+            Ok(node) => Ok(node),
+            Err(error) => {
+                self.set_stage(Stage::Errored);
+                error!(%error, volume.uuid=%self.volume_id, "Could not get grpc address of the node agent. Moving Switchover req to Errored");
+                Err(anyhow!(
+                    "Could not get grpc address of the node agent: {error}"
+                ))
+            }
+        }
+    }
+    fn handle_republish_exhaustion(&mut self) -> Result<(), anyhow::Error> {
+        if self.fast_exhaustion_retry {
+            self.fast_exhaustion_retry = false;
+            info!("Retrying Republish after cleaning up targets");
+            return Ok(());
+        }
+        Err(anyhow!("Retrying Republish after cleaning up targets"))
+    }
+    fn set_stage(&self, stage: Stage) {
+        *self.stage.0.write() = stage;
+    }
+    fn stage(&self) -> Stage {
+        *self.stage.0.read()
     }
 
     /// Start_op must be called before starting the respective stage operation on the request.
     /// Start_op will store the request with updated stage in formation in etcd.
-    pub async fn start_op(&self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+    pub(crate) async fn start_op(&self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
         let spec: SwitchOverSpec = self.into();
         etcd.store_obj(&spec).await
     }
@@ -137,7 +208,7 @@ impl SwitchOverRequest {
     /// Complete_op must be called after completion of the respective stage operation on the
     /// request.
     /// Complete_op will store the request in etcd with either updated stage or error message.
-    pub async fn complete_op(
+    pub(crate) async fn complete_op(
         &self,
         result: bool,
         msg: String,
@@ -157,7 +228,7 @@ impl SwitchOverRequest {
     }
 
     /// Delete the request from the persistent store.
-    pub async fn delete_request(&self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+    pub(crate) async fn delete_request(&self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
         let spec = SwitchOverSpec::from(self);
         etcd.delete_obj(&spec).await
     }
@@ -195,68 +266,35 @@ impl SwitchOverRequest {
                 ) =>
             {
                 error!(volume.uuid=%self.volume_id, %error, "Cancelling switchover");
-                self.stage = Stage::Errored;
+                self.set_stage(Stage::Errored);
                 Err(error.into())
             }
-            Err(err) if err.kind == ReplyErrorKind::ResourceExhausted => {
+            Err(error) if error.kind == ReplyErrorKind::ResourceExhausted => {
+                // todo: if we hit this we should try again with move = false?
                 // Cleanup volume targets that are not registered as Nvme Subsystems in the Node.
                 if let Some(new_path) = self.new_path.clone() {
-                    if let Ok(uri) = Uri::builder()
-                        .scheme("http")
-                        .authority(self.callback_uri.to_string())
-                        .path_and_query("")
-                        .build()
-                    {
-                        let node_client = NodeAgentClient::new(uri, None).await;
-                        let request = GetController::new(new_path);
-                        match node_client.get_nvme_controller(&request, None).await {
-                            Ok(target_address) => {
-                                let request = DestroyShutdownTargets::new(
-                                    self.volume_id.clone(),
-                                    Some(
-                                        target_address
-                                            .0
-                                            .iter()
-                                            .map(|addr| addr.address().to_string())
-                                            .collect(),
-                                    ),
-                                );
-                                client()
-                                    .destroy_shutdown_target(&request, None)
-                                    .await
-                                    .map_err(|err| anyhow!(err.to_string()))?;
-                                info!("Retrying Republish after cleaning up targets");
-                                return Ok(());
-                            }
-                            Err(err) if matches!(err.kind, ReplyErrorKind::NotFound) => {
-                                let request =
-                                    DestroyShutdownTargets::new(self.volume_id.clone(), None);
-                                client()
-                                    .destroy_shutdown_target(&request, None)
-                                    .await
-                                    .map_err(|err| anyhow!(err.to_string()))?;
-                                info!("Retrying Republish after cleaning up targets");
-                                return Ok(());
-                            }
-                            Err(error) => {
-                                let err = format!(
-                                    "Failed to list Nvme subsystems for the volume, error: {error}"
-                                );
-                                Err(anyhow!(err))
-                            }
+                    let uri = self.build_node_uri()?;
+                    let node_client = NodeAgentClient::new(uri, None).await;
+                    let request = GetController::new(new_path);
+                    match node_client.get_nvme_controller(&request, None).await {
+                        Ok(target_addresses) => {
+                            self.destroy_shutdown_targets(target_addresses.into_inner())
+                                .await?;
+                            return self.handle_republish_exhaustion();
                         }
-                    } else {
-                        self.stage = Stage::Errored;
-                        Err(anyhow!(
-                            "Could not convert node grpc address to required format"
-                        ))
+                        Err(err) if matches!(err.kind, ReplyErrorKind::NotFound) => {
+                            self.destroy_all_shutdown_targets().await?;
+                            return self.handle_republish_exhaustion();
+                        }
+                        Err(error) => Err(anyhow!(
+                            "Failed to list Nvme subsystems for the volume, error: {error}"
+                        )),
                     }
                 } else {
-                    self.stage = Stage::Errored;
-                    Err(anyhow!("Could not get the last published nvme path"))
+                    Err(error.into())
                 }
             }
-            Err(error) => Err(anyhow!(error.to_string())),
+            Err(error) => Err(error.into()),
         }?;
         self.publish_context = vol.spec().publish_context;
         self.new_path = match vol.state().target {
@@ -264,7 +302,7 @@ impl SwitchOverRequest {
             _ => None,
         };
         if self.new_path.is_none() {
-            error!(volume.uuid=%self.volume_id, "Could not find device uri for the volume. Marking request as errored");
+            error!(volume.uuid=%self.volume_id, "Could not find device uri for the volume");
             return Err(anyhow!("Couldnt find device uri for the volume"));
         }
         self.complete_op(true, "".to_string(), etcd).await?;
@@ -276,14 +314,39 @@ impl SwitchOverRequest {
     async fn delete_target(&mut self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
         self.start_op(etcd).await?;
 
-        info!(volume.uuid=%self.volume_id, "Deleting volume target");
-        let destroy_request = DestroyShutdownTargets::new(self.volume_id.clone(), None);
-        client()
-            .destroy_shutdown_target(&destroy_request, None)
-            .await?;
+        self.destroy_all_shutdown_targets().await?;
+
         self.complete_op(true, "".to_string(), etcd).await?;
         self.update_next_stage();
         Ok(())
+    }
+
+    async fn destroy_all_shutdown_targets(&self) -> Result<(), anyhow::Error> {
+        let destroy_request = DestroyShutdownTargets::new(self.volume_id.clone(), None);
+        self.request_destroy_shutdown_targets(destroy_request).await
+    }
+    async fn request_destroy_shutdown_targets(
+        &self,
+        request: DestroyShutdownTargets,
+    ) -> Result<(), anyhow::Error> {
+        info!(volume.uuid=%self.volume_id, "Deleting shutdown volume targets");
+
+        match client().destroy_shutdown_target(&request, None).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind == ReplyErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+    async fn destroy_shutdown_targets(
+        &self,
+        subsystems: Vec<NvmeSubsystem>,
+    ) -> Result<(), anyhow::Error> {
+        let targets = subsystems
+            .into_iter()
+            .map(|addr| addr.into_address())
+            .collect::<Vec<_>>();
+        let destroy_request = DestroyShutdownTargets::new(self.volume_id.clone(), Some(targets));
+        self.request_destroy_shutdown_targets(destroy_request).await
     }
 
     /// Deletes Successful Switchover request from etcd.
@@ -300,11 +363,23 @@ impl SwitchOverRequest {
     }
 
     /// Deletes Errored Switchover request from etcd.
-    async fn errored_switchover(&mut self, etcd: &EtcdStore) -> Result<(), anyhow::Error> {
+    async fn errored_switchover(
+        &mut self,
+        etcd: &EtcdStore,
+        nodes: &NodeList,
+    ) -> Result<(), anyhow::Error> {
         self.start_op(etcd).await?;
         info!(volume.uuid=%self.volume_id, "Error occurred while processing Switchover request");
+
+        // Should we do this here, or go via the delete targets stage with an extra error
+        // information in order to transition to either success or error stage?
+        self.destroy_all_shutdown_targets().await?;
+
         match self.delete_request(etcd).await {
-            Ok(_) => Ok(()),
+            Ok(_) => {
+                nodes.remove_failed_path(&self.existing_nqn).await;
+                Ok(())
+            }
             Err(_) => Err(anyhow!(
                 "Encountered error while trying to delete SwitchOverSpec from etcd for {}",
                 self.volume_id
@@ -320,61 +395,58 @@ impl SwitchOverRequest {
     ) -> Result<(), anyhow::Error> {
         self.start_op(etcd).await?;
         info!(volume.uuid=%self.volume_id, "Sending new volume target to node agent");
-        if let Ok(uri) = Uri::builder()
-            .scheme("http")
-            .authority(self.callback_uri.to_string())
-            .path_and_query("")
-            .build()
-        {
-            info!(%uri, "Creating node agent client using callback uri");
-            if let Some(new_path) = self.new_path.clone() {
-                let replace_request = ReplacePath::new(
-                    self.existing_nqn.clone(),
-                    new_path.clone(),
-                    self.publish_context.clone(),
-                );
-                let client = NodeAgentClient::new(uri, None).await;
+        let uri = self.build_node_uri()?;
+        info!(%uri, "Creating node agent client using callback uri");
+        if let Some(new_path) = self.new_path.clone() {
+            let replace_request = ReplacePath::new(
+                self.existing_nqn.clone(),
+                new_path.clone(),
+                self.publish_context.clone(),
+            );
+            let client = NodeAgentClient::new(uri, None).await;
 
-                if let Err(e) = client.replace_path(&replace_request, None).await {
-                    return if e.kind == ReplyErrorKind::FailedPrecondition {
-                        error!(nexus.path=%self.existing_nqn, "HA Node agent could not find failed Nvme path");
+            match client.replace_path(&replace_request, None).await {
+                Ok(_) => Ok(()),
+                Err(error) if error.kind == ReplyErrorKind::FailedPrecondition => {
+                    warn!(path=%self.existing_nqn, "HA Node agent could not find failed Nvme path");
+                    // otherwise this means we were able to reconnect even before we got called!
+                    if !self.reuse_existing {
                         info!(volume.uuid=%self.volume_id, "Moving Switchover request to Errored state");
-                        self.stage = Stage::Errored;
+                        self.set_stage(Stage::Errored);
                         Err(anyhow!("HA Node agent could not lookup old Nvme path"))
-                    } else if matches!(
-                        e.kind,
+                    } else {
+                        Ok(())
+                    }
+                }
+                Err(error)
+                    if matches!(
+                        error.kind,
                         ReplyErrorKind::Aborted
                             | ReplyErrorKind::Timeout
                             | ReplyErrorKind::NotFound
-                    ) {
-                        info!(volume.uuid=%self.volume_id, "Retrying Republish without older target reuse");
-                        self.set_reuse_existing(false);
-                        self.stage = Stage::RepublishVolume;
-                        Err(anyhow!("Nvme path replacement failed with older target"))
-                    } else {
-                        Err(anyhow!("Nvme path replacement failed"))
-                    };
+                    ) =>
+                {
+                    info!(volume.uuid=%self.volume_id, "Retrying Republish without older target reuse");
+                    self.set_reuse_existing(false);
+                    self.set_stage(Stage::RepublishVolume);
+                    return Err(anyhow!("Nvme path replacement failed with older target"));
                 }
-                nodes
-                    .remove_failed_path(format!("{}{}", NVME_TARGET_NQN_PREFIX, self.volume_id))
-                    .await;
-                self.complete_op(true, "".to_string(), etcd).await?;
-                self.update_next_stage();
-                Ok(())
-            } else {
-                Err(anyhow!("Could not to get new nexus target for the volume"))
-            }
+                Err(error) => Err(anyhow!("Nvme path replacement failed: {error}")),
+            }?;
+
+            nodes.remove_failed_path(&self.existing_nqn).await;
+            self.complete_op(true, "".to_string(), etcd).await?;
+            self.update_next_stage();
+            Ok(())
         } else {
-            self.stage = Stage::Errored;
-            error!(volume.uuid=%self.volume_id, "Could not get grpc address of the node agent. Moving Switchover req to Errored");
-            Err(anyhow!("Could not get grpc address of the node agent"))
+            Err(anyhow!("Could not to get new nexus target for the volume"))
         }
     }
 }
 
 /// SwitchOverEngine defines spec for switchover engine.
 #[derive(Debug, Clone)]
-pub struct SwitchOverEngine {
+pub(crate) struct SwitchOverEngine {
     etcd: EtcdStore,
     nodes: NodeList,
     channel: UnboundedSender<SwitchOverRequest>,
@@ -394,7 +466,7 @@ enum ReQueue {
 
 impl SwitchOverEngine {
     /// Creates a new switchover engine to process Nvme path failures.
-    pub fn new(etcd: EtcdStore, nodes: NodeList) -> Self {
+    pub(crate) fn new(etcd: EtcdStore, nodes: NodeList) -> Self {
         let (rq_tx, rq_rx) = unbounded_channel();
 
         let sw = SwitchOverEngine {
@@ -406,9 +478,12 @@ impl SwitchOverEngine {
         sw.init_worker(Arc::new(Mutex::new(rq_rx)));
         sw
     }
+    pub(crate) fn nodes(&self) -> &NodeList {
+        &self.nodes
+    }
 
     /// Instantiates worker task to asynchronously process Switchover request.
-    pub fn init_worker(&self, recv: Arc<Mutex<UnboundedReceiver<SwitchOverRequest>>>) {
+    pub(crate) fn init_worker(&self, recv: Arc<Mutex<UnboundedReceiver<SwitchOverRequest>>>) {
         for i in 0 .. WORKER_NUM {
             info!(worker = i, "Spawning Switchover Engine worker");
             let cloned_self = self.clone();
@@ -439,12 +514,12 @@ impl SwitchOverEngine {
     /// Failed requests are sent back to the work queue to be picked up later.
     async fn work_request(&self, mut request: SwitchOverRequest) {
         loop {
-            let result = match request.stage {
+            let result = match request.stage() {
                 Stage::Init => request.initialize(&self.etcd).await,
                 Stage::RepublishVolume => request.republish_volume(&self.etcd).await,
                 Stage::ReplacePath => request.replace_path(&self.etcd, &self.nodes).await,
                 Stage::DeleteTarget => request.delete_target(&self.etcd).await,
-                Stage::Errored => match request.errored_switchover(&self.etcd).await {
+                Stage::Errored => match request.errored_switchover(&self.etcd, &self.nodes).await {
                     Ok(_) => break,
                     Err(e) => Err(e),
                 },
@@ -473,7 +548,7 @@ impl SwitchOverEngine {
     }
 
     /// Sends Switchover request to the channel after sleeping for sometime (if necessary).
-    pub fn enqueue(&self, req: SwitchOverRequest) {
+    pub(crate) fn enqueue(&self, req: SwitchOverRequest) {
         let tx_clone = self.channel.clone();
         tokio::spawn(async move {
             let errored_request = req.retry_count > 0;
@@ -492,7 +567,7 @@ impl SwitchOverEngine {
 
 impl From<&SwitchOverRequest> for SwitchOverSpec {
     fn from(req: &SwitchOverRequest) -> Self {
-        let op = OperationState::new(req.stage.into(), None);
+        let op = OperationState::new(req.stage().into(), None);
         Self {
             callback_uri: req.callback_uri,
             node_name: req.node_name.clone(),
@@ -518,7 +593,7 @@ impl From<&SwitchOverSpec> for SwitchOverRequest {
         Self {
             callback_uri: req.callback_uri,
             volume_id: req.volume.clone(),
-            stage,
+            stage: SwitchOverStage::new(stage),
             node_name: req.node_name.clone(),
             timestamp: req.timestamp,
             existing_nqn: req.existing_nqn.clone(),
@@ -526,6 +601,7 @@ impl From<&SwitchOverSpec> for SwitchOverRequest {
             retry_count: req.retry_count,
             reuse_existing: req.reuse_existing,
             publish_context: req.publish_context.clone(),
+            fast_exhaustion_retry: true,
         }
     }
 }
@@ -562,14 +638,14 @@ fn switchover_ord() {
     let sock1: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     let vol1 = VolumeId::try_from("ec4e66fd-3b33-4439-b504-d49aba53da26").unwrap();
     let sw1 = SwitchOverRequest::new(sock1, vol1.clone(), "nn".into(), "nw".to_string());
-    let mut sw2 = SwitchOverRequest::new(sock1, vol1.clone(), "nn".into(), "nw".to_string());
-    sw2.stage = Stage::Errored;
-    let mut sw3 = SwitchOverRequest::new(sock1, vol1.clone(), "nn".into(), "nw".to_string());
-    sw3.stage = Stage::Successful;
-    let mut sw4 = SwitchOverRequest::new(sock1, vol1.clone(), "nn".into(), "nw".to_string());
-    sw4.stage = Stage::RepublishVolume;
-    let mut sw5 = SwitchOverRequest::new(sock1, vol1, "nn".into(), "nw".to_string());
-    sw5.stage = Stage::RepublishVolume;
+    let sw2 = SwitchOverRequest::new(sock1, vol1.clone(), "nn".into(), "nw".to_string());
+    sw2.set_stage(Stage::Errored);
+    let sw3 = SwitchOverRequest::new(sock1, vol1.clone(), "nn".into(), "nw".to_string());
+    sw3.set_stage(Stage::Successful);
+    let sw4 = SwitchOverRequest::new(sock1, vol1.clone(), "nn".into(), "nw".to_string());
+    sw4.set_stage(Stage::RepublishVolume);
+    let sw5 = SwitchOverRequest::new(sock1, vol1, "nn".into(), "nw".to_string());
+    sw5.set_stage(Stage::RepublishVolume);
     let mut test_vec = vec![
         sw3.clone(),
         sw2.clone(),

--- a/control-plane/agents/src/bin/ha/cluster/volume.rs
+++ b/control-plane/agents/src/bin/ha/cluster/volume.rs
@@ -1,60 +1,69 @@
 use crate::{
     etcd::EtcdStore,
     nodes::NodeList,
-    switchover::{SwitchOverEngine, SwitchOverRequest},
+    switchover::{SwitchOverEngine, SwitchOverRequest, SwitchOverStage},
 };
 use std::{convert::TryFrom, net::SocketAddr};
-use stor_port::types::v0::transport::{NodeId, VolumeId};
+use stor_port::{
+    transport_api::{ReplyError, ResourceKind},
+    types::v0::transport::{NodeId, VolumeId},
+};
 use utils::NVME_TARGET_NQN_PREFIX;
 
 /// Defines spec for VolumeMover.
 #[derive(Debug, Clone)]
-pub struct VolumeMover {
+pub(crate) struct VolumeMover {
     etcd: EtcdStore,
     engine: SwitchOverEngine,
 }
 
 impl VolumeMover {
-    pub fn new(etcd: EtcdStore, nodes: NodeList) -> Self {
-        let sw = SwitchOverEngine::new(etcd.clone(), nodes);
-
-        Self { engine: sw, etcd }
+    /// Create a new `Self`.
+    pub(crate) fn new(etcd: EtcdStore, nodes: NodeList) -> Self {
+        let engine = SwitchOverEngine::new(etcd.clone(), nodes);
+        Self { engine, etcd }
     }
 
     /// Switchover build the switchover request for the given nqn and send it to SwitchOverEngine.
     #[tracing::instrument(level = "info", skip(self), err)]
-    pub async fn switchover(
+    pub(crate) async fn switchover(
         &self,
         node: NodeId,
         uri: SocketAddr,
         nqn: String,
-    ) -> Result<(), anyhow::Error> {
-        if !nqn.starts_with(NVME_TARGET_NQN_PREFIX) {
-            return Err(anyhow::anyhow!("Invalid nqn prefix"));
-        }
+    ) -> Result<SwitchOverStage, ReplyError> {
+        let volume = nqn.strip_prefix(NVME_TARGET_NQN_PREFIX).ok_or_else(|| {
+            ReplyError::invalid_argument(ResourceKind::NvmePath, "nqn", nqn.to_owned())
+        })?;
 
-        let volume = nqn
-            .strip_prefix(NVME_TARGET_NQN_PREFIX)
-            .ok_or_else(|| anyhow::anyhow!("Failed to retrieve volume UUID from nqn"))?;
-
-        let volume_uuid = VolumeId::try_from(volume)?;
+        let volume_uuid = VolumeId::try_from(volume).map_err(|error| {
+            ReplyError::invalid_argument(ResourceKind::Volume, "volume", error.to_string())
+        })?;
 
         let req = SwitchOverRequest::new(uri, volume_uuid, node, nqn);
+        let stage_arc = req.stage_arc();
 
         // calling start_op here to store the request in etcd
-        req.start_op(&self.etcd).await?;
+        req.start_op(&self.etcd).await.map_err(|error| {
+            ReplyError::failed_persist(
+                ResourceKind::NvmePath,
+                error.to_string(),
+                "Failed to start switchover request".into(),
+            )
+        })?;
         self.engine.enqueue(req);
-        Ok(())
+        Ok(stage_arc)
     }
 
     /// Send batch of switchover request to SwitchOverEngine.
     #[tracing::instrument(level = "info", skip(self), err)]
-    pub async fn send_switchover_req(
+    pub(crate) async fn send_switchover_req(
         &self,
-        mut req: Vec<SwitchOverRequest>,
+        mut requests: Vec<SwitchOverRequest>,
     ) -> Result<(), anyhow::Error> {
-        req.sort();
-        for entry in req {
+        requests.sort();
+        for entry in requests {
+            self.engine.nodes().insert_failed_request(&entry).await;
             entry.start_op(&self.etcd).await?;
             self.engine.enqueue(entry);
         }

--- a/control-plane/agents/src/bin/ha/node/server.rs
+++ b/control-plane/agents/src/bin/ha/node/server.rs
@@ -370,16 +370,13 @@ impl NodeAgentOperations for NodeAgentSvc {
         match Subsystem::try_from_nqn(nqn.as_str()) {
             Ok(subsys_list) => {
                 let controller_list = subsys_list
-                    .iter()
-                    .filter(|controller| {
-                        controller.state == "live" && controller.state == "connecting"
-                    })
-                    .map(|controller| NvmeCtrller::new(controller.clone().address))
+                    .into_iter()
+                    .map(|controller| NvmeCtrller::new(controller.address))
                     .collect();
                 Ok(NvmeSubsys(controller_list))
             }
             Err(_) => Err(ReplyError::not_found(
-                ResourceKind::Unknown,
+                ResourceKind::NvmeSubsystem,
                 "Node agent".to_string(),
                 "Could not find any subsystems for the supplied nqn".to_string(),
             )),

--- a/control-plane/grpc/proto/v1/ha/cluster_agent.proto
+++ b/control-plane/grpc/proto/v1/ha/cluster_agent.proto
@@ -7,7 +7,7 @@ package v1.ha_cluster_agent;
 // Service for managing cluster-agent rpc calls
 service HaClusterRpc {
   rpc RegisterNodeAgent (HaNodeInfo) returns (google.protobuf.Empty) {}
-  rpc ReportFailedNvmePaths (ReportFailedNvmePathsRequest) returns (google.protobuf.Empty) {}
+  rpc ReportFailedNvmePaths (ReportFailedNvmePathsRequest) returns (FailedNvmePathsResponse) {}
 }
 
 // Node information
@@ -30,4 +30,19 @@ message ReportFailedNvmePathsRequest {
   string endpoint = 2;
   // List of failed
   repeated FailedNvmePath failed_paths = 3;
+}
+
+// Failed paths reporting.
+message FailedNvmePathsResponse {
+  // List of failed paths.
+  // If reporting completely succeeded then no path is returned.
+  repeated FailedNvmePathResponse failed_paths = 1;
+}
+
+// Reporting of each path.
+message FailedNvmePathResponse {
+  // gRPC Code of the path reporting.
+  int32 status_code = 1;
+  // The NQN of this path.
+  string failed_nqn = 2;
 }

--- a/control-plane/grpc/src/context.rs
+++ b/control-plane/grpc/src/context.rs
@@ -63,6 +63,8 @@ pub fn timeout_grpc(op_id: MessageId, timeout_opts: TimeoutOptions) -> Duration 
 
                 MessageIdVs::CreatePool => min_timeouts.pool(),
                 MessageIdVs::DestroyPool => min_timeouts.pool(),
+
+                MessageIdVs::ReplacePathInfo => min_timeouts.nvme_reconnect(),
                 _ => base,
             },
         };

--- a/control-plane/stor-port/src/types/v0/transport/cluster_agent.rs
+++ b/control-plane/stor-port/src/types/v0/transport/cluster_agent.rs
@@ -81,6 +81,59 @@ impl ReportFailedPaths {
     pub fn failed_paths(&self) -> &Vec<FailedPath> {
         &self.failed_paths
     }
+
+    /// Remove path from request.
+    pub fn remove_path(&mut self, path: &str) {
+        self.failed_paths.retain(|p| p.target_nqn != path);
+    }
+}
+
+/// Report failed NVMe paths.
+#[derive(Default, Debug)]
+pub struct FailedPathsResponse {
+    failed_paths: Vec<FailedPathResponse>,
+}
+impl FailedPathsResponse {
+    /// Create a new `Self`.
+    pub fn new(failed_paths: Vec<FailedPathResponse>) -> Self {
+        Self { failed_paths }
+    }
+    /// Adds a new failed path.
+    pub fn push(&mut self, status_code: tonic::Code, failed_path: &str) {
+        self.failed_paths
+            .push(FailedPathResponse::new(status_code, failed_path.into()));
+    }
+    /// Check if they're no reported paths.
+    pub fn is_empty(&self) -> bool {
+        self.failed_paths.is_empty()
+    }
+    /// Check if all path reporting succeeded.
+    pub fn is_all_ok(&self) -> bool {
+        self.failed_paths
+            .iter()
+            .all(|p| p.status_code == tonic::Code::Ok)
+    }
+    /// Convert into a list of failed paths.
+    pub fn into_failed_paths(self) -> Vec<FailedPathResponse> {
+        self.failed_paths
+    }
+}
+/// A specific failed path response.
+#[derive(Debug)]
+pub struct FailedPathResponse {
+    /// The status code related to this report failure.
+    pub status_code: tonic::Code,
+    /// The failed path reported.
+    pub failed_nqn: String,
+}
+impl FailedPathResponse {
+    /// Create a new `Self`.
+    pub fn new(status_code: tonic::Code, failed_nqn: String) -> Self {
+        Self {
+            status_code,
+            failed_nqn,
+        }
+    }
 }
 
 /// Request struct to get Nvme subsystems registered for a given nqn.
@@ -118,6 +171,10 @@ impl NvmeSubsystem {
     /// Get IP address of the Nvme Subsystem.
     pub fn address(&self) -> &str {
         self.address.as_str()
+    }
+    /// Get IP address of the Nvme Subsystem.
+    pub fn into_address(self) -> String {
+        self.address
     }
 }
 

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -333,7 +333,8 @@ impl BuilderConfigure for Components {
         Ok(cfg.with_spec_map(|spec| {
             let spec = spec
                 .with_direct_bind("/etc/machine-id")
-                .with_direct_bind("/sys/class/dmi/id/product_uuid");
+                .with_direct_bind("/sys/class/dmi/id/product_uuid")
+                .with_env("PLATFORM_TYPE", "deployer");
             if let Some(uid) = &self.1.cluster_uid {
                 spec.with_env("NOPLATFORM_UUID", uid)
             } else {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -35,6 +35,18 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/0874168639713f547c05947c76124f78441ea46c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "nixpkgs-22_11": {
+        "branch": "release-22.11",
+        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
+        "homepage": "https://github.com/NixOS/nixpkgs",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7b09f986c2afc6db5fccc6770a35184bbe11531f",
+        "sha256": "0pl27fkbwi09jwc34jvqcpaka7hzj2jzy0kp8fy0qcd075289fgj",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7b09f986c2afc6db5fccc6770a35184bbe11531f.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "rust-overlay": {
         "branch": "master",
         "description": "Pure and reproducible nix overlay for binary distributed rust toolchains",

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ let
   pkgs = import sources.nixpkgs {
     overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { }) ];
   };
+  pkgs_22 = import sources.nixpkgs-22_11 { };
 in
 with pkgs;
 let
@@ -43,7 +44,7 @@ mkShell {
   ++ pkgs.lib.optionals (system != "aarch64-darwin") [
     e2fsprogs
     libxfs
-    nvme-cli
+    pkgs_22.nvme-cli
     # python3.9-pyopenssl-22.0.0 marked as broken but fixed on master..
     pytest_inputs
     tini

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -25,6 +25,7 @@ class StartOptions:
     ha_cluster_agent: bool = False
     fio_spdk: bool = False
     io_engine_coreisol: bool = False
+    io_engine_devices: [str] = ()
 
     def args(self):
         args = [
@@ -64,6 +65,8 @@ class StartOptions:
             args.append("--fio-spdk")
         if self.io_engine_coreisol:
             args.append("--io-engine-isolate")
+        for device in self.io_engine_devices:
+            args.append(f"--io-engine-devices={device}")
 
         agent_arg = "--agents=Core"
         if self.ha_node_agent:
@@ -96,6 +99,7 @@ class Deployer(object):
         node_agent=False,
         fio_spdk=False,
         io_engine_coreisol=False,
+        io_engine_devices=[],
     ):
         options = StartOptions(
             io_engines,
@@ -115,6 +119,7 @@ class Deployer(object):
             ha_cluster_agent=cluster_agent,
             fio_spdk=fio_spdk,
             io_engine_coreisol=io_engine_coreisol,
+            io_engine_devices=io_engine_devices,
         )
         Deployer.start_with_opts(options)
 

--- a/tests/bdd/common/fio.py
+++ b/tests/bdd/common/fio.py
@@ -18,6 +18,7 @@ class Fio(object):
         io_depth=64,
         direct=True,
         size=None,
+        norandommap=True,
         offset=0,
         extra_args="",
     ):
@@ -33,6 +34,7 @@ class Fio(object):
         self.direct = direct
         self.io_depth = io_depth
         self.offset = offset
+        self.norandommap = norandommap
 
         if device is None == uri is None:
             raise "Device and Uri as exclusive!"
@@ -57,7 +59,9 @@ class Fio(object):
             args = f"{args} --size={self.size}"
         if self.direct:
             args = f"{args} --direct=1"
-        args = f"{args} --offset={self.offset} --bs={self.bs} --rw={self.rw} --group_reporting=1 --norandommap=1"
+        if self.norandommap:
+            args = f"{args} --norandommap=1"
+        args = f"{args} --offset={self.offset} --bs={self.bs} --rw={self.rw} --group_reporting=1"
         args = f"{args} --iodepth={self.io_depth} {self.extra_args}"
         return args
 

--- a/tests/bdd/features/ha/robustness.feature
+++ b/tests/bdd/features/ha/robustness.feature
@@ -1,0 +1,30 @@
+Feature: Switchover Robustness
+
+  Background:
+    Given a deployer cluster
+
+  Scenario: reconnecting the new target times out
+    Given a single replica volume
+    And a connected nvme initiator
+    And a reconnect_delay set to 15s
+    When we restart the volume target node
+    And the ha clustering republishes
+    Then the path should be established
+
+  Scenario: path failure with no free nodes
+    Given a 2 replica volume
+    And a connected nvme initiator
+    When we cordon the non-target node
+    And we stop the volume target node
+    When the ha clustering fails a few times
+    And we uncordon the non-target node
+    Then the path should be established
+
+  Scenario: temporary path failure with no other nodes
+    Given a 2 replica volume
+    And a connected nvme initiator
+    When we cordon the non-target node
+    And we stop the volume target node
+    When the ha clustering fails a few times
+    And we restart the volume target node
+    Then the path should be established

--- a/tests/bdd/features/ha/test_robustness.py
+++ b/tests/bdd/features/ha/test_robustness.py
@@ -1,0 +1,217 @@
+"""Switchover Robustness feature tests."""
+
+import os
+import time
+from urllib.parse import urlparse
+
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+)
+import pytest
+import subprocess
+
+from retrying import retry
+
+from common.deployer import Deployer
+from common.apiclient import ApiClient
+from common.docker import Docker
+from common.fio import Fio
+from common.nvme import (
+    nvme_connect,
+    nvme_disconnect,
+    nvme_list_subsystems,
+    nvme_set_reconnect_delay,
+)
+
+from openapi.model.create_pool_body import CreatePoolBody
+from openapi.model.create_volume_body import CreateVolumeBody
+from openapi.model.publish_volume_body import PublishVolumeBody
+from openapi.model.volume_policy import VolumePolicy
+from openapi.model.protocol import Protocol
+
+VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
+VOLUME_SIZE = int(20 * 1024 * 1024)
+POOL_SIZE = 100 * 1024 * 1024
+TARGET_NODE_1 = "io-engine-1"
+TARGET_NODE_2 = "io-engine-2"
+
+
+@pytest.fixture(autouse=True)
+def init(disks):
+    Deployer.start(
+        2,
+        cache_period="1s",
+        reconcile_period="1s",
+        cluster_agent=True,
+        node_agent=True,
+        csi_node=True,
+    )
+
+    for disk_index in range(0, 2):
+        node_index = disk_index + 1
+        name = f"pool-{node_index}"
+        node = f"io-engine-{node_index}"
+        ApiClient.pools_api().put_node_pool(
+            node, name, CreatePoolBody([disks[disk_index]])
+        )
+    yield
+    Deployer.stop()
+
+
+@scenario("robustness.feature", "reconnecting the new target times out")
+def test_reconnecting_the_new_target_times_out():
+    """reconnecting the new target times out."""
+
+
+@scenario("robustness.feature", "path failure with no free nodes")
+def test_path_failure_with_no_free_nodes():
+    """path failure with no free nodes."""
+
+
+@scenario("robustness.feature", "temporary path failure with no other nodes")
+def test_temporary_path_failure_with_no_other_nodes():
+    """temporary path failure with no other nodes."""
+
+
+@given("a connected nvme initiator")
+def a_connected_nvme_initiator(connect_to_first_path):
+    """a connected nvme initiator."""
+
+
+@given("a deployer cluster")
+def a_deployer_cluster(init):
+    """a deployer cluster."""
+
+
+@given("a reconnect_delay set to 15s")
+def a_reconnect_delay_set_to_15s():
+    """a reconnect_delay set to 15s."""
+    volume = pytest.volume
+    device_uri = volume.state["target"]["deviceUri"]
+    nvme_set_reconnect_delay(device_uri, 15)
+
+
+@given("a single replica volume")
+def a_single_replica_volume():
+    """a single replica volume."""
+    ApiClient.volumes_api().put_volume(
+        VOLUME_UUID, CreateVolumeBody(VolumePolicy(True), 1, VOLUME_SIZE, False)
+    )
+    volume = ApiClient.volumes_api().put_volume_target(
+        VOLUME_UUID,
+        publish_volume_body=PublishVolumeBody({}, Protocol("nvmf"), node=TARGET_NODE_1),
+    )
+    pytest.volume = volume
+
+
+@given("a 2 replica volume")
+def a_2_replica_volume():
+    """a 2 replica volume."""
+    ApiClient.volumes_api().put_volume(
+        VOLUME_UUID, CreateVolumeBody(VolumePolicy(True), 2, VOLUME_SIZE, False)
+    )
+    volume = ApiClient.volumes_api().put_volume_target(
+        VOLUME_UUID,
+        publish_volume_body=PublishVolumeBody({}, Protocol("nvmf"), node=TARGET_NODE_1),
+    )
+    pytest.volume = volume
+
+
+@when("we cordon the non-target node")
+def we_cordon_the_nontarget_node():
+    """we cordon the non-target node."""
+    ApiClient.nodes_api().put_node_cordon(TARGET_NODE_2, "d")
+    wait_node_cordon(TARGET_NODE_2)
+
+
+@when("the ha clustering republishes")
+def the_ha_clustering_republishes():
+    """the ha clustering republishes."""
+
+
+@when("we restart the volume target node")
+def we_restart_the_volume_target_node():
+    """we restart the volume target."""
+    Docker.restart_container(TARGET_NODE_1)
+
+
+@when("we stop the volume target node")
+def we_stop_the_volume_target_node():
+    """we stop the volume target."""
+    Docker.stop_container(TARGET_NODE_1)
+
+
+@when("we uncordon the non-target node")
+def we_uncordon_the_nontarget_node():
+    """we uncordon the non-target node."""
+    ApiClient.nodes_api().delete_node_cordon(TARGET_NODE_2, "d")
+
+
+@when("the ha clustering fails a few times")
+def the_ha_clustering_fails_a_few_times():
+    """the ha clustering fails a few times."""
+    # we have no way of determining this? maybe through etcd?
+    time.sleep(5)
+
+
+@then("the path should be established")
+def the_path_should_be_established(connect_to_first_path):
+    """the path should be established."""
+    wait_initiator_reconnect(connect_to_first_path)
+
+
+@when("we restart the volume target node")
+def we_restart_the_volume_target_node():
+    """we restart the volume target node."""
+    Docker.restart_container(TARGET_NODE_1)
+
+
+@pytest.fixture
+def tmp_files():
+    files = []
+    for index in range(0, 2):
+        files.append(f"/tmp/disk_{index}")
+    yield files
+
+
+@pytest.fixture
+def disks(tmp_files):
+    for disk in tmp_files:
+        if os.path.exists(disk):
+            os.remove(disk)
+        with open(disk, "w") as file:
+            file.truncate(POOL_SIZE)
+    # /tmp is mapped into /host/tmp within the io-engine containers
+    yield list(map(lambda file: f"/host{file}", tmp_files))
+    for disk in tmp_files:
+        if os.path.exists(disk):
+            os.remove(disk)
+
+
+@pytest.fixture
+def connect_to_first_path():
+    volume = pytest.volume
+    device_uri = volume.state["target"]["deviceUri"]
+    yield nvme_connect(device_uri)
+    nvme_disconnect(device_uri)
+
+
+@retry(wait_fixed=1000, stop_max_attempt_number=40)
+def wait_initiator_reconnect(connect_to_first_path):
+    device = connect_to_first_path
+    desc = nvme_list_subsystems(device)
+    assert (
+        len(desc["Subsystems"]) == 1
+    ), "Must be exactly one NVMe subsystem for target nexus"
+    subsystem = desc["Subsystems"][0]
+    assert len(subsystem["Paths"]) == 1, "Must be exactly one I/O path to target nexus"
+    assert subsystem["Paths"][0]["State"] == "live", "I/O path is not healthy"
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=10)
+def wait_node_cordon(node):
+    node = ApiClient.nodes_api().get_node(node)
+    assert "cordonedstate" in node.spec.cordondrainstate

--- a/tests/bdd/requirements.txt
+++ b/tests/bdd/requirements.txt
@@ -1,4 +1,4 @@
-pytest-bdd
+pytest-bdd==6.0.0
 python-dateutil
 retrying
 urllib3

--- a/utils/platform/src/deployer/mod.rs
+++ b/utils/platform/src/deployer/mod.rs
@@ -1,0 +1,25 @@
+use crate::{PlatformInfo, PlatformNS, PlatformUid};
+
+/// No specific platform (deployer cluster using containers).
+/// Internally works as `None` platform.
+pub(super) struct Deployer(super::none::None);
+
+impl Deployer {
+    /// Create a new `Self`.
+    pub(super) fn new() -> Self {
+        Self(super::none::None::new())
+    }
+    fn none(&self) -> &super::none::None {
+        &self.0
+    }
+}
+
+impl PlatformInfo for Deployer {
+    fn uid(&self) -> PlatformUid {
+        self.none().uid()
+    }
+
+    fn namespace(&self) -> &PlatformNS {
+        self.none().namespace()
+    }
+}

--- a/utils/platform/src/none/mod.rs
+++ b/utils/platform/src/none/mod.rs
@@ -3,12 +3,14 @@ use crate::{PlatformInfo, PlatformNS, PlatformUid};
 /// No specific platform.
 /// Attempt to retrieve the platform uuid from (in order):
 /// env var `NOPLATFORM_UUID_VAR`
+/// machine id file `MACHINE_ID`
 /// hardcoded from var `DUMMY_PLATFORM_UUID`
 pub(super) struct None {
     platform_uuid: PlatformUid,
     platform_ns: PlatformNS,
 }
 
+const MACHINE_ID: &str = "/etc/machine-id";
 const NOPLATFORM_UUID_VAR: &str = "NOPLATFORM_UUID";
 const DUMMY_PLATFORM_UUID: &str = "dummy-uuid";
 const DUMMY_PLATFORM_NS: &str = "default";
@@ -19,7 +21,7 @@ impl None {
         let platform_uuid = if let Ok(uuid) = std::env::var(NOPLATFORM_UUID_VAR) {
             uuid
         } else {
-            DUMMY_PLATFORM_UUID.to_string()
+            std::fs::read_to_string(MACHINE_ID).unwrap_or_else(|_| DUMMY_PLATFORM_UUID.to_string())
         };
 
         Self {


### PR DESCRIPTION
    test(switchover/bdd): add robustness tests
    
    Add tests to help exercise some corner cases seen during bug study.
    Tbh these are not very precise as it's difficult to re-create some corner cases,
    but nonetheless they are probably a decent starting point and can be used to help
    manually try to recreate these issues in a more automated fashion.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(switchover): adds several corner case fixes
    
    Replace path is not idempotent in case the connection was established without moving path.
    gRPC Timeouts for connection are not enough which leads into moving the target
    when not necessary.
    Report of failed paths does not differentiate errors at all.
    Report of failed paths returns only 1 error.. we should have an error per path as we report.
     in batches.
    In case of no resources for republish volume the ha cluster retries in a loop with no delay.
    or backoff..
    In error case we don’t clean up shutdown targets.
    On switchover failure, failed paths are not cleared in the cluster agent.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    chore(python/bdd): pin to version 6
    
    Newer version (not sure which exactly) seems to generate the test cases without a name.
    todo: determine best version to use
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(ha-node): add subsystem sync for platform none
    
    On the deployer the udev code we have for listening to disk events does not seem to work.
    For now, assume it is incompatible and add a subsystem sync just for platform none.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
