### PR TITLE
Multi tag fix

### DIFF
--- a/.github/workflows/release_artifacts.yml
+++ b/.github/workflows/release_artifacts.yml
@@ -9,6 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - run: |
+        # BUG: HEAD tag is fetched as lightweight instead of annotated
+        # https://github.com/actions/checkout/issues/290
+        if [ "${{ github.ref_type }}" == "tag" ]; then
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+        fi
     - uses: cachix/install-nix-action@v15
       with:
         nix_path: nixpkgs=channel:nixos

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,7 @@ dockerhub_tag_exists() {
 
 # Get the tag at the HEAD
 get_tag() {
-  vers=`git tag --points-at HEAD`
+  vers=`git tag --points-at HEAD | tail -n 1`
   echo -n $vers
 }
 get_hash() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,7 @@ dockerhub_tag_exists() {
 
 # Get the tag at the HEAD
 get_tag() {
-  vers=`git tag --points-at HEAD | tail -n 1`
+  vers=`git describe --exact-match 2>/dev/null || echo ""`
   echo -n $vers
 }
 get_hash() {


### PR DESCRIPTION
Fix for build failure as below , when multiple tags are on HEAD 
Building mayadata/mcp-core:v1.0.6 v1.0.7 ...
building '/nix/store/alzvq957g8xky34yz9bqfqqs74yx2dld-mayastor-version.drv'...
error: The path name 'control-plane-v1.0.6 v1.0.7' is invalid: the ' ' character is invalid. Path names are alphanumeric and can include the symbols +-._?= and must not begin with a period. Note: If 'control-plane-v1.0.6 v1.0.7' is a source file and you cannot rename it on disk, builtins.path { name = ... } can be used to give it an alternative name.
(use '--show-trace' to show detailed location information)

Also, modified the GA to display tag version on kubectl binary 