### PR TITLE
build: various improvements

### DIFF
--- a/.github/workflows/pr-submodule-branch.yml
+++ b/.github/workflows/pr-submodule-branch.yml
@@ -1,0 +1,24 @@
+name: Submodule Branch Check
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+  push:
+    branches:
+      - develop
+      - 'release/**'
+jobs:
+  submodule-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check root submodules branch
+        run: |
+          pr_branch="${{ github.event.pull_request.base.ref }}"
+          if [ -n "$pr_branch" ]; then
+            check_branch="$pr_branch"
+          else
+            check_branch="${{ github.ref_name }}"
+          fi
+          ./scripts/git/set-submodule-branches.sh --branch "$check_branch"
+          cat .gitmodules
+          git diff --exit-code ".gitmodules"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "utils/dependencies"]
 	path = utils/dependencies
 	url = https://github.com/openebs/mayastor-dependencies.git
+    branch = develop
 [submodule "rpc/api"]
 	path = rpc/api
 	url = https://github.com/openebs/mayastor-api.git
+    branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "utils/dependencies"]
 	path = utils/dependencies
 	url = https://github.com/openebs/mayastor-dependencies.git
-    branch = develop
+	branch = develop
 [submodule "rpc/api"]
 	path = rpc/api
 	url = https://github.com/openebs/mayastor-api.git
-    branch = develop
+	branch = develop

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,9 @@
-{ system ? null, allInOne ? true, incremental ? false, img_tag ? "" }:
+{ system ? null, allInOne ? true, incremental ? false, img_tag ? "", tag ? "" }:
 let
   sources = import ./nix/sources.nix;
   hostSystem = (import sources.nixpkgs { }).hostPlatform.system;
   pkgs = import sources.nixpkgs {
-    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { inherit allInOne incremental img_tag; }) ];
+    overlays = [ (_: _: { inherit sources; }) (import ./nix/overlay.nix { inherit allInOne incremental img_tag tag; }) ];
     system = if system != null then system else hostSystem;
   };
 in

--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, git }:
+{ lib, stdenv, git, tag ? "" }:
 let
   whitelistSource = src: allowedPrefixes:
     builtins.filterSource
@@ -16,17 +16,28 @@ stdenv.mkDerivation {
   buildCommand = ''
     cd $src
     export GIT_DIR=".git"
-    vers=`${git}/bin/git tag --points-at HEAD`
+
+    vers=${tag}
+    if [ -z "$vers" ]; then
+      vers=`${git}/bin/git tag --points-at HEAD`
+    fi
     if [ -z "$vers" ]; then
       vers=`${git}/bin/git rev-parse --short=12 HEAD`
     fi
     echo -n $vers >$out
 
-    vers=$(${git}/bin/git describe --abbrev=12 --always --long)
+    if [ "${tag}" != "" ]; then
+      vers="${tag}-0-g$(${git}/bin/git rev-parse --short=12 HEAD)"
+    else
+      vers=$(${git}/bin/git describe --abbrev=12 --always --long)
+    fi
     echo -n $vers >$long
 
     # when we point to a tag, it's just the tag
-    vers=$(${git}/bin/git describe --abbrev=12 --always)
+    vers=${tag}
+    if [ -z "$vers" ]; then
+        vers=$(${git}/bin/git describe --abbrev=12 --always)
+    fi
     echo -n $vers >$tag_or_long
   '';
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,6 +1,6 @@
-{ allInOne ? true, incremental ? false, img_tag ? "" }:
+{ allInOne ? true, incremental ? false, img_tag ? "", tag ? "" }:
 self: super: {
   images = super.callPackage ./pkgs/images { inherit img_tag; };
-  control-plane = super.callPackage ./pkgs/control-plane { inherit allInOne incremental; };
+  control-plane = super.callPackage ./pkgs/control-plane { inherit allInOne incremental tag; };
   openapi-generator = super.callPackage ./pkgs/openapi-generator { };
 }

--- a/nix/pkgs/control-plane/default.nix
+++ b/nix/pkgs/control-plane/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, git, lib, pkgs, allInOne, incremental }:
+{ stdenv, git, lib, pkgs, allInOne, incremental, tag ? "" }:
 let
-  versionDrv = import ../../lib/version.nix { inherit lib stdenv git; };
+  versionDrv = import ../../lib/version.nix { inherit lib stdenv git tag; };
   version = builtins.readFile "${versionDrv}";
   gitVersions = {
     "version" = version;

--- a/scripts/git/set-submodule-branches.sh
+++ b/scripts/git/set-submodule-branches.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+submodule_set_branch_all() {
+  branch=${1:-}
+  if [ -n "$branch" ]; then
+    branch="--branch $branch"
+  else
+    branch="--default"
+  fi
+  for mod in `git config --file .gitmodules --get-regexp path | awk '{ print $2 }'`; do
+    git submodule set-branch $branch $mod
+  done
+}
+
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+SET_BRANCH=
+CLEAR_BRANCH=
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    -b|--branch)
+      shift
+      BRANCH=$1
+      shift
+      ;;
+    -c|--clear)
+      CLEAR_BRANCH=="y"
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+
+
+if [ "$BRANCH" == "develop" ] || [ "${BRANCH#release/}" != "${BRANCH}" ]; then
+  SET_BRANCH="${BRANCH}"
+fi
+
+if [ -n "$CLEAR_BRANCH" ]; then
+  submodule_set_branch_all ""
+elif [ -n "$SET_BRANCH" ]; then
+  submodule_set_branch_all "$SET_BRANCH"
+else
+  echo "Not modifying branch"
+fi

--- a/scripts/nix/git-submodule-init.sh
+++ b/scripts/nix/git-submodule-init.sh
@@ -19,6 +19,7 @@ done
 submodule_init() {
   for mod in `git config --file .gitmodules --get-regexp path | awk '{ print $2 }'`; do
     if [ -n "$FORCE" ] || [ ! -f $mod/.git ]; then
+      git submodule deinit $FORCE $mod
       git submodule update $FORCE --init --recursive $mod
     fi
     pushd $mod 1>/dev/null

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,6 +44,7 @@ Options:
   --skip-publish             Don't publish built images.
   --image           <image>  Specify what image to build.
   --alias-tag       <tag>    Explicit alias for short commit hash tag.
+  --tag             <tag>    Explicit tag (overrides the git tag).
   --incremental              Builds components in two stages allowing for faster rebuilds during development.
   --build-bins               Builds all the static binaries.
   --build-bin                Specify which binary to build.
@@ -120,6 +121,14 @@ while [ "$#" -gt 0 ]; do
       ALIAS=$1
       shift
       ;;
+    --tag)
+      shift
+      if [ "$TAG" != "" ]; then
+        echo "Overriding $TAG with $1"
+      fi
+      TAG=$1
+      shift
+      ;;
     --image)
       shift
       IMAGES="$IMAGES $1"
@@ -191,15 +200,21 @@ fi
 alias_tag=
 if [ -n "$ALIAS" ]; then
   alias_tag=$ALIAS
+  # when alias is created from branch-name we want to keep the hash and have it pushed to CI because
+  # the alias will change daily.
+  OVERRIDE_COMMIT_HASH="true"
 elif [ "$BRANCH" == "develop" ]; then
   alias_tag="$BRANCH"
 elif [ "${BRANCH#release-}" != "${BRANCH}" ]; then
   alias_tag="${BRANCH}"
 fi
 
-if [ -z "$CI" ] && [ -z "$TAG" ] && [ -n "$alias_tag" ]; then
-  OVERRIDE_COMMIT_HASH="true"
+if [ -n "$TAG" ] && [ "$TAG" != "$(get_tag)" ]; then
+  # Set the TAG which basically allows building the binaries as if it were a git tag
+  NIX_TAG_ARGS="--argstr tag $TAG"
+  NIX_BUILD="$NIX_BUILD $NIX_TAG_ARGS"
 fi
+
 TAG=${TAG:-$HASH}
 if [ -n "$OVERRIDE_COMMIT_HASH" ]; then
   # Set the TAG to the alias and remove the alias
@@ -239,7 +254,7 @@ done
 if [ -n "$UPLOAD" ] && [ -z "$SKIP_PUBLISH" ]; then
   # Upload them
   for img in $UPLOAD; do
-    if [ -z "$REGISTRY" ] && [ -z "$OVERRIDE_COMMIT_HASH" ] && dockerhub_tag_exists $image $TAG; then
+    if [ -z "$REGISTRY" ] && [ -n "$CI" ] && dockerhub_tag_exists $image $TAG; then
       echo "Skipping $image:$TAG that already exists"
       continue
     fi

--- a/scripts/rust/branch_ancestor.sh
+++ b/scripts/rust/branch_ancestor.sh
@@ -23,7 +23,7 @@ if [[ "$BRANCH" =~ ^release/.* ]] || [ "$BRANCH" = "develop" ]; then
 else
   source "$ROOTDIR/scripts/git/branch_ancestor.sh"
 
-  BRANCH="$(findBranchesSharingFirstCommonCommit . origin/develop origin/release | cut -d' ' -f1)"
+  BRANCH="$(findBranchesSharingFirstCommonCommit . origin/develop origin/release/ | cut -d' ' -f1)"
   BRANCH=${BRANCH##origin/}
 
   if [ "$BRANCH" == "" ]; then

--- a/tests/bdd/requirements.txt
+++ b/tests/bdd/requirements.txt
@@ -5,3 +5,4 @@ urllib3
 docker
 asyncssh
 etcd3
+requests==2.25.0

--- a/utils/utils-lib/src/version.rs
+++ b/utils/utils-lib/src/version.rs
@@ -3,7 +3,7 @@ pub mod macros {
     #[macro_export]
     macro_rules! version_info {
         () => {{
-            $crate::version_info_inner!($crate::long_raw_version_str())
+            $crate::version_info_inner!(None, $crate::long_raw_version_str())
         }};
     }
 


### PR DESCRIPTION
    ci(gha/submodule): ensure submodules point to the right branch
    
    Will help avoid mistakes if anyone uses update --remote...
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    chore: don't show crate version on log
    
    We never update the crate version, and it's actually very misleading...
    So let's hide it until we start to update it properly.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build(images): add tag argument
    
    Allows one to explicitly build the binaries with a given tag, as opposed to the alias-tag
    which simply adds a docker image tag alias.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>