### PR TITLE
fix(nexus_cleanup): cleanup old nexuses post volume destroy

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/garbage_collector.rs
@@ -33,10 +33,7 @@ impl TaskPoller for GarbageCollector {
                 Ok(guard) => guard,
                 Err(_) => continue,
             };
-            // if the nexus is in shutdown state don't let the reconcilers act on it.
-            if !nexus.lock().is_shutdown() {
-                let _ = nexus.garbage_collect(context).await;
-            }
+            let _ = nexus.garbage_collect(context).await;
         }
         PollResult::Ok(PollerState::Idle)
     }

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -149,7 +149,9 @@ impl ResourceLifecycle for OperationGuardArc<VolumeSpec> {
             let nexus = nexus_arc.lock().deref().clone();
             match nexus_arc.operation_guard_wait().await {
                 Ok(mut guard) => {
-                    let destroy = DestroyNexus::from(&nexus).with_disown(&request.uuid);
+                    let destroy = DestroyNexus::from(&nexus)
+                        .with_disown(&request.uuid)
+                        .with_lazy(true);
                     if let Err(error) = guard.destroy(registry, &destroy).await {
                         nexus.warn_span(|| {
                             tracing::warn!(


### PR DESCRIPTION
With this PR we set lazy as true when creating DestroyNexus. This sets NexusStatus as Deleting which allows reconciler to handle deletion if initial attempt fails for some reason.