### PR TITLE
Several fixes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
@@ -64,7 +64,7 @@ async fn hot_spare_reconcile(
             hot_spare_nexus_reconcile(&mut volume, &volume_state, context).await
         }
         VolumeStatus::Faulted => PollResult::Ok(PollerState::Idle),
-        VolumeStatus::Shutdown => PollResult::Ok(PollerState::Idle),
+        VolumeStatus::ShuttingDown | VolumeStatus::Shutdown => PollResult::Ok(PollerState::Idle),
     }
 }
 

--- a/control-plane/agents/src/bin/core/nexus/operations.rs
+++ b/control-plane/agents/src/bin/core/nexus/operations.rs
@@ -47,6 +47,9 @@ impl ResourceLifecycle for OperationGuardArc<NexusSpec> {
                 node_id: request.node.to_string(),
             });
         }
+        if request.children.is_empty() {
+            return Err(SvcError::InvalidArguments {});
+        }
 
         let node = registry.node_wrapper(&request.node).await?;
 

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -10,7 +10,7 @@ use std::{collections::HashMap, time::Duration};
 use stor_port::{
     transport_api::{ReplyErrorKind, ResourceKind},
     types::v0::{
-        openapi::{apis::specs_api::tower::client::direct::Specs, models::SpecStatus},
+        openapi::{apis::specs_api::tower::client::direct::Specs, models, models::SpecStatus},
         store::nexus::NexusSpec,
         transport::{
             CreateVolume, DestroyShutdownTargets, DestroyVolume, Filter, GetSpecs, Nexus,
@@ -96,6 +96,14 @@ async fn old_nexus_delete_after_vol_destroy() {
         republished_node, target_node,
         "expected nexus node to change post republish"
     );
+
+    let nexus_api = rest_client.nexuses_api();
+    let nexuses = nexus_api.get_nexuses().await.unwrap();
+    tracing::info!("Nexuses after republish: {nexuses:?}");
+
+    assert!(nexuses
+        .iter()
+        .any(|n| n.state == models::NexusState::Shutdown));
 
     let nexuses = nexus_client
         .get(Filter::None, None)

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -6,7 +6,7 @@ use crate::{
             operations_helper::{
                 GuardedOperationsHelper, OperationSequenceGuard, ResourceSpecsLocked,
             },
-            OperationGuardArc, TraceSpan, TraceStrLog,
+            OperationGuardArc, ResourceUid, TraceSpan, TraceStrLog,
         },
         scheduling::resources::{HealthyChildItems, ReplicaItem},
     },
@@ -604,6 +604,12 @@ impl OperationGuardArc<VolumeSpec> {
             }
         }
         nexus_replicas.truncate(vol_spec.num_replicas as usize);
+
+        if nexus_replicas.is_empty() {
+            return Err(SvcError::NoOnlineReplicas {
+                id: vol_spec.uid_str(),
+            });
+        }
 
         // Create the nexus on the requested node
         let (guard, nexus) = OperationGuardArc::<NexusSpec>::create(

--- a/control-plane/grpc/proto/v1/nexus/nexus.proto
+++ b/control-plane/grpc/proto/v1/nexus/nexus.proto
@@ -45,6 +45,8 @@ enum NexusStatus {
   Faulted = 3;
   // shutdown i.e. blocked from serving IO
   Shutdown = 4;
+  // shutdown in progress: not able to serve I/O
+  ShuttingDown = 5;
 }
 
 message Child {

--- a/control-plane/grpc/src/operations/nexus/traits.rs
+++ b/control-plane/grpc/src/operations/nexus/traits.rs
@@ -184,6 +184,7 @@ impl From<nexus::NexusStatus> for NexusStatus {
             nexus::NexusStatus::Online => Self::Online,
             nexus::NexusStatus::Degraded => Self::Degraded,
             nexus::NexusStatus::Faulted => Self::Faulted,
+            nexus::NexusStatus::ShuttingDown => Self::ShuttingDown,
             nexus::NexusStatus::Shutdown => Self::Shutdown,
         }
     }
@@ -194,6 +195,7 @@ impl From<NexusStatus> for nexus::NexusStatus {
             NexusStatus::Online => Self::Online,
             NexusStatus::Degraded => Self::Degraded,
             NexusStatus::Faulted => Self::Faulted,
+            NexusStatus::ShuttingDown => Self::ShuttingDown,
             NexusStatus::Shutdown => Self::Shutdown,
             NexusStatus::Unknown => Self::Unknown,
         }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2374,6 +2374,7 @@ components:
         - Online
         - Degraded
         - Faulted
+        - ShuttingDown
         - Shutdown
     Nexus:
       example:

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -155,30 +155,21 @@ pub struct CreateNexusSnapshotReplicaStatus {
 #[derive(Serialize, Deserialize, Debug, Clone, EnumString, Display, Eq, PartialEq)]
 pub enum NexusStatus {
     /// Default Unknown state.
-    Unknown = 0,
+    Unknown,
     /// Healthy and working.
-    Online = 1,
+    Online,
     /// Not healthy but is able to serve IO (i.e. rebuild is in progress).
-    Degraded = 2,
+    Degraded,
     /// Broken and unable to serve IO.
-    Faulted = 3,
+    Faulted,
     /// Shutdown state, i.e. blocked from serving IO.
-    Shutdown = 4,
+    Shutdown,
+    /// Shutdown in progress: not able to serve I/O.
+    ShuttingDown,
 }
 impl Default for NexusStatus {
     fn default() -> Self {
         Self::Unknown
-    }
-}
-impl From<i32> for NexusStatus {
-    fn from(src: i32) -> Self {
-        match src {
-            1 => Self::Online,
-            2 => Self::Degraded,
-            3 => Self::Faulted,
-            4 => Self::Shutdown,
-            _ => Self::Unknown,
-        }
     }
 }
 impl From<NexusStatus> for models::NexusState {
@@ -189,6 +180,7 @@ impl From<NexusStatus> for models::NexusState {
             NexusStatus::Faulted => Self::Faulted,
             NexusStatus::Unknown => Self::Unknown,
             NexusStatus::Shutdown => Self::Shutdown,
+            NexusStatus::ShuttingDown => Self::ShuttingDown,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -182,6 +182,7 @@ impl From<VolumeStatus> for models::VolumeStatus {
             VolumeStatus::Online => models::VolumeStatus::Online,
             VolumeStatus::Degraded => models::VolumeStatus::Degraded,
             VolumeStatus::Faulted => models::VolumeStatus::Faulted,
+            VolumeStatus::ShuttingDown => models::VolumeStatus::Unknown,
             VolumeStatus::Shutdown => models::VolumeStatus::Unknown,
         }
     }

--- a/tests/bdd/features/snapshot/create/test_feature.py
+++ b/tests/bdd/features/snapshot/create/test_feature.py
@@ -18,6 +18,7 @@ from openapi.model.volume_policy import VolumePolicy
 from openapi.model.protocol import Protocol
 from openapi.model.publish_volume_body import PublishVolumeBody
 from openapi.model.replica_state import ReplicaState
+from openapi.model.pool_status import PoolStatus
 from openapi.model.node_status import NodeStatus
 from openapi.exceptions import NotFoundException
 import openapi.exceptions
@@ -514,6 +515,8 @@ def restart_node(name):
 def wait_node_ready(name):
     node = ApiClient.nodes_api().get_node(name)
     assert node.state.status == NodeStatus("Online")
+    for pool in ApiClient.pools_api().get_node_pools(name):
+        assert pool.state.status == PoolStatus("Online")
 
 
 def timestamp_within(timestamp, minutes=1):


### PR DESCRIPTION
    fix(core/nexus): add children empty validation
    
    Avoids even attempting to call into the dataplane.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(grpc/openapi): wrong shutdown conversion and missing shutting down
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
