### PR TITLE
Snapshot - Update Rpc api and Various Fixes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/mod.rs
@@ -18,6 +18,8 @@ type ReplicaClient = rpc::v1::replica::replica_rpc_client::ReplicaRpcClient<Chan
 type NexusClient = rpc::v1::nexus::nexus_rpc_client::NexusRpcClient<Channel>;
 /// The V1 PoolClient.
 type PoolClient = rpc::v1::pool::pool_rpc_client::PoolRpcClient<Channel>;
+/// The V1 SnapshotClient.
+type SnapshotClient = rpc::v1::snapshot::snapshot_rpc_client::SnapshotRpcClient<Channel>;
 
 /// A collection of all clients for the Io-Engine V1 services.
 #[derive(Clone, Debug)]
@@ -26,6 +28,7 @@ pub(crate) struct RpcClient {
     replica: ReplicaClient,
     nexus: NexusClient,
     pool: PoolClient,
+    snapshot: SnapshotClient,
     context: GrpcContext,
 }
 
@@ -45,7 +48,8 @@ impl RpcClient {
             host: HostClient::new(channel.clone()),
             replica: ReplicaClient::new(channel.clone()),
             nexus: NexusClient::new(channel.clone()),
-            pool: PoolClient::new(channel),
+            pool: PoolClient::new(channel.clone()),
+            snapshot: SnapshotClient::new(channel),
             context: context.clone(),
         })
     }
@@ -64,6 +68,10 @@ impl RpcClient {
     /// Get the v1 pool client.
     fn pool(&self) -> PoolClient {
         self.pool.clone()
+    }
+    /// Get the v1 snapshot client.
+    fn snapshot(&self) -> SnapshotClient {
+        self.snapshot.clone()
     }
 
     async fn fetcher_client(&self) -> Result<Self, SvcError> {

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
@@ -323,8 +323,8 @@ impl crate::controller::io_engine::NexusSnapshotApi for super::RpcClient {
         request: &CreateNexusSnapshot,
     ) -> Result<CreateNexusSnapshotResp, SvcError> {
         let response = self
-            .nexus()
-            .create_snapshot(request.to_rpc())
+            .snapshot()
+            .create_nexus_snapshot(request.to_rpc())
             .await
             .context(GrpcRequestError {
                 resource: ResourceKind::Nexus,

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -128,7 +128,7 @@ impl IoEngineToAgent for v1::replica::ReplicaSpaceUsage {
     }
 }
 
-impl TryIoEngineToAgent for v1::nexus::NexusCreateSnapshotResponse {
+impl TryIoEngineToAgent for v1::snapshot::NexusCreateSnapshotResponse {
     type AgentMessage = transport::CreateNexusSnapshotResp;
     fn try_to_agent(&self) -> Result<Self::AgentMessage, SvcError> {
         let nexus = self
@@ -165,7 +165,7 @@ impl TryIoEngineToAgent for v1::nexus::NexusCreateSnapshotResponse {
 
 /// Helper implementation to be used as part of nexus snapshot
 /// response translation.
-impl TryIoEngineToAgent for v1::nexus::NexusCreateSnapshotReplicaStatus {
+impl TryIoEngineToAgent for v1::snapshot::NexusCreateSnapshotReplicaStatus {
     type AgentMessage = transport::CreateNexusSnapshotReplicaStatus;
     fn try_to_agent(&self) -> Result<Self::AgentMessage, SvcError> {
         Ok(Self::AgentMessage {
@@ -180,7 +180,7 @@ impl TryIoEngineToAgent for v1::nexus::NexusCreateSnapshotReplicaStatus {
     }
 }
 
-impl TryIoEngineToAgent for v1::replica::CreateReplicaSnapshotResponse {
+impl TryIoEngineToAgent for v1::snapshot::CreateReplicaSnapshotResponse {
     type AgentMessage = transport::ReplicaSnapshot;
     fn try_to_agent(&self) -> Result<Self::AgentMessage, SvcError> {
         self.snapshot
@@ -192,7 +192,7 @@ impl TryIoEngineToAgent for v1::replica::CreateReplicaSnapshotResponse {
 
 /// Translate gRPC single snapshot representation to snapshot
 /// descriptor single snapshot representation in control-plane.
-impl TryIoEngineToAgent for v1::replica::ReplicaSnapshot {
+impl TryIoEngineToAgent for v1::snapshot::SnapshotInfo {
     type AgentMessage = transport::ReplicaSnapshotDescr;
     fn try_to_agent(&self) -> Result<Self::AgentMessage, SvcError> {
         Ok(Self::AgentMessage::new(
@@ -209,15 +209,15 @@ impl TryIoEngineToAgent for v1::replica::ReplicaSnapshot {
                 .clone()
                 .and_then(|t| std::time::SystemTime::try_from(t).ok())
                 .unwrap_or(UNIX_EPOCH),
-            ReplicaId::try_from(self.replica_uuid.as_str()).map_err(|_| SvcError::InvalidUuid {
-                uuid: self.replica_uuid.to_owned(),
+            ReplicaId::try_from(self.source_uuid.as_str()).map_err(|_| SvcError::InvalidUuid {
+                uuid: self.source_uuid.to_owned(),
                 kind: ResourceKind::Replica,
             })?,
             // todo: from new api changes
             PoolUuid::default(),
             // todo: from new api changes
             PoolId::default(),
-            self.replica_size,
+            self.source_size,
             self.entity_id.clone(),
             self.txn_id.clone(),
             self.valid_snapshot,
@@ -485,9 +485,9 @@ impl AgentToIoEngine for transport::NexusChildActionKind {
 }
 
 impl AgentToIoEngine for transport::CreateNexusSnapshot {
-    type IoEngineMessage = v1::nexus::NexusCreateSnapshotRequest;
+    type IoEngineMessage = v1::snapshot::NexusCreateSnapshotRequest;
     fn to_rpc(&self) -> Self::IoEngineMessage {
-        v1::nexus::NexusCreateSnapshotRequest {
+        v1::snapshot::NexusCreateSnapshotRequest {
             nexus_uuid: self.nexus().to_string(),
             entity_id: self.params().entity().to_string(),
             txn_id: self.params().txn_id().to_string(),
@@ -498,7 +498,7 @@ impl AgentToIoEngine for transport::CreateNexusSnapshot {
 }
 
 impl AgentToIoEngine for CreateNexusSnapReplDescr {
-    type IoEngineMessage = v1::nexus::NexusCreateSnapshotReplicaDescriptor;
+    type IoEngineMessage = v1::snapshot::NexusCreateSnapshotReplicaDescriptor;
     fn to_rpc(&self) -> Self::IoEngineMessage {
         Self::IoEngineMessage {
             replica_uuid: self.replica.to_string(),
@@ -509,9 +509,9 @@ impl AgentToIoEngine for CreateNexusSnapReplDescr {
 }
 
 impl AgentToIoEngine for transport::CreateReplicaSnapshot {
-    type IoEngineMessage = v1::replica::CreateReplicaSnapshotRequest;
+    type IoEngineMessage = v1::snapshot::CreateReplicaSnapshotRequest;
     fn to_rpc(&self) -> Self::IoEngineMessage {
-        v1::replica::CreateReplicaSnapshotRequest {
+        v1::snapshot::CreateReplicaSnapshotRequest {
             replica_uuid: self.replica().to_string(),
             snapshot_uuid: self.params().uuid().to_string(),
             snapshot_name: self.params().name().to_string(),

--- a/control-plane/agents/src/bin/core/controller/reconciler/persistent_store.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/persistent_store.rs
@@ -22,8 +22,11 @@ impl TaskPoller for PersistentStoreReconciler {
             let dirty_replicas = specs.reconcile_dirty_replicas(context.registry()).await;
             let dirty_nexuses = specs.reconcile_dirty_nexuses(context.registry()).await;
             let dirty_volumes = specs.reconcile_dirty_volumes(context.registry()).await;
+            let dirty_snapshots = specs
+                .reconcile_dirty_volume_snapshots(context.registry())
+                .await;
 
-            if dirty_nexuses || dirty_replicas || dirty_volumes || dirty_pools {
+            if dirty_nexuses || dirty_replicas || dirty_volumes || dirty_pools || dirty_snapshots {
                 return PollResult::Ok(PollerState::Busy);
             }
         }

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -232,7 +232,10 @@ pub(crate) trait GuardedOperationsHelper:
         Self::Inner: StorableObject,
     {
         match on_fail {
-            OnCreateFail::LeaveAsIs => error,
+            OnCreateFail::LeaveAsIs => {
+                self.lock().clear_op();
+                error
+            }
             OnCreateFail::SetDeleting => {
                 // Let the garbage collector delete the spec gracefully.
                 // This will ensure we'll delete previously created resources.
@@ -531,12 +534,31 @@ pub(crate) trait GuardedOperationsHelper:
         Self::Inner: SpecTransaction<O>,
         Self::Inner: StorableObject,
     {
+        self.handle_incomplete_ops_ext(registry, OnCreateFail::SetDeleting)
+            .await
+    }
+    /// Operations that have started but were not able to complete because access to the
+    /// persistent store was lost.
+    /// Returns whether the incomplete operation has now been handled.
+    async fn handle_incomplete_ops_ext<O>(
+        &mut self,
+        registry: &Registry,
+        on_fail: OnCreateFail,
+    ) -> bool
+    where
+        Self::Inner: SpecTransaction<O>,
+        Self::Inner: StorableObject,
+    {
         let spec_status = self.lock().status();
         match spec_status {
             SpecStatus::Creating => {
-                // Go to deleting stage to make sure we clean-up previously allocated resources.
-                self.lock().set_status(SpecStatus::Deleting);
-                true
+                if matches!(on_fail, OnCreateFail::SetDeleting) {
+                    // Go to deleting stage to make sure we clean-up previously allocated resources.
+                    self.lock().set_status(SpecStatus::Deleting);
+                    true
+                } else {
+                    self.handle_incomplete_updates(registry).await
+                }
             }
             SpecStatus::Deleted => {
                 self.delete_spec(registry).await.ok();

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -417,15 +417,18 @@ pub(crate) trait GuardedOperationsHelper:
         Self::Inner: SpecTransaction<Self::UpdateOp>,
         Self::Inner: StorableObject,
     {
-        let spec_clone = {
+        let (spec_clone, log_op) = {
             let mut spec = self.lock().clone();
+            let log_op = spec.log_op(&update_operation);
             spec.start_update_inner(registry, state, update_operation)
                 .await?;
             *self.lock() = spec.clone();
-            spec
+            (spec, log_op.0)
         };
 
-        self.store_operation_log(registry, &spec_clone).await?;
+        if log_op {
+            self.store_operation_log(registry, &spec_clone).await?;
+        }
         Ok(spec_clone)
     }
 
@@ -442,10 +445,15 @@ pub(crate) trait GuardedOperationsHelper:
         Self::Inner: SpecTransaction<O>,
         Self::Inner: StorableObject,
     {
+        let store_obj = spec_clone.flush_pending_op();
         match result {
             Ok(val) => {
                 tracing::info!(?val, "complete_update");
 
+                if !store_obj {
+                    self.complete_op();
+                    return Ok(val);
+                }
                 spec_clone.commit_op();
                 let stored = registry.store_obj(&spec_clone).await;
                 match stored {
@@ -460,6 +468,10 @@ pub(crate) trait GuardedOperationsHelper:
                 }
             }
             Err(error) => {
+                if !store_obj {
+                    self.lock().clear_op();
+                    return Err(error);
+                }
                 spec_clone.clear_op();
                 let stored = registry.store_obj(&spec_clone).await;
                 let mut spec = self.lock();

--- a/control-plane/agents/src/bin/core/nexus/specs.rs
+++ b/control-plane/agents/src/bin/core/nexus/specs.rs
@@ -92,7 +92,7 @@ impl SpecOperationsHelper for NexusSpec {
     }
 
     fn dirty(&self) -> bool {
-        self.pending_op()
+        self.has_pending_op()
     }
     fn kind(&self) -> ResourceKind {
         ResourceKind::Nexus

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -182,7 +182,7 @@ impl SpecOperationsHelper for NodeSpec {
     }
 
     fn dirty(&self) -> bool {
-        self.pending_op()
+        self.has_pending_op()
     }
     fn kind(&self) -> ResourceKind {
         ResourceKind::Node

--- a/control-plane/agents/src/bin/core/pool/specs.rs
+++ b/control-plane/agents/src/bin/core/pool/specs.rs
@@ -72,7 +72,7 @@ impl SpecOperationsHelper for PoolSpec {
     fn dirty(&self) -> bool {
         // The pool spec can be dirty if a pool create operation fails to complete because it cannot
         // write to etcd.
-        self.pending_op()
+        self.has_pending_op()
     }
     fn kind(&self) -> ResourceKind {
         ResourceKind::Pool
@@ -161,7 +161,7 @@ impl SpecOperationsHelper for ReplicaSpec {
         self.start_op(ReplicaOperation::Destroy);
     }
     fn dirty(&self) -> bool {
-        self.pending_op()
+        self.has_pending_op()
     }
     fn kind(&self) -> ResourceKind {
         ResourceKind::Replica

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -116,7 +116,7 @@ async fn snapshot() {
             None,
         )
         .await
-        .expect_err("unimplemented");
+        .unwrap();
 
     tracing::info!("Nexus Snapshot: {nexus_snapshot:?}");
 

--- a/control-plane/agents/src/bin/core/volume/registry.rs
+++ b/control-plane/agents/src/bin/core/volume/registry.rs
@@ -223,11 +223,9 @@ impl Registry {
         };
 
         let pool_id = snapshot.source_id().pool_id();
-        let pool_uuid = snapshot.source_id().pool_uuid();
         let pool_node = self.pool_node(pool_id).await.ok_or(err())?;
         let node = self.node_wrapper(&pool_node).await?;
         let snapshot = node.snapshot(snapshot.uuid()).await;
-        let snapshot = snapshot.map(|snap| snap.with_pool_info(pool_id, pool_uuid));
         snapshot.ok_or(err())
     }
     /// Get the snapshot state for the specified volume.
@@ -280,8 +278,6 @@ impl Registry {
                 });
             }
         }
-
-        tracing::info!("S: {snapshot:?}");
 
         Ok(grpc_mod::VolumeSnapshot::new(
             &snapshot,

--- a/control-plane/agents/src/bin/core/volume/snapshot_helpers.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_helpers.rs
@@ -72,7 +72,7 @@ impl SpecOperationsHelper for VolumeSnapshot {
         self.start_op(VolumeSnapshotOperation::Destroy);
     }
     fn dirty(&self) -> bool {
-        self.pending_op()
+        self.has_pending_op()
     }
     fn kind(&self) -> ResourceKind {
         ResourceKind::VolumeSnapshot

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -407,11 +407,10 @@ impl OperationGuardArc<VolumeSnapshot> {
         registry: &Registry,
     ) -> Result<(), SvcError> {
         let specs = registry.specs();
+        let source = replica_snapshot.spec().source_id();
 
         // Get the pool using the replica snapshot's pool and extract the node_id.
-        let node_id = specs
-            .pool(replica_snapshot.spec().source_id().pool_id())?
-            .node;
+        let node_id = specs.pool(source.pool_id())?.node;
 
         // Get the corresponding node wrapper for the same.
         let node_wrapper = registry.node_wrapper(&node_id).await?;
@@ -420,6 +419,7 @@ impl OperationGuardArc<VolumeSnapshot> {
         node_wrapper
             .destroy_repl_snapshot(&DestroyReplicaSnapshot::new(
                 replica_snapshot.spec().uuid().clone(),
+                source.pool_uuid().clone(),
             ))
             .await?;
 

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -240,7 +240,7 @@ impl ResourcePruning for OperationGuardArc<VolumeSnapshot> {
                 spec.metadata()
                     .stale_transactions()
                     .into_values()
-                    .flat_map(|v| v.into_iter())
+                    .flatten()
                     .collect(),
                 registry,
             )

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -3,7 +3,7 @@ use crate::{
         registry::Registry,
         resources::{
             operations_helper::{
-                GuardedOperationsHelper, OperationSequenceGuard, ResourceSpecs,
+                GuardedOperationsHelper, OnCreateFail, OperationSequenceGuard, ResourceSpecs,
                 ResourceSpecsLocked, SpecOperationsHelper,
             },
             OperationGuardArc, ResourceMutex, TraceSpan, TraceStrLog,
@@ -698,7 +698,7 @@ impl ResourceSpecsLocked {
     }
 
     /// Worker that reconciles dirty VolumeSpecs's with the persistent store.
-    /// This is useful when nexus operations are performed but we fail to
+    /// This is useful when volume operations are performed but we fail to
     /// update the spec with the persistent store.
     pub(crate) async fn reconcile_dirty_volumes(&self, registry: &Registry) -> bool {
         let mut pending_ops = false;
@@ -707,6 +707,26 @@ impl ResourceSpecsLocked {
         for volume_spec in volumes {
             if let Ok(mut guard) = volume_spec.operation_guard() {
                 if !guard.handle_incomplete_ops(registry).await {
+                    // Not all pending operations could be handled.
+                    pending_ops = true;
+                }
+            }
+        }
+        pending_ops
+    }
+
+    /// Worker that reconciles dirty VolumeSnapshot's with the persistent store.
+    /// This is useful when snapshot operations are performed but we fail to
+    /// update the spec with the persistent store.
+    pub(crate) async fn reconcile_dirty_volume_snapshots(&self, registry: &Registry) -> bool {
+        let mut pending_ops = false;
+
+        for snapshot in self.volume_snapshots_rsc() {
+            if let Ok(mut guard) = snapshot.operation_guard() {
+                if !guard
+                    .handle_incomplete_ops_ext(registry, OnCreateFail::LeaveAsIs)
+                    .await
+                {
                     // Not all pending operations could be handled.
                     pending_ops = true;
                 }

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -970,7 +970,7 @@ impl SpecOperationsHelper for VolumeSpec {
         self.start_op(VolumeOperation::Destroy);
     }
     fn dirty(&self) -> bool {
-        self.pending_op()
+        self.has_pending_op()
     }
     fn kind(&self) -> ResourceKind {
         ResourceKind::Volume

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -806,7 +806,7 @@ fn snapshot_to_csi(snapshot: models::VolumeSnapshot) -> Snapshot {
         size_bytes: snapshot.state.size as i64,
         snapshot_id: snapshot.definition.spec.uuid.to_string(),
         source_volume_id: snapshot.definition.spec.source_volume.to_string(),
-        creation_time: prost_types::Timestamp::from_str(&snapshot.state.creation_timestamp).ok(),
+        creation_time: prost_types::Timestamp::from_str(&snapshot.state.timestamp).ok(),
         ready_to_use: snapshot.state.clone_ready.unwrap_or_default(),
     }
 }

--- a/control-plane/grpc/src/operations/volume/traits_snapshots.rs
+++ b/control-plane/grpc/src/operations/volume/traits_snapshots.rs
@@ -89,7 +89,7 @@ impl From<&stor_port::types::v0::store::snapshots::volume::VolumeSnapshot> for V
             },
             meta: VolumeSnapshotMeta {
                 status: value.status().clone(),
-                creation_timestamp: value
+                timestamp: value
                     .metadata()
                     .timestamp()
                     .map(|t| std::time::SystemTime::from(t).into()),
@@ -111,7 +111,7 @@ pub struct VolumeSnapshotMeta {
     status: SpecStatus<()>,
 
     /// Creation timestamp of the snapshot (set after creation time).
-    creation_timestamp: Option<prost_types::Timestamp>,
+    timestamp: Option<prost_types::Timestamp>,
 
     /// Transaction Id that defines this snapshot when it is created.
     txn_id: SnapshotTxId,
@@ -124,7 +124,7 @@ pub struct VolumeSnapshotMeta {
 impl VolumeSnapshotMeta {
     /// Get the volume snapshot timestamp.
     pub fn timestamp(&self) -> Option<&prost_types::Timestamp> {
-        self.creation_timestamp.as_ref()
+        self.timestamp.as_ref()
     }
     /// Get the volume snapshot transaction id.
     pub fn txn_id(&self) -> &SnapshotTxId {
@@ -141,7 +141,7 @@ pub struct ReplicaSnapshot {
     /// The id of the snapshot.
     uuid: SnapshotId,
     /// Creation timestamp of the snapshot (set after creation time).
-    creation_timestamp: Option<prost_types::Timestamp>,
+    timestamp: Option<prost_types::Timestamp>,
     /// A transaction id for this request.
     txn_id: SnapshotTxId,
     source_id: ReplicaId,
@@ -151,7 +151,7 @@ impl From<&v0::store::snapshots::replica::ReplicaSnapshot> for ReplicaSnapshot {
         ReplicaSnapshot {
             status: value.status().clone(),
             uuid: value.spec().uuid().clone(),
-            creation_timestamp: value.meta().timestamp().map(|t| prost_types::Timestamp {
+            timestamp: value.meta().timestamp().map(|t| prost_types::Timestamp {
                 seconds: t.timestamp(),
                 nanos: t.timestamp_subsec_nanos() as i32,
             }),
@@ -383,7 +383,7 @@ impl TryFrom<volume::VolumeSnapshot> for VolumeSnapshot {
                 status: common::SpecStatus::from_i32(meta.spec_status)
                     .unwrap_or_default()
                     .into(),
-                creation_timestamp: meta.timestamp,
+                timestamp: meta.timestamp,
                 txn_id: meta.txn_id,
                 transactions: meta
                     .transactions
@@ -506,7 +506,7 @@ impl TryFrom<volume::ReplicaSnapshot> for ReplicaSnapshot {
             uuid: value
                 .uuid
                 .try_into_id(ResourceKind::ReplicaSnapshot, "uuid")?,
-            creation_timestamp: value.timestamp.into_opt(),
+            timestamp: value.timestamp.into_opt(),
             txn_id: value.txn_id,
             source_id: value
                 .source_id
@@ -539,7 +539,7 @@ impl TryFrom<VolumeSnapshot> for volume::VolumeSnapshot {
                                     .map(|r| volume::ReplicaSnapshot {
                                         uuid: r.uuid.to_string(),
                                         spec_status: common::SpecStatus::from(&r.status) as i32,
-                                        timestamp: r.creation_timestamp.clone(),
+                                        timestamp: r.timestamp.clone(),
                                         txn_id: r.txn_id.clone(),
                                         source_id: r.source_id.to_string(),
                                     })

--- a/control-plane/plugin/src/resources/snapshot.rs
+++ b/control-plane/plugin/src/resources/snapshot.rs
@@ -38,12 +38,7 @@ impl VolumeSnapshotArgs {
 impl CreateRow for openapi::models::VolumeSnapshot {
     fn row(&self) -> Row {
         let state = &self.state;
-        row![
-            state.uuid,
-            state.creation_timestamp,
-            state.size,
-            state.source_volume
-        ]
+        row![state.uuid, state.timestamp, state.size, state.source_volume]
     }
 }
 

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3220,7 +3220,7 @@ components:
         Volume Snapshot Metadata information.
       type: object
       properties:
-        creation_timestamp:
+        timestamp:
           description: Timestamp when snapshot is taken on the storage system.
           type: string
           format: date-time
@@ -3262,7 +3262,7 @@ components:
           minimum: 0
         source_volume:
           $ref: '#/components/schemas/VolumeId'
-        creation_timestamp:
+        timestamp:
           description: Timestamp when snapshot is taken on the storage system.
           type: string
           format: date-time
@@ -3279,7 +3279,7 @@ components:
         - uuid
         - size
         - source_volume
-        - creation_timestamp
+        - timestamp
         - ready
         - replica_snapshots
     ReplicaSnapshot:
@@ -3306,7 +3306,7 @@ components:
           $ref: '#/components/schemas/SnapshotId'
         source_id:
           $ref: '#/components/schemas/ReplicaId'
-        creation_timestamp:
+        timestamp:
           description: Timestamp when replica snapshot is taken on the storage system.
           type: string
           format: date-time
@@ -3323,7 +3323,7 @@ components:
       required:
         - uuid
         - source_id
-        - creation_timestamp
+        - timestamp
         - size
         - referenced_size
         - state

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2765,6 +2765,7 @@ components:
                 - Unshare
                 - AddChild
                 - RemoveChild
+                - Shutdown
             result:
               description: Result of the operation
               type: boolean
@@ -2956,6 +2957,8 @@ components:
                 - Publish
                 - Republish
                 - Unpublish
+                - CreateSnapshot
+                - DestroySnapshot
             result:
               description: Result of the operation
               type: boolean

--- a/control-plane/stor-port/src/types/v0/store/mod.rs
+++ b/control-plane/stor-port/src/types/v0/store/mod.rs
@@ -65,19 +65,34 @@ impl<T: std::cmp::PartialEq> SpecStatus<T> {
 
 /// Transaction Operations for a Spec
 pub trait SpecTransaction<Operation> {
-    /// Check for a pending operation
-    fn pending_op(&self) -> bool;
-    /// Commit the operation to the spec and clear it
+    /// Check for a pending operation.
+    fn has_pending_op(&self) -> bool;
+    /// Commit the operation to the spec and clear it.
     fn commit_op(&mut self);
-    /// Clear the operation
+    /// Clear the operation.
     fn clear_op(&mut self);
-    /// Add a new pending operation
+    /// Add a new pending operation.
     fn start_op(&mut self, operation: Operation);
-    /// Sets the result of the operation
+    /// Sets the result of the operation.
     fn set_op_result(&mut self, result: bool);
     /// Allow this operation while deleting a spec.
     fn allow_op_deleting(&mut self, _operation: &Operation) -> bool {
         false
+    }
+    /// Check if an operation needs to be performed as a transaction
+    /// (ie if we need to log the opertion to the pstor before attempting to perform it)
+    /// and if we need to update pstor on completion.
+    fn log_op(&self, _operation: &Operation) -> (bool, bool) {
+        (true, true)
+    }
+    /// Return the pending operation, if any.
+    fn pending_op(&self) -> Option<&Operation>;
+    /// Check if an operation needs to be flushed to the pstor.
+    fn flush_pending_op(&self) -> bool {
+        match self.pending_op() {
+            Some(op) => self.log_op(op).1,
+            None => false,
+        }
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus.rs
@@ -223,7 +223,7 @@ pub struct NexusOperationState {
 }
 
 impl SpecTransaction<NexusOperation> for NexusSpec {
-    fn pending_op(&self) -> bool {
+    fn has_pending_op(&self) -> bool {
         self.operation.is_some()
     }
 
@@ -270,6 +270,10 @@ impl SpecTransaction<NexusOperation> for NexusSpec {
         if let Some(op) = &mut self.operation {
             op.result = Some(result);
         }
+    }
+
+    fn pending_op(&self) -> Option<&NexusOperation> {
+        self.operation.as_ref().map(|o| &o.operation)
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -530,7 +530,7 @@ pub struct NodeOperationState {
 }
 
 impl SpecTransaction<NodeOperation> for NodeSpec {
-    fn pending_op(&self) -> bool {
+    fn has_pending_op(&self) -> bool {
         self.operation.is_some()
     }
 
@@ -578,5 +578,21 @@ impl SpecTransaction<NodeOperation> for NodeSpec {
         if let Some(op) = &mut self.operation {
             op.result = Some(result);
         }
+    }
+
+    fn log_op(&self, operation: &NodeOperation) -> (bool, bool) {
+        match operation {
+            NodeOperation::Cordon(_) => (false, false),
+            NodeOperation::Uncordon(_) => (false, false),
+            NodeOperation::Drain(_) => (false, false),
+            NodeOperation::AddDrainingVolumes(_) => (false, false),
+            NodeOperation::RemoveDrainingVolumes(_) => (false, false),
+            NodeOperation::RemoveAllDrainingVolumes() => (false, false),
+            NodeOperation::SetDrained() => (false, false),
+        }
+    }
+
+    fn pending_op(&self) -> Option<&NodeOperation> {
+        self.operation.as_ref().map(|o| &o.operation)
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -121,7 +121,7 @@ pub struct PoolOperationState {
 }
 
 impl SpecTransaction<PoolOperation> for PoolSpec {
-    fn pending_op(&self) -> bool {
+    fn has_pending_op(&self) -> bool {
         self.operation.is_some()
     }
 
@@ -154,6 +154,10 @@ impl SpecTransaction<PoolOperation> for PoolSpec {
         if let Some(op) = &mut self.operation {
             op.result = Some(result);
         }
+    }
+
+    fn pending_op(&self) -> Option<&PoolOperation> {
+        self.operation.as_ref().map(|o| &o.operation)
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/replica.rs
@@ -243,7 +243,7 @@ pub struct ReplicaOperationState {
 }
 
 impl SpecTransaction<ReplicaOperation> for ReplicaSpec {
-    fn pending_op(&self) -> bool {
+    fn has_pending_op(&self) -> bool {
         self.operation.is_some()
     }
 
@@ -290,6 +290,20 @@ impl SpecTransaction<ReplicaOperation> for ReplicaSpec {
 
     fn allow_op_deleting(&mut self, operation: &ReplicaOperation) -> bool {
         matches!(operation, ReplicaOperation::OwnerUpdate(_))
+    }
+
+    fn log_op(&self, operation: &ReplicaOperation) -> (bool, bool) {
+        match operation {
+            ReplicaOperation::Create => (true, true),
+            ReplicaOperation::Destroy => (true, true),
+            ReplicaOperation::Share(_, _) => (true, true),
+            ReplicaOperation::Unshare => (true, true),
+            ReplicaOperation::OwnerUpdate(_) => (false, true),
+        }
+    }
+
+    fn pending_op(&self) -> Option<&ReplicaOperation> {
+        self.operation.as_ref().map(|o| &o.operation)
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/snapshots/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/replica.rs
@@ -190,7 +190,7 @@ impl AsOperationSequencer for ReplicaSnapshot {
     }
 }
 impl SpecTransaction<ReplicaSnapshotOperation> for ReplicaSnapshot {
-    fn pending_op(&self) -> bool {
+    fn has_pending_op(&self) -> bool {
         self.metadata.operation.is_some()
     }
 
@@ -223,6 +223,10 @@ impl SpecTransaction<ReplicaSnapshotOperation> for ReplicaSnapshot {
         if let Some(op) = &mut self.metadata.operation {
             op.result = Some(result);
         }
+    }
+
+    fn pending_op(&self) -> Option<&ReplicaSnapshotOperation> {
+        self.metadata.operation.as_ref().map(|o| &o.operation)
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
@@ -99,7 +99,7 @@ pub struct VolumeSnapshotMeta {
     operation: Option<VolumeSnapshotOperationState>,
 
     /// Creation timestamp of the snapshot (set after creation time).
-    creation_timestamp: Option<DateTime<Utc>>,
+    timestamp: Option<DateTime<Utc>>,
     /// Size of the snapshot (typically follows source size).
     size: u64,
     /// Transaction Id that defines this snapshot when it is created.
@@ -117,7 +117,7 @@ impl VolumeSnapshotMeta {
     }
     /// Get the snapshot timestamp.
     pub fn timestamp(&self) -> &Option<DateTime<Utc>> {
-        &self.creation_timestamp
+        &self.timestamp
     }
     /// Get the snapshot transaction id.
     pub fn txn_id(&self) -> &SnapshotTxId {
@@ -252,6 +252,7 @@ impl SpecTransaction<VolumeSnapshotOperation> for VolumeSnapshot {
                 self.metadata.txn_id = info.txn_id.clone();
                 if let Some(result) = info.complete.lock().unwrap().as_ref() {
                     self.metadata.size = result.replica.meta().size();
+                    self.metadata.timestamp = Some(result.timestamp);
                     // replace-in-place the logged replica specs.
                     self.metadata
                         .transactions
@@ -265,7 +266,6 @@ impl SpecTransaction<VolumeSnapshotOperation> for VolumeSnapshot {
             }
             VolumeSnapshotOperation::CleanupStaleTransactions => {}
         }
-        self.clear_op();
     }
 
     fn clear_op(&mut self) {
@@ -273,8 +273,12 @@ impl SpecTransaction<VolumeSnapshotOperation> for VolumeSnapshot {
             return;
         };
         match op.operation {
-            VolumeSnapshotOperation::Create(info) => {
-                self.metadata.txn_id = info.txn_id;
+            VolumeSnapshotOperation::Create(mut info) => {
+                self.metadata.txn_id = info.txn_id.clone();
+                info.replica.set_status_deleting();
+                self.metadata
+                    .transactions
+                    .insert(info.txn_id, vec![info.replica]);
             }
             VolumeSnapshotOperation::Destroy => {}
             VolumeSnapshotOperation::CleanupStaleTransactions => {}

--- a/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
@@ -236,7 +236,7 @@ impl AsOperationSequencer for VolumeSnapshot {
     }
 }
 impl SpecTransaction<VolumeSnapshotOperation> for VolumeSnapshot {
-    fn pending_op(&self) -> bool {
+    fn has_pending_op(&self) -> bool {
         self.metadata.operation.is_some()
     }
 
@@ -277,7 +277,7 @@ impl SpecTransaction<VolumeSnapshotOperation> for VolumeSnapshot {
                 self.metadata.txn_id = info.txn_id;
             }
             VolumeSnapshotOperation::Destroy => {}
-            VolumeSnapshotOperation::CleanupStaleTransactions => todo!(),
+            VolumeSnapshotOperation::CleanupStaleTransactions => {}
         }
     }
 
@@ -292,6 +292,10 @@ impl SpecTransaction<VolumeSnapshotOperation> for VolumeSnapshot {
         if let Some(op) = &mut self.metadata.operation {
             op.result = Some(result);
         }
+    }
+
+    fn pending_op(&self) -> Option<&VolumeSnapshotOperation> {
+        self.metadata.operation.as_ref().map(|o| &o.operation)
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/switchover.rs
+++ b/control-plane/stor-port/src/types/v0/store/switchover.rs
@@ -140,7 +140,7 @@ impl ObjectKey for SwitchOverSpecKey {
 }
 
 impl SpecTransaction<Operation> for SwitchOverSpec {
-    fn pending_op(&self) -> bool {
+    fn has_pending_op(&self) -> bool {
         self.operation.is_some()
     }
 
@@ -178,5 +178,9 @@ impl SpecTransaction<Operation> for SwitchOverSpec {
         if let Some(op) = &mut self.operation {
             op.result = Some(result);
         }
+    }
+
+    fn pending_op(&self) -> Option<&Operation> {
+        self.operation.as_ref().map(|o| &o.operation)
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -123,7 +123,7 @@ pub struct ReplicaSnapshotDescr {
     snap_size: u64,
     /// Number of clones created from this snapshot.
     num_clones: u64,
-    /// Snapshot creation_timestamp.
+    /// Snapshot timestamp.
     snap_time: SystemTime,
     /// UUID of the replica this snapshot is taken from.
     replica_uuid: ReplicaId,

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -98,12 +98,13 @@ impl CreateReplicaSnapshot {
 pub struct DestroyReplicaSnapshot {
     /// Id of the snapshot to be deleted.
     pub snap_id: SnapshotId,
+    pub pool_uuid: PoolUuid,
 }
 
 impl DestroyReplicaSnapshot {
     /// Create new request.
-    pub fn new(snap_id: SnapshotId) -> Self {
-        Self { snap_id }
+    pub fn new(snap_id: SnapshotId, pool_uuid: PoolUuid) -> Self {
+        Self { snap_id, pool_uuid }
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/transport/snapshot.rs
+++ b/control-plane/stor-port/src/types/v0/transport/snapshot.rs
@@ -108,7 +108,12 @@ impl GenericSnapshotParameters {
 
 /// The request type to list replica's snapshots.
 #[derive(Default)]
-pub struct ListReplicaSnapshots {
-    /// If Some, list snapshots from this replica only.
-    pub replica: Option<ReplicaId>,
+pub enum ListReplicaSnapshots {
+    /// All snapshots.
+    #[default]
+    All,
+    /// All snapshots from the given source.
+    ReplicaSnapshots(ReplicaId),
+    /// The specific snapshot.
+    Snapshot(SnapshotId),
 }

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -34,6 +34,7 @@ fn main() {
                 "api/protobuf/v1/nexus.proto",
                 "api/protobuf/v1/pool.proto",
                 "api/protobuf/v1/json.proto",
+                "api/protobuf/v1/snapshot.proto",
             ],
             &["api/protobuf/v1"],
         )

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -453,9 +453,7 @@ pub mod v1 {
     pub mod replica {
         pub use super::pb::{
             destroy_replica_request, replica_rpc_client, CreateReplicaRequest,
-            CreateReplicaSnapshotRequest, CreateReplicaSnapshotResponse,
-            DeleteReplicaSnapshotRequest, DestroyReplicaRequest, ListReplicaOptions,
-            ListReplicaSnapshotsRequest, ListReplicasResponse, Replica, ReplicaSnapshot,
+            DestroyReplicaRequest, ListReplicaOptions, ListReplicasResponse, Replica,
             ReplicaSpaceUsage, ShareReplicaRequest, UnshareReplicaRequest,
         };
     }
@@ -466,13 +464,21 @@ pub mod v1 {
             nexus_rpc_client, AddChildNexusRequest, AddChildNexusResponse, Child, ChildAction,
             ChildOperationRequest, ChildState, ChildStateReason, CreateNexusRequest,
             CreateNexusResponse, DestroyNexusRequest, FaultNexusChildRequest, ListNexusOptions,
-            ListNexusResponse, Nexus, NexusCreateSnapshotReplicaDescriptor,
-            NexusCreateSnapshotReplicaStatus, NexusCreateSnapshotRequest,
-            NexusCreateSnapshotResponse, NexusNvmePreemption, NexusState, NvmeAnaState,
+            ListNexusResponse, Nexus, NexusNvmePreemption, NexusState, NvmeAnaState,
             NvmeReservation, PublishNexusRequest, PublishNexusResponse, RebuildHistoryRecord,
             RebuildHistoryRequest, RebuildHistoryResponse, RebuildJobState,
             RemoveChildNexusRequest, RemoveChildNexusResponse, ShutdownNexusRequest,
             UnpublishNexusRequest, UnpublishNexusResponse,
+        };
+    }
+
+    pub mod snapshot {
+        pub use super::pb::{
+            destroy_snapshot_request, snapshot_rpc_client, CreateReplicaSnapshotRequest,
+            CreateReplicaSnapshotResponse, DestroySnapshotRequest, ListSnapshotsRequest,
+            ListSnapshotsResponse, Nexus, NexusCreateSnapshotReplicaDescriptor,
+            NexusCreateSnapshotReplicaStatus, NexusCreateSnapshotRequest,
+            NexusCreateSnapshotResponse, SnapshotInfo,
         };
     }
 

--- a/shell.nix
+++ b/shell.nix
@@ -56,6 +56,7 @@ mkShell {
 
   # variables used to easily create containers with docker files
   ETCD_BIN = "${pkgs.etcd}/bin/etcd";
+  ETCDCTL_API = "3";
 
   # using the nix rust toolchain
   USE_NIX_RUST = "${toString (!norust)}";

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -19,10 +19,7 @@ pub const STORE_OP_TIMEOUT: &str = "5s";
 pub const STORE_LEASE_LOCK_TTL: &str = "30s";
 
 fn target_tag() -> String {
-    // until we address rpc api changes
-    let _ = TARGET_BRANCH;
-    "ed04bc1be11c".to_string()
-    // TARGET_BRANCH.replace('/', "-")
+    TARGET_BRANCH.replace('/', "-")
 }
 
 /// Fio Spdk image.


### PR DESCRIPTION
    fix(agents/core): handle pending snapshot operations

    When create fails for LeaveAsIs, clear the existing op.
    On failure, set stale transaction as deleting.
    Reconcile dirty volume snapshots.

    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(agents/core): don't use transaction for node and certain other operations

    Also add missing openapi operations enums.

    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

      fix(snapshot/pool): collect pool information from rpc

      Also enable list of all snapshots now that the bug has been resolved in the dataplane.

      Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

      feat(snapshot): update io_engine controller to make use of updated api

      Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

      chore: update rpc and dependencies submodules

      Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>