### PR TITLE
Timeouts

### DIFF
--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -90,6 +90,8 @@ pub(crate) struct RegistryInner<S: Store> {
     config: parking_lot::RwLock<CoreRegistryConfig>,
     /// system-wide maximum number of concurrent rebuilds allowed.
     max_rebuilds: Option<NumRebuilds>,
+    /// The maximum number of concurrent create volume requests.
+    create_volume_limit: usize,
     /// Enablement of host access control.
     host_acl: Vec<HostAccessControl>,
     /// Check for the legacy product version's key prefix present.
@@ -113,6 +115,7 @@ impl Registry {
         reconcile_idle_period: std::time::Duration,
         faulted_child_wait_period: Option<std::time::Duration>,
         max_rebuilds: Option<NumRebuilds>,
+        create_volume_limit: usize,
         host_acl: Vec<HostAccessControl>,
         thin_args: ThinArgs,
     ) -> Result<Self, SvcError> {
@@ -159,6 +162,7 @@ impl Registry {
                         })?,
                 ),
                 max_rebuilds,
+                create_volume_limit,
                 host_acl,
                 legacy_prefix_present: product_v1_prefix,
                 thin_args,
@@ -261,6 +265,10 @@ impl Registry {
     /// Wait period before attempting to online a faulted child.
     pub(crate) fn faulted_child_wait_period(&self) -> Option<std::time::Duration> {
         self.faulted_child_wait_period
+    }
+    /// The maximum number of concurrent create volume requests.
+    pub(crate) fn create_volume_limit(&self) -> usize {
+        self.create_volume_limit
     }
 
     /// Get a reference to the actual state of the nodes.

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -71,6 +71,10 @@ pub(crate) struct CliArgs {
     #[clap(long, short, default_value = utils::DEFAULT_REQ_TIMEOUT)]
     pub(crate) request_timeout: humantime::Duration,
 
+    /// The maximum number of concurrent create volume requests.
+    #[clap(long, default_value = "10")]
+    create_volume_limit: usize,
+
     /// Control hosts access control via their NQN's.
     #[clap(long, use_value_delimiter = true, default_value = utils::DEFAULT_HOST_ACCESS_CONTROL)]
     pub(crate) hosts_acl: Vec<HostAccessControl>,
@@ -151,6 +155,7 @@ async fn server(cli_args: CliArgs) {
         cli_args.reconcile_idle_period.into(),
         cli_args.faulted_child_wait_period.map(|t| t.into()),
         cli_args.max_rebuilds,
+        cli_args.create_volume_limit,
         if cli_args.hosts_acl.contains(&HostAccessControl::None) {
             vec![]
         } else {

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -300,6 +300,10 @@ pub enum SvcError {
     ReplicaSnapMiss { replica: String },
     #[snafu(display("Replica's {} snapshot failed with status {}", replica, status))]
     ReplicaSnapError { replica: String, status: u32 },
+    #[snafu(display("The service is busy, cannot process request"))]
+    ServiceBusy {},
+    #[snafu(display("The service is shutdown, cannot process request"))]
+    ServiceShutdown {},
 }
 
 impl SvcError {
@@ -816,6 +820,18 @@ impl From<SvcError> for ReplyError {
             SvcError::InvalidSnapshotSource { .. } => ReplyError {
                 kind: ReplyErrorKind::InvalidArgument,
                 resource: ResourceKind::VolumeSnapshot,
+                source: desc.to_string(),
+                extra: error_str,
+            },
+            SvcError::ServiceBusy {} => ReplyError {
+                kind: ReplyErrorKind::Aborted,
+                resource: ResourceKind::Unknown,
+                source: desc.to_string(),
+                extra: error_str,
+            },
+            SvcError::ServiceShutdown {} => ReplyError {
+                kind: ReplyErrorKind::Unavailable,
+                resource: ResourceKind::Unknown,
                 source: desc.to_string(),
                 extra: error_str,
             },

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -109,10 +109,7 @@ impl IoEngineApiClient {
 
         let url = clients::tower::Url::parse(endpoint)
             .map_err(|error| anyhow!("Invalid API endpoint URL {}: {:?}", endpoint, error))?;
-        let concurrency_limit: usize = std::env::var("MAX_CONCURRENT_RPC")
-            .ok()
-            .and_then(|i| i.parse().ok())
-            .unwrap_or(10usize);
+        let concurrency_limit = cfg.create_volume_limit() * 2;
         let tower = clients::tower::Configuration::builder()
             .with_timeout(cfg.io_timeout())
             .with_concurrency_limit(Some(concurrency_limit))
@@ -125,7 +122,7 @@ impl IoEngineApiClient {
             })?;
 
         REST_CLIENT.get_or_init(|| Self {
-            rest_client: clients::tower::ApiClient::new(tower),
+            rest_client: clients::tower::ApiClient::new(tower.clone()),
         });
 
         info!(

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -25,6 +25,7 @@ pub enum ApiClientError {
     ResourceNotExists(String),
     NotImplemented(String),
     RequestTimeout(String),
+    Aborted(String),
     Conflict(String),
     ResourceExhausted(String),
     // Generic operation errors.
@@ -71,6 +72,7 @@ impl From<clients::tower::Error<RestJsonError>> for ApiClientError {
                         StatusCode::REQUEST_TIMEOUT => Self::RequestTimeout(detailed),
                         StatusCode::CONFLICT => Self::Conflict(detailed),
                         StatusCode::INSUFFICIENT_STORAGE => Self::ResourceExhausted(detailed),
+                        StatusCode::SERVICE_UNAVAILABLE => Self::Aborted(detailed),
                         status => Self::GenericOperation(status, detailed),
                     }
                 }

--- a/control-plane/csi-driver/src/bin/controller/config.rs
+++ b/control-plane/csi-driver/src/bin/controller/config.rs
@@ -13,6 +13,8 @@ pub(crate) struct CsiControllerConfig {
     io_timeout: Duration,
     /// Node Plugin selector label.
     node_selector: HashMap<String, String>,
+    /// Max Outstanding Create Volume Requests.
+    create_volume_limit: usize,
 }
 
 impl CsiControllerConfig {
@@ -32,6 +34,10 @@ impl CsiControllerConfig {
             .context("I/O timeout must be specified")?
             .parse::<humantime::Duration>()?;
 
+        let create_volume_limit = *args
+            .get_one::<usize>("create-volume-limit")
+            .context("create-volume-limit must be specified")?;
+
         let node_selector = csi_driver::csi_node_selector_parse(
             args.get_many::<String>("node-selector")
                 .map(|s| s.map(|s| s.as_str())),
@@ -41,6 +47,7 @@ impl CsiControllerConfig {
             rest_endpoint: rest_endpoint.into(),
             io_timeout: io_timeout.into(),
             node_selector,
+            create_volume_limit,
         });
         Ok(())
     }
@@ -55,6 +62,11 @@ impl CsiControllerConfig {
     /// Get REST API endpoint.
     pub(crate) fn rest_endpoint(&self) -> &str {
         &self.rest_endpoint
+    }
+
+    /// The maximum number of concurrent create volume requests.
+    pub(crate) fn create_volume_limit(&self) -> usize {
+        self.create_volume_limit
     }
 
     /// Get I/O timeout for REST API operations.

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -89,6 +89,7 @@ impl From<ApiClientError> for Status {
             ApiClientError::NotImplemented(reason) => Status::unimplemented(reason),
             ApiClientError::RequestTimeout(reason) => Status::deadline_exceeded(reason),
             ApiClientError::Conflict(reason) => Status::unavailable(reason),
+            ApiClientError::Aborted(reason) => Status::unavailable(reason),
             error => Status::internal(format!("Operation failed: {error:?}")),
         }
     }

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -23,8 +23,29 @@ const VOLUME_NAME_PATTERN: &str =
 const SNAPSHOT_NAME_PATTERN: &str =
     r"snapshot-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})";
 
-#[derive(Debug, Default)]
-pub(crate) struct CsiControllerSvc {}
+#[derive(Debug)]
+pub(crate) struct CsiControllerSvc {
+    create_volume_limiter: std::sync::Arc<tokio::sync::Semaphore>,
+}
+impl CsiControllerSvc {
+    pub(crate) fn new(cfg: &CsiControllerConfig) -> Self {
+        Self {
+            create_volume_limiter: std::sync::Arc::new(tokio::sync::Semaphore::new(
+                cfg.create_volume_limit(),
+            )),
+        }
+    }
+    async fn create_volume_permit(&self) -> Result<tokio::sync::SemaphorePermit, tonic::Status> {
+        tokio::time::timeout(
+            // if we take too long waiting for our turn just abort..
+            std::time::Duration::from_secs(3),
+            self.create_volume_limiter.acquire(),
+        )
+        .await
+        .map_err(|_| tonic::Status::aborted("Too many create volumes in progress"))?
+        .map_err(|_| tonic::Status::unavailable("Service is shutdown"))
+    }
+}
 
 /// Check whether target volume capabilities are valid. As of now, only
 /// SingleNodeWriter capability is supported.
@@ -90,10 +111,15 @@ fn check_existing_volume(
     let spec = &volume.spec;
 
     if spec.status != SpecStatus::Created {
-        return Err(Status::already_exists(format!(
+        let message = format!(
             "Existing volume {} is in insufficient state: {:?}",
             spec.uuid, spec.status
-        )));
+        );
+        return Err(if spec.status == SpecStatus::Creating {
+            Status::aborted(message)
+        } else {
+            Status::already_exists(message)
+        });
     }
 
     if spec.num_replicas < replica_count {
@@ -145,6 +171,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
     ) -> Result<tonic::Response<CreateVolumeResponse>, tonic::Status> {
         let args = request.into_inner();
         tracing::trace!(request = ?args);
+        let _permit = self.create_volume_permit().await?;
 
         if args.volume_content_source.is_some() {
             return Err(Status::invalid_argument(
@@ -323,7 +350,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             None => {
                 return Err(Status::invalid_argument("Missing volume capability"));
             }
-        };
+        }
 
         // Check if the volume is already published.
         let volume = IoEngineApiClient::get_client()
@@ -680,7 +707,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                 return Err(Status::invalid_argument(format!(
                     "Expected the snapshot name in snapshot-<UUID> format: {}",
                     request.name
-                )))
+                )));
             }
         };
         tracing::Span::current().record("snapshot.uuid", snapshot_uuid_str.as_str());

--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -12,6 +12,8 @@ use client::{ApiClientError, CreateVolumeTopology, IoEngineApiClient};
 use config::CsiControllerConfig;
 
 const CSI_SOCKET: &str = "/var/tmp/csi.sock";
+const CONCURRENCY_LIMIT: usize = 10;
+const REST_TIMEOUT: &str = "30s";
 
 /// Initialize all components before starting the CSI controller.
 fn initialize_controller(args: &ArgMatches) -> anyhow::Result<()> {
@@ -53,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
                 .short('t')
                 .long("rest-timeout")
                 .env("REST_TIMEOUT")
-                .default_value("30s"),
+                .default_value(REST_TIMEOUT),
         )
         .arg(
             Arg::new("node-selector")
@@ -65,6 +67,15 @@ async fn main() -> anyhow::Result<()> {
                 .help(
                     "The node selector label which this plugin will report as part of its topology.\n\
                     Example:\n --node-selector key=value --node-selector key2=value2",
+                ),
+        )
+        .arg(
+            Arg::new("create-volume-limit")
+                .long("create-volume-limit")
+                .value_parser(clap::value_parser!(usize))
+                .default_value(CONCURRENCY_LIMIT.to_string())
+                .help(
+                    "The number of worker threads that process requests"
                 ),
         )
         .get_matches();

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -213,10 +213,11 @@ if [ -n "$TAG" ] && [ "$TAG" != "$(get_tag)" ]; then
   # Set the TAG which basically allows building the binaries as if it were a git tag
   NIX_TAG_ARGS="--argstr tag $TAG"
   NIX_BUILD="$NIX_BUILD $NIX_TAG_ARGS"
+  alias_tag=
 fi
 
 TAG=${TAG:-$HASH}
-if [ -n "$OVERRIDE_COMMIT_HASH" ]; then
+if [ -n "$OVERRIDE_COMMIT_HASH" ] && [ -n "$alias_tag" ]; then
   # Set the TAG to the alias and remove the alias
   NIX_TAG_ARGS="--argstr img_tag $alias_tag"
   NIX_BUILD="$NIX_BUILD $NIX_TAG_ARGS"


### PR DESCRIPTION
    feat(core-agent): add concurrency limiter for create volume ops
    
    Add limiter of 10 concurrent create volume operations.
    Also allow wait up to 10s waiting for a permit, before aborting the request.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(csi-driver): configure concurrency limits for create_volume
    
    During IO load creating replicas becomes a slow operation which creates a lot of back-pressure.
    We need a better way to handle things but for now let's limit to 10 concurrent requests by default.
    Also increase timeouts to 33s which should be sufficient for most cases I tested.
    
    todo: add concurrency limits as a service layer for more flexibility
    todo: add rate-limiter to agent-core

    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>