### PR TITLE
feat(rebuild_history): resource map implementation for rebuild history

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod v0;
 pub(crate) mod v1;
 
 pub(crate) use client::*;
+use std::collections::HashMap;
 
 use agents::errors::SvcError;
 use async_trait::async_trait;
@@ -14,10 +15,10 @@ use stor_port::{
         AddNexusChild, ApiVersion, CreateNexus, CreateNexusSnapshot, CreateNexusSnapshotResp,
         CreatePool, CreateReplica, CreateReplicaSnapshot, DestroyNexus, DestroyPool,
         DestroyReplica, DestroyReplicaSnapshot, FaultNexusChild, GetBlockDevices, GetRebuildRecord,
-        ImportPool, ListReplicaSnapshots, Nexus, NexusChildAction, NexusChildActionContext,
-        NexusChildActionKind, NexusId, NodeId, PoolState, RebuildHistory, Register,
-        RemoveNexusChild, Replica, ReplicaSnapshot, ShareNexus, ShareReplica, ShutdownNexus,
-        UnshareNexus, UnshareReplica,
+        ImportPool, ListRebuildRecord, ListReplicaSnapshots, Nexus, NexusChildAction,
+        NexusChildActionContext, NexusChildActionKind, NexusId, NodeId, PoolState, RebuildHistory,
+        Register, RemoveNexusChild, Replica, ReplicaSnapshot, ShareNexus, ShareReplica,
+        ShutdownNexus, UnshareNexus, UnshareReplica,
     },
 };
 
@@ -153,10 +154,15 @@ pub(crate) trait NexusSnapshotApi {
 #[async_trait]
 pub(crate) trait NexusChildRebuildApi {
     /// Lists rebuild history for a given nexus.
-    async fn list_rebuild_history(
+    async fn get_rebuild_history(
         &self,
         request: &GetRebuildRecord,
     ) -> Result<RebuildHistory, SvcError>;
+
+    async fn list_rebuild_record(
+        &self,
+        request: &ListRebuildRecord,
+    ) -> Result<HashMap<NexusId, RebuildHistory>, SvcError>;
 }
 
 /// The trait for replica snapshot operations like create, remove, list.

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/mod.rs
@@ -7,7 +7,10 @@ mod translation;
 use crate::controller::io_engine::{ApiVersion, GrpcContext, NexusChildRebuildApi};
 use agents::errors::{GrpcConnect, SvcError};
 use rpc::io_engine::IoEngineClientV0;
-use stor_port::types::v0::transport::{GetRebuildRecord, RebuildHistory};
+use std::collections::HashMap;
+use stor_port::types::v0::transport::{
+    GetRebuildRecord, ListRebuildRecord, NexusId, RebuildHistory,
+};
 
 use snafu::ResultExt;
 use stor_port::transport_api::ResourceKind;
@@ -48,10 +51,21 @@ impl RpcClient {
 
 #[async_trait::async_trait]
 impl NexusChildRebuildApi for RpcClient {
-    async fn list_rebuild_history(
+    async fn get_rebuild_history(
         &self,
         _request: &GetRebuildRecord,
     ) -> Result<RebuildHistory, SvcError> {
+        Err(SvcError::Unimplemented {
+            resource: ResourceKind::Nexus,
+            request: "get_rebuild_history".to_string(),
+            source: Status::unimplemented("api still unimplemented"),
+        })
+    }
+
+    async fn list_rebuild_record(
+        &self,
+        _request: &ListRebuildRecord,
+    ) -> Result<HashMap<NexusId, RebuildHistory>, SvcError> {
         Err(SvcError::Unimplemented {
             resource: ResourceKind::Nexus,
             request: "get_rebuild_history".to_string(),

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -628,6 +628,15 @@ impl AgentToIoEngine for transport::GetRebuildRecord {
     }
 }
 
+impl AgentToIoEngine for transport::ListRebuildRecord {
+    type IoEngineMessage = v1::nexus::ListRebuildHistoryRequest;
+    fn to_rpc(&self) -> Self::IoEngineMessage {
+        v1::nexus::ListRebuildHistoryRequest {
+            count: self.count(),
+        }
+    }
+}
+
 impl TryIoEngineToAgent for v1::nexus::RebuildHistoryResponse {
     type AgentMessage = transport::RebuildHistory;
     /// This converts gRPC rebuild history object into Control plane object.

--- a/control-plane/agents/src/bin/core/controller/resources/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/nexus/mod.rs
@@ -1,7 +1,7 @@
 use super::{ResourceMutex, ResourceUid};
 use stor_port::types::v0::{
     store::nexus::{NexusSpec, NexusState},
-    transport::NexusId,
+    transport::{NexusId, RebuildHistory},
 };
 
 impl ResourceMutex<NexusSpec> {
@@ -19,6 +19,13 @@ impl ResourceUid for ResourceMutex<NexusSpec> {
 }
 
 impl ResourceUid for NexusSpec {
+    type Uid = NexusId;
+    fn uid(&self) -> &Self::Uid {
+        &self.uuid
+    }
+}
+
+impl ResourceUid for RebuildHistory {
     type Uid = NexusId;
     fn uid(&self) -> &Self::Uid {
         &self.uuid

--- a/control-plane/agents/src/bin/core/tests/rebuild/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/rebuild/mod.rs
@@ -1,9 +1,8 @@
 //! This file contains tests for rebuild scenarios, specifically around
 //! partial(log-based) rebuild, but not limited to that.
-
 use deployer_cluster::{Cluster, ClusterBuilder};
-
-use std::{collections::HashMap, time::Duration};
+use grpc::operations::nexus::traits::NexusOperations;
+use std::{collections::HashMap, thread::sleep, time::Duration};
 use stor_port::types::v0::{
     openapi::{
         models,
@@ -12,65 +11,154 @@ use stor_port::types::v0::{
             ReplicaState, VolumePolicy, VolumeStatus,
         },
     },
-    transport::VolumeId,
+    transport::{Filter, GetRebuildRecord, NexusId, NexusStatus, RebuildHistory, VolumeId},
 };
+// Wait time for the nexus to be online from Degraded state.
+const REBUILD_WAIT_TIME: u64 = 12;
+const CHILD_WAIT: u64 = 5;
 
 async fn build_cluster(num_ioe: u32, pool_size: u64, _num_pools: u32) -> Cluster {
-    let reconcile_period = Duration::from_secs(1);
-    let child_twait = Duration::from_secs(15);
+    let reconcile_period = Duration::from_millis(300);
+    let child_twait = Duration::from_secs(CHILD_WAIT);
     ClusterBuilder::builder()
         .with_rest(true)
         .with_io_engines(num_ioe)
         .with_faulted_child_wait_period(child_twait)
         .with_reconcile_period(reconcile_period, reconcile_period)
-        .with_cache_period("1s")
+        .with_cache_period("250ms")
         .with_tmpfs_pool(pool_size)
         .build()
         .await
         .unwrap()
 }
 
-async fn wait_till_pool_online(
-    cluster: &Cluster,
-    replica: &Replica,
-    timeout: Duration,
-) -> Option<Pool> {
-    let client = cluster.rest_v00();
-    let pool_api = client.pools_api();
-    let start = std::time::Instant::now();
-
-    loop {
-        let pool = pool_api.get_pool(replica.pool.as_str()).await.unwrap();
-        tracing::info!("Waiting for pool to be Online - {:?}", pool);
-        if pool.state.is_some() && (pool.state.clone().unwrap().status == PoolStatus::Online) {
-            tracing::info!("Pool is Online now");
-            return Some(pool);
-        }
-
-        if std::time::Instant::now() > (start + timeout)
-            && (pool.state.is_none() || pool.state.as_ref().unwrap().status != PoolStatus::Online)
-        {
-            tracing::info!("Timeout waiting for pool to be Online - {:?}", pool);
-            return None;
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
-}
-
-// This test
-// 1. creates a volume with 3 replicas, faults one of them by restarting container.
-// 2. Expects child's replica to be online again within 15sec period.
-// 3. Attempts to online the child.
-// 4. Child should get successfully onlined and partial rebuild happen.
-// 5. If online call fails, full rebuild of child happens.
+// This test:
+// Creates a 3 replica volume and publishes it,
+// validates that rebuild record is empty for the published nexus,
+// stops io engine hosting one of the child,
+// polls for rebuild history and validates there is 1 record for the nexus,
+// validates that rebuild type is Full rebuild,
+// validates that faulted child is removed from nexus.
 #[tokio::test]
-async fn replica_wait_and_partial_rebuild() {
+async fn rebuild_history_for_full_rebuild() {
     let cluster = build_cluster(4, 52428800, 0).await; // 50MiB pool size
 
     let vol_target = cluster.node(0).to_string();
     let api_client = cluster.rest_v00();
     let volume_api = api_client.volumes_api();
+    let nexus_client = cluster.grpc_client().nexus();
 
+    let body = CreateVolumeBody::new(VolumePolicy::new(true), 3, 10485760u64, false);
+    let volid = VolumeId::new();
+    let volume = volume_api.put_volume(&volid, body).await.unwrap();
+    let volume = volume_api
+        .put_volume_target(
+            &volume.spec.uuid,
+            PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                vol_target.clone().to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+            ),
+        )
+        .await
+        .expect("Failed to publish volume");
+
+    let volume_state = volume.state.clone();
+    let nexus = volume_state.target.unwrap();
+    let nexus_id = NexusId::from(nexus.uuid);
+    sleep(Duration::from_millis(500));
+    // Before triggering rebuild, we expect rebuild history record to be available for the nexus
+    // without any history of rebuild.
+    let history = nexus_client
+        .get_rebuild_history(&GetRebuildRecord::new(nexus_id.clone()), None)
+        .await
+        .expect("Failed to get rebuild record");
+    assert_eq!(
+        nexus_id, history.uuid,
+        "Cant match nexus id in rebuild history"
+    );
+    assert_eq!(
+        0,
+        history.records.len(),
+        "Number of rebuild record should be 0"
+    );
+
+    let volume_state = volume.state.clone();
+    assert_eq!(volume_state.status, VolumeStatus::Online);
+    let nexus = volume_state.target.unwrap();
+    assert_eq!(nexus.children.len(), 3);
+    nexus
+        .children
+        .iter()
+        .for_each(|c| assert_eq!(c.state, ChildState::Online));
+
+    // Check where the replicas are, apart from vol target node.
+    let replicas = api_client.replicas_api().get_replicas().await.unwrap();
+    tracing::info!({?replicas}, "Available replicas - ");
+    let testrep = replicas.iter().find(|r| r.node != vol_target).unwrap();
+    let testrep_node = &testrep.node;
+    tracing::info!(
+        "Stopping node {testrep_node} having replica {}",
+        testrep.uri.clone()
+    );
+
+    // Stop the container and don't restart.
+    cluster
+        .composer()
+        .stop(&testrep_node.to_string())
+        .await
+        .expect("container stop failure");
+    let nexus_client = cluster.grpc_client().nexus();
+    let history = poll_rebuild_history(&nexus_client, nexus_id.clone())
+        .await
+        .expect("Failed to get rebuild record");
+    assert_eq!(
+        nexus_id, history.uuid,
+        "Cant match nexus id in rebuild history"
+    );
+    assert_eq!(
+        1,
+        history.records.len(),
+        "Number of rebuild history is not equal to 1"
+    );
+
+    assert!(
+        !history.records.get(0).unwrap().is_partial,
+        "Rebuild type is not Full rebuild"
+    );
+    // Fetch replicas again.
+    let replicas_now = api_client.replicas_api().get_replicas().await.unwrap();
+    // The replica picked for test must not be online now again.
+    assert!(!replicas_now.iter().any(|r| r.uri == testrep.uri));
+
+    // Get the volume again for validations.
+    let vol = volume_api.get_volume(volid.uuid()).await.unwrap();
+    let volume_state = vol.state;
+    let nexus = volume_state.target.unwrap();
+    // The child must not be in the nexus anymore.
+    let is_removed = !nexus.children.iter().any(|c| c.uri == testrep.uri);
+    assert!(is_removed);
+}
+
+// This test:
+// Creates a 3 replica volume and publishes it,
+// validates that rebuild record is empty for the published nexus,
+// restarts io engine hosting one of the child,
+// polls for rebuild history and validates there is 1 record for the nexus,
+// validates that rebuild type is Partial rebuild,
+// validates that previously faulted child is not removed from nexus.
+
+#[tokio::test]
+async fn rebuild_history_for_partial_rebuild() {
+    let cluster = build_cluster(4, 52428800, 0).await; // 50MiB pool size
+
+    let vol_target = cluster.node(0).to_string();
+    let api_client = cluster.rest_v00();
+    let volume_api = api_client.volumes_api();
+    let nexus_client = cluster.grpc_client().nexus();
     let body = CreateVolumeBody::new(VolumePolicy::new(true), 3, 10485760u64, false);
     let volid = VolumeId::new();
     let volume = volume_api.put_volume(&volid, body).await.unwrap();
@@ -89,9 +177,26 @@ async fn replica_wait_and_partial_rebuild() {
         .await
         .unwrap();
 
-    let volume_state = volume.state;
+    let volume_state = volume.state.clone();
     assert!(volume_state.status == VolumeStatus::Online);
     let nexus = volume_state.target.unwrap();
+    let nexus_id = NexusId::from(nexus.uuid);
+    sleep(Duration::from_millis(500));
+    // Before triggering rebuild, we expect rebuild history record to be available for the nexus
+    // without any history of rebuild.
+    let history = nexus_client
+        .get_rebuild_history(&GetRebuildRecord::new(nexus_id.clone()), None)
+        .await
+        .expect("Failed to get rebuild record");
+    assert_eq!(
+        nexus_id, history.uuid,
+        "Can't match nexus id in rebuild history"
+    );
+    assert_eq!(
+        0,
+        history.records.len(),
+        "Number of rebuild record should be 0"
+    );
     assert_eq!(nexus.children.len(), 3);
     nexus
         .children
@@ -116,14 +221,16 @@ async fn replica_wait_and_partial_rebuild() {
         .expect("container stop failure");
 
     // Check the pool on restarted node is imported back.
-    wait_till_pool_online(&cluster, testrep, Duration::from_secs(20)).await;
+    wait_pool_online(&cluster, testrep, Duration::from_secs(6))
+        .await
+        .expect("Pool didn't get into online state");
 
     // Fetch replicas again.
     let replicas_now = api_client.replicas_api().get_replicas().await.unwrap();
     // The replica picked for test must be online now again.
     assert!(replicas_now.iter().any(|r| r.uri == testrep.uri));
     if let Some(rep) = replicas_now.iter().find(|r| r.uri == testrep.uri) {
-        assert!(rep.state == ReplicaState::Online);
+        assert_eq!(rep.state, ReplicaState::Online);
     }
 
     // Get the volume again for validations.
@@ -133,85 +240,100 @@ async fn replica_wait_and_partial_rebuild() {
     // The child must be still in the nexus.
     let is_removed = !nexus.children.iter().any(|c| c.uri == testrep.uri);
     assert!(!is_removed);
-    // TODO: We can additionally check that the volume state eventually becomes Online,
-    // and doesn't remain Degraded once the partial rebuild finishes. Currently no support for
-    // getting rebuild info via nexus grpc client NexusOperations.
-}
+    let nexus_id = NexusId::from(volume.state.target.unwrap().uuid);
 
-// This test
-// 1. creates a volume with 3 replicas, faults one of them by stopping container.
-// 2. Expects child's replica to stay offline for faulted child wait period.
-// 3. Since replica doesn't come online within wait period, child gets removed from nexus.
-// 4. Validate child should not be present in nexus.
-#[tokio::test]
-async fn replica_wait_and_full_rebuild() {
-    let cluster = build_cluster(4, 52428800, 0).await; // 50MiB pool size
-
-    let vol_target = cluster.node(0).to_string();
-    let api_client = cluster.rest_v00();
-    let volume_api = api_client.volumes_api();
-
-    let body = CreateVolumeBody::new(VolumePolicy::new(true), 3, 10485760u64, false);
-    let volid = VolumeId::new();
-    let volume = volume_api.put_volume(&volid, body).await.unwrap();
-    let volume = volume_api
-        .put_volume_target(
-            &volume.spec.uuid,
-            PublishVolumeBody::new_all(
-                HashMap::new(),
-                None,
-                vol_target.clone().to_string(),
-                models::VolumeShareProtocol::Nvmf,
-                None,
-                cluster.csi_node(0),
-            ),
-        )
+    wait_nexus_online(&nexus_client, nexus_id.clone())
         .await
-        .unwrap();
+        .expect("Rebuild didnt finish in 30 secs");
 
-    let volume_state = volume.state;
-    assert!(volume_state.status == VolumeStatus::Online);
-    let nexus = volume_state.target.unwrap();
-    assert_eq!(nexus.children.len(), 3);
-    nexus
-        .children
-        .iter()
-        .for_each(|c| assert!(c.state == ChildState::Online));
+    let history = nexus_client
+        .get_rebuild_history(&GetRebuildRecord::new(nexus_id.clone()), None)
+        .await
+        .expect("Failed to get rebuild record");
 
-    // Check where the replicas are, apart from vol target node.
-    let replicas = api_client.replicas_api().get_replicas().await.unwrap();
-    tracing::info!({?replicas}, "Available replicas - ");
-    let testrep = replicas.iter().find(|r| r.node != vol_target).unwrap();
-    let testrep_node = &testrep.node;
-    tracing::info!(
-        "Stopping node {testrep_node} having replica {}",
-        testrep.uri.clone()
+    assert_eq!(
+        nexus_id, history.uuid,
+        "Cant match nexus id in rebuild history"
     );
 
-    // Stop the container and don't restart.
-    cluster
-        .composer()
-        .stop(&testrep_node.to_string())
-        .await
-        .expect("container stop failure");
+    assert_eq!(
+        1,
+        history.records.len(),
+        "Number of rebuild history is not equal to 1"
+    );
 
-    // Check the pool on restarted node shouldn't be online.
-    // This must expire the wait timeout.
-    wait_till_pool_online(&cluster, testrep, Duration::from_secs(20)).await;
+    assert!(
+        history.records.get(0).unwrap().is_partial,
+        "Rebuild type is not Partial rebuild"
+    )
+}
 
-    // Fetch replicas again.
-    let replicas_now = api_client.replicas_api().get_replicas().await.unwrap();
-    // The replica picked for test must not be online now again.
-    assert!(!replicas_now.iter().any(|r| r.uri == testrep.uri));
+/// Checks if node is online, returns true if yes.
+async fn wait_nexus_online(nexus_client: &impl NexusOperations, nexus: NexusId) -> Result<(), ()> {
+    let timeout = Duration::from_secs(REBUILD_WAIT_TIME);
+    let start = std::time::Instant::now();
+    loop {
+        let nexus = nexus_client
+            .get(Filter::Nexus(nexus.clone()), None)
+            .await
+            .expect("Cant get Nexus object");
+        if let Some(nexus) = nexus.0.get(0) {
+            if nexus.status == NexusStatus::Online {
+                return Ok(());
+            }
+        }
+        if std::time::Instant::now() > (start + timeout) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    Err(())
+}
 
-    // Get the volume again for validations.
-    let vol = volume_api.get_volume(volid.uuid()).await.unwrap();
-    let volume_state = vol.state;
-    let nexus = volume_state.target.unwrap();
-    // The child must not be in the nexus anymore.
-    let is_removed = !nexus.children.iter().any(|c| c.uri == testrep.uri);
-    assert!(is_removed);
-    // TODO: We can additionally check that the volume state eventually becomes Online,
-    // and doesn't remain degraded once the full rebuild finishes. Currently no support for
-    // getting rebuild info via nexus grpc client NexusOperations.
+/// Checks if nexus has rebuild record for predefined interval.
+async fn poll_rebuild_history(
+    nexus_client: &impl NexusOperations,
+    nexus_id: NexusId,
+) -> Result<RebuildHistory, ()> {
+    let timeout = Duration::from_secs(REBUILD_WAIT_TIME);
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(record) = nexus_client
+            .get_rebuild_history(&GetRebuildRecord::new(nexus_id.clone()), None)
+            .await
+        {
+            if !record.records.is_empty() {
+                return Ok(record);
+            }
+            if std::time::Instant::now() > (start + timeout) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+    Err(())
+}
+
+/// Checks if pool is online. Returns pool if yes, None if not.
+async fn wait_pool_online(cluster: &Cluster, replica: &Replica, timeout: Duration) -> Option<Pool> {
+    let client = cluster.rest_v00();
+    let pool_api = client.pools_api();
+    let start = std::time::Instant::now();
+
+    loop {
+        let pool = pool_api.get_pool(replica.pool.as_str()).await.unwrap();
+        tracing::info!("Waiting for pool to be Online - {:?}", pool);
+        if pool.state.is_some() && (pool.state.clone().unwrap().status == PoolStatus::Online) {
+            tracing::info!("Pool is Online now");
+            return Some(pool);
+        }
+
+        if std::time::Instant::now() > (start + timeout)
+            && (pool.state.is_none() || pool.state.as_ref().unwrap().status != PoolStatus::Online)
+        {
+            tracing::info!("Timeout waiting for pool to be Online - {:?}", pool);
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
 }

--- a/control-plane/stor-port/src/transport_api/v0.rs
+++ b/control-plane/stor-port/src/transport_api/v0.rs
@@ -55,6 +55,7 @@ impl_message!(FaultNexusChild);
 impl_message!(NexusChildAction);
 impl_message!(ShutdownNexus);
 impl_message!(GetRebuildRecord);
+impl_message!(ListRebuildRecord);
 impl_message!(CreateNexusSnapshot);
 
 impl_vector_request_token!(Volumes, Volume);

--- a/control-plane/stor-port/src/types/v0/transport/mod.rs
+++ b/control-plane/stor-port/src/types/v0/transport/mod.rs
@@ -165,6 +165,8 @@ pub enum MessageIdVs {
     GetNvmeSubsystems,
     /// Get Rebuild records.
     GetRebuildRecord,
+    /// List rebuild records.
+    ListRebuildRecord,
 }
 
 impl From<MessageIdVs> for MessageId {

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -746,6 +746,25 @@ pub struct GetRebuildRecord {
     pub nexus: NexusId,
 }
 
+/// List rebuild history request.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct ListRebuildRecord {
+    /// Maximum number of rebuild records per nexus.
+    count: Option<u32>,
+}
+
+impl ListRebuildRecord {
+    /// Returns instance of self.
+    pub fn new(count: Option<u32>) -> Self {
+        Self { count }
+    }
+
+    /// Get count from the request.
+    pub fn count(&self) -> Option<u32> {
+        self.count
+    }
+}
+
 impl GetRebuildRecord {
     /// Returns instance of self.
     pub fn new(uuid: NexusId) -> Self {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -464,11 +464,12 @@ pub mod v1 {
             nexus_rpc_client, AddChildNexusRequest, AddChildNexusResponse, Child, ChildAction,
             ChildOperationRequest, ChildState, ChildStateReason, CreateNexusRequest,
             CreateNexusResponse, DestroyNexusRequest, FaultNexusChildRequest, ListNexusOptions,
-            ListNexusResponse, Nexus, NexusNvmePreemption, NexusState, NvmeAnaState,
-            NvmeReservation, PublishNexusRequest, PublishNexusResponse, RebuildHistoryRecord,
-            RebuildHistoryRequest, RebuildHistoryResponse, RebuildJobState,
-            RemoveChildNexusRequest, RemoveChildNexusResponse, ShutdownNexusRequest,
-            UnpublishNexusRequest, UnpublishNexusResponse,
+            ListNexusResponse, ListRebuildHistoryRequest, Nexus, NexusNvmePreemption, NexusState,
+            NvmeAnaState, NvmeReservation, PublishNexusRequest, PublishNexusResponse,
+            RebuildHistoryMapResponse, RebuildHistoryRecord, RebuildHistoryRequest,
+            RebuildHistoryResponse, RebuildJobState, RemoveChildNexusRequest,
+            RemoveChildNexusResponse, ShutdownNexusRequest, UnpublishNexusRequest,
+            UnpublishNexusResponse,
         };
     }
 


### PR DESCRIPTION
We have added rebuild history resource map in the Nodewrapper. This uses list_rebuild_record rpc to periodically update rebuild history of all nexus in the node.

This PR also adds test for rebuild history in control plane.