### PR TITLE
fix(snapshot/retry): add txnid to the snapshot name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "hyper",
  "indexmap",
  "itertools",
+ "nix",
  "nvmeadm",
  "once_cell",
  "opentelemetry",
@@ -2185,15 +2186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,8 +2283,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
- "pin-utils",
  "static_assertions",
 ]
 

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -55,6 +55,7 @@ tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 hyper = { version = "0.14.24", features = [ "client", "http1", "http2", "tcp", "stream" ] }
 opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread"] }
 tracing = "0.1.37"
+nix = { version = "0.26.2", default-features = false }
 
 grpc = { path = "../grpc" }
 shutdown = { path = "../../utils/shutdown" }

--- a/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
@@ -1,26 +1,28 @@
 pub(crate) mod client;
 /// Message translation to agent types from rpc v0,v1 types.
 mod translation;
+pub(crate) mod types;
 pub(crate) mod v0;
 pub(crate) mod v1;
 
 pub(crate) use client::*;
-use std::collections::HashMap;
 
+use crate::controller::io_engine::types::{CreateNexusSnapshot, CreateNexusSnapshotResp};
 use agents::errors::SvcError;
-use async_trait::async_trait;
 use stor_port::{
     transport_api::v0::BlockDevices,
     types::v0::transport::{
-        AddNexusChild, ApiVersion, CreateNexus, CreateNexusSnapshot, CreateNexusSnapshotResp,
-        CreatePool, CreateReplica, CreateReplicaSnapshot, DestroyNexus, DestroyPool,
-        DestroyReplica, DestroyReplicaSnapshot, FaultNexusChild, GetBlockDevices, GetRebuildRecord,
-        ImportPool, ListRebuildRecord, ListReplicaSnapshots, Nexus, NexusChildAction,
-        NexusChildActionContext, NexusChildActionKind, NexusId, NodeId, PoolState, RebuildHistory,
-        Register, RemoveNexusChild, Replica, ReplicaSnapshot, ShareNexus, ShareReplica,
-        ShutdownNexus, UnshareNexus, UnshareReplica,
+        AddNexusChild, ApiVersion, CreateNexus, CreatePool, CreateReplica, CreateReplicaSnapshot,
+        DestroyNexus, DestroyPool, DestroyReplica, DestroyReplicaSnapshot, FaultNexusChild,
+        GetBlockDevices, GetRebuildRecord, ImportPool, ListRebuildRecord, ListReplicaSnapshots,
+        Nexus, NexusChildAction, NexusChildActionContext, NexusChildActionKind, NexusId, NodeId,
+        PoolState, RebuildHistory, Register, RemoveNexusChild, Replica, ReplicaSnapshot,
+        ShareNexus, ShareReplica, ShutdownNexus, UnshareNexus, UnshareReplica,
     },
 };
+
+use async_trait::async_trait;
+use std::collections::HashMap;
 
 #[async_trait]
 #[dyn_clonable::clonable]

--- a/control-plane/agents/src/bin/core/controller/io_engine/types.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/types.rs
@@ -1,0 +1,25 @@
+use std::time::SystemTime;
+use stor_port::types::v0::transport;
+
+/// Re-export creation types.
+pub(crate) use transport::{CreateNexusSnapReplDescr, CreateNexusSnapshot};
+
+/// A response for the nexus snapshot request.
+pub struct CreateNexusSnapshotResp {
+    /// The nexus involved in the snapshot operation.
+    pub nexus: transport::Nexus,
+    /// Timestamp when the nexus was paused to take the snapshot on all replicas.
+    pub snap_time: SystemTime,
+    /// Results of snapping each replica as part of this snapshot request.
+    pub replicas_status: Vec<CreateNexusSnapshotReplicaStatus>,
+    /// Replicas which weren't snapped as part of this request.
+    pub skipped: Vec<transport::ReplicaId>,
+}
+
+/// Per-replica status of the snapshot operation.
+pub struct CreateNexusSnapshotReplicaStatus {
+    /// UUID of replica.
+    pub replica_uuid: transport::ReplicaId,
+    /// Result of snapping this replica.
+    pub error: Option<nix::errno::Errno>,
+}

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/nexus.rs
@@ -1,13 +1,17 @@
 use super::translation::{rpc_nexus_to_agent, rpc_nexus_v2_to_agent, AgentToIoEngine};
-use crate::controller::io_engine::{translation::IoEngineToAgent, NexusListApi};
+use crate::controller::io_engine::{
+    translation::IoEngineToAgent,
+    types::{CreateNexusSnapshot, CreateNexusSnapshotResp},
+    NexusListApi,
+};
 use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::io_engine::Null;
 use stor_port::{
     transport_api::ResourceKind,
     types::v0::transport::{
-        AddNexusChild, Child, CreateNexus, CreateNexusSnapshot, CreateNexusSnapshotResp,
-        DestroyNexus, FaultNexusChild, Nexus, NexusChildAction, NexusChildActionContext, NexusId,
-        NodeId, RemoveNexusChild, ShareNexus, ShutdownNexus, UnshareNexus,
+        AddNexusChild, Child, CreateNexus, DestroyNexus, FaultNexusChild, Nexus, NexusChildAction,
+        NexusChildActionContext, NexusId, NodeId, RemoveNexusChild, ShareNexus, ShutdownNexus,
+        UnshareNexus,
     },
 };
 

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
@@ -2,21 +2,23 @@ use super::{
     super::NexusListApi,
     translation::{rpc_nexus_to_agent, AgentToIoEngine},
 };
-use crate::controller::io_engine::translation::TryIoEngineToAgent;
+use crate::controller::io_engine::{
+    translation::TryIoEngineToAgent,
+    types::{CreateNexusSnapshot, CreateNexusSnapshotResp},
+};
 use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::v1::nexus::ListNexusOptions;
-use std::collections::HashMap;
 use stor_port::{
     transport_api::ResourceKind,
     types::v0::transport::{
-        AddNexusChild, CreateNexus, CreateNexusSnapshot, CreateNexusSnapshotResp, DestroyNexus,
-        FaultNexusChild, GetRebuildRecord, ListRebuildRecord, Nexus, NexusChildAction,
-        NexusChildActionContext, NexusId, NodeId, RebuildHistory, RemoveNexusChild, ShareNexus,
-        ShutdownNexus, UnshareNexus,
+        AddNexusChild, CreateNexus, DestroyNexus, FaultNexusChild, GetRebuildRecord,
+        ListRebuildRecord, Nexus, NexusChildAction, NexusChildActionContext, NexusId, NodeId,
+        RebuildHistory, RemoveNexusChild, ShareNexus, ShutdownNexus, UnshareNexus,
     },
 };
 
 use snafu::ResultExt;
+use std::collections::HashMap;
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::NexusListApi for super::RpcClient {
@@ -320,6 +322,7 @@ impl super::RpcClient {
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::NexusSnapshotApi for super::RpcClient {
+    #[tracing::instrument(name = "rpc::v1::nexus::snapshot", level = "debug", skip(self))]
     async fn create_nexus_snapshot(
         &self,
         request: &CreateNexusSnapshot,

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
@@ -46,6 +46,7 @@ impl crate::controller::io_engine::ReplicaListApi for super::RpcClient {
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::ReplicaApi for super::RpcClient {
+    #[tracing::instrument(name = "rpc::v1::replica::create", level = "debug", skip(self))]
     async fn create_replica(&self, request: &CreateReplica) -> Result<Replica, SvcError> {
         let rpc_replica = self
             .replica()
@@ -103,6 +104,7 @@ impl crate::controller::io_engine::ReplicaApi for super::RpcClient {
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::ReplicaSnapshotApi for super::RpcClient {
+    #[tracing::instrument(name = "rpc::v1::replica::snapshot", level = "debug", skip(self))]
     async fn create_repl_snapshot(
         &self,
         request: &CreateReplicaSnapshot,

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -171,6 +171,7 @@ pub(crate) trait GuardedOperationsHelper:
 
                 let mut spec_clone = self.lock().clone();
                 spec_clone.commit_op();
+
                 let stored = registry.store_obj(&spec_clone).await;
                 match stored {
                     Ok(_) => {

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -1,6 +1,7 @@
 use crate::{
     controller::{
         io_engine::{
+            types::{CreateNexusSnapshot, CreateNexusSnapshotResp},
             GrpcClient, GrpcClientLocked, GrpcContext, NexusApi, NexusChildActionApi,
             NexusChildApi, NexusChildRebuildApi, NexusShareApi, NexusSnapshotApi, PoolApi,
             ReplicaApi, ReplicaSnapshotApi,
@@ -21,14 +22,14 @@ use stor_port::{
         store,
         store::{nexus::NexusState, replica::ReplicaState},
         transport::{
-            AddNexusChild, ApiVersion, Child, CreateNexus, CreateNexusSnapshot,
-            CreateNexusSnapshotResp, CreatePool, CreateReplica, CreateReplicaSnapshot,
-            DestroyNexus, DestroyPool, DestroyReplica, DestroyReplicaSnapshot, FaultNexusChild,
-            GetRebuildRecord, ImportPool, ListRebuildRecord, ListReplicaSnapshots, MessageIdVs,
-            Nexus, NexusChildAction, NexusChildActionContext, NexusChildActionKind, NexusId,
-            NodeId, NodeState, NodeStatus, PoolId, PoolState, RebuildHistory, Register,
-            RemoveNexusChild, Replica, ReplicaId, ReplicaName, ReplicaSnapshot, ShareNexus,
-            ShareReplica, ShutdownNexus, SnapshotId, UnshareNexus, UnshareReplica, VolumeId,
+            AddNexusChild, ApiVersion, Child, CreateNexus, CreatePool, CreateReplica,
+            CreateReplicaSnapshot, DestroyNexus, DestroyPool, DestroyReplica,
+            DestroyReplicaSnapshot, FaultNexusChild, GetRebuildRecord, ImportPool,
+            ListRebuildRecord, ListReplicaSnapshots, MessageIdVs, Nexus, NexusChildAction,
+            NexusChildActionContext, NexusChildActionKind, NexusId, NodeId, NodeState, NodeStatus,
+            PoolId, PoolState, RebuildHistory, Register, RemoveNexusChild, Replica, ReplicaId,
+            ReplicaName, ReplicaSnapshot, ShareNexus, ShareReplica, ShutdownNexus, SnapshotId,
+            UnshareNexus, UnshareReplica, VolumeId,
         },
     },
 };

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -1,6 +1,9 @@
 use crate::{
     controller::{
-        io_engine::{NexusSnapshotApi, ReplicaSnapshotApi},
+        io_engine::{
+            types::{CreateNexusSnapReplDescr, CreateNexusSnapshot},
+            NexusSnapshotApi, ReplicaSnapshotApi,
+        },
         registry::Registry,
         resources::{
             operations::{ResourceLifecycleWithLifetime, ResourcePruning, ResourceSnapshotting},
@@ -27,8 +30,8 @@ use stor_port::{
             volume::{VolumeOperation, VolumeSpec, VolumeTarget},
         },
         transport::{
-            CreateNexusSnapReplDescr, CreateNexusSnapshot, CreateReplicaSnapshot,
-            DestroyReplicaSnapshot, NodeId, SnapshotId, SnapshotParameters, SnapshotTxId, VolumeId,
+            CreateReplicaSnapshot, DestroyReplicaSnapshot, NodeId, SnapshotId, SnapshotParameters,
+            SnapshotTxId, VolumeId,
         },
     },
 };
@@ -350,10 +353,10 @@ impl OperationGuardArc<VolumeSnapshot> {
             }),
         }?;
 
-        if snapped.status != 0 {
+        if let Some(error) = snapped.error {
             return Err(SvcError::ReplicaSnapError {
                 replica: replica_snap.spec().uuid().to_string(),
-                status: snapped.status,
+                error,
             });
         }
 

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -300,8 +300,11 @@ pub enum SvcError {
     ReplicaSnapSkipped { replica: String },
     #[snafu(display("Replica's {} snapshot was unexpectedly not taken", replica))]
     ReplicaSnapMiss { replica: String },
-    #[snafu(display("Replica's {} snapshot failed with status {}", replica, status))]
-    ReplicaSnapError { replica: String, status: u32 },
+    #[snafu(display("Replica's {} snapshot failed with error {}", replica, error))]
+    ReplicaSnapError {
+        replica: String,
+        error: nix::errno::Errno,
+    },
     #[snafu(display("The service is busy, cannot process request"))]
     ServiceBusy {},
     #[snafu(display("The service is shutdown, cannot process request"))]

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -34,7 +34,7 @@ rpc = { path = "../../rpc" }
 grpc = { path = "../grpc" }
 tokio = { version = "1.25.0", features = ["full"] }
 clap =  { version = "4.1.4", features = ["color", "env", "string"] }
-nix = "0.26.2"
+nix = { version = "0.26.2", default-features = false, features = [ "ioctl", "fs" ] }
 strum = "0.24.1"
 strum_macros = "0.24.3"
 heck = "0.4.1"

--- a/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
@@ -61,7 +61,6 @@ impl VolumeSnapshot {
                 self.spec().uuid(),
                 self.spec().source_id().to_string(),
                 self.metadata().prepare(),
-                self.spec().uuid().to_string(),
             ),
         );
         Some(params)

--- a/control-plane/stor-port/src/types/v0/transport/misc.rs
+++ b/control-plane/stor-port/src/types/v0/transport/misc.rs
@@ -128,6 +128,13 @@ macro_rules! rpc_impl_string_id {
                 $Name(uuid::Uuid::new_v4().to_string())
             }
         }
+        impl std::ops::Deref for $Name {
+            type Target = str;
+
+            fn deref(&self) -> &Self::Target {
+                self.as_str()
+            }
+        }
     };
 }
 

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -81,6 +81,7 @@ rpc_impl_string_uuid!(NexusId, "UUID of a nexus");
 
 /// A request for creating snapshot of a nexus, which essentially means a snapshot
 /// of all(or selected) replicas associated with that nexus.
+#[derive(Debug)]
 pub struct CreateNexusSnapshot {
     params: SnapshotParameters<NexusId>,
     replica_desc: Vec<CreateNexusSnapReplDescr>,
@@ -113,8 +114,7 @@ impl CreateNexusSnapshot {
 
 /// A descriptor that specifies the replicas which need to taken snapshot
 /// of specifically.
-#[derive(Clone)]
-#[allow(unused)]
+#[derive(Clone, Debug)]
 pub struct CreateNexusSnapReplDescr {
     /// UUID of the replica involved in snapshot operation.
     pub replica: ReplicaId,
@@ -129,26 +129,6 @@ impl CreateNexusSnapReplDescr {
             snap_uuid,
         }
     }
-}
-
-/// A response for the nexus snapshot request.
-pub struct CreateNexusSnapshotResp {
-    /// The nexus involved in the snapshot operation.
-    pub nexus: Nexus,
-    /// Timestamp when the nexus was paused to take the snapshot on all replicas.
-    pub snap_time: SystemTime,
-    /// Results of snapping each replica as part of this snapshot request.
-    pub replicas_status: Vec<CreateNexusSnapshotReplicaStatus>,
-    /// Replicas which weren't snapped as part of this request.
-    pub skipped: Vec<ReplicaId>,
-}
-
-/// Per-replica status of the snapshot operation.
-pub struct CreateNexusSnapshotReplicaStatus {
-    /// UUID of replica.
-    pub replica_uuid: ReplicaId,
-    /// Result of snapping this replica.
-    pub status: u32,
 }
 
 /// Nexus State information

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -75,6 +75,7 @@ impl Replica {
 }
 
 /// The request type to create a replica's snapshot.
+#[derive(Debug)]
 pub struct CreateReplicaSnapshot {
     params: SnapshotParameters<ReplicaId>,
 }

--- a/control-plane/stor-port/src/types/v0/transport/snapshot.rs
+++ b/control-plane/stor-port/src/types/v0/transport/snapshot.rs
@@ -11,7 +11,8 @@ pub type SnapshotTxId = String;
 pub type SnapshotName = String;
 
 /// Common set of snapshot parameters used for snapshot creation against `TargetId`.
-pub struct SnapshotParameters<TargetId> {
+#[derive(Debug)]
+pub struct SnapshotParameters<TargetId: Debug> {
     /// Name of the target which we'll aim create snapshot at, which can either be
     /// a nexus or a replica at the moment.
     target: TargetId,
@@ -19,7 +20,7 @@ pub struct SnapshotParameters<TargetId> {
 }
 
 /// Common set of snapshot parameters used for snapshot creation.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct GenericSnapshotParameters {
     /// Unique identification of the snapshot.
     uuid: SnapshotId,
@@ -31,7 +32,7 @@ pub struct GenericSnapshotParameters {
     name: SnapshotName,
 }
 
-impl<TargetId> SnapshotParameters<TargetId> {
+impl<TargetId: Debug> SnapshotParameters<TargetId> {
     /// Create a new set of snapshot parameters.
     pub fn new(target: impl Into<TargetId>, params: GenericSnapshotParameters) -> Self {
         Self {
@@ -72,13 +73,15 @@ impl GenericSnapshotParameters {
         uuid: impl Into<SnapshotId>,
         entity_id: impl Into<SnapshotEntId>,
         txn_id: impl Into<SnapshotTxId>,
-        name: impl Into<SnapshotName>,
     ) -> Self {
+        let uuid = uuid.into();
+        let txn_id = txn_id.into();
+        let name = format!("{uuid}/{txn_id}");
         Self {
-            uuid: uuid.into(),
+            uuid,
             entity_id: entity_id.into(),
-            txn_id: txn_id.into(),
-            name: name.into(),
+            txn_id,
+            name,
         }
     }
 

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -622,12 +622,18 @@ impl ClusterBuilder {
     #[must_use]
     pub fn with_tmpfs_pool(mut self, size: u64) -> Self {
         for node in 0 .. self.opts.io_engines {
-            let disk = TmpDiskFile::new(&Uuid::new_v4().to_string(), size);
-            if let Some(pools) = self.pools.get_mut(&node) {
-                pools.push(PoolDisk::Tmp(disk));
-            } else {
-                self.pools.insert(node, vec![PoolDisk::Tmp(disk)]);
-            }
+            self = self.with_tmpfs_pool_ix(node, size);
+        }
+        self
+    }
+    /// Add a tmpfs img pool with `disk` to the indexed io-engine node with the specified `size`.
+    #[must_use]
+    pub fn with_tmpfs_pool_ix(mut self, node: u32, size: u64) -> Self {
+        let disk = TmpDiskFile::new(&Uuid::new_v4().to_string(), size);
+        if let Some(pools) = self.pools.get_mut(&node) {
+            pools.push(PoolDisk::Tmp(disk));
+        } else {
+            self.pools.insert(node, vec![PoolDisk::Tmp(disk)]);
         }
         self
     }


### PR DESCRIPTION
This allows for safer retries as the snapshot name will not clash. Add timeout test which leads to a snapshot in the dataplane, but not in the control-plane. The retry on the control-plane should then succeed creating a new snapshot in the data-plane. todo: clean-up previous snapshot transaction in creating status?