### PR TITLE
Partial rebuild fixes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/policies/rebuild_policies.rs
+++ b/control-plane/agents/src/bin/core/controller/policies/rebuild_policies.rs
@@ -69,7 +69,6 @@ impl RuleSet {
     }
 
     fn default_faulted_child_timewait() -> Duration {
-        tracing::info!("default timed-wait TWAIT_SPERF(10 mins)");
         TWAIT_SPERF
     }
 }

--- a/control-plane/agents/src/bin/core/controller/policies/rebuild_policies.rs
+++ b/control-plane/agents/src/bin/core/controller/policies/rebuild_policies.rs
@@ -22,7 +22,6 @@ const TWAIT_SPERF: std::time::Duration = Duration::new(600, 0);
 /// A time period optimized for better redundancy and quicker rebuild decisions.
 const TWAIT_SAVAIL: std::time::Duration = Duration::new(300, 0);
 const TWAIT_ZERO: std::time::Duration = Duration::new(0, 0);
-// 100GiB = 100 * 1024 * 1024 * 1024 bytes
 const VOL_SIZE_100GIB: u64 = 107374182400;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq)]

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -24,13 +24,9 @@ use crate::{
 use agents::errors::SvcError;
 use capacity::enospc_children_onliner;
 use garbage_collector::GarbageCollector;
-use std::{
-    convert::TryFrom,
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+
 use stor_port::{
-    transport_api::{ErrorChain, ResourceKind},
+    transport_api::ErrorChain,
     types::v0::{
         store::{
             nexus::{NexusSpec, ReplicaUri},
@@ -38,12 +34,20 @@ use stor_port::{
         },
         transport::{
             Child, ChildStateReason, ChildUri, CreateNexus, Nexus, NexusChildActionContext,
-            NexusShareProtocol, NexusStatus, NodeStatus, Replica, ShareNexus, UnshareNexus,
+            NexusShareProtocol, NexusStatus, NodeStatus, ReplicaId, ShareNexus, UnshareNexus,
         },
     },
 };
+
+use std::{
+    convert::TryFrom,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
 use tokio::sync::RwLock;
-use tracing::{info, Instrument};
+use tracing::Instrument;
+
 /// Nexus Reconciler loop
 #[derive(Debug)]
 pub(crate) struct NexusReconciler {
@@ -147,62 +151,70 @@ pub(super) async fn handle_faulted_children(
     let child_count = nexus_state.children.len();
     if nexus_state.status == NexusStatus::Degraded && child_count > 1 {
         for child in nexus_state.children.iter().filter(|c| c.state.faulted()) {
-            let _ = handle_child_rebuild(nexus, child, &nexus_state, context).await;
+            let _ = handle_faulted_child(nexus, child, &nexus_state, context).await;
         }
     }
     Ok(PollerState::Idle)
 }
 
-/// Checks rebuild policy for the child. Depending on the policy performs the either waits for
-/// child to comeback for specified duration or does Full rebuild straightaway.
-#[tracing::instrument(skip(nexus, context), level = "trace", fields(nexus.uuid = %nexus.uuid, request.reconcile = true))]
-async fn handle_child_rebuild(
+/// Handles faulted nexus children.
+/// Depending on the fault policy it either waits for specified duration until the child comes back
+/// or it opts for a full rebuilding by faulting the child instead.
+async fn handle_faulted_child(
     nexus_spec: &mut OperationGuardArc<NexusSpec>,
     child: &Child,
     nexus: &Nexus,
     context: &PollContext,
 ) -> Result<(), SvcError> {
     let wait_duration = RuleSet::faulted_child_wait(nexus, context.registry());
-    let is_elapsed = wait_duration_elapsed(child.faulted_at, wait_duration, &child.uri);
+
+    let Some(child_uuid) = nexus_spec.as_ref().replica_uri(&child.uri).map(|r| r.uuid()) else {
+        tracing::warn!(%child.uri, "Unknown Child found, a full rebuild is required");
+        return faulted_children_remover(nexus_spec, child, context).await;
+    };
+
     let is_rebuild_failed = child.state_reason == ChildStateReason::RebuildFailed;
-    if !is_rebuild_failed
-        && get_child_replica(nexus_spec.as_ref(), child, context)
-            .await
-            .is_ok()
-    {
-        info!(%child.uri, "Child's Replica is Online within the partial rebuild window");
+    if !is_rebuild_failed && child_replica_online(child_uuid, context).await {
+        let child_uuid = child_uuid.clone();
+        tracing::info!(%child.uri, child.uuid=%child_uuid, "Child's replica is back online within the partial rebuild window");
         if let Err(error) = online_nexus_child(nexus_spec, &child.uri, context).await {
-            info!(%child.uri, "Initializing Full rebuild as online child attempt failed for child, failed with : {:?}", error);
-            faulted_children_remover(nexus_spec, child, context).await?
+            tracing::warn!(
+                %child.uri,
+                child.uuid=%child_uuid,
+                %error,
+                "Failed to online child, a full rebuild is required"
+            );
+            faulted_children_remover(nexus_spec, child, context).await?;
         }
-    } else if is_rebuild_failed || is_elapsed {
-        info!(%child.uri, "Start full rebuild for child, elapsed: {}, child state reason: {:?}", is_elapsed.to_string(), child.state_reason);
-        faulted_children_remover(nexus_spec, child, context).await?
+    } else if is_rebuild_failed {
+        tracing::warn!(%child.uri, child.uuid=%child_uuid, "Child rebuild failed, a full rebuild is required");
+        faulted_children_remover(nexus_spec, child, context).await?;
+    } else if wait_duration_elapsed(child.faulted_at, wait_duration, &child.uri) {
+        tracing::warn!(%child.uri, child.uuid=%child_uuid, ?wait_duration, "Partial rebuild window elapsed, a full rebuild is required");
+        faulted_children_remover(nexus_spec, child, context).await?;
     } else {
-        info!(%child.uri, "Child's Replica is not online yet");
+        tracing::info!(%child.uri, child.uuid=%child_uuid, "Child's replica is not online yet");
     }
     Ok(())
 }
 
 /// Removes child from nexus children list to initiate Full rebuild of child.
-#[tracing::instrument(skip(nexus, context), level = "trace", fields(nexus.uuid = %nexus.uuid(), request.reconcile = true))]
-pub(super) async fn faulted_children_remover(
+async fn faulted_children_remover(
     nexus: &mut OperationGuardArc<NexusSpec>,
     child: &Child,
     context: &PollContext,
 ) -> Result<(), SvcError> {
     let nexus_uuid = nexus.uuid();
     let nexus_state = context.registry().nexus(nexus_uuid).await?;
-    let nexus_spec_clone = nexus.as_ref().clone();
-    nexus_spec_clone.warn_span(|| {
-        tracing::warn!(%child.uri, %child.state, %child.state_reason, "Attempting to remove faulted child")
+    nexus.warn_span(|| {
+        tracing::warn!(%child.uri, %child.state, %child.state_reason, ?child.faulted_at, "Attempting to remove faulted child")
     });
     nexus
         .remove_child_by_uri(context.registry(), &nexus_state, &child.uri, true)
         .await?;
 
-    nexus_spec_clone.warn_span(|| {
-        tracing::warn!(%child.uri, %child.state, %child.state_reason, "Successfully removed faulted child")
+    nexus.warn_span(|| {
+        tracing::warn!(%child.uri, %child.state, %child.state_reason, ?child.faulted_at, "Successfully removed faulted child")
     });
     Ok(())
 }
@@ -215,7 +227,7 @@ fn wait_duration_elapsed(
 ) -> bool {
     if let Some(fault_time) = fault_time {
         if let Ok(elapsed) = fault_time.elapsed() {
-            info!(
+            tracing::info!(
                 child.uri = %uri,
                 "waited {:?} for child to comeback. Wait time is {:?}",
                 elapsed, wait_duration
@@ -226,18 +238,10 @@ fn wait_duration_elapsed(
     false
 }
 
-/// If we can get replica for a child from registry. It means that child node is online, Pool is
-/// imported containing the child/replica.
-async fn get_child_replica(
-    nexus: &NexusSpec,
-    child: &Child,
-    context: &PollContext,
-) -> Result<Replica, SvcError> {
-    let replica_uri = nexus.replica_uri(&child.uri).ok_or(SvcError::NotFound {
-        kind: ResourceKind::Replica,
-        id: "Child replica not found".to_string(),
-    })?;
-    context.registry().replica(replica_uri.uuid()).await
+/// Check if a child's replica is online.
+/// If the node has gone offline the replica will not be present in the registry.
+async fn child_replica_online(child_uuid: &ReplicaId, context: &PollContext) -> bool {
+    context.registry().replica(child_uuid).await.is_ok()
 }
 
 /// Tries to mark child as Online. Returns error on failing to do so.
@@ -252,9 +256,7 @@ pub(super) async fn online_nexus_child(
     let ctx = NexusChildActionContextNode::new(online_context, context.registry());
     // TODO: Check if we can handle things differently for different SvcError.
     node.online_child(ctx).await?;
-    info!(
-        %child, "Successfully made child online in nexus :{:?}", nexus.uuid()
-    );
+    nexus.info_span(|| tracing::info!(child.uri = %child.as_str(), "Successfully onlined child"));
     Ok(())
 }
 

--- a/control-plane/agents/src/bin/core/controller/resources/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/nexus/mod.rs
@@ -70,6 +70,7 @@ macro_rules! nexus_span {
                 }
             }
             Some(_) => {
+                // todo: check for volume uuid as well!
                 $func();
             }
         }

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -47,11 +47,11 @@ pub struct Nexus {
     pub allowed_hosts: Vec<HostNqn>,
 }
 impl Nexus {
-    /// Check if the nexus contains the provided `ChildUri`
+    /// Check if the nexus contains the provided `ChildUri`.
     pub fn contains_child(&self, uri: &ChildUri) -> bool {
         self.children.iter().any(|c| &c.uri == uri)
     }
-    /// Check if the nexus contains the provided `ChildUri`
+    /// Check if the nexus contains the provided `ChildUri`.
     pub fn child(&self, uri: &str) -> Option<&Child> {
         self.children.iter().find(|c| c.uri.as_str() == uri)
     }

--- a/tests/bdd/requirements.txt
+++ b/tests/bdd/requirements.txt
@@ -1,8 +1,8 @@
 pytest-bdd==6.0.0
-python-dateutil
-retrying
-urllib3
-docker
-asyncssh
-etcd3
+python-dateutil==2.8.2
+retrying==1.3.4
+urllib3==1.26.15
+docker==5.0.3
+asyncssh==2.13.1
+etcd3==0.12.0
 requests==2.25.0


### PR DESCRIPTION
    ci(bdd/python): pin requirements versions
    
    Previously we encountered some issues when updating requirements, so let's pin them to prevent
    future updates from breaking CI.

---

    fix(partial-rebuild): don't wait if fault timestamp is unset
    
    Fault timestamp was only added recently, and so when dealing with an dataplane <2.1 we have to take
    this into account.
    When the timestamp is not set then simply remove the child to trigger full rebuild as soon as
    possible.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor: enhance rebuild traces
    
    Add missing child uuid and volume uuid to partial rebuild traces.
    Reword to distinguish rebuild failed from timeout.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
