### PR TITLE
Get snapshot state and add pool destroy validation

### DIFF
--- a/control-plane/agents/src/bin/core/controller/scheduling/affinity_group.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/affinity_group.rs
@@ -28,7 +28,7 @@ pub(crate) fn get_restricted_nodes(
             // Fetch the list of nodes where the volume replicas are placed. If some
             // volume doesn't exist yet, this list will be empty
             // for that volume.
-            let node_ids = specs.get_volume_replica_nodes(registry, volume);
+            let node_ids = specs.get_volume_replica_nodes(volume);
             // Add a new node in the list if it doesn't already exist.
             let filtered_nodes: Vec<NodeId> = node_ids
                 .into_iter()

--- a/control-plane/agents/src/bin/core/controller/states.rs
+++ b/control-plane/agents/src/bin/core/controller/states.rs
@@ -180,11 +180,20 @@ impl ResourceStates {
         self.replicas.get(id)
     }
 
+    /// Get a snapshot with the given ID.
+    pub(crate) fn snapshot_state(
+        &self,
+        id: &SnapshotId,
+    ) -> Option<&ResourceMutex<ReplicaSnapshotState>> {
+        self.snapshots.get(id)
+    }
+
     /// Clear all state information.
     pub(crate) fn clear_all(&mut self) {
         self.nexuses.clear();
         self.pools.clear();
         self.replicas.clear();
+        self.snapshots.clear();
     }
 
     /// Takes an iterator of resources resourced by an 'Arc' and 'Mutex' and returns a vector of

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -554,6 +554,12 @@ impl NodeWrapper {
             .replica_state(replica_id)
             .map(|r| r.lock().replica.clone())
     }
+    /// Get snapshot from `snapshot_id`.
+    pub(crate) fn snapshot(&self, snapshot_id: &SnapshotId) -> Option<ReplicaSnapshot> {
+        self.resources()
+            .snapshot_state(snapshot_id)
+            .map(|r| r.lock().snapshot.clone())
+    }
     /// Is the node online.
     pub(crate) fn is_online(&self) -> bool {
         self.status() == NodeStatus::Online
@@ -947,6 +953,8 @@ pub(crate) trait GetterOps {
     async fn nexuses(&self) -> Vec<Nexus>;
     async fn nexus(&self, nexus_id: &NexusId) -> Option<Nexus>;
     async fn volume_nexus(&self, volume_id: &VolumeId) -> Option<Nexus>;
+
+    async fn snapshot(&self, snapshot: &SnapshotId) -> Option<ReplicaSnapshot>;
 }
 
 #[async_trait]
@@ -986,6 +994,11 @@ impl GetterOps for Arc<tokio::sync::RwLock<NodeWrapper>> {
     async fn volume_nexus(&self, volume_id: &VolumeId) -> Option<Nexus> {
         let node = self.read().await;
         node.volume_nexus(volume_id)
+    }
+
+    async fn snapshot(&self, snapshot: &SnapshotId) -> Option<ReplicaSnapshot> {
+        let node = self.read().await;
+        node.snapshot(snapshot)
     }
 }
 

--- a/control-plane/agents/src/bin/core/volume/service.rs
+++ b/control-plane/agents/src/bin/core/volume/service.rs
@@ -21,7 +21,7 @@ use grpc::{
             DeleteVolumeSnapshotInfo, DestroyShutdownTargetsInfo, DestroyVolumeInfo,
             PublishVolumeInfo, RepublishVolumeInfo, SetVolumeReplicaInfo, ShareVolumeInfo,
             UnpublishVolumeInfo, UnshareVolumeInfo, VolumeOperations, VolumeSnapshot,
-            VolumeSnapshotState, VolumeSnapshots,
+            VolumeSnapshots,
         },
         Pagination,
     },
@@ -349,11 +349,7 @@ impl Service {
                 &VolumeSnapshotUserSpec::new(volume.uuid(), request.snap_id),
             )
             .await?;
-
-        let spec = snapshot.as_ref().spec();
-        let info = CreateVolumeSnapshot::new(spec.source_id(), spec.uuid().clone());
-        // todo: get state from registry..
-        let state = VolumeSnapshotState::new(info, 0, None);
+        let state = self.registry.snapshot_state(snapshot.as_ref()).await?;
         Ok(VolumeSnapshot::new(snapshot.as_ref().into(), state))
     }
 

--- a/control-plane/rest/service/src/v0/snapshots.rs
+++ b/control-plane/rest/service/src/v0/snapshots.rs
@@ -78,7 +78,8 @@ impl apis::actix_server::Snapshots for RestApi {
             ),
             state: models::VolumeSnapshotState::new_all(
                 snap.state().uuid(),
-                snap.state().size(),
+                // todo: should be optional?
+                snap.state().size().unwrap_or_default(),
                 snap.state().source_id(),
                 snap.state()
                     .timestamp()

--- a/control-plane/stor-port/src/types/v0/store/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/replica.rs
@@ -9,7 +9,7 @@ use crate::{
         },
         transport::{
             self, CreateReplica, HostNqn, NodeId, PoolId, PoolUuid, Protocol, ReplicaId,
-            ReplicaName, ReplicaOwners, ReplicaShareProtocol,
+            ReplicaName, ReplicaOwners, ReplicaShareProtocol, VolumeId,
         },
     },
     IntoOption, IntoVec,
@@ -102,6 +102,10 @@ impl ReplicaSpec {
     /// Get the pool name.
     pub fn pool_name(&self) -> &PoolId {
         self.pool.pool_name()
+    }
+    /// Check if this replica is owned by the volume.
+    pub fn owned_by(&self, id: &VolumeId) -> bool {
+        self.owners.owned_by(id)
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/snapshots/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/replica.rs
@@ -1,14 +1,39 @@
 use super::{SnapshotId, SnapshotSpec};
 use crate::types::v0::{
     store::{AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction},
-    transport::{ReplicaId, SnapshotParameters, SnapshotTxId, VolumeId},
+    transport::{PoolId, ReplicaId, SnapshotParameters, SnapshotTxId, VolumeId},
 };
 use chrono::{DateTime, Utc};
 use pstor::{ApiVersion, ObjectKey, StorableObject, StorableObjectType};
 use serde::{Deserialize, Serialize};
 
+/// User specification of a replica snapshot source.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct ReplicaSnapshotSource {
+    replica_id: ReplicaId,
+    pool_id: PoolId,
+}
+impl ReplicaSnapshotSource {
+    /// Create a new `Self` from the given parameters.
+    /// todo: use pool uuid
+    pub fn new(replica_id: &ReplicaId, pool_id: &PoolId) -> Self {
+        Self {
+            replica_id: replica_id.clone(),
+            pool_id: pool_id.clone(),
+        }
+    }
+    /// Get the snapshot source id.
+    pub fn replica_id(&self) -> &ReplicaId {
+        &self.replica_id
+    }
+    /// Get the snapshot id.
+    pub fn pool_id(&self) -> &PoolId {
+        &self.pool_id
+    }
+}
+
 /// User specification of a replica snapshot.
-pub type ReplicaSnapshotSpec = SnapshotSpec<ReplicaId>;
+pub type ReplicaSnapshotSpec = SnapshotSpec<ReplicaSnapshotSource>;
 /// State of the ReplicaSnapshotSpec Spec.
 pub type ReplicaSnapshotSpecStatus = SpecStatus<()>;
 

--- a/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
@@ -59,9 +59,9 @@ impl VolumeSnapshot {
             self.spec().source_id(),
             GenericSnapshotParameters::new(
                 self.spec().uuid(),
-                self.spec.source_id.to_string(),
-                self.metadata.prepare(),
-                "what's-my-name?",
+                self.spec().source_id().to_string(),
+                self.metadata().prepare(),
+                self.spec().uuid().to_string(),
             ),
         );
         Some(params)
@@ -124,6 +124,10 @@ impl VolumeSnapshotMeta {
     /// Get the transactions.
     pub fn transactions(&self) -> &HashMap<SnapshotTxId, Vec<ReplicaSnapshot>> {
         &self.transactions
+    }
+    /// Get the current replica snapshots.
+    pub fn replica_snapshots(&self) -> Option<&Vec<ReplicaSnapshot>> {
+        self.transactions.get(&self.txn_id)
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -340,3 +340,9 @@ pub struct DestroyPool {
     /// Id of the pool.
     pub id: PoolId,
 }
+impl DestroyPool {
+    /// Create a new `Self` from the given parameters.
+    pub fn new(node: NodeId, id: PoolId) -> Self {
+        Self { node, id }
+    }
+}

--- a/control-plane/stor-port/src/types/v0/transport/snapshot.rs
+++ b/control-plane/stor-port/src/types/v0/transport/snapshot.rs
@@ -98,6 +98,12 @@ impl GenericSnapshotParameters {
     pub fn name(&self) -> &SnapshotName {
         &self.name
     }
+
+    /// Modify the uuid.
+    pub fn with_uuid(mut self, uuid: &SnapshotId) -> Self {
+        self.uuid = uuid.clone();
+        self
+    }
 }
 
 /// The request type to list replica's snapshots.

--- a/tests/bdd/features/snapshot/csi/controller/operations.feature
+++ b/tests/bdd/features/snapshot/csi/controller/operations.feature
@@ -6,9 +6,9 @@ Feature: Snapshot - CSI Controller Operations
     Scenario: Create Snapshot Operation is implemented
         Given a single replica volume
         When a CreateSnapshotRequest request is sent to the CSI controller
-        Then it should succeed
+        Then the creation should succeed
 
-    Scenario: Delete Snapshot Operation is not implemented
+    Scenario: Delete Snapshot Operation is implemented
         When a DeleteSnapshotRequest request is sent to the CSI controller
         Then the deletion should succeed
 

--- a/tests/bdd/features/snapshot/csi/controller/test_operations.py
+++ b/tests/bdd/features/snapshot/csi/controller/test_operations.py
@@ -49,9 +49,8 @@ def test_create_snapshot_operation_is_implemented():
     """Create Snapshot Operation is implemented."""
 
 
-# @pytest.mark.skip("This would be fixed in the upcoming changes")
-@scenario("operations.feature", "Delete Snapshot Operation is not implemented")
-def test_delete_snapshot_operation_is_not_implemented():
+@scenario("operations.feature", "Delete Snapshot Operation is implemented")
+def test_delete_snapshot_operation_is_implemented():
     """Delete Snapshot Operation."""
 
 
@@ -71,12 +70,6 @@ def a_single_replica_volume():
     """a single replica volume."""
     yield csi_create_1_replica_nvmf_volume1()
     csi_delete_1_replica_nvmf_volume1()
-
-
-@then("it should succeed")
-def it_should_succeed(snapshot_response):
-    """it should succeed."""
-    assert snapshot_response.snapshot.source_volume_id == VOLUME1_UUID
 
 
 @when(
@@ -118,8 +111,15 @@ def a_listsnapshotrequest_request_is_sent_to_the_csi_controller(csi_instance):
     return grpc_error.value
 
 
+@then("the creation should succeed")
+def the_creation_should_succeed(snapshot_response):
+    """the creation should succeed."""
+    assert snapshot_response.snapshot.source_volume_id == VOLUME1_UUID
+
+
 @then("the deletion should succeed")
 def the_deletion_should_succeed(grpc_error):
+    """the deletion should succeed."""
     assert grpc_error is None
 
 


### PR DESCRIPTION
    fix(snapshot/pool-destroy): don't destroy pool if it has snapshots
    
    Block pool destruction if there are snapshots on it.
    This can happen if we delete a volume but not its snapshots.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(snapshot/state): retrieve the replica snapshot states
    
    Add pool id to the replica snapshot spec. Why? Consider what happens when the source volume is
    deleted, we no longer have the replica so we cannot determine where the snapshot resides?!
    Using the pool id allows to determine where the snapshot resides.
    todo: Should we use the pool uuid instead?
    todo: refactor VolumeSnapshotState to be able to represent a snapshot state
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>