### PR TITLE
fix: use operation guard to nodes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/resources/operations.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations.rs
@@ -1,6 +1,40 @@
 use crate::controller::registry::Registry;
 use agents::errors::SvcError;
 
+/// Resource Cordon Operations.
+#[async_trait::async_trait]
+pub(crate) trait ResourceCordon {
+    type CordonOutput: Sync + Send + Sized;
+    type UncordonOutput: Sync + Send + Sized;
+
+    /// Cordon the resource.
+    async fn cordon(
+        &mut self,
+        registry: &Registry,
+        label: String,
+    ) -> Result<Self::CordonOutput, SvcError>;
+    /// Uncordon the resource.
+    async fn uncordon(
+        &mut self,
+        registry: &Registry,
+        label: String,
+    ) -> Result<Self::UncordonOutput, SvcError>;
+}
+
+/// Resource Drain Operations.
+#[async_trait::async_trait]
+pub(crate) trait ResourceDrain {
+    type DrainOutput: Sync + Send + Sized;
+    /// Drain the resource.
+    async fn drain(
+        &mut self,
+        registry: &Registry,
+        label: String,
+    ) -> Result<Self::DrainOutput, SvcError>;
+    /// Mark the resource as drained.
+    async fn set_drained(&mut self, registry: &Registry) -> Result<Self::DrainOutput, SvcError>;
+}
+
 /// Resource Lifecycle Operations.
 #[async_trait::async_trait]
 pub(crate) trait ResourceLifecycle {

--- a/control-plane/agents/src/bin/core/node/mod.rs
+++ b/control-plane/agents/src/bin/core/node/mod.rs
@@ -1,3 +1,5 @@
+mod operations;
+mod operations_helper;
 mod registry;
 /// Node Service
 pub(super) mod service;

--- a/control-plane/agents/src/bin/core/node/operations.rs
+++ b/control-plane/agents/src/bin/core/node/operations.rs
@@ -1,0 +1,140 @@
+use agents::errors::SvcError;
+
+use stor_port::types::v0::store::node::{DrainingVolumes, NodeOperation, NodeSpec};
+
+use crate::controller::{
+    registry::Registry,
+    resources::{
+        operations::{ResourceCordon, ResourceDrain},
+        operations_helper::GuardedOperationsHelper,
+        OperationGuardArc,
+    },
+};
+
+/// Resource Cordon Operations.
+#[async_trait::async_trait]
+impl ResourceCordon for OperationGuardArc<NodeSpec> {
+    type CordonOutput = NodeSpec;
+    type UncordonOutput = NodeSpec;
+
+    /// Cordon a node via operation guard functions.
+    async fn cordon(
+        &mut self,
+        registry: &Registry,
+        label: String,
+    ) -> Result<Self::CordonOutput, SvcError> {
+        let cloned_node_spec = self.lock().clone();
+        let spec_clone = self
+            .start_update(registry, &cloned_node_spec, NodeOperation::Cordon(label))
+            .await?;
+
+        self.complete_update(registry, Ok(self.as_ref().clone()), spec_clone)
+            .await
+    }
+
+    /// Uncordon a node via operation guard functions.
+    async fn uncordon(
+        &mut self,
+        registry: &Registry,
+        label: String,
+    ) -> Result<Self::UncordonOutput, SvcError> {
+        let cloned_node_spec = self.lock().clone();
+        let spec_clone = self
+            .start_update(registry, &cloned_node_spec, NodeOperation::Uncordon(label))
+            .await?;
+
+        self.complete_update(registry, Ok(self.as_ref().clone()), spec_clone)
+            .await
+    }
+}
+
+/// Resource Drain Operations.
+#[async_trait::async_trait]
+impl ResourceDrain for OperationGuardArc<NodeSpec> {
+    type DrainOutput = NodeSpec;
+
+    /// Drain a node via operation guard functions.
+    async fn drain(
+        &mut self,
+        registry: &Registry,
+        label: String,
+    ) -> Result<Self::DrainOutput, SvcError> {
+        let cloned_node_spec = self.lock().clone();
+        let spec_clone = self
+            .start_update(registry, &cloned_node_spec, NodeOperation::Drain(label))
+            .await?;
+
+        self.complete_update(registry, Ok(self.as_ref().clone()), spec_clone)
+            .await
+    }
+
+    /// Mark a node as drained via operation guard functions.
+    async fn set_drained(&mut self, registry: &Registry) -> Result<Self::DrainOutput, SvcError> {
+        let cloned_node_spec = self.lock().clone();
+        let spec_clone = self
+            .start_update(registry, &cloned_node_spec, NodeOperation::SetDrained())
+            .await?;
+
+        self.complete_update(registry, Ok(self.as_ref().clone()), spec_clone)
+            .await
+    }
+}
+
+/// Node drain Operations.
+impl OperationGuardArc<NodeSpec> {
+    /// Drain the set of draining volumes to the stored set.
+    pub(crate) async fn add_draining_volumes(
+        &mut self,
+        registry: &Registry,
+        volumes: DrainingVolumes,
+    ) -> Result<NodeSpec, SvcError> {
+        let cloned_node_spec = self.lock().clone();
+        let spec_clone = self
+            .start_update(
+                registry,
+                &cloned_node_spec,
+                NodeOperation::AddDrainingVolumes(volumes),
+            )
+            .await?;
+
+        self.complete_update(registry, Ok(self.as_ref().clone()), spec_clone)
+            .await
+    }
+
+    /// Remove the set of draining volumes from the stored set.
+    pub(crate) async fn remove_draining_volumes(
+        &mut self,
+        registry: &Registry,
+        volumes: DrainingVolumes,
+    ) -> Result<NodeSpec, SvcError> {
+        let cloned_node_spec = self.lock().clone();
+        let spec_clone = self
+            .start_update(
+                registry,
+                &cloned_node_spec,
+                NodeOperation::RemoveDrainingVolumes(volumes),
+            )
+            .await?;
+
+        self.complete_update(registry, Ok(self.as_ref().clone()), spec_clone)
+            .await
+    }
+
+    /// Remove all draining volumes from the stored set.
+    pub(crate) async fn remove_all_draining_volumes(
+        &mut self,
+        registry: &Registry,
+    ) -> Result<NodeSpec, SvcError> {
+        let cloned_node_spec = self.lock().clone();
+        let spec_clone = self
+            .start_update(
+                registry,
+                &cloned_node_spec,
+                NodeOperation::RemoveAllDrainingVolumes(),
+            )
+            .await?;
+
+        self.complete_update(registry, Ok(self.as_ref().clone()), spec_clone)
+            .await
+    }
+}

--- a/control-plane/agents/src/bin/core/node/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/node/operations_helper.rs
@@ -1,0 +1,31 @@
+use stor_port::types::v0::{store::node::NodeSpec, transport::VolumeId};
+
+use crate::controller::resources::OperationGuardArc;
+
+use std::{collections::HashSet, time::SystemTime};
+
+impl OperationGuardArc<NodeSpec> {
+    /// Get the draining timestamp on this node.
+    pub(crate) async fn node_draining_timestamp(&self) -> Option<SystemTime> {
+        let locked_node = self.lock();
+        locked_node.draining_timestamp()
+    }
+
+    /// Get the number of draining volumes on this node.
+    pub(crate) async fn node_draining_volume_count(&self) -> usize {
+        let locked_node = self.lock();
+        locked_node.draining_volume_count()
+    }
+
+    /// Get the draining volumes on this node.
+    pub(crate) async fn node_draining_volumes(&self) -> HashSet<VolumeId> {
+        let locked_node = self.lock();
+        locked_node.draining_volumes()
+    }
+
+    /// Set the draining timestamp on this node.
+    pub(crate) async fn set_draining_timestamp_if_none(&self) {
+        let mut locked_node = self.lock();
+        locked_node.set_draining_timestamp_if_none();
+    }
+}

--- a/control-plane/stor-port/src/types/v0/store/mod.rs
+++ b/control-plane/stor-port/src/types/v0/store/mod.rs
@@ -84,17 +84,24 @@ pub trait SpecTransaction<Operation> {
 /// Sequence operations for a resource without locking it
 /// Allows for multiple reconciliation operation steps to be executed in sequence whilst
 /// blocking access from front-end operations (rest)
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct OperationSequence {
-    uuid: String,
     state: OperationSequenceState,
     log_error: bool,
 }
 impl OperationSequence {
     /// Create new `Self` with a uuid for observability
-    pub fn new(uuid: impl Into<String>) -> Self {
+    pub fn new() -> Self {
         Self {
-            uuid: uuid.into(),
+            state: Default::default(),
+            log_error: true,
+        }
+    }
+}
+
+impl Default for OperationSequence {
+    fn default() -> Self {
+        Self {
             state: Default::default(),
             log_error: true,
         }

--- a/control-plane/stor-port/src/types/v0/store/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus.rs
@@ -330,7 +330,7 @@ impl From<&CreateNexus> for NexusSpec {
             share: Protocol::None,
             managed: request.managed,
             owner: request.owner.clone(),
-            sequencer: OperationSequence::new(request.uuid.clone()),
+            sequencer: OperationSequence::new(),
             operation: None,
             nvmf_config: request.config.clone(),
             status_info: NexusStatusInfo::new(false),

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -182,17 +182,18 @@ impl NodeSpec {
         node_nqn: Option<HostNqn>,
     ) -> Self {
         Self {
-            id: id.clone(),
+            id,
             endpoint,
             labels,
             cordon_drain_state,
             node_nqn,
             draining_volumes: HashSet::new(),
             draining_timestamp: None,
-            sequencer: OperationSequence::new(id),
+            sequencer: OperationSequence::new(),
             operation: None,
         }
     }
+
     /// Node Nvme HOSTNQN.
     pub fn node_nqn(&self) -> &Option<HostNqn> {
         &self.node_nqn

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -2,7 +2,10 @@
 use crate::{
     types::v0::{
         openapi::models,
-        store::definitions::{ObjectKey, StorableObject, StorableObjectType},
+        store::{
+            definitions::{ObjectKey, StorableObject, StorableObjectType},
+            AsOperationSequencer, OperationSequence, SpecTransaction,
+        },
         transport::{self, HostNqn, NodeId, VolumeId},
     },
     IntoOption,
@@ -161,6 +164,12 @@ pub struct NodeSpec {
     draining_volumes: HashSet<VolumeId>,
     #[serde(skip)] // Do not store.
     draining_timestamp: Option<SystemTime>,
+    /// The operation sequence resource is in.
+    #[serde(skip)]
+    sequencer: OperationSequence,
+    /// Record of the operation in progress.
+    #[serde(default)] // Ensure backwards compatibility.
+    pub operation: Option<NodeOperationState>,
 }
 
 impl NodeSpec {
@@ -173,13 +182,15 @@ impl NodeSpec {
         node_nqn: Option<HostNqn>,
     ) -> Self {
         Self {
-            id,
+            id: id.clone(),
             endpoint,
             labels,
             cordon_drain_state,
             node_nqn,
             draining_volumes: HashSet::new(),
             draining_timestamp: None,
+            sequencer: OperationSequence::new(id),
+            operation: None,
         }
     }
     /// Node Nvme HOSTNQN.
@@ -414,6 +425,16 @@ impl From<NodeSpec> for models::NodeSpec {
     }
 }
 
+impl AsOperationSequencer for NodeSpec {
+    fn as_ref(&self) -> &OperationSequence {
+        &self.sequencer
+    }
+
+    fn as_mut(&mut self) -> &mut OperationSequence {
+        &mut self.sequencer
+    }
+}
+
 impl From<CordonDrainState> for models::CordonDrainState {
     fn from(node_ds: CordonDrainState) -> Self {
         match node_ds {
@@ -471,5 +492,90 @@ impl StorableObject for NodeSpec {
 
     fn key(&self) -> Self::Key {
         NodeSpecKey(self.id.clone())
+    }
+}
+
+/// Parameter for changing the set of draining volumes.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct DrainingVolumes {
+    volumes: HashSet<VolumeId>,
+}
+impl DrainingVolumes {
+    /// Create a new DrainingVolumes object.
+    pub fn new(volumes: HashSet<VolumeId>) -> Self {
+        Self { volumes }
+    }
+}
+
+/// Available Node Operations.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum NodeOperation {
+    Cordon(String),
+    Uncordon(String),
+    Drain(String),
+    AddDrainingVolumes(DrainingVolumes),
+    RemoveDrainingVolumes(DrainingVolumes),
+    RemoveAllDrainingVolumes(),
+    SetDrained(),
+}
+
+/// Operation State for a Node spec resource.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct NodeOperationState {
+    /// Record of the operation
+    pub operation: NodeOperation,
+    /// Result of the operation
+    pub result: Option<bool>,
+}
+
+impl SpecTransaction<NodeOperation> for NodeSpec {
+    fn pending_op(&self) -> bool {
+        self.operation.is_some()
+    }
+
+    fn commit_op(&mut self) {
+        if let Some(op) = self.operation.clone() {
+            match op.operation {
+                NodeOperation::Cordon(label) => {
+                    self.cordon(label);
+                }
+                NodeOperation::Drain(label) => {
+                    self.set_drain(label);
+                }
+                NodeOperation::Uncordon(label) => {
+                    self.uncordon(label);
+                }
+                NodeOperation::AddDrainingVolumes(volumes) => {
+                    self.add_draining_volumes(volumes.volumes);
+                }
+                NodeOperation::RemoveDrainingVolumes(volumes) => {
+                    self.remove_draining_volumes(volumes.volumes);
+                }
+                NodeOperation::RemoveAllDrainingVolumes() => {
+                    self.remove_all_draining_volumes();
+                }
+                NodeOperation::SetDrained() => {
+                    self.set_drained();
+                }
+            }
+        }
+        self.clear_op();
+    }
+
+    fn clear_op(&mut self) {
+        self.operation = None;
+    }
+
+    fn start_op(&mut self, operation: NodeOperation) {
+        self.operation = Some(NodeOperationState {
+            operation,
+            result: None,
+        })
+    }
+
+    fn set_op_result(&mut self, result: bool) {
+        if let Some(op) = &mut self.operation {
+            op.result = Some(result);
+        }
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -51,7 +51,7 @@ impl From<&CreatePool> for PoolSpec {
             disks: request.disks.clone(),
             status: PoolSpecStatus::Creating,
             labels: request.labels.clone(),
-            sequencer: OperationSequence::new(request.id.clone()),
+            sequencer: OperationSequence::new(),
             operation: None,
         }
     }

--- a/control-plane/stor-port/src/types/v0/store/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/replica.rs
@@ -369,7 +369,7 @@ impl From<&CreateReplica> for ReplicaSpec {
             status: ReplicaSpecStatus::Creating,
             managed: request.managed,
             owners: request.owners.clone(),
-            sequencer: OperationSequence::new(request.uuid.clone()),
+            sequencer: OperationSequence::new(),
             operation: None,
             allowed_hosts: request.allowed_hosts.clone(),
         }

--- a/control-plane/stor-port/src/types/v0/store/snapshots/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/replica.rs
@@ -31,12 +31,7 @@ impl ReplicaSnapshot {
     ) -> Self {
         Self {
             status: ReplicaSnapshotSpecStatus::Creating,
-            metadata: ReplicaSnapshotMeta::new(
-                spec.uuid(),
-                vol_params.uuid(),
-                vol_params.txn_id(),
-                size,
-            ),
+            metadata: ReplicaSnapshotMeta::new(vol_params.uuid(), vol_params.txn_id(), size),
             spec,
         }
     }
@@ -74,9 +69,9 @@ pub struct ReplicaSnapshotMeta {
 }
 impl ReplicaSnapshotMeta {
     /// Return a new `Self` from the given parameters.
-    pub fn new(uuid: &SnapshotId, parent: &SnapshotId, txn_id: &SnapshotTxId, size: u64) -> Self {
+    pub fn new(parent: &SnapshotId, txn_id: &SnapshotTxId, size: u64) -> Self {
         Self {
-            sequencer: OperationSequence::new(uuid.to_string()),
+            sequencer: OperationSequence::new(),
             operation: None,
             creation_timestamp: None,
             size,

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -578,7 +578,7 @@ impl From<&CreateVolume> for VolumeSpec {
             status: VolumeSpecStatus::Creating,
             policy: request.policy.clone(),
             topology: request.topology.clone(),
-            sequencer: OperationSequence::new(request.uuid.clone()),
+            sequencer: OperationSequence::new(),
             last_nexus_id: None,
             operation: None,
             thin: request.thin,
@@ -659,9 +659,9 @@ impl AffinityGroupSpec {
     /// Create a new AffinityGroupSpec.
     pub fn new(id: AffinityGroupId, volumes: Vec<VolumeId>) -> Self {
         Self {
-            id: id.clone(),
+            id,
             volumes,
-            sequencer: OperationSequence::new(id),
+            sequencer: OperationSequence::new(),
         }
     }
     /// Name of the Affinity Group.


### PR DESCRIPTION
Add operation guard functionality to protect against concurrent modifications to the node spec.
TODO support ResourceLifecycle for nodes.