### PR TITLE
fix(capacity/thin): don't remove enospc nexuses with no space in replicas

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
@@ -43,7 +43,7 @@ pub(crate) async fn enospc_children_onliner(
     PollResult::Ok(PollerState::Idle)
 }
 
-async fn online_enospc(
+pub(super) async fn child_enospc_onlineable(
     nexus: &mut OperationGuardArc<NexusSpec>,
     child: &Child,
     registry: &Registry,
@@ -119,6 +119,16 @@ async fn online_enospc(
             required: required_free_space,
         });
     }
+
+    Ok(())
+}
+
+async fn online_enospc(
+    nexus: &mut OperationGuardArc<NexusSpec>,
+    child: &Child,
+    registry: &Registry,
+) -> Result<(), SvcError> {
+    child_enospc_onlineable(nexus, child, registry).await?;
 
     let nexus_node = &nexus.as_ref().node;
     let node = registry.node_wrapper(nexus_node).await?;

--- a/control-plane/agents/src/bin/core/tests/volume/capacity.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/capacity.rs
@@ -26,152 +26,12 @@ async fn online_enospc_child() {
         .await
         .unwrap();
 
+    let (volume_1, volume_2) =
+        common_enospc_builder(&cluster, cache_period, reconcile_period, 2).await;
+
     let api_client = cluster.rest_v00();
-    let volumes_api = api_client.volumes_api();
     let pools_api = api_client.pools_api();
-    let replica_api = api_client.replicas_api();
-
-    let volume_size = 80u64 * 1024 * 1024;
-    let mut volume_1 = volumes_api
-        .put_volume(
-            &"ec4e66fd-3b33-4439-b504-d49aba53da26".parse().unwrap(),
-            models::CreateVolumeBody::new(models::VolumePolicy::new(true), 2, volume_size, true),
-        )
-        .await
-        .unwrap();
-    volume_1 = volumes_api
-        .put_volume_target(
-            &volume_1.spec.uuid,
-            PublishVolumeBody::new_all(
-                HashMap::new(),
-                None,
-                cluster.node(0).to_string(),
-                models::VolumeShareProtocol::Nvmf,
-                None,
-                cluster.csi_node(0),
-            ),
-        )
-        .await
-        .unwrap();
-    let uri = volume_1.state.target.as_ref().unwrap().device_uri.as_str();
-    let _drop_target = DeviceDisconnect(nvmeadm::NvmeTarget::try_from(uri).unwrap());
-
-    let mut volume_2 = volumes_api
-        .put_volume(
-            &"ec4e66fd-3b33-4439-b504-d49aba53da27".parse().unwrap(),
-            models::CreateVolumeBody::new(models::VolumePolicy::new(true), 2, volume_size, true),
-        )
-        .await
-        .unwrap();
-    volume_2 = volumes_api
-        .put_volume_target(
-            &volume_2.spec.uuid,
-            PublishVolumeBody::new_all(
-                HashMap::new(),
-                None,
-                cluster.node(0).to_string(),
-                models::VolumeShareProtocol::Nvmf,
-                None,
-                cluster.csi_node(0),
-            ),
-        )
-        .await
-        .unwrap();
-    let uri = volume_2.state.target.as_ref().unwrap().device_uri.as_str();
-    let _drop_target2 = DeviceDisconnect(nvmeadm::NvmeTarget::try_from(uri).unwrap());
-
-    let pools = pools_api.get_pools().await.unwrap();
-    tracing::info!(?pools, "Here's the pools");
-
-    let replicas = replica_api.get_replicas().await.unwrap();
-    tracing::info!(?replicas, "Here's the replicas");
-
-    let mut node = cluster.csi_node_client(0).await.unwrap();
-    node.node_stage_volume(&volume_1).await.unwrap();
-    let response = node
-        .internal()
-        .find_volume(FindVolumeRequest {
-            volume_id: volume_1.spec.uuid.to_string(),
-        })
-        .await
-        .unwrap();
-    tracing::info!(?response);
-    let device_path_1 = response.into_inner().device_path;
-
-    node.node_stage_volume(&volume_2).await.unwrap();
-    let response = node
-        .internal()
-        .find_volume(FindVolumeRequest {
-            volume_id: volume_2.spec.uuid.to_string(),
-        })
-        .await
-        .unwrap();
-    tracing::info!(?response);
-    let device_path_2 = response.into_inner().device_path;
-
-    let name = cluster.csi_container(0);
-    let dev_path_1 = format!("of={device_path_1}");
-
-    let dd_1 = cluster.composer().exec(
-        name.as_str(),
-        vec![
-            "dd",
-            "if=/dev/urandom",
-            dev_path_1.as_str(),
-            "bs=64k",
-            "count=640",
-        ],
-    );
-    let dev_path_2 = format!("of={device_path_2}");
-    let dd_2 = cluster.composer().exec(
-        name.as_str(),
-        vec![
-            "dd",
-            "if=/dev/urandom",
-            dev_path_2.as_str(),
-            "bs=64k",
-            "count=640",
-        ],
-    );
-
-    let output = futures::future::join(dd_1, dd_2).await;
-    tracing::info!("\n{:?}", output);
-
-    // 1. really need a way to by pass the cache!
-    // for now simply wait for the cache period!
-    tokio::time::sleep(cache_period * 2).await;
-    log_thin(&cluster).await;
-
-    let dd_1 = cluster.composer().exec(
-        name.as_str(),
-        vec!["dd", "if=/dev/urandom", dev_path_1.as_str(), "bs=64k"],
-    );
-    let dd_2 = cluster.composer().exec(
-        name.as_str(),
-        vec!["dd", "if=/dev/urandom", dev_path_2.as_str(), "bs=64k"],
-    );
-    let output = futures::future::join(dd_1, dd_2).await;
-
-    cluster
-        .composer()
-        .exec(
-            cluster.csi_container(0).as_str(),
-            vec!["nvme", "disconnect-all"],
-        )
-        .await
-        .unwrap();
-
-    tracing::info!("\n{:?}", output);
-
-    tokio::time::sleep(reconcile_period * 2).await;
-    log_thin(&cluster).await;
-
-    // no children should be removed as there's no space for the larger replica
-    let current_replicas = replica_api.get_replicas().await.unwrap();
-    let new_replicas = current_replicas
-        .iter()
-        .any(|r| !replicas.iter().any(|or| or.uuid == r.uuid));
-    assert!(!new_replicas, "There should be no new replicas");
+    let volumes_api = api_client.volumes_api();
 
     let volume_1 = volumes_api.get_volume(&volume_1.spec.uuid).await.unwrap();
     assert_eq!(volume_1.state.status, models::VolumeStatus::Degraded);
@@ -262,4 +122,208 @@ async fn wait_till_1_volume_healthy(volume_client: &dyn VolumeOperations) {
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
+}
+
+#[tokio::test]
+async fn faulted_nexus_enospc_child() {
+    let cache_period = Duration::from_millis(250);
+    let reconcile_period = Duration::from_millis(3000);
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_io_engines(2)
+        .with_pool(1, "malloc:///p1?size_mb=100")
+        .with_csi(false, true)
+        .with_options(|o| o.with_isolated_io_engine(true))
+        .with_cache_period(&humantime::Duration::from(cache_period).to_string())
+        .with_reconcile_period(reconcile_period, reconcile_period)
+        .build()
+        .await
+        .unwrap();
+
+    let (volume_1, volume_2) =
+        common_enospc_builder(&cluster, cache_period, reconcile_period, 1).await;
+
+    let api_client = cluster.rest_v00();
+    let volumes_api = api_client.volumes_api();
+
+    let volume_1 = volumes_api.get_volume(&volume_1.spec.uuid).await.unwrap();
+    assert_eq!(volume_1.state.status, models::VolumeStatus::Faulted);
+    let volume_2 = volumes_api.get_volume(&volume_2.spec.uuid).await.unwrap();
+    assert_eq!(volume_2.state.status, models::VolumeStatus::Faulted);
+
+    volumes_api.del_volume(&volume_2.spec.uuid).await.unwrap();
+
+    // After making up space, the other volume nexus should be recreated!
+
+    let volume_client = cluster.grpc_client().volume();
+    wait_till_1_volume_healthy(&volume_client).await;
+
+    let volume_1 = volumes_api.get_volume(&volume_1.spec.uuid).await.unwrap();
+    assert_eq!(volume_1.state.status, models::VolumeStatus::Online);
+}
+
+async fn common_enospc_builder(
+    cluster: &Cluster,
+    cache_period: Duration,
+    reconcile_period: Duration,
+    replicas: u8,
+) -> (models::Volume, models::Volume) {
+    let api_client = cluster.rest_v00();
+    let volumes_api = api_client.volumes_api();
+    let pools_api = api_client.pools_api();
+    let replica_api = api_client.replicas_api();
+
+    let volume_size = 80u64 * 1024 * 1024;
+    let mut volume_1 = volumes_api
+        .put_volume(
+            &"ec4e66fd-3b33-4439-b504-d49aba53da26".parse().unwrap(),
+            models::CreateVolumeBody::new(
+                models::VolumePolicy::new(true),
+                replicas,
+                volume_size,
+                true,
+            ),
+        )
+        .await
+        .unwrap();
+    volume_1 = volumes_api
+        .put_volume_target(
+            &volume_1.spec.uuid,
+            PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                cluster.node(0).to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+            ),
+        )
+        .await
+        .unwrap();
+    let uri = volume_1.state.target.as_ref().unwrap().device_uri.as_str();
+    let _drop_target = DeviceDisconnect(nvmeadm::NvmeTarget::try_from(uri).unwrap());
+
+    let mut volume_2 = volumes_api
+        .put_volume(
+            &"ec4e66fd-3b33-4439-b504-d49aba53da27".parse().unwrap(),
+            models::CreateVolumeBody::new(
+                models::VolumePolicy::new(true),
+                replicas,
+                volume_size,
+                true,
+            ),
+        )
+        .await
+        .unwrap();
+    volume_2 = volumes_api
+        .put_volume_target(
+            &volume_2.spec.uuid,
+            PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                cluster.node(0).to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+            ),
+        )
+        .await
+        .unwrap();
+    let uri = volume_2.state.target.as_ref().unwrap().device_uri.as_str();
+    let _drop_target2 = DeviceDisconnect(nvmeadm::NvmeTarget::try_from(uri).unwrap());
+
+    let pools = pools_api.get_pools().await.unwrap();
+    tracing::info!(?pools, "Here's the pools");
+
+    let replicas = replica_api.get_replicas().await.unwrap();
+    tracing::info!(?replicas, "Here's the replicas");
+
+    let mut node = cluster.csi_node_client(0).await.unwrap();
+    node.node_stage_volume(&volume_1).await.unwrap();
+    let response = node
+        .internal()
+        .find_volume(FindVolumeRequest {
+            volume_id: volume_1.spec.uuid.to_string(),
+        })
+        .await
+        .unwrap();
+    tracing::info!(?response);
+    let device_path_1 = response.into_inner().device_path;
+
+    node.node_stage_volume(&volume_2).await.unwrap();
+    let response = node
+        .internal()
+        .find_volume(FindVolumeRequest {
+            volume_id: volume_2.spec.uuid.to_string(),
+        })
+        .await
+        .unwrap();
+    tracing::info!(?response);
+    let device_path_2 = response.into_inner().device_path;
+
+    let name = cluster.csi_container(0);
+    let dev_path_1 = format!("of={device_path_1}");
+
+    let dd_1 = cluster.composer().exec(
+        name.as_str(),
+        vec![
+            "dd",
+            "if=/dev/urandom",
+            dev_path_1.as_str(),
+            "bs=64k",
+            "count=640",
+        ],
+    );
+    let dev_path_2 = format!("of={device_path_2}");
+    let dd_2 = cluster.composer().exec(
+        name.as_str(),
+        vec![
+            "dd",
+            "if=/dev/urandom",
+            dev_path_2.as_str(),
+            "bs=64k",
+            "count=640",
+        ],
+    );
+
+    let output = futures::future::join(dd_1, dd_2).await;
+    tracing::info!("\n{:?}", output);
+
+    // 1. really need a way to by pass the cache!
+    // for now simply wait for the cache period!
+    tokio::time::sleep(cache_period * 2).await;
+    log_thin(cluster).await;
+
+    let dd_1 = cluster.composer().exec(
+        name.as_str(),
+        vec!["dd", "if=/dev/urandom", dev_path_1.as_str(), "bs=64k"],
+    );
+    let dd_2 = cluster.composer().exec(
+        name.as_str(),
+        vec!["dd", "if=/dev/urandom", dev_path_2.as_str(), "bs=64k"],
+    );
+    let output = futures::future::join(dd_1, dd_2).await;
+
+    cluster
+        .composer()
+        .exec(
+            cluster.csi_container(0).as_str(),
+            vec!["nvme", "disconnect-all"],
+        )
+        .await
+        .unwrap();
+
+    tracing::info!("\n{:?}", output);
+
+    tokio::time::sleep(reconcile_period * 2).await;
+    log_thin(cluster).await;
+
+    // no children should be removed as there's no space for the larger replica
+    let current_replicas = replica_api.get_replicas().await.unwrap();
+    let new_replicas = current_replicas
+        .iter()
+        .any(|r| !replicas.iter().any(|or| or.uuid == r.uuid));
+    assert!(!new_replicas, "There should be no new replicas");
+
+    (volume_1, volume_2)
 }


### PR DESCRIPTION
There's no point in faulting these nexuses because we can't write to the replicas anyway. Ensure that there's some slack left before attempting to remove these nexuses.