### PR TITLE
Update Terraform

### DIFF
--- a/terraform/cluster/main.tf
+++ b/terraform/cluster/main.tf
@@ -8,6 +8,8 @@ module "k8s" {
   overlay_cidr       = var.overlay_cidr
   nr_hugepages       = var.nr_hugepages
   kubernetes_version = var.kubernetes_version
+  kubernetes_cni     = var.kubernetes_cni
+  kubernetes_runtime = var.kubernetes_runtime
 }
 
 module "provider" {

--- a/terraform/cluster/mod/k8s/kubeadm_config.yaml
+++ b/terraform/cluster/mod/k8s/kubeadm_config.yaml
@@ -11,6 +11,9 @@ kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: ${master_ip}
   bindPort: 6443
+nodeRegistration:
+  #criSocket: "/var/run/crio/crio.sock"
+  #criSocket: "unix:///var/run/containerd/containerd.sock"
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 apiServer:
@@ -27,6 +30,9 @@ kind: ClusterConfiguration
 networking:
   #serviceSubnet: "10.96.0.0/12"
   podSubnet: ${pod_cidr}
+imageRepository: "registry.k8s.io"
+dns:
+  imageRepository: "registry.k8s.io/coredns"
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/terraform/cluster/mod/k8s/main.tf
+++ b/terraform/cluster/mod/k8s/main.tf
@@ -13,6 +13,8 @@ variable "node_list" {}
 variable "nr_hugepages" {}
 
 variable "kubernetes_version" {}
+variable "kubernetes_runtime" {}
+variable "kubernetes_cni" {}
 
 
 resource "null_resource" "k8s" {
@@ -51,9 +53,12 @@ locals {
   install = [
     for _ in range(var.num_nodes) : templatefile("${path.module}/repo.sh", {
       kube_version = var.kubernetes_version
+      kube_runtime = var.kubernetes_runtime
     })
   ]
-  master = templatefile("${path.module}/master.sh", {})
+  master = templatefile("${path.module}/master.sh", {
+    cni_url = var.kubernetes_cni
+  })
   node = templatefile("${path.module}/node.sh", {
     master_ip    = element(var.node_list, 0)
     token        = var.k8s_cluster_token

--- a/terraform/cluster/mod/k8s/main.tf
+++ b/terraform/cluster/mod/k8s/main.tf
@@ -25,50 +25,38 @@ resource "null_resource" "k8s" {
   }
 
   provisioner "file" {
-    content     = data.template_file.master-configuration.rendered
+    content     = local.master-configuration
     destination = "/tmp/kubeadm_config.yaml"
   }
 
 
   provisioner "remote-exec" {
-    inline = [element(data.template_file.install.*.rendered, count.index)]
+    inline = [element(local.install, count.index)]
   }
 
   provisioner "remote-exec" {
     inline = [
-      count.index == 0 ? data.template_file.master.rendered : data.template_file.node.rendered
+      count.index == 0 ? local.master : local.node
     ]
   }
 }
 
-data "template_file" "master-configuration" {
-  template = file("${path.module}/kubeadm_config.yaml")
-
-  vars = {
+locals {
+  master-configuration = templatefile("${path.module}/kubeadm_config.yaml", {
     master_ip = element(var.node_list, 0)
     token     = var.k8s_cluster_token
     cert_sans = element(var.node_list, 0)
     pod_cidr  = var.overlay_cidr
-  }
-}
-
-data "template_file" "install" {
-  count    = var.num_nodes
-  template = file("${path.module}/repo.sh")
-  vars = {
-    kube_version = var.kubernetes_version
-  }
-}
-
-data "template_file" "master" {
-  template = file("${path.module}/master.sh")
-}
-
-data "template_file" "node" {
-  template = file("${path.module}/node.sh")
-  vars = {
+  })
+  install = [
+    for _ in range(var.num_nodes) : templatefile("${path.module}/repo.sh", {
+      kube_version = var.kubernetes_version
+    })
+  ]
+  master = templatefile("${path.module}/master.sh", {})
+  node = templatefile("${path.module}/node.sh", {
     master_ip    = element(var.node_list, 0)
     token        = var.k8s_cluster_token
     nr_hugepages = var.nr_hugepages
-  }
+  })
 }

--- a/terraform/cluster/mod/k8s/master.sh
+++ b/terraform/cluster/mod/k8s/master.sh
@@ -13,4 +13,4 @@ while ! nc -z localhost 6443; do
   sleep 5
 done
 
-kubectl apply -f https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter.yaml
+kubectl apply -f https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.5.4/daemonset/kubeadm-kuberouter.yaml

--- a/terraform/cluster/mod/k8s/master.sh
+++ b/terraform/cluster/mod/k8s/master.sh
@@ -13,4 +13,4 @@ while ! nc -z localhost 6443; do
   sleep 5
 done
 
-kubectl apply -f https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.5.4/daemonset/kubeadm-kuberouter.yaml
+kubectl apply -f ${cni_url}

--- a/terraform/cluster/mod/k8s/node.sh
+++ b/terraform/cluster/mod/k8s/node.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exo pipefail
+set -xeuo pipefail
 
 function addKernelModules() {
     for module in $@; do
@@ -21,7 +21,12 @@ sudo grep -qa container=lxc /proc/1/environ || (
     case $DISTRO in
         Ubuntu)
             echo "loading nvme kernel modules"
-            sudo apt -y install `apt search linux-modules-extra | fgrep \`uname -r\` | sed -e "s/,.*//"`
+            kernel_extra=$(apt-cache search linux-modules-extra | fgrep $(uname -r) | sed -e "s/,.*//" -e "s/ -.*//")
+            if [ -z "$kernel_extra" ]; then
+              echo "Can't find kernel modules!"
+            else
+              sudo apt-get -y install $kernel_extra
+            fi
             addKernelModules nvme-tcp
             ;;
         *)

--- a/terraform/cluster/mod/k8s/repo.sh
+++ b/terraform/cluster/mod/k8s/repo.sh
@@ -1,89 +1,83 @@
 #!/bin/bash
-set -xo pipefail
+set -xeuo pipefail
 
+# crio is not currently fully working, we are able to create a cluster but our pods can't seem to reach service ips...
+RUNTIME="containerd"
 DISTRO=$(cat /etc/os-release | awk '/^NAME="/ {print $1}' | awk -F\" '{print $2}')
-if [ ! "$DISTRO" == "Ubuntu" ]; then
-  echo "Script only tested on Ubuntu"
+if [ ! "$DISTRO" = "Ubuntu" ]; then
+  echo "Script only supports Ubuntu"
   exit 1
 fi
+if [ -n "${kube_version}" ]; then
+  KUBE_VERSION="=${kube_version}"
+fi
+KVM_HOST_IP=$(ip -f inet addr show ens3 | awk '/inet / {print $2}' | awk -F. '{print $1"."$2"."$3".1"}')
+echo "$KVM_HOST_IP kvmhost" | sudo tee -a /etc/hosts
 
-sudo apt-get update && sudo apt-get install -y apt-transport-https curl \
-  ca-certificates software-properties-common
-
+if [ "$RUNTIME" = "crio" ]; then
+  # Add Cri-o repo
+  OS="xUbuntu_$(lsb_release -rs)"
+  VERSION=1.26
+  sudo add-apt-repository --yes "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/ /"
+  sudo add-apt-repository --yes "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/ /"
+  curl -L https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:$VERSION/$OS/Release.key | sudo apt-key add -
+  curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/Release.key | sudo apt-key add -
+elif [ "$RUNTIME" = "containerd" ]; then
+  # Add Docker repo
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  sudo add-apt-repository --yes "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+fi
 
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
 deb https://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 
-
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-#sudo mkdir -p /etc/apt/keyrings
-#curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-sudo add-apt-repository --yes "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-
-#echo \
-#  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-#  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-if [ -n "${kube_version}" ]; then
-  KUBE_VERSION="=${kube_version}"
-fi
-
 sudo apt-get update
-sudo apt-get install -y -o Options::=--force-confdef \
-  -o Dpkg::Options::=--force-confnew kubelet$KUBE_VERSION kubeadm$KUBE_VERSION kubectl$KUBE_VERSION docker-ce \
-  containerd.io docker-ce-cli
 
+sudo apt-get install -y apt-transport-https curl ca-certificates software-properties-common
+
+# Install k8s
+sudo apt-get install -y -o Options::=--force-confdef \
+  -o Dpkg::Options::=--force-confnew kubelet$KUBE_VERSION kubeadm$KUBE_VERSION kubectl$KUBE_VERSION
 sudo apt-mark hold kubelet kubeadm kubectl
 
-sudo tee /etc/docker/daemon.json >/dev/null <<EOF
-{
-  "exec-opts": ["native.cgroupdriver=systemd"],
-  "log-driver": "json-file",
-  "log-opts": {
-    "max-size": "100m"
-  },
-  "storage-driver":  "overlay2",
-  "insecure-registries" : ["kvmhost:5000"]
-}
-EOF
-
-KVM_HOST_IP=$(ip -f inet addr show ens3 | awk '/inet / {print $2}' | awk -F. '{print $1"."$2"."$3".1"}')
-echo "$KVM_HOST_IP kvmhost" | sudo tee -a /etc/hosts
-
-sudo mkdir -p /etc/systemd/system/docker.service.d
-
-sudo systemctl daemon-reload
-sudo systemctl restart docker
-
-sudo tee /etc/modules-load.d/containerd.conf >/dev/null <<EOF
+# Configure persistent loading of modules
+sudo tee /etc/modules-load.d/k8s.conf <<EOF
 overlay
 br_netfilter
 EOF
-
+# Ensure you load modules
 sudo modprobe overlay
 sudo modprobe br_netfilter
 
-# Setup required sysctl params, these persist across reboots.
-sudo sysctl --system
-sudo mkdir -p /etc/containerd
-sudo containerd config default | sudo tee /etc/containerd/config.toml
-
-sudo sed -i 's/\[plugins."io.containerd.grpc.v1.cri".registry.mirrors\]/\[plugins."io.containerd.grpc.v1.cri".registry.mirrors\]\n        \[plugins."io.containerd.grpc.v1.cri".registry.mirrors."kvmhost:5000"\]\n          endpoint = \["http:\/\/kvmhost:5000"\]/g' /etc/containerd/config.toml
-sudo sed -i 's/\[plugins."io.containerd.grpc.v1.cri".registry.configs\]/\[plugins."io.containerd.grpc.v1.cri".registry.configs\]\n        \[plugins."io.containerd.grpc.v1.cri".registry.configs."kvmhost:5000".tls\]\n          insecure_skip_verify = true/g' /etc/containerd/config.toml
-
-# Rebooting a node does not kill the containers they are running resulting
-# in a vary long timeout before the system moves forward.
-#
-# There are various bugs upstream detailing this and it supposed to be fixed a few weeks ago (June)
-# This is *not* that fix rather a work around. The containers will not shut down "cleanly".
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-sudo tee /etc/sysctl.d/system/containerd.service.d/override.conf >/dev/null <<EOF
-[Service]
-KillMode=mixed
+# Set up required sysctl params
+sudo tee /etc/sysctl.d/kubernetes.conf<<EOF
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
 EOF
 
+# Setup required sysctl params, these persist across reboots.
+sudo sysctl --system
 
-# Restart containerd
-sudo systemctl restart containerd
+# Install CRI-O
+if [ "$RUNTIME" = "crio" ]; then
+  sudo apt install -y cri-o cri-o-runc
+elif [ "$RUNTIME" = "containerd" ]; then
+  sudo apt install -y containerd.io
+
+  # Configure containerd and start service
+  sudo mkdir -p /etc/containerd
+  containerd config default | sudo tee /etc/containerd/config.toml
+  sudo sed -i 's/            SystemdCgroup = false/            SystemdCgroup = true/' /etc/containerd/config.toml
+  sudo sed -i 's/\[plugins."io.containerd.grpc.v1.cri".registry.mirrors\]/\[plugins."io.containerd.grpc.v1.cri".registry.mirrors\]\n        \[plugins."io.containerd.grpc.v1.cri".registry.mirrors."kvmhost:5000"\]\n          endpoint = \["http:\/\/kvmhost:5000"\]/g' /etc/containerd/config.toml
+  sudo sed -i 's/\[plugins."io.containerd.grpc.v1.cri".registry.configs\]/\[plugins."io.containerd.grpc.v1.cri".registry.configs\]\n        \[plugins."io.containerd.grpc.v1.cri".registry.configs."kvmhost:5000".tls\]\n          insecure_skip_verify = true/g' /etc/containerd/config.toml
+fi
+
+# Start and enable Service
+sudo systemctl daemon-reload
+
+sudo systemctl restart $RUNTIME
+sudo systemctl enable $RUNTIME
+systemctl status $RUNTIME --no-pager

--- a/terraform/cluster/mod/k8s/repo.sh
+++ b/terraform/cluster/mod/k8s/repo.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# crio is not currently fully working, we are able to create a cluster but our pods can't seem to reach service ips...
-RUNTIME="containerd"
+RUNTIME="${kube_runtime}"
 DISTRO=$(cat /etc/os-release | awk '/^NAME="/ {print $1}' | awk -F\" '{print $2}')
 if [ ! "$DISTRO" = "Ubuntu" ]; then
   echo "Script only supports Ubuntu"

--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -111,3 +111,17 @@ variable "kubeconfig_output" {
   description = "Where to copy the kube configuration file to."
   default     = "~/.kube/config"
 }
+
+variable "kubernetes_runtime" {
+  type        = string
+  description = "Container runtime (crio or containerd)"
+  # crio is not currently fully working, we are able to create a cluster but our pods can't seem to reach service ips...
+  default     = "containerd"
+}
+
+variable "kubernetes_cni" {
+  type        = string
+  description = "URL containing the CNI plugin yaml"
+  # default = "https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.5.4/daemonset/kubeadm-kuberouter.yaml"
+  default     = "https://raw.githubusercontent.com/flannel-io/flannel/v0.21.5/Documentation/kube-flannel.yml"
+}

--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -60,8 +60,8 @@ variable "bridge_name" {
 variable "qcow2_image" {
   type        = string
   description = "Ubuntu image for VMs - only needed for libvirt provider"
-  default     = "~/terraform_images/ubuntu-20.04-server-cloudimg-amd64.img"
-  #default = "~/terraform_images/ubuntu-22.04-server-cloudimg-amd64.img"
+  #default     = "~/terraform_images/ubuntu-20.04-server-cloudimg-amd64.img"
+  default = "~/terraform_images/ubuntu-22.04-server-cloudimg-amd64.img"
 }
 
 variable "overlay_cidr" {

--- a/terraform/shell.nix
+++ b/terraform/shell.nix
@@ -12,7 +12,7 @@ mkShell {
     jq
     utillinux
     which
-    (terraform.withPlugins (p: [ p.libvirt p.null p.template p.lxd p.kubernetes p.helm p.local ]))
+    (terraform.withPlugins (p: [ p.libvirt p.null p.lxd p.kubernetes p.helm p.local ]))
     tflint
   ];
 }


### PR DESCRIPTION
    feat(terraform): add options to configure cni and runtime
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(terraform): replace deprecated template_file
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    chore: update k8s terraform
    
    Update runtimes to crio (not working) and containerd (working!), allowing them to work with
    the 22.04 ubuntu LTS.
    Explicitly sets the new registry "registry.k8s.io" allowing this provision older k8s versions but
    also bumps the default to 1.26!
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
