### PR TITLE
fix(partial-rebuild/log): don't wait for replica if we can't partial rebuild

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -237,6 +237,7 @@ impl IoEngineToAgent for v0::Child {
                 .map(|f| From::from(ExternalType(f)))
                 .unwrap_or(ChildStateReason::Unknown),
             faulted_at: None,
+            has_io_log: None,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -272,6 +272,7 @@ impl IoEngineToAgent for v1::nexus::Child {
                 .fault_timestamp
                 .clone()
                 .and_then(|t| std::time::SystemTime::try_from(t).ok()),
+            has_io_log: Some(self.has_io_log),
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
@@ -98,7 +98,7 @@ async fn hot_spare_nexus_reconcile(
     squash_results(results)
 }
 
-#[tracing::instrument(skip(context, nexus), fields(nexus.uuid = %nexus.uuid(), volume.uuid = tracing::field::Empty, request.reconcile = true))]
+#[tracing::instrument(skip(context, nexus), fields(nexus.uuid = %nexus.uuid(), nexus.node = %nexus.as_ref().node, volume.uuid = tracing::field::Empty, request.reconcile = true))]
 async fn generic_nexus_reconciler(
     nexus: &mut OperationGuardArc<NexusSpec>,
     context: &PollContext,

--- a/control-plane/grpc/src/operations/nexus/traits.rs
+++ b/control-plane/grpc/src/operations/nexus/traits.rs
@@ -279,6 +279,7 @@ impl TryFrom<nexus::Child> for Child {
                 .map(ChildStateReason::from)
                 .unwrap_or(ChildStateReason::Unknown),
             faulted_at: None,
+            has_io_log: None,
         };
         Ok(child)
     }

--- a/control-plane/stor-port/src/types/v0/store/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus.rs
@@ -370,6 +370,7 @@ impl From<&NexusSpec> for transport::Nexus {
                     rebuild_progress: None,
                     state_reason: ChildStateReason::Unknown,
                     faulted_at: None,
+                    has_io_log: None,
                 })
                 .collect(),
             device_uri: "".to_string(),

--- a/control-plane/stor-port/src/types/v0/transport/child.rs
+++ b/control-plane/stor-port/src/types/v0/transport/child.rs
@@ -18,6 +18,9 @@ pub struct Child {
     pub state_reason: ChildStateReason,
     /// Last faulted timestamp of this child.
     pub faulted_at: Option<SystemTime>,
+    /// Indicates whether the nexus has an IO log for this child, which can be used for
+    /// partially rebuilding the child.
+    pub has_io_log: Option<bool>,
 }
 impl Child {
     /// If if the state reason is lack of space.

--- a/tests/bdd/features/rebuild/log-based-rebuild.feature
+++ b/tests/bdd/features/rebuild/log-based-rebuild.feature
@@ -15,10 +15,10 @@ Feature: Partial Rebuild
     But the replica is not online again within the timed-wait period
     Then a full rebuild starts after some time
 
-  Scenario: Node goes permanently down while log based rebuild running
+  Scenario: Node goes down while log based rebuild running
     Given a volume with three replicas, filled with user data
     When a child becomes faulted
     And the replica is online again within the timed-wait period
     Then log-based rebuild starts after some time
-    But the node hosting rebuilding replica crashes permanently
-    Then a full rebuild starts after some time
+    But the node hosting rebuilding replica crashes
+    Then a full rebuild starts before the timed-wait period

--- a/tests/bdd/features/rebuild/test_log_based_rebuild.py
+++ b/tests/bdd/features/rebuild/test_log_based_rebuild.py
@@ -47,7 +47,6 @@ RECONCILE_PERIOD_SECS = "1s"
 FAULTED_CHILD_WAIT_SECS = 10
 FIO_RUN = 15
 SLEEP_BEFORE_START = 5
-faulted_child_uri = None
 
 
 @pytest.fixture(autouse=True)
@@ -118,13 +117,12 @@ def test_faulted_child_is_online_again_within_timedwait_period():
     """Faulted child is online again within timed-wait period."""
 
 
-@pytest.mark.skip(reason="blocked due to GTM-684")
 @scenario(
     "log-based-rebuild.feature",
-    "Node goes permanently down while log based rebuild running",
+    "Node goes down while log based rebuild running",
 )
-def test_node_goes_permanently_down_while_log_based_rebuild_running():
-    """Node goes permanently down while log based rebuild running."""
+def test_node_goes_down_while_log_based_rebuild_running():
+    """Node goes down while log based rebuild running."""
 
 
 @given("io-engine is installed and running")
@@ -169,13 +167,19 @@ def a_child_becomes_faulted():
     # Check the replica becomes unhealthy by waiting for the volume to become degraded.
     Docker.stop_container(NODE_2_NAME)
     wait_for_degraded_volume()
+    wait_child_faulted()
+
+
+@retry(wait_fixed=100, stop_max_attempt_number=20)
+def wait_child_faulted():
     vol = ApiClient.volumes_api().get_volume(VOLUME_UUID)
     target = vol.state.target
     childlist = target["children"]
+    pytest.faulted_child_uri = None
     for child in childlist:
-        if child["state"] == ChildState("Faulted"):
-            faulted_child_uri = child["uri"]
-            assert faulted_child_uri is not None
+        if ChildState(child["state"]) == ChildState("Faulted"):
+            pytest.faulted_child_uri = child["uri"]
+    assert pytest.faulted_child_uri is not None, "Failed to find Faulted child!"
 
 
 @when("a non-local child becomes faulted")
@@ -220,11 +224,10 @@ def a_full_rebuild_starts_after_some_time():
     target = vol.state.target
     childlist = target["children"]
     assert len(childlist) == NUM_VOLUME_REPLICAS
-    check_child_removal()
     for child in childlist:
-        if child["state"] == ChildState("Degraded"):
-            assert child["uri"] != faulted_child_uri
-            assert child["rebuild_progress"] != 0
+        if ChildState(child["state"]) == ChildState("Degraded"):
+            assert child["uri"] != pytest.faulted_child_uri
+            assert child["rebuildProgress"] != 0
 
 
 @then("log-based rebuild starts after some time")
@@ -237,17 +240,38 @@ def log_based_rebuild_starts_after_some_time():
     target = vol.state.target
     childlist = target["children"]
     assert len(childlist) == NUM_VOLUME_REPLICAS
+    assert pytest.faulted_child_uri is not None
     for child in childlist:
-        if child["uri"] == faulted_child_uri:
-            assert child["state"] == ChildState("Degraded")
-            assert child["state_reason"] == ChildStateReason("OutOfSync")
+        if child["uri"] == pytest.faulted_child_uri:
+            assert ChildState(child["state"]) == ChildState("Degraded")
 
 
-@then("the node hosting rebuilding replica crashes permanently")
-def the_node_hosting_rebuilding_replica_crashes_permanently():
-    """the node hosting rebuilding replica crashes permanently."""
+@then("a full rebuild starts before the timed-wait period")
+def a_full_rebuild_starts_before_the_timedwait_period():
+    """a full rebuild starts before the timed-wait period."""
+    rebuild_ongoing_before_timed_wait()
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=10)
+def rebuild_ongoing_before_timed_wait():
+    vol = ApiClient.volumes_api().get_volume(VOLUME_UUID)
+    target = vol.state.target
+    childlist = target["children"]
+    assert len(childlist) == NUM_VOLUME_REPLICAS
+    degraded = list(
+        filter(
+            lambda child: str(child["state"]) == "Degraded",
+            childlist,
+        )
+    )
+    print(degraded)
+    assert len(degraded) is 1, "Should find one degraded child"
+
+
+@then("the node hosting rebuilding replica crashes")
+def the_node_hosting_rebuilding_replica_crashes():
+    """the node hosting rebuilding replica crashes."""
     Docker.kill_container(NODE_2_NAME)
-    check_child_removal()
 
 
 @retry(wait_fixed=500, stop_max_attempt_number=2)
@@ -256,12 +280,12 @@ def check_child_removal():
     child_list = vol.state.target["children"]
     child_removed = True
     for child in child_list:
-        if faulted_child_uri == child["uri"]:
+        if pytest.faulted_child_uri == child["uri"]:
             child_removed = False
             break
     assert (
         child_removed
-    ), f"child list is {child_list}, faulted child : {faulted_child_uri}"
+    ), f"child list is {child_list}, faulted child : {pytest.faulted_child_uri}"
 
 
 @retry(wait_fixed=200, stop_max_attempt_number=20)


### PR DESCRIPTION
Update rpc api to access new rebuild log flag.
If there is no IO log in the child, this means we can't partial rebuild, so there's no point waiting for the replica to return, simply fault and full rebuild.