### PR TITLE
feat(snapshot/create): list replica snapshot on published vol snap

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
@@ -150,7 +150,6 @@ impl crate::controller::io_engine::ReplicaSnapshotApi for super::RpcClient {
             })?;
 
         let ret = response.into_inner();
-        let ret_vec = ret.snapshots.iter().map(|s| s.try_to_agent()).collect();
-        ret_vec
+        ret.snapshots.iter().map(|s| s.try_to_agent()).collect()
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -198,7 +198,7 @@ impl TryIoEngineToAgent for v1::replica::ReplicaSnapshot {
             snap_uuid: SnapshotId::try_from(self.snapshot_uuid.as_str()).map_err(|_| {
                 SvcError::InvalidUuid {
                     uuid: self.snapshot_uuid.to_owned(),
-                    kind: ResourceKind::VolumeSnapshot,
+                    kind: ResourceKind::ReplicaSnapshot,
                 }
             })?,
             snap_name: self.snapshot_name.clone(),
@@ -208,6 +208,7 @@ impl TryIoEngineToAgent for v1::replica::ReplicaSnapshot {
                 .timestamp
                 .clone()
                 .and_then(|t| std::time::SystemTime::try_from(t).ok())
+                // only valid on create, not on list! should we handle this as None ?
                 .unwrap_or(UNIX_EPOCH),
             replica_uuid: ReplicaId::try_from(self.replica_uuid.as_str()).map_err(|_| {
                 SvcError::InvalidUuid {
@@ -218,6 +219,7 @@ impl TryIoEngineToAgent for v1::replica::ReplicaSnapshot {
             replica_size: self.replica_size,
             entity_id: self.entity_id.clone(),
             txn_id: self.txn_id.clone(),
+            valid: self.valid_snapshot,
         })
     }
 }

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -100,6 +100,24 @@ pub(crate) trait GuardedOperationsHelper:
 
     /// Start a create operation and attempt to log the transaction to the store.
     /// In case of error, the log is undone and an error is returned.
+    /// Also updates it's inner value to the operation.
+    async fn start_create_update<O>(
+        &mut self,
+        registry: &Registry,
+        request: &Self::Create,
+    ) -> Result<Self::Inner, SvcError>
+    where
+        Self::Inner: PartialEq<Self::Create>,
+        Self::Inner: SpecTransaction<O>,
+        Self::Inner: StorableObject,
+    {
+        let result = self.start_create(registry, request).await?;
+        self.update();
+        Ok(result)
+    }
+
+    /// Start a create operation and attempt to log the transaction to the store.
+    /// In case of error, the log is undone and an error is returned.
     async fn start_create<O>(
         &self,
         registry: &Registry,

--- a/control-plane/agents/src/bin/core/volume/snapshot_helpers.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_helpers.rs
@@ -21,7 +21,7 @@ use stor_port::{
             volume::VolumeSpec,
             SpecStatus, SpecTransaction,
         },
-        transport::{SnapshotParameters, VolumeId},
+        transport::{Replica, SnapshotParameters, VolumeId},
     },
 };
 
@@ -29,7 +29,7 @@ use stor_port::{
 /// means a snapshot of all(or selected) healthy replicas associated with that volume.
 pub(super) struct PrepareVolumeSnapshot {
     pub(super) parameters: SnapshotParameters<VolumeId>,
-    pub(super) replica_snapshot: ReplicaSnapshot,
+    pub(super) replica_snapshot: (Replica, ReplicaSnapshot),
     pub(super) completer: VolumeSnapshotCompleter,
 }
 

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -278,6 +278,12 @@ pub enum SvcError {
     },
     #[snafu(display("Snapshots for multi-replica volumes are not allowed"))]
     NReplSnapshotNotAllowed {},
+    #[snafu(display("Replica's {} snapshot was unexpectedly skipped", replica))]
+    ReplicaSnapSkipped { replica: String },
+    #[snafu(display("Replica's {} snapshot was unexpectedly not taken", replica))]
+    ReplicaSnapMiss { replica: String },
+    #[snafu(display("Replica's {} snapshot failed with status {}", replica, status))]
+    ReplicaSnapError { replica: String, status: u32 },
 }
 
 impl SvcError {
@@ -763,6 +769,24 @@ impl From<SvcError> for ReplyError {
             },
             SvcError::NReplSnapshotNotAllowed {} => ReplyError {
                 kind: ReplyErrorKind::FailedPrecondition,
+                resource: ResourceKind::VolumeSnapshot,
+                source: desc.to_string(),
+                extra: error_str,
+            },
+            SvcError::ReplicaSnapSkipped { .. } => ReplyError {
+                kind: ReplyErrorKind::Aborted,
+                resource: ResourceKind::VolumeSnapshot,
+                source: desc.to_string(),
+                extra: error_str,
+            },
+            SvcError::ReplicaSnapMiss { .. } => ReplyError {
+                kind: ReplyErrorKind::Aborted,
+                resource: ResourceKind::VolumeSnapshot,
+                source: desc.to_string(),
+                extra: error_str,
+            },
+            SvcError::ReplicaSnapError { .. } => ReplyError {
+                kind: ReplyErrorKind::Aborted,
                 resource: ResourceKind::VolumeSnapshot,
                 source: desc.to_string(),
                 extra: error_str,

--- a/control-plane/grpc/proto/v1/misc/common.proto
+++ b/control-plane/grpc/proto/v1/misc/common.proto
@@ -107,6 +107,8 @@ enum ResourceKind {
   AffinityGroup = 17;
   // Volume Snapshot
   VolumeSnapshot = 18;
+  // Replica Snapshot
+  ReplicaSnapshot = 19;
 }
 
 // Filter by Node and Replica id

--- a/control-plane/grpc/src/misc/traits.rs
+++ b/control-plane/grpc/src/misc/traits.rs
@@ -30,6 +30,7 @@ impl From<ResourceKind> for common::ResourceKind {
             ResourceKind::NvmePath => Self::NvmePath,
             ResourceKind::AffinityGroup => Self::AffinityGroup,
             ResourceKind::VolumeSnapshot => Self::VolumeSnapshot,
+            ResourceKind::ReplicaSnapshot => Self::ReplicaSnapshot,
         }
     }
 }
@@ -55,6 +56,7 @@ impl From<common::ResourceKind> for ResourceKind {
             common::ResourceKind::NvmePath => Self::NvmePath,
             common::ResourceKind::AffinityGroup => Self::AffinityGroup,
             common::ResourceKind::VolumeSnapshot => Self::VolumeSnapshot,
+            common::ResourceKind::ReplicaSnapshot => Self::ReplicaSnapshot,
         }
     }
 }

--- a/control-plane/stor-port/src/transport_api/mod.rs
+++ b/control-plane/stor-port/src/transport_api/mod.rs
@@ -1,11 +1,11 @@
 #![warn(missing_docs)]
 //! All the different messages which can be sent/received to/from the control
-//! plane services and io-engine
-//! We could split these out further into categories when they start to grow
+//! plane services and io-engine.
+//! We could split these out further into categories when they start to grow.
 
-/// send messages traits
+/// Send messages traits.
 pub mod macros;
-/// Version 0 of the messages
+/// Version 0 of the messages.
 pub mod v0;
 
 pub use macros::*;
@@ -21,9 +21,9 @@ use strum_macros::{AsRefStr, Display};
 use tokio::task::JoinError;
 use tonic::Code;
 
-/// Report error chain
+/// Report error chain.
 pub trait ErrorChain {
-    /// full error chain as a string separated by ':'
+    /// Full error chain as a string separated by ':'.
     fn full_string(&self) -> String;
 }
 
@@ -32,7 +32,7 @@ where
     T: std::error::Error,
 {
     /// loops through the error chain and formats into a single string
-    /// containing all the lower level errors
+    /// containing all the lower level errors.
     fn full_string(&self) -> String {
         let mut msg = format!("{self}");
         let mut opt_source = self.source();
@@ -44,13 +44,13 @@ where
     }
 }
 
-/// Message id which uniquely identifies every type of unsolicited message
+/// Message id which uniquely identifies every type of unsolicited message.
 /// The solicited (replies) message do not currently carry an id as they
-/// are sent to a specific requested channel
+/// are sent to a specific requested channel.
 #[derive(Debug, PartialEq, Clone)]
 #[allow(non_camel_case_types)]
 pub enum MessageId {
-    /// Version 0
+    /// Version 0.
     v0(MessageIdVs),
 }
 
@@ -107,44 +107,46 @@ pub trait Message {
     fn id(&self) -> MessageId;
 }
 
-/// All the different variants of Resources
+/// All the different variants of Resources.
 #[derive(Serialize, Deserialize, Debug, Clone, AsRefStr, Display, Eq, PartialEq)]
 pub enum ResourceKind {
-    /// Unknown or unspecified resource
+    /// Unknown or unspecified resource.
     Unknown,
-    /// Node resource
+    /// Node resource.
     Node,
-    /// Pool resource
+    /// Pool resource.
     Pool,
-    /// Replica resource
+    /// Replica resource.
     Replica,
-    /// Replica state
+    /// Replica state.
     ReplicaState,
-    /// Replica spec
+    /// Replica spec.
     ReplicaSpec,
-    /// Nexus resource
+    /// Replica snapshot.
+    ReplicaSnapshot,
+    /// Nexus resource.
     Nexus,
-    /// Child resource
+    /// Child resource.
     Child,
-    /// Volume resource
+    /// Volume resource.
     Volume,
-    /// Volume snapshot
+    /// Volume snapshot.
     VolumeSnapshot,
-    /// Json Grpc methods
+    /// Json Grpc methods.
     JsonGrpc,
-    /// Block devices
+    /// Block devices.
     Block,
-    /// Watch
+    /// Watch.
     Watch,
-    /// Spec
+    /// Spec.
     Spec,
-    /// State
+    /// State.
     State,
-    /// Nvme Subsystem
+    /// Nvme Subsystem.
     NvmeSubsystem,
-    /// Nvme Controller Path
+    /// Nvme Controller Path.
     NvmePath,
-    /// Affinity Group
+    /// Affinity Group.
     AffinityGroup,
 }
 

--- a/control-plane/stor-port/src/types/v0/store/snapshots/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/replica.rs
@@ -72,7 +72,10 @@ impl ReplicaSnapshotMeta {
     pub fn new(parent: &SnapshotId, txn_id: &SnapshotTxId, size: u64) -> Self {
         Self {
             sequencer: OperationSequence::new(),
-            operation: None,
+            operation: Some(ReplicaSnapshotOperationState {
+                operation: ReplicaSnapshotOperation::Create,
+                result: None,
+            }),
             creation_timestamp: None,
             size,
             meta: SnapshotMeta::Volume {

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -75,7 +75,7 @@ impl Replica {
     }
 }
 
-/// The request type to create snapshot of a replica.
+/// The request type to create a replica's snapshot.
 pub struct CreateReplicaSnapshot {
     params: SnapshotParameters<ReplicaId>,
 }
@@ -120,6 +120,8 @@ pub struct ReplicaSnapshotDescr {
     pub entity_id: String,
     /// Unique transaction id for snapshot.
     pub txn_id: String,
+    /// Validity of the snapshot: the xattr metadata might be corrupted
+    pub valid: bool,
 }
 impl ReplicaSnapshotDescr {
     /// Returns the snapshot timestamp.

--- a/control-plane/stor-port/src/types/v0/transport/snapshot.rs
+++ b/control-plane/stor-port/src/types/v0/transport/snapshot.rs
@@ -100,14 +100,15 @@ impl GenericSnapshotParameters {
     }
 }
 
-/// The request type to delete a snapshot of a replica.
+/// The request type to delete a replica's snapshot.
 pub struct DestroyReplicaSnapshot {
-    /// Incoming snapshot id to be deleted.
+    /// Id of the snapshot to be deleted.
     pub snap_id: SnapshotId,
 }
 
-/// The request type to list the snapshots of a replica.
+/// The request type to list replica's snapshots.
+#[derive(Default)]
 pub struct ListReplicaSnapshots {
-    /// Incoming replica id to list snapshots for.
+    /// If Some, list snapshots from this replica only.
     pub replica: Option<ReplicaId>,
 }

--- a/terraform/cluster/mod/k8s/master.sh
+++ b/terraform/cluster/mod/k8s/master.sh
@@ -14,3 +14,5 @@ while ! nc -z localhost 6443; do
 done
 
 kubectl apply -f ${cni_url}
+wget https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.3/components.yaml
+sed 's/- --secure-port=4443/- --secure-port=4443\n        - --kubelet-insecure-tls/' components.yaml | kubectl apply -f -


### PR DESCRIPTION
When snapping a published volume, list the individual replicas from their nodes. Fix bug which caused the operation create to not be updated on the snapshot.