### PR TITLE
chore: update release/1.0 to use new k8s registry

### DIFF
--- a/chart/templates/csi-deployment.yaml
+++ b/chart/templates/csi-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- include "rest_agent_init_container" . }}
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.1
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"
@@ -40,7 +40,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/csi-deployment.yaml
+++ b/deploy/csi-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           name: rest-probe
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.1
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"
@@ -47,7 +47,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
           args:
             - "--v=2"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
Update installation yaml files to use
 registry.k8s.io
instead of
 k8s.gcr.io to registry.k8s.io