### PR TITLE
fix(switchover/cluster): add old target reuse as fallback

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/node/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/node/nexus.rs
@@ -60,6 +60,7 @@ async fn republish_volume(
         frontend_node.clone(),
         VolumeShareProtocol::Nvmf,
         false,
+        false,
     );
     tracing::info!(
         volume.uuid = vol_uuid.as_str(),

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -75,6 +75,7 @@ async fn lazy_delete_shutdown_targets() {
                 share: VolumeShareProtocol::Nvmf,
                 reuse_existing: true,
                 frontend_node: cluster.node(0),
+                reuse_existing_fallback: false,
             },
             None,
         )
@@ -89,6 +90,7 @@ async fn lazy_delete_shutdown_targets() {
                 share: VolumeShareProtocol::Nvmf,
                 reuse_existing: true,
                 frontend_node: cluster.node(1),
+                reuse_existing_fallback: false,
             },
             None,
         )
@@ -236,6 +238,7 @@ async fn volume_republish_nexus_recreation() {
                 target_node: None,
                 reuse_existing: true,
                 frontend_node: cluster.node(1),
+                reuse_existing_fallback: false,
             },
             None,
         )
@@ -316,6 +319,7 @@ async fn node_exhaustion() {
                 target_node: None,
                 reuse_existing: false,
                 frontend_node: cluster.node(1),
+                reuse_existing_fallback: false,
             },
             None,
         )
@@ -331,6 +335,7 @@ async fn node_exhaustion() {
                 target_node: None,
                 reuse_existing: false,
                 frontend_node: cluster.node(1),
+                reuse_existing_fallback: false,
             },
             None,
         )
@@ -346,6 +351,7 @@ async fn node_exhaustion() {
                 target_node: None,
                 reuse_existing: false,
                 frontend_node: cluster.node(1),
+                reuse_existing_fallback: false,
             },
             None,
         )

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -242,6 +242,8 @@ message RepublishVolumeRequest {
   bool reuse_existing = 4;
   // the node where front-end IO will be sent from
   string frontend_node = 5;
+  /// Allows reusing the existing target, but prefers a target move.
+  bool reuse_existing_fallback = 6;
 }
 
 // Unpublish a volume from any node where it may be published

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -1210,6 +1210,8 @@ pub trait RepublishVolumeInfo: Send + Sync + std::fmt::Debug {
     fn share(&self) -> VolumeShareProtocol;
     /// Republish reusing current target.
     fn reuse_existing(&self) -> bool;
+    /// Allows reusing the existing target, but prefers a target move.
+    fn reuse_existing_fallback(&self) -> bool;
 }
 
 impl RepublishVolumeInfo for RepublishVolume {
@@ -1232,6 +1234,10 @@ impl RepublishVolumeInfo for RepublishVolume {
     fn reuse_existing(&self) -> bool {
         self.reuse_existing
     }
+
+    fn reuse_existing_fallback(&self) -> bool {
+        self.reuse_existing_fallback
+    }
 }
 
 impl From<&dyn RepublishVolumeInfo> for RepublishVolume {
@@ -1242,6 +1248,7 @@ impl From<&dyn RepublishVolumeInfo> for RepublishVolume {
             frontend_node: data.frontend_node(),
             share: data.share(),
             reuse_existing: data.reuse_existing(),
+            reuse_existing_fallback: data.reuse_existing_fallback(),
         }
     }
 }
@@ -1255,6 +1262,7 @@ impl From<&dyn RepublishVolumeInfo> for RepublishVolumeRequest {
             share: protocol as i32,
             reuse_existing: data.reuse_existing(),
             frontend_node: data.frontend_node().to_string(),
+            reuse_existing_fallback: data.reuse_existing_fallback(),
         }
     }
 }
@@ -1289,6 +1297,10 @@ impl RepublishVolumeInfo for ValidatedRepublishVolumeRequest {
 
     fn reuse_existing(&self) -> bool {
         self.inner.reuse_existing
+    }
+
+    fn reuse_existing_fallback(&self) -> bool {
+        self.inner.reuse_existing_fallback
     }
 }
 

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -164,6 +164,7 @@ impl apis::actix_server::Volumes for RestApi {
                             target_node: publish_volume_body.node.map(|id| id.into()),
                             share: publish_volume_body.protocol.into(),
                             reuse_existing: publish_volume_body.reuse_existing.unwrap_or(true),
+                            reuse_existing_fallback: false,
                             frontend_node: publish_volume_body
                                 .frontend_node
                                 .unwrap_or_default()

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -510,6 +510,7 @@ impl PublishVolume {
 /// Republishes the target on a new node (pre-selected or determined by the control-plane).
 /// If online, the previous target nexus is first shutdown which may gives us enough time for the
 /// switchover as it'd be prevent from failing any IO outright.
+/// todo: add builder new..
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RepublishVolume {
@@ -523,6 +524,8 @@ pub struct RepublishVolume {
     pub share: VolumeShareProtocol,
     /// Allows reusing of the current target.
     pub reuse_existing: bool,
+    /// Allows reusing the existing target, but prefers a target move.
+    pub reuse_existing_fallback: bool,
 }
 impl RepublishVolume {
     /// Create new `RepublishVolume` based on the provided arguments.
@@ -532,6 +535,7 @@ impl RepublishVolume {
         frontend_node: NodeId,
         share: VolumeShareProtocol,
         reuse_existing: bool,
+        reuse_existing_fallback: bool,
     ) -> Self {
         Self {
             uuid,
@@ -539,6 +543,7 @@ impl RepublishVolume {
             frontend_node,
             share,
             reuse_existing,
+            reuse_existing_fallback,
         }
     }
 }

--- a/tests/bdd/common/docker.py
+++ b/tests/bdd/common/docker.py
@@ -27,6 +27,18 @@ class Docker(object):
             container_state = container.attrs["State"]
             return container_state["Status"]
 
+    @staticmethod
+    def container_ip(container_name):
+        docker_client = docker.from_env()
+        try:
+            container = docker_client.containers.get(container_name)
+        except docker.errors.NotFound as exc:
+            raise Exception("{} container not found", container_name)
+        else:
+            return container.attrs["NetworkSettings"]["Networks"]["cluster"][
+                "IPAddress"
+            ]
+
     # Kill a container with the given name.
     @staticmethod
     def kill_container(name):

--- a/tests/bdd/features/ha/robustness.feature
+++ b/tests/bdd/features/ha/robustness.feature
@@ -28,3 +28,11 @@ Feature: Switchover Robustness
     When the ha clustering fails a few times
     And we restart the volume target node
     Then the path should be established
+
+  Scenario: second failure during switchover with no other nodes
+    Given a 2 replica volume
+    And a connected nvme initiator
+    When the volume target node has io-path broken
+    And the ha clustering fails as there is no other node
+    When the volume target node has io-path fixed
+    Then the path should be established


### PR DESCRIPTION
It's possible for a connection to fail after we've republished. In this case, if there's no other nodes available we'll get stuck here forever. This change allows us to reuse the previously failed node if it's available again. Adds a bdd test for this scenario.