### PR TITLE
Cherry-pick #524

### DIFF
--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -59,17 +59,17 @@ impl OperationGuardArc<VolumeSpec> {
         let nexus = NexusId::new();
         let resv_key = nexus.as_u128() as u64;
         let range = match self.as_ref().config() {
-            None => NvmfControllerIdRange::new_min(),
+            None => NvmfControllerIdRange::new_min(2),
             Some(cfg) => {
                 // todo: should the cluster agent tell us which controller Id to use?
                 #[allow(clippy::if_same_then_else)]
                 if self.published() {
-                    cfg.config().controller_id_range().next()
+                    cfg.config().controller_id_range().next(2)
                 } else {
                     // if we're not published should we start over?
                     // for now let's carry on to next as there might some cases where we unpublish
                     // but the initiator doesn't disconnect properly.
-                    cfg.config().controller_id_range().next()
+                    cfg.config().controller_id_range().next(2)
                 }
             }
         };


### PR DESCRIPTION
feat: allow for a range of 2 controller ids when publishing

Previously we had a strict limit of only 1 controller range. This effectively means only 1 initiator can connect to our volume target.
However it seems that when an initiator times out before the target "notices" this we end up getting a new connection whilst the old one is still in place, and thus the new connect call fails!

Why were we so strict? Because the current code in the dataplane can not guarantee that older initiators connected with allow_any set to true will be disconnected when we set a new allowed list!
So is it safe to bump this? We believe so, because currently CSI sets allowed list of 1 for all published volumes, so when updating this list the previous one should be booted out!

todo: update dataplane to boot out any connected host!