### PR TITLE
Snapshot CSI list

### DIFF
--- a/control-plane/agents/src/bin/core/tests/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/nexus/mod.rs
@@ -29,7 +29,7 @@ async fn nexus() {
 
     let io_engine = cluster.node(0);
     let node_client = cluster.grpc_client().node();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     let rep_client = cluster.grpc_client().replica();
@@ -150,7 +150,7 @@ async fn nexus_share_transaction() {
     let node_client = cluster.grpc_client().node();
     let registry_client = cluster.grpc_client().registry();
     let nexus_client = cluster.grpc_client().nexus();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     let local = "malloc:///local?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0da".into();
@@ -417,7 +417,7 @@ async fn nexus_child_transaction() {
     let node_client = cluster.grpc_client().node();
     let registry_client = cluster.grpc_client().registry();
     let nexus_client = cluster.grpc_client().nexus();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     let child2 = "malloc:///ch2?size_mb=12&uuid=4a7b0566-8ec6-49e0-a8b2-1d9a292cf59b";

--- a/control-plane/agents/src/bin/core/tests/node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/node/mod.rs
@@ -45,7 +45,7 @@ async fn node() {
     let maya_name = cluster.node(0);
     let grpc = format!("{}:10124", cluster.node_ip(0));
     let node_client = cluster.grpc_client().node();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
     assert_eq!(nodes.0.len(), 1);
     assert_eq!(
@@ -59,7 +59,7 @@ async fn node() {
         )
     );
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
     assert_eq!(nodes.0.len(), 1);
     // still Online because the node is reachable via gRPC!
@@ -76,7 +76,7 @@ async fn node() {
 
     cluster.composer().kill(maya_name.as_str()).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
     assert_eq!(nodes.0.len(), 1);
     assert_eq!(
@@ -98,7 +98,7 @@ async fn node() {
         .await
         .expect("Should have restarted by now");
 
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
     assert_eq!(nodes.0.len(), 1);
     assert_eq!(
@@ -119,7 +119,7 @@ async fn node() {
         .await
         .expect("Should have restarted by now");
 
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
     assert_eq!(nodes.0.len(), 1);
     assert_eq!(
@@ -141,7 +141,7 @@ async fn large_cluster() {
         .unwrap();
 
     let node_client = cluster.grpc_client().node();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
     assert_eq!(nodes.0.len(), expected_nodes);
 
@@ -151,7 +151,7 @@ async fn large_cluster() {
         .await
         .expect("Should have restarted by now");
 
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
     assert_eq!(nodes.0.len(), expected_nodes);
 }

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -44,7 +44,7 @@ async fn pool() {
     let rep_client = cluster.grpc_client().replica();
 
     let io_engine = cluster.node(0);
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     let pool = pool_client
@@ -302,7 +302,7 @@ async fn replica_transaction() {
     let pool_client = cluster.grpc_client().pool();
     let rep_client = cluster.grpc_client().replica();
 
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     let pools = pool_client.get(Filter::None, None).await.unwrap();
@@ -557,7 +557,7 @@ async fn reconciler_missing_pool_state() {
 
     let node_client = cluster.grpc_client().node();
 
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     let client = cluster.rest_v00();
@@ -681,7 +681,7 @@ async fn reconciler_deleting_pool_on_node_down() {
         .unwrap();
 
     let node_client = cluster.grpc_client().node();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     let pool_1_id = cluster.pool(0, 0);
@@ -785,7 +785,7 @@ async fn reconciler_deleting_dirty_pool() {
     let node_client = cluster.grpc_client().node();
     let pool_client = cluster.grpc_client().pool();
 
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     let pools = pool_client.get(Filter::None, None).await.unwrap();

--- a/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
@@ -34,7 +34,7 @@ async fn garbage_collection() {
         .unwrap();
 
     let node_client = cluster.grpc_client().node();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     unused_nexus_reconcile(&cluster).await;
@@ -132,7 +132,7 @@ async fn offline_replicas_reconcile(cluster: &Cluster, reconcile_period: Duratio
         .await
         .unwrap();
 
-    let nodes = rest_api.nodes_api().get_nodes().await.unwrap();
+    let nodes = rest_api.nodes_api().get_nodes(None).await.unwrap();
     let replica_nodes = rest_api.replicas_api().get_replicas().await.unwrap();
     let replica_nodes = replica_nodes
         .into_iter()
@@ -281,7 +281,7 @@ async fn unused_reconcile(cluster: &Cluster) {
         .values()
         .map(|r| r.node.clone().unwrap())
         .collect::<Vec<_>>();
-    let nodes = rest_api.nodes_api().get_nodes().await.unwrap();
+    let nodes = rest_api.nodes_api().get_nodes(None).await.unwrap();
     let unused_node = nodes
         .iter()
         .find(|r| !data_replicas_nodes.contains(&r.id))
@@ -525,7 +525,7 @@ async fn volume_nexus_reconcile() {
         .unwrap();
 
     let node_client = cluster.grpc_client().node();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     missing_nexus_reconcile(&cluster).await;

--- a/control-plane/agents/src/bin/core/tests/volume/helpers.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/helpers.rs
@@ -155,13 +155,13 @@ pub(crate) async fn is_node_online(
     let start = std::time::Instant::now();
     loop {
         let node = node_client
-            .get(Filter::Node(node_id.clone()), None)
+            .get(Filter::Node(node_id.clone()), true, None)
             .await
             .expect("Cant get node object");
         if let Some(node) = node.0.get(0) {
             if node.state().unwrap().status == NodeStatus::Online {
                 return Ok(());
-            };
+            }
         }
         if std::time::Instant::now() > (start + timeout) {
             break;

--- a/control-plane/agents/src/bin/core/tests/volume/helpers.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/helpers.rs
@@ -147,7 +147,7 @@ pub(crate) async fn wait_till_volume_children(
 }
 
 /// Checks if node is online, returns true if yes.
-pub(crate) async fn is_node_online(
+pub(crate) async fn wait_node_online(
     node_client: &impl NodeOperations,
     node_id: NodeId,
 ) -> Result<(), ()> {
@@ -159,7 +159,7 @@ pub(crate) async fn is_node_online(
             .await
             .expect("Cant get node object");
         if let Some(node) = node.0.get(0) {
-            if node.state().unwrap().status == NodeStatus::Online {
+            if node.state().map(|n| &n.status) == Some(&NodeStatus::Online) {
                 return Ok(());
             }
         }

--- a/control-plane/agents/src/bin/core/tests/volume/hotspare.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/hotspare.rs
@@ -33,7 +33,7 @@ async fn hotspare() {
         .unwrap();
 
     let node_client = cluster.grpc_client().node();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     hotspare_faulty_children(&cluster).await;
@@ -257,7 +257,12 @@ async fn hotspare_missing_children(cluster: &Cluster) {
 /// When more than 1 replicas are faulted at the same time, the new replicas should be spread
 /// across the existing pools, and no pool nor any node should be reused
 async fn hotspare_replica_count_spread(cluster: &Cluster) {
-    let nodes = cluster.rest_v00().nodes_api().get_nodes().await.unwrap();
+    let nodes = cluster
+        .rest_v00()
+        .nodes_api()
+        .get_nodes(None)
+        .await
+        .unwrap();
     assert!(
         nodes.len() >= 3,
         "We need enough nodes to be able to add at least 2 replicas"

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -50,7 +50,7 @@ async fn volume() {
         .unwrap();
 
     let node_client = cluster.grpc_client().node();
-    let nodes = node_client.get(Filter::None, None).await.unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
     test_volume(&cluster).await;

--- a/control-plane/agents/src/bin/jsongrpc/service.rs
+++ b/control-plane/agents/src/bin/jsongrpc/service.rs
@@ -38,7 +38,7 @@ impl JsonGrpcSvc {
             .get()
             .expect("Client is not initialised")
             .node() // get node client
-            .get(Filter::Node(request.clone().node), None)
+            .get(Filter::Node(request.clone().node), false, None)
             .await
         {
             Ok(response) => response,

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -146,14 +146,21 @@ impl IoEngineApiClient {
 impl IoEngineApiClient {
     /// List all nodes available in IoEngine cluster.
     pub(crate) async fn list_nodes(&self) -> Result<Vec<Node>, ApiClientError> {
-        let response = self.rest_client.nodes_api().get_nodes().await?;
+        let response = self.rest_client.nodes_api().get_nodes(None).await?;
         Ok(response.into_body())
     }
 
     /// Get a particular node available in IoEngine cluster.
     pub(crate) async fn get_node(&self, node_id: &str) -> Result<Node, ApiClientError> {
-        let response = self.rest_client.nodes_api().get_node(node_id).await?;
-        Ok(response.into_body())
+        let response = self
+            .rest_client
+            .nodes_api()
+            .get_nodes(Some(node_id))
+            .await?;
+        match response.into_body().pop() {
+            Some(node) => Ok(node),
+            None => Err(ApiClientError::ResourceNotExists("Node not found".into())),
+        }
     }
 
     /// List all pools available in IoEngine cluster.

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -138,7 +138,7 @@ impl VolumeTopologyMapper {
 
 #[tonic::async_trait]
 impl rpc::csi::controller_server::Controller for CsiControllerSvc {
-    #[instrument(error, fields(volume.uuid = tracing::field::Empty), skip(self))]
+    #[instrument(err, fields(volume.uuid = tracing::field::Empty), skip(self))]
     async fn create_volume(
         &self,
         request: tonic::Request<CreateVolumeRequest>,
@@ -264,7 +264,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             volume: Some(volume),
         }))
     }
-    #[instrument(error, fields(volume.uuid = %request.get_ref().volume_id), skip(self))]
+    #[instrument(err, fields(volume.uuid = %request.get_ref().volume_id), skip(self))]
     async fn delete_volume(
         &self,
         request: tonic::Request<DeleteVolumeRequest>,
@@ -288,7 +288,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         Ok(Response::new(DeleteVolumeResponse {}))
     }
 
-    #[instrument(error, fields(volume.uuid = %request.get_ref().volume_id), skip(self))]
+    #[instrument(err, fields(volume.uuid = %request.get_ref().volume_id), skip(self))]
     async fn controller_publish_volume(
         &self,
         request: tonic::Request<ControllerPublishVolumeRequest>,
@@ -423,7 +423,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         }))
     }
 
-    #[instrument(error, fields(volume.uuid = %request.get_ref().volume_id), skip(self))]
+    #[instrument(err, fields(volume.uuid = %request.get_ref().volume_id), skip(self))]
     async fn controller_unpublish_volume(
         &self,
         request: tonic::Request<ControllerUnpublishVolumeRequest>,
@@ -472,7 +472,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         Ok(Response::new(ControllerUnpublishVolumeResponse {}))
     }
 
-    #[instrument(error, fields(volume.uuid = %request.get_ref().volume_id), skip(self))]
+    #[instrument(err, fields(volume.uuid = %request.get_ref().volume_id), skip(self))]
     async fn validate_volume_capabilities(
         &self,
         request: tonic::Request<ValidateVolumeCapabilitiesRequest>,
@@ -524,7 +524,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         Ok(Response::new(response))
     }
 
-    #[instrument(error, skip(self))]
+    #[instrument(err, skip(self))]
     async fn list_volumes(
         &self,
         request: tonic::Request<ListVolumesRequest>,
@@ -571,7 +571,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         }))
     }
 
-    #[instrument(error, skip(self))]
+    #[instrument(err, skip(self))]
     async fn get_capacity(
         &self,
         request: tonic::Request<GetCapacityRequest>,
@@ -630,7 +630,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         }))
     }
 
-    #[instrument(error, skip(self))]
+    #[instrument(err, skip(self))]
     async fn controller_get_capabilities(
         &self,
         _request: tonic::Request<ControllerGetCapabilitiesRequest>,
@@ -656,7 +656,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         }))
     }
 
-    #[instrument(error, fields(volume.uuid = request.get_ref().source_volume_id, snapshot.source_uuid = request.get_ref().source_volume_id, snapshot.uuid), skip(self))]
+    #[instrument(err, fields(volume.uuid = request.get_ref().source_volume_id, snapshot.source_uuid = request.get_ref().source_volume_id, snapshot.uuid), skip(self))]
     async fn create_snapshot(
         &self,
         request: tonic::Request<CreateSnapshotRequest>,
@@ -697,7 +697,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         }))
     }
 
-    #[instrument(error, fields(snapshot.uuid = request.get_ref().snapshot_id), skip(self))]
+    #[instrument(err, fields(snapshot.uuid = request.get_ref().snapshot_id), skip(self))]
     async fn delete_snapshot(
         &self,
         request: tonic::Request<DeleteSnapshotRequest>,
@@ -722,7 +722,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         Ok(Response::new(DeleteSnapshotResponse {}))
     }
 
-    #[instrument(error, fields(volume.uuid = request.get_ref().source_volume_id, snapshot.source_uuid = request.get_ref().source_volume_id, snapshot.uuid), skip(self))]
+    #[instrument(err, fields(volume.uuid = request.get_ref().source_volume_id, snapshot.source_uuid = request.get_ref().source_volume_id, snapshot.uuid), skip(self))]
     async fn list_snapshots(
         &self,
         request: tonic::Request<ListSnapshotsRequest>,
@@ -732,11 +732,8 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             if src.is_empty() {
                 return Ok(None);
             }
-            Ok(Some(Uuid::parse_str(src).map_err(|_e| {
-                Status::invalid_argument(format!(
-                    "Malformed {entity} UUID: {}",
-                    request.source_volume_id
-                ))
+            Ok(Some(Uuid::parse_str(src).map_err(|error| {
+                Status::invalid_argument(format!("{error}: Malformed {entity} UUID: {src}"))
             })?))
         };
         let snap_uuid = opt_uuid(&request.snapshot_id, "snapshot")?;
@@ -758,7 +755,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         }))
     }
 
-    #[instrument(error, skip(self))]
+    #[instrument(err, skip(self))]
     async fn controller_expand_volume(
         &self,
         _request: tonic::Request<ControllerExpandVolumeRequest>,
@@ -766,7 +763,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         Err(Status::unimplemented("Not implemented"))
     }
 
-    #[instrument(error, skip(self))]
+    #[instrument(err, skip(self))]
     async fn controller_get_volume(
         &self,
         _request: tonic::Request<ControllerGetVolumeRequest>,

--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
                 .short('t')
                 .long("rest-timeout")
                 .env("REST_TIMEOUT")
-                .default_value("5s"),
+                .default_value("30s"),
         )
         .arg(
             Arg::new("node-selector")

--- a/control-plane/grpc/proto/v1/node/node.proto
+++ b/control-plane/grpc/proto/v1/node/node.proto
@@ -64,6 +64,8 @@ message GetNodesRequest {
     // filter by node id
     common.NodeFilter node = 1;
   }
+  // ignore 404 not found errors
+  bool ignore_notfound = 2;
 }
 
 // Reponse to the GetNodes request

--- a/control-plane/grpc/src/operations/node/client.rs
+++ b/control-plane/grpc/src/operations/node/client.rs
@@ -42,14 +42,23 @@ impl NodeClient {
 #[tonic::async_trait]
 impl NodeOperations for NodeClient {
     #[tracing::instrument(name = "NodeClient::get", level = "debug", skip(self), err)]
-    async fn get(&self, filter: Filter, ctx: Option<Context>) -> Result<Nodes, ReplyError> {
+    async fn get(
+        &self,
+        filter: Filter,
+        ignore_notfound: bool,
+        ctx: Option<Context>,
+    ) -> Result<Nodes, ReplyError> {
         let req: GetNodesRequest = match filter {
             Filter::Node(id) => GetNodesRequest {
                 filter: Some(get_nodes_request::Filter::Node(NodeFilter {
                     node_id: id.into(),
                 })),
+                ignore_notfound,
             },
-            _ => GetNodesRequest { filter: None },
+            _ => GetNodesRequest {
+                filter: None,
+                ignore_notfound,
+            },
         };
         let req = self.request(req, ctx, MessageIdVs::GetNodes);
         let response = self.client().get_nodes(req).await?.into_inner();

--- a/control-plane/grpc/src/operations/node/server.rs
+++ b/control-plane/grpc/src/operations/node/server.rs
@@ -39,7 +39,7 @@ impl NodeGrpc for NodeServer {
     ) -> Result<tonic::Response<node::GetNodesReply>, tonic::Status> {
         let req: GetNodesRequest = request.into_inner();
         let filter = req.filter.map(Into::into).unwrap_or_default();
-        match self.service.get(filter, None).await {
+        match self.service.get(filter, false, None).await {
             Ok(nodes) => Ok(Response::new(GetNodesReply {
                 reply: Some(get_nodes_reply::Reply::Nodes(nodes.into())),
             })),

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -21,11 +21,16 @@ use stor_port::{
 /// Trait implemented by services which support node operations.
 #[tonic::async_trait]
 pub trait NodeOperations: Send + Sync {
-    /// Get nodes based on the filters
-    async fn get(&self, filter: Filter, ctx: Option<Context>) -> Result<Nodes, ReplyError>;
-    /// Liveness probe for node service
+    /// Get nodes based on the filters.
+    async fn get(
+        &self,
+        filter: Filter,
+        ignore_notfound: bool,
+        ctx: Option<Context>,
+    ) -> Result<Nodes, ReplyError>;
+    /// Liveness probe for node service.
     async fn probe(&self, ctx: Option<Context>) -> Result<bool, ReplyError>;
-    /// Get the all or usable blockdevices from a particular node
+    /// Get the all or usable blockdevices from a particular node.
     async fn get_block_devices(
         &self,
         get_blockdevice: &dyn GetBlockDeviceInfo,

--- a/control-plane/plugin/src/resources/cordon.rs
+++ b/control-plane/plugin/src/resources/cordon.rs
@@ -32,7 +32,7 @@ impl Get for NodeCordon {
 #[async_trait(?Send)]
 impl List for NodeCordons {
     async fn list(output: &OutputFormat) {
-        match RestClient::client().nodes_api().get_nodes().await {
+        match RestClient::client().nodes_api().get_nodes(None).await {
             Ok(nodes) => {
                 // iterate through the nodes and filter for only those that have cordon or drain
                 // labels

--- a/control-plane/plugin/src/resources/drain.rs
+++ b/control-plane/plugin/src/resources/drain.rs
@@ -30,7 +30,7 @@ impl Get for NodeDrain {
 #[async_trait(?Send)]
 impl List for NodeDrains {
     async fn list(output: &OutputFormat) {
-        match RestClient::client().nodes_api().get_nodes().await {
+        match RestClient::client().nodes_api().get_nodes(None).await {
             Ok(nodes) => {
                 // iterate through the nodes and filter for only those that have drain labels
                 // then print with the format NodeDisplayFormat::Drain

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -65,7 +65,7 @@ impl GetHeaderRow for openapi::models::Node {
 #[async_trait(?Send)]
 impl List for Nodes {
     async fn list(output: &utils::OutputFormat) {
-        match RestClient::client().nodes_api().get_nodes().await {
+        match RestClient::client().nodes_api().get_nodes(None).await {
             Ok(nodes) => {
                 // Print table, json or yaml based on output format.
                 utils::print_table(output, nodes.into_body());

--- a/control-plane/plugin/src/resources/tests.rs
+++ b/control-plane/plugin/src/resources/tests.rs
@@ -191,7 +191,7 @@ async fn get_nodes() {
         .await
         .rest_v00()
         .nodes_api()
-        .get_nodes()
+        .get_nodes(None)
         .await
         .unwrap();
     let node_state = nodes[0].state.as_ref().unwrap().clone();

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -189,6 +189,11 @@ paths:
       tags:
         - Nodes
       operationId: get_nodes
+      parameters:
+        - in: query
+          name: node_id
+          schema:
+            $ref: '#/components/schemas/NodeId'
       responses:
         '200':
           description: OK

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -256,7 +256,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/ServerError'
       security:
-        - JWT: [ ]
+        - JWT: []
     delete:
       tags:
         - Nodes
@@ -284,7 +284,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/ServerError'
       security:
-        - JWT: [ ]
+        - JWT: []
   '/nodes/{id}/drain/{label}':
     put:
       tags:
@@ -313,7 +313,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/ServerError'
       security:
-        - JWT: [ ]
+        - JWT: []
   '/nodes/{id}/nexuses':
     get:
       tags:
@@ -1497,7 +1497,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/ServerError'
       security:
-        - JWT: [ ]
+        - JWT: []
   '/volumes/{volume_id}/shutdown_targets':
     delete:
       tags:
@@ -1682,7 +1682,30 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: []
-  '/snapshots/{snapshot_id}':
+  '/volumes/snapshots/{snapshot_id}':
+    get:
+      tags:
+        - Snapshots
+      operationId: get_volumes_snapshot
+      parameters:
+        - in: path
+          name: snapshot_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/SnapshotId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VolumeSnapshot'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: []
     delete:
       tags:
         - Snapshots
@@ -1702,11 +1725,24 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: []
-  '/snapshots':
+  '/volumes/snapshots':
     get:
       tags:
         - Snapshots
-      operationId: get_snapshots
+      operationId: get_volumes_snapshots
+      parameters:
+        - in: query
+          name: snapshot_id
+          description: The uuid of the snapshot to retrieve.
+          schema:
+            $ref: '#/components/schemas/SnapshotId'
+          required: false
+        - in: query
+          name: volume_id
+          description: The uuid of the snapshots source volume.
+          schema:
+            $ref: '#/components/schemas/SnapshotId'
+          required: false
       responses:
         '200':
           description: OK

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -11,7 +11,7 @@ impl apis::actix_server::Nodes for RestApi {
         let node = node(
             id.clone(),
             client()
-                .get(Filter::Node(id.into()), None)
+                .get(Filter::Node(id.into()), false, None)
                 .await?
                 .into_inner()
                 .get(0),
@@ -19,9 +19,21 @@ impl apis::actix_server::Nodes for RestApi {
         Ok(node.into())
     }
 
-    async fn get_nodes() -> Result<Vec<models::Node>, RestError<RestJsonError>> {
-        let nodes = client().get(Filter::None, None).await?;
-        Ok(nodes.into_inner().into_vec())
+    async fn get_nodes(
+        Query(node_id): Query<Option<String>>,
+    ) -> Result<Vec<models::Node>, RestError<RestJsonError>> {
+        match node_id {
+            Some(node_id) => {
+                let nodes = client()
+                    .get(Filter::Node(node_id.into()), true, None)
+                    .await?;
+                Ok(nodes.into_inner().into_vec())
+            }
+            None => {
+                let nodes = client().get(Filter::None, false, None).await?;
+                Ok(nodes.into_inner().into_vec())
+            }
+        }
     }
 
     async fn put_node_cordon(

--- a/control-plane/rest/service/src/v0/snapshots.rs
+++ b/control-plane/rest/service/src/v0/snapshots.rs
@@ -38,10 +38,6 @@ impl apis::actix_server::Snapshots for RestApi {
         Ok(())
     }
 
-    async fn get_snapshots() -> Result<Vec<VolumeSnapshot>, RestError<RestJsonError>> {
-        Err(ReplyError::unimplemented("Snapshot service is not implemented".to_string()).into())
-    }
-
     async fn get_volume_snapshot(
         Path((_volume_id, _snapshot_id)): Path<(Uuid, Uuid)>,
     ) -> Result<VolumeSnapshot, RestError<RestJsonError>> {
@@ -50,6 +46,18 @@ impl apis::actix_server::Snapshots for RestApi {
 
     async fn get_volume_snapshots(
         Path(_volume_id): Path<Uuid>,
+    ) -> Result<Vec<VolumeSnapshot>, RestError<RestJsonError>> {
+        Err(ReplyError::unimplemented("Snapshot service is not implemented".to_string()).into())
+    }
+
+    async fn get_volumes_snapshot(
+        Path(_snapshot_id): Path<Uuid>,
+    ) -> Result<VolumeSnapshot, RestError<RestJsonError>> {
+        Err(ReplyError::unimplemented("Snapshot service is not implemented".to_string()).into())
+    }
+
+    async fn get_volumes_snapshots(
+        Query((_snapshot_id, _volume_id)): Query<(Option<Uuid>, Option<Uuid>)>,
     ) -> Result<Vec<VolumeSnapshot>, RestError<RestJsonError>> {
         Err(ReplyError::unimplemented("Snapshot service is not implemented".to_string()).into())
     }

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -81,7 +81,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
     .unwrap()
     .v00();
 
-    let nodes = client.nodes_api().get_nodes().await.unwrap();
+    let nodes = client.nodes_api().get_nodes(None).await.unwrap();
     info!("Nodes: {:#?}", nodes);
     assert_eq!(nodes.len(), 2);
     let io_engine1 = cluster.node(0);
@@ -454,7 +454,7 @@ async fn client_invalid_token() {
 
     let error = client
         .nodes_api()
-        .get_nodes()
+        .get_nodes(None)
         .await
         .expect_err("Request should fail with invalid token");
 

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -33,27 +33,36 @@ pub struct Deregister {
 
 /// Node Service
 ///
-/// Get storage nodes by filter
+/// Get storage nodes by filter.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct GetNodes {
     filter: Filter,
+    ignore_notfound: bool,
 }
 
 impl GetNodes {
-    /// New get nodes request
-    pub fn new(filter: Filter) -> Self {
-        Self { filter }
+    /// New get nodes request.
+    pub fn new(filter: Filter, ignore_notfound: bool) -> Self {
+        Self {
+            filter,
+            ignore_notfound,
+        }
     }
-    /// Return `Self` to request all nodes (`None`) or a specific node (`NodeId`)
+    /// Return `Self` to request all nodes (`None`) or a specific node (`NodeId`).
     pub fn from(node_id: impl Into<Option<NodeId>>) -> Self {
         let node_id = node_id.into();
         Self {
             filter: node_id.map_or(Filter::None, Filter::Node),
+            ignore_notfound: true,
         }
     }
-    /// Get the inner `Filter`
+    /// Get the inner `Filter`.
     pub fn filter(&self) -> &Filter {
         &self.filter
+    }
+    /// Check to ignore error when not found.
+    pub fn ignore_notfound(&self) -> bool {
+        self.ignore_notfound
     }
 }
 

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -104,7 +104,7 @@ impl CoreAgent {
 
         loop {
             let filter = Filter::Node(node.into());
-            if let Ok(nodes) = core.node().get(filter, None).await {
+            if let Ok(nodes) = core.node().get(filter, false, None).await {
                 if let Some(node) = nodes.0.into_iter().find(|n| n.id().as_str() == node) {
                     if node.state().map(|s| &s.status) == Some(&NodeStatus::Online) {
                         return;

--- a/nix/pkgs/openapi-generator/source.json
+++ b/nix/pkgs/openapi-generator/source.json
@@ -1,6 +1,6 @@
 {
   "owner": "openebs",
   "repo": "openapi-generator",
-  "rev": "613a9a90c05b70ff0dedea2dc3f6fd4541802d22",
-  "hash": "sha256-xg/fKEvjkJsXnoo9dZyQFI8MjgLy+bxCl3HvdwL95j0="
+  "rev": "56a5b778937762f184361cfa8d7f4781b958fde0",
+  "hash": "sha256-L+eAO4HtgdL0e96kKthi4MyZcmHwEgRneR+T5RDyBok="
 }

--- a/tests/bdd/features/snapshot/csi/controller/test_operations.py
+++ b/tests/bdd/features/snapshot/csi/controller/test_operations.py
@@ -22,7 +22,7 @@ POOL1_NAME = "pool-1"
 NODE1 = "io-engine-1"
 VOLUME1_SIZE = 1024 * 1024 * 32
 SNAP1_NAME = "snapshot-3f49d30d-a446-4b40-b3f6-f439345f1ce9"
-SNAP1_UUID = "3f49d30d-a446-4b40-b3f6-f439345f1ce9"
+SNAP1_UUID = SNAP1_NAME.strip("snapshot-")
 
 
 @pytest.fixture(scope="module")
@@ -113,7 +113,7 @@ def a_deletesnapshotrequest_request_is_sent_to_the_csi_controller(csi_instance):
 def a_listsnapshotrequest_request_is_sent_to_the_csi_controller(csi_instance):
     """a ListSnapshotRequest request is sent to the CSI controller."""
     with pytest.raises(grpc.RpcError) as grpc_error:
-        request = pb.ListSnapshotsRequest(snapshot_id=SNAP1_NAME)
+        request = pb.ListSnapshotsRequest(snapshot_id=SNAP1_UUID)
         csi_instance.controller.ListSnapshots(request)
     return grpc_error.value
 

--- a/tests/io-engine/tests/rebuild.rs
+++ b/tests/io-engine/tests/rebuild.rs
@@ -147,7 +147,12 @@ async fn concurrent_rebuilds() {
                 // if the nodes are still responsive allow for a bit more slack if the CI
                 // performance is slow.
                 let mut nodes_ok = true;
-                let nodes = cluster.rest_v00().nodes_api().get_nodes().await.unwrap();
+                let nodes = cluster
+                    .rest_v00()
+                    .nodes_api()
+                    .get_nodes(None)
+                    .await
+                    .unwrap();
                 for node in nodes {
                     if let Ok(mut handle) = cluster.grpc_handle(&node.id).await {
                         if handle.ping().await.is_err() {

--- a/utils/pstor-usage/src/pools.rs
+++ b/utils/pstor-usage/src/pools.rs
@@ -23,7 +23,7 @@ impl PoolMgr {
         size_bytes: u64,
         use_malloc: bool,
     ) -> anyhow::Result<impl ResourceMgr> {
-        let node_ids = client.nodes_api().get_nodes().await?;
+        let node_ids = client.nodes_api().get_nodes(None).await?;
         let node_ids = node_ids.into_iter().map(|n| n.id).collect::<Vec<_>>();
 
         if let Some((dir, _)) = Self::pool_dir(use_malloc) {

--- a/utils/pstor-usage/src/volumes.rs
+++ b/utils/pstor-usage/src/volumes.rs
@@ -70,7 +70,7 @@ impl ResourceDelete for Vec<models::Volume> {
 #[async_trait::async_trait]
 impl ResourceUpdates for Vec<models::Volume> {
     async fn modify(&self, client: &ApiClient, count: u32) -> anyhow::Result<()> {
-        let nodes = client.nodes_api().get_nodes().await?;
+        let nodes = client.nodes_api().get_nodes(None).await?;
         let node_ids = nodes.into_iter().map(|n| n.id).collect::<Vec<_>>();
         let mut node_index = 0;
 


### PR DESCRIPTION
    fix(test/nexus-gc): wait until nexus spec is removed
    
    Also shorten the reconciler duration to wait for less time..
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(csi): don't trigger node not found error on volume publish
    
    When we want to check if a node is a storage node, skip the not found error.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(snapshot/csi/list): add volume snapshot list handler
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(openapi): add volumes snapshots operation
    
    Add new volumes snapshots operation which is needed for csi list, taking both the snap and volume
    id's.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
