### PR TITLE
fix(core/io-engine): implement snapshot trait for the rpc client

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
@@ -11,7 +11,8 @@ use async_trait::async_trait;
 use stor_port::{
     transport_api::v0::BlockDevices,
     types::v0::transport::{
-        AddNexusChild, ApiVersion, CreateNexus, CreatePool, CreateReplica, DestroyNexus,
+        AddNexusChild, ApiVersion, CreateNexus, CreateNexusSnapshot, CreateNexusSnapshotResp,
+        CreatePool, CreateReplica, CreateReplicaSnapshot, CreateReplicaSnapshotResp, DestroyNexus,
         DestroyPool, DestroyReplica, FaultNexusChild, GetBlockDevices, ImportPool, Nexus,
         NexusChildAction, NexusChildActionContext, NexusChildActionKind, NexusId, NodeId,
         PoolState, Register, RemoveNexusChild, Replica, ShareNexus, ShareReplica, ShutdownNexus,
@@ -32,6 +33,8 @@ pub(crate) trait NodeApi:
     + NexusChildApi<Nexus, Nexus, ()>
     + NexusChildActionApi<NexusChildActionContext>
     + HostApi
+    + NexusSnapshotApi
+    + ReplicaSnapshotApi
     + Sync
     + Send
     + Clone
@@ -135,16 +138,24 @@ where
     }
 }
 
-/// The trait for snapshot operations like create, remove, list.
+/// The trait for nexus snapshot operations like create, remove, list.
 #[async_trait]
-pub(crate) trait SnapshotApi {
-    type CreateIn: Send + Sync;
-    type CreateOutput: Send + Sync + Sized;
+pub(crate) trait NexusSnapshotApi {
     /// Create a snapshot using the incoming request.
-    async fn create_snapshot(
+    async fn create_nexus_snapshot(
         &self,
-        request: &Self::CreateIn,
-    ) -> Result<Self::CreateOutput, SvcError>;
+        request: &CreateNexusSnapshot,
+    ) -> Result<CreateNexusSnapshotResp, SvcError>;
+}
+
+/// The trait for replica snapshot operations like create, remove, list.
+#[async_trait]
+pub(crate) trait ReplicaSnapshotApi {
+    /// Create a snapshot using the incoming request.
+    async fn create_repl_snapshot(
+        &self,
+        request: &CreateReplicaSnapshot,
+    ) -> Result<CreateReplicaSnapshotResp, SvcError>;
 }
 
 #[async_trait]

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/nexus.rs
@@ -5,9 +5,9 @@ use rpc::io_engine::Null;
 use stor_port::{
     transport_api::ResourceKind,
     types::v0::transport::{
-        AddNexusChild, Child, CreateNexus, DestroyNexus, FaultNexusChild, Nexus, NexusChildAction,
-        NexusChildActionContext, NexusId, NodeId, RemoveNexusChild, ShareNexus, ShutdownNexus,
-        UnshareNexus,
+        AddNexusChild, Child, CreateNexus, CreateNexusSnapshot, CreateNexusSnapshotResp,
+        DestroyNexus, FaultNexusChild, Nexus, NexusChildAction, NexusChildActionContext, NexusId,
+        NodeId, RemoveNexusChild, ShareNexus, ShutdownNexus, UnshareNexus,
     },
 };
 
@@ -251,5 +251,19 @@ impl super::RpcClient {
                 id: nexus.to_string(),
             }),
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::controller::io_engine::NexusSnapshotApi for super::RpcClient {
+    async fn create_nexus_snapshot(
+        &self,
+        _request: &CreateNexusSnapshot,
+    ) -> Result<CreateNexusSnapshotResp, SvcError> {
+        Err(SvcError::GrpcRequestError {
+            resource: ResourceKind::Nexus,
+            request: "create_snapshot".to_string(),
+            source: tonic::Status::unimplemented(""),
+        })
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/replica.rs
@@ -4,7 +4,8 @@ use rpc::io_engine::Null;
 use stor_port::{
     transport_api::ResourceKind,
     types::v0::transport::{
-        CreateReplica, DestroyReplica, NodeId, Replica, ShareReplica, UnshareReplica,
+        CreateReplica, CreateReplicaSnapshot, CreateReplicaSnapshotResp, DestroyReplica, NodeId,
+        Replica, ShareReplica, UnshareReplica,
     },
 };
 
@@ -92,5 +93,19 @@ impl crate::controller::io_engine::ReplicaApi for super::RpcClient {
             .into_inner()
             .uri;
         Ok(uri)
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::controller::io_engine::ReplicaSnapshotApi for super::RpcClient {
+    async fn create_repl_snapshot(
+        &self,
+        _request: &CreateReplicaSnapshot,
+    ) -> Result<CreateReplicaSnapshotResp, SvcError> {
+        Err(SvcError::GrpcRequestError {
+            resource: ResourceKind::Replica,
+            request: "create_snapshot".to_string(),
+            source: tonic::Status::unimplemented(""),
+        })
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
@@ -1,5 +1,7 @@
-use super::translation::{rpc_nexus_to_agent, AgentToIoEngine};
-use crate::controller::io_engine::{NexusListApi, SnapshotApi};
+use super::{
+    super::NexusListApi,
+    translation::{rpc_nexus_to_agent, AgentToIoEngine},
+};
 use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::v1::nexus::ListNexusOptions;
 use stor_port::{
@@ -314,13 +316,11 @@ impl super::RpcClient {
 }
 
 #[async_trait::async_trait]
-impl SnapshotApi for Nexus {
-    type CreateIn = CreateNexusSnapshot;
-    type CreateOutput = CreateNexusSnapshotResp;
-    async fn create_snapshot(
+impl crate::controller::io_engine::NexusSnapshotApi for super::RpcClient {
+    async fn create_nexus_snapshot(
         &self,
-        _request: &Self::CreateIn,
-    ) -> Result<Self::CreateOutput, SvcError> {
+        _request: &CreateNexusSnapshot,
+    ) -> Result<CreateNexusSnapshotResp, SvcError> {
         Err(SvcError::GrpcRequestError {
             resource: ResourceKind::Nexus,
             request: "create_snapshot".to_string(),

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
@@ -1,5 +1,4 @@
 use super::translation::{rpc_replica_to_agent, AgentToIoEngine};
-use crate::controller::io_engine::SnapshotApi;
 use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::v1::replica::ListReplicaOptions;
 use stor_port::{
@@ -99,13 +98,11 @@ impl crate::controller::io_engine::ReplicaApi for super::RpcClient {
 }
 
 #[async_trait::async_trait]
-impl SnapshotApi for Replica {
-    type CreateIn = CreateReplicaSnapshot;
-    type CreateOutput = CreateReplicaSnapshotResp;
-    async fn create_snapshot(
+impl crate::controller::io_engine::ReplicaSnapshotApi for super::RpcClient {
+    async fn create_repl_snapshot(
         &self,
-        _request: &Self::CreateIn,
-    ) -> Result<Self::CreateOutput, SvcError> {
+        _request: &CreateReplicaSnapshot,
+    ) -> Result<CreateReplicaSnapshotResp, SvcError> {
         Err(SvcError::GrpcRequestError {
             resource: ResourceKind::Replica,
             request: "create_snapshot".to_string(),

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -26,7 +26,9 @@ use stor_port::{
 };
 
 use crate::controller::{
-    io_engine::{NexusChildActionApi, NexusChildApi, NexusShareApi},
+    io_engine::{
+        NexusChildActionApi, NexusChildApi, NexusShareApi, NexusSnapshotApi, ReplicaSnapshotApi,
+    },
     registry::Registry,
     states::Either,
 };
@@ -34,6 +36,7 @@ use async_trait::async_trait;
 use parking_lot::RwLock;
 use std::{ops::DerefMut, sync::Arc};
 use stor_port::types::v0::transport::{
+    CreateNexusSnapshot, CreateNexusSnapshotResp, CreateReplicaSnapshot, CreateReplicaSnapshotResp,
     ImportPool, NexusChildAction, NexusChildActionContext, NexusChildActionKind,
 };
 use tracing::{debug, trace, warn};
@@ -1374,6 +1377,26 @@ impl NexusChildActionApi<NexusChildActionContextNode> for Arc<tokio::sync::RwLoc
         let nexus = dataplane.child_action(request).await?;
         self.update_nexus_state(Either::Insert(nexus.clone())).await;
         Ok(nexus)
+    }
+}
+
+#[async_trait]
+impl NexusSnapshotApi for Arc<tokio::sync::RwLock<NodeWrapper>> {
+    async fn create_nexus_snapshot(
+        &self,
+        _request: &CreateNexusSnapshot,
+    ) -> Result<CreateNexusSnapshotResp, SvcError> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl ReplicaSnapshotApi for Arc<tokio::sync::RwLock<NodeWrapper>> {
+    async fn create_repl_snapshot(
+        &self,
+        _request: &CreateReplicaSnapshot,
+    ) -> Result<CreateReplicaSnapshotResp, SvcError> {
+        todo!()
     }
 }
 


### PR DESCRIPTION
Add trait to the rpc client rather than the resources, matching the existing infra. Also add generic parameter to allow implementing the same trait with different parameters.