### PR TITLE
feat(snapshot/create): add core agent create volume snapshot logic

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -403,8 +403,8 @@ impl AgentToIoEngine for CreateNexusSnapReplDescr {
     fn to_rpc(&self) -> Self::IoEngineMessage {
         Self::IoEngineMessage {
             replica_uuid: self.replica.to_string(),
-            snapshot_uuid: self.snap_uuid.as_ref().map(|u| u.to_string()),
-            skip: self.skip,
+            snapshot_uuid: Some(self.snap_uuid.to_string()),
+            skip: false,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -346,8 +346,8 @@ impl ChildItemSorters {
         a: &ChildItem,
         b: &ChildItem,
     ) -> std::cmp::Ordering {
-        let a_is_local = &a.state().node == request.target_node();
-        let b_is_local = &b.state().node == request.target_node();
+        let a_is_local = Some(&a.state().node) == request.target_node();
+        let b_is_local = Some(&b.state().node) == request.target_node();
         match (a_is_local, b_is_local) {
             (true, false) => std::cmp::Ordering::Less,
             (false, true) => std::cmp::Ordering::Greater,

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -169,7 +169,7 @@ impl OperationGuardArc<VolumeSpec> {
         state: VolumeState,
         spec_clone: VolumeSpec,
     ) -> Result<Volume, SvcError> {
-        // Create a ag guard to prevent candidate collision.
+        // Create an ag guard to prevent candidate collision.
         let _ag_guard = match registry.specs().get_or_create_affinity_group(&spec_clone) {
             Some(ag) => Some(ag.operation_guard_wait().await?),
             _ => None,
@@ -227,7 +227,7 @@ impl OperationGuardArc<VolumeSpec> {
                 .await?;
 
             // todo: we could ignore it here, since we've already removed it from the nexus
-            // now remove the replica from the pool
+            //  now remove the replica from the pool
             let result = self.destroy_replica(registry, remove.spec()).await;
 
             self.complete_update(registry, result, spec_clone).await?;

--- a/control-plane/stor-port/src/types/v0/store/snapshots/mod.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/mod.rs
@@ -13,10 +13,10 @@ pub struct SnapshotSpec<SourceId: Clone> {
 
 impl<SourceId: Clone> SnapshotSpec<SourceId> {
     /// Create a new `Self` from the given parameters.
-    pub fn new(source_id: &SourceId, uuid: &SnapshotId) -> Self {
+    pub fn new(source_id: &SourceId, uuid: SnapshotId) -> Self {
         Self {
             source_id: source_id.clone(),
-            uuid: uuid.clone(),
+            uuid,
         }
     }
     /// Get the snapshot source id.

--- a/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
@@ -1,12 +1,12 @@
 use super::{replica::ReplicaSnapshot, SnapshotId, SnapshotSpec};
 use crate::types::v0::{
     store::{AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction},
-    transport::VolumeId,
+    transport::{GenericSnapshotParameters, SnapshotParameters, SnapshotTxId, VolumeId},
 };
 use chrono::{DateTime, Utc};
 use pstor::{ApiVersion, ObjectKey, StorableObject, StorableObjectType};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 /// User specification of a volume snapshot.
 /// todo: is e-derivations a better way of doing this?
@@ -49,6 +49,31 @@ impl VolumeSnapshot {
     pub fn metadata(&self) -> &VolumeSnapshotMeta {
         &self.metadata
     }
+    pub fn prepare(&self) -> Option<SnapshotParameters<VolumeId>> {
+        if !self.status.creating() {
+            // we're done..
+            return None;
+        }
+
+        let params = SnapshotParameters::new(
+            self.spec().source_id(),
+            GenericSnapshotParameters::new(
+                self.spec().uuid(),
+                "my-entity",
+                self.metadata.prepare(),
+                "my-name",
+            ),
+        );
+        Some(params)
+    }
+}
+impl From<&VolumeSnapshotUserSpec> for VolumeSnapshot {
+    fn from(value: &VolumeSnapshotUserSpec) -> Self {
+        Self::new(VolumeSnapshotUserSpec::new(
+            value.source_id(),
+            value.uuid().clone(),
+        ))
+    }
 }
 
 /// Control-plane snapshot metadata, used for book-keeping.
@@ -64,7 +89,7 @@ pub struct VolumeSnapshotMeta {
     /// Size of the snapshot (typically follows source size).
     size: u64,
     /// Transaction Id that defines this snapshot when it is created.
-    txn_id: String,
+    txn_id: SnapshotTxId,
     /// Replicas which "reference" to this snapshot as its parent, indexed by the transaction
     /// id when they were attempted.
     /// The "actual" snapshots can be accessed by the key `txn_id`.
@@ -75,6 +100,18 @@ impl VolumeSnapshotMeta {
     /// Get the snapshot operation state.
     pub fn operation(&self) -> &Option<VolumeSnapshotOperationState> {
         &self.operation
+    }
+
+    pub fn prepare(&self) -> SnapshotTxId {
+        // If this is a create retry, then we must allocate a new transaction id, and prepare
+        // replicas
+        if !self.txn_id.is_empty() {
+            let _ = 1;
+            SnapshotTxId::new()
+        } else {
+            // Otherwise, then it's our first time, right?
+            SnapshotTxId::new()
+        }
     }
 }
 
@@ -89,37 +126,53 @@ pub struct VolumeSnapshotOperationState {
 
 /// Available VolumeSnapshot Operations.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum VolumeSnapshotOperation {
     Create(VolumeSnapshotCreateInfo),
     Destroy,
 }
 
+/// Completion info for volume snapshot create operation.
+pub type VolumeSnapshotCompleter = Arc<std::sync::Mutex<Option<VolumeSnapshotCreateResult>>>;
+
 /// Snapshot create information, used to set the initial data as part of the write log and also
 /// the completion channel that is used to get the resulting data.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct VolumeSnapshotCreateInfo {
-    txn_id: String,
-    replicas: Vec<ReplicaSnapshot>,
+    txn_id: SnapshotTxId,
+    replica: ReplicaSnapshot,
     #[serde(skip, default)]
-    complete: Option<std::sync::Arc<std::sync::Mutex<VolumeSnapshotCreateResult>>>,
+    complete: VolumeSnapshotCompleter,
 }
 impl VolumeSnapshotCreateInfo {
     /// Get a new `Self` from the given parameters.
     pub fn new(
-        txn_id: impl Into<String>,
-        replicas: Vec<ReplicaSnapshot>,
-        complete: std::sync::Arc<std::sync::Mutex<VolumeSnapshotCreateResult>>,
+        txn_id: impl Into<SnapshotTxId>,
+        replica: ReplicaSnapshot,
+        complete: &VolumeSnapshotCompleter,
     ) -> Self {
         Self {
             txn_id: txn_id.into(),
-            replicas,
-            complete: Some(complete),
+            replica,
+            complete: complete.clone(),
         }
     }
 }
 impl PartialEq for VolumeSnapshotCreateInfo {
-    fn eq(&self, _other: &Self) -> bool {
-        false
+    fn eq(&self, other: &Self) -> bool {
+        self.txn_id
+            .eq(&other.txn_id)
+            .then(|| self.replica.eq(&other.replica))
+            .unwrap_or_default()
+    }
+}
+
+impl PartialEq<VolumeSnapshotCreateInfo> for VolumeSnapshot {
+    fn eq(&self, other: &VolumeSnapshotCreateInfo) -> bool {
+        // This is a bit nuanced, actually we simply expect that the txn_id is not the
+        // same as we don't allow reusing the txn_id. Instead, if we have the same txn_id then
+        // we should check if all is created and ready!
+        !self.metadata.txn_id.eq(&other.txn_id)
     }
 }
 
@@ -127,7 +180,16 @@ impl PartialEq for VolumeSnapshotCreateInfo {
 #[derive(Debug, Clone, PartialEq)]
 pub struct VolumeSnapshotCreateResult {
     /// The resulting replicas including their success status.
-    pub replicas: Vec<ReplicaSnapshot>,
+    /// todo: add support for multiple replica snapshots.
+    pub replica: ReplicaSnapshot,
+    /// The actual timestamp returned by the dataplane.
+    pub timestamp: DateTime<Utc>,
+}
+impl VolumeSnapshotCreateResult {
+    /// Create a new `Self` based on the given parameters.
+    pub fn new(replica: ReplicaSnapshot, timestamp: DateTime<Utc>) -> Self {
+        Self { replica, timestamp }
+    }
 }
 
 impl AsOperationSequencer for VolumeSnapshot {
@@ -153,12 +215,12 @@ impl SpecTransaction<VolumeSnapshotOperation> for VolumeSnapshot {
                 self.status = SpecStatus::Deleted;
             }
             VolumeSnapshotOperation::Create(info) => {
-                if let Some(result) = info.complete {
-                    let result = result.lock().unwrap();
+                if let Some(result) = info.complete.lock().unwrap().take() {
+                    self.metadata.size = result.replica.meta().size();
                     // replace-in-place the logged replica specs.
                     self.metadata
                         .transactions
-                        .insert(info.txn_id, result.replicas.clone());
+                        .insert(info.txn_id, vec![result.replica]);
                     self.status = SpecStatus::Created(());
                 }
                 // else means we've restarted with the op in progress... and the snapshot was not

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -79,8 +79,8 @@ impl From<Nexus> for models::Nexus {
 
 rpc_impl_string_uuid!(NexusId, "UUID of a nexus");
 
-/// A gRPC request type for creating snapshot of a nexus, which essentially
-/// means a snapshot of all(or selected) replicas associated with that nexus.
+/// A request for creating snapshot of a nexus, which essentially means a snapshot
+/// of all(or selected) replicas associated with that nexus.
 pub struct CreateNexusSnapshot {
     params: SnapshotParameters<NexusId>,
     replica_desc: Vec<CreateNexusSnapReplDescr>,
@@ -118,10 +118,17 @@ impl CreateNexusSnapshot {
 pub struct CreateNexusSnapReplDescr {
     /// UUID of the replica involved in snapshot operation.
     pub replica: ReplicaId,
-    /// Optional UUID input for the snapshot to be created.
-    pub snap_uuid: Option<SnapshotId>,
-    /// Whether this replica is to be skipped from current snapshot operation.
-    pub skip: bool,
+    /// UUID input for the snapshot to be created.
+    pub snap_uuid: SnapshotId,
+}
+impl CreateNexusSnapReplDescr {
+    /// Return a new `Self` from the given parameters.
+    pub fn new(replica: &ReplicaId, snap_uuid: SnapshotId) -> Self {
+        Self {
+            replica: replica.clone(),
+            snap_uuid,
+        }
+    }
 }
 
 /// A response for the nexus snapshot request.

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use crate::{types::v0::store::nexus::ReplicaUri, IntoOption};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt::Debug, ops::Deref, time::SystemTime};
 use strum_macros::{Display, EnumString};
@@ -101,8 +102,8 @@ pub struct CreateReplicaSnapshotResp {
     pub snap_describe: ReplicaSnapshotDescr,
 }
 
-#[allow(unused)]
 /// A single snapshot descriptor.
+#[allow(unused)]
 pub struct ReplicaSnapshotDescr {
     /// UUID of the snapshot.
     snap_uuid: SnapshotId,
@@ -122,6 +123,12 @@ pub struct ReplicaSnapshotDescr {
     entity_id: String,
     /// Unique transaction id for snapshot.
     txn_id: String,
+}
+impl ReplicaSnapshotDescr {
+    /// Returns the snapshot timestamp.
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.snap_time.into()
+    }
 }
 
 /// Name of a Replica.

--- a/control-plane/stor-port/src/types/v0/transport/snapshot.rs
+++ b/control-plane/stor-port/src/types/v0/transport/snapshot.rs
@@ -10,11 +10,17 @@ pub type SnapshotTxId = String;
 /// The name of a snapshot.
 pub type SnapshotName = String;
 
-/// Common set of snapshot parameters used for snapshot creation.
+/// Common set of snapshot parameters used for snapshot creation against `TargetId`.
 pub struct SnapshotParameters<TargetId> {
     /// Name of the target which we'll aim create snapshot at, which can either be
     /// a nexus or a replica at the moment.
     target: TargetId,
+    params: GenericSnapshotParameters,
+}
+
+/// Common set of snapshot parameters used for snapshot creation.
+#[derive(Clone)]
+pub struct GenericSnapshotParameters {
     /// Unique identification of the snapshot.
     uuid: SnapshotId,
     /// Entity id of the entity involved.
@@ -27,19 +33,10 @@ pub struct SnapshotParameters<TargetId> {
 
 impl<TargetId> SnapshotParameters<TargetId> {
     /// Create a new set of snapshot parameters.
-    pub fn new(
-        target: impl Into<TargetId>,
-        uuid: impl Into<SnapshotId>,
-        entity_id: impl Into<SnapshotEntId>,
-        txn_id: impl Into<SnapshotTxId>,
-        name: impl Into<SnapshotName>,
-    ) -> Self {
+    pub fn new(target: impl Into<TargetId>, params: GenericSnapshotParameters) -> Self {
         Self {
             target: target.into(),
-            uuid: uuid.into(),
-            entity_id: entity_id.into(),
-            txn_id: txn_id.into(),
-            name: name.into(),
+            params,
         }
     }
 
@@ -47,6 +44,44 @@ impl<TargetId> SnapshotParameters<TargetId> {
     pub fn target(&self) -> &TargetId {
         &self.target
     }
+    /// Get a reference to the generic snapshot parameters.
+    pub fn params(&self) -> &GenericSnapshotParameters {
+        &self.params
+    }
+    /// Get a reference to the snapshot uuid.
+    pub fn uuid(&self) -> &SnapshotId {
+        &self.params.uuid
+    }
+    /// Get a reference to the entity id.
+    pub fn entity(&self) -> &SnapshotEntId {
+        &self.params.entity_id
+    }
+    /// Get a reference to the transaction id.
+    pub fn txn_id(&self) -> &SnapshotTxId {
+        &self.params.txn_id
+    }
+    /// Get a reference to the snapshot name.
+    pub fn name(&self) -> &SnapshotName {
+        &self.params.name
+    }
+}
+
+impl GenericSnapshotParameters {
+    /// Create a new set of snapshot parameters.
+    pub fn new(
+        uuid: impl Into<SnapshotId>,
+        entity_id: impl Into<SnapshotEntId>,
+        txn_id: impl Into<SnapshotTxId>,
+        name: impl Into<SnapshotName>,
+    ) -> Self {
+        Self {
+            uuid: uuid.into(),
+            entity_id: entity_id.into(),
+            txn_id: txn_id.into(),
+            name: name.into(),
+        }
+    }
+
     /// Get a reference to the snapshot uuid.
     pub fn uuid(&self) -> &SnapshotId {
         &self.uuid


### PR DESCRIPTION
Implements the core logic for creating a volume snapshot. A snapshot resource is created for creation or retry and a new txn id is allocated for this operation.
todo: should we start destroying previous txn id here?

If the volume is published then creation goes via the nexus rather than the replica, but in either case we prepare a ReplicaSnapshot so we can keep track of the operation. This allows us, for example, to clean up later if we fail/crash/etc.

todo: on retries, check if the txn_id has already been created! (in case the ctrl-plane crashes).