### PR TITLE
Several Snapshtot and Drain Fixes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -541,7 +541,7 @@ pub(super) async fn faulted_nexus_remover(
         return PollResult::Ok(PollerState::Idle);
     };
 
-    if nexus_state.status != NexusStatus::Faulted {
+    if nexus_state.status != NexusStatus::Faulted && nexus_state.status != NexusStatus::Shutdown {
         return PollResult::Ok(PollerState::Idle);
     }
 

--- a/control-plane/agents/src/bin/core/controller/reconciler/node/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/node/nexus.rs
@@ -5,7 +5,7 @@ use crate::controller::{
         operations_helper::OperationSequenceGuard,
         OperationGuard, OperationGuardArc, ResourceMutex,
     },
-    task_poller::{PollEvent, PollResult, PollTimer, PollerState},
+    task_poller::{PollEvent, PollResult, PollTimer, PollTriggerEvent, PollerState},
 };
 use agents::errors::SvcError;
 use std::{collections::HashSet, time::Duration};
@@ -52,7 +52,10 @@ impl TaskPoller for NodeNexusReconciler {
     }
 
     async fn poll_event(&mut self, context: &PollContext) -> bool {
-        matches!(context.event(), PollEvent::TimedRun)
+        matches!(
+            context.event(),
+            PollEvent::TimedRun | PollEvent::Triggered(PollTriggerEvent::NodeDrain)
+        )
     }
 }
 

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -923,12 +923,19 @@ impl ResourceSpecsLocked {
         }
 
         // patch up the missing replica nexus owners
-        let nexuses = self.nexuses();
-        for replica in self.replicas() {
-            nexuses
-                .iter()
+        for replica in self.read().replicas.values() {
+            self.read()
+                .nexuses
+                .values()
                 .filter(|n| n.lock().contains_replica(replica.uuid()))
                 .for_each(|n| replica.lock().owners.add_owner(&n.lock().uuid));
+        }
+        // add runtime information for volume snapshots
+        for snapshot in self.read().volume_snapshots.values() {
+            let volume_id = snapshot.immutable_ref().spec().source_id();
+            if let Some(volume) = self.read().volumes.get(volume_id) {
+                volume.lock().runtime_info.insert_snapshot(snapshot.uuid());
+            }
         }
 
         // Remove all entries of v1 key prefix.

--- a/control-plane/agents/src/bin/core/controller/task_poller.rs
+++ b/control-plane/agents/src/bin/core/controller/task_poller.rs
@@ -1,51 +1,53 @@
 use crate::controller::{registry::Registry, resources::operations_helper::ResourceSpecsLocked};
 use agents::errors::SvcError;
 
-/// Poll Event that identifies why a poll is running
+/// Poll Event that identifies why a poll is running.
 #[derive(Debug, Clone)]
 pub(crate) enum PollEvent {
-    /// Poller period elapsed
+    /// Poller period elapsed.
     TimedRun,
-    /// Request Triggered by another component
+    /// Request Triggered by another component.
     /// example: A node has come back online so it could be a good idea to run the
-    /// reconciliation loop's as soon as possible
+    /// reconciliation loop's as soon as possible.
     Triggered(PollTriggerEvent),
-    /// Shutdown the pollers
+    /// Shutdown the pollers.
     Shutdown,
 }
 
-/// Poll Trigger source
+/// Poll Trigger source.
 #[derive(Debug, Clone)]
 pub(crate) enum PollTriggerEvent {
-    /// A node state has changed to Online
+    /// A node state has changed to Online.
     NodeStateChangeOnline,
-    /// A volume has been published in a Degraded state
-    /// eg: may need replicas to be carved and/or added
+    /// A volume has been published in a Degraded state.
+    /// eg: may need replicas to be carved and/or added.
     VolumeDegraded,
     /// Resource Set to Deleting from Creating, garbage collection required.
     ResourceCreatingToDeleting,
-    /// The Agent is starting up
+    /// The Agent is starting up.
     Start,
+    /// A node needs to be drained.
+    NodeDrain,
 }
 
-/// State of a poller
+/// State of a poller.
 #[derive(Eq, PartialEq)]
 pub(crate) enum PollerState {
-    /// No immediate work remains to be done
+    /// No immediate work remains to be done.
     Idle,
-    /// There is still work outstanding
+    /// There is still work outstanding.
     Busy,
 }
-/// Result of a poll with the poller state
+/// Result of a poll with the poller state.
 pub(crate) type PollResult = Result<PollerState, SvcError>;
 
-/// The period at which a reconciliation loop is polled
-/// It's defined as a number of ticks
-/// Each tick has the period of the base poll period
+/// The period at which a reconciliation loop is polled.
+/// It's defined as a number of ticks.
+/// Each tick has the period of the base poll period.
 pub(crate) type PollPeriods = u32;
 
-/// PollTimer polls a timer and returns true to indicate that the reconciler should be polled
-/// If true, the timer is reloaded back to the setup period
+/// PollTimer polls a timer and returns true to indicate that the reconciler should be polled.
+/// If true, the timer is reloaded back to the setup period.
 #[derive(Debug)]
 pub(crate) struct PollTimer {
     period: PollPeriods,
@@ -53,7 +55,7 @@ pub(crate) struct PollTimer {
 }
 
 impl PollTimer {
-    /// Create a new `Self` for the given period
+    /// Create a new `Self` for the given period.
     pub(crate) fn from(period: PollPeriods) -> Self {
         Self {
             period,
@@ -61,7 +63,7 @@ impl PollTimer {
         }
     }
     /// True when the timer reaches the bottom indicating the reconciler should be polled
-    /// (the counter is auto-reloaded)
+    /// (the counter is auto-reloaded).
     pub(crate) fn poll(&mut self) -> bool {
         if self.ready() {
             self.reload();
@@ -82,41 +84,40 @@ impl PollTimer {
     }
 }
 
-/// Poll Context passed around the poll handlers
+/// Poll Context passed around the poll handlers.
 pub(crate) struct PollContext {
-    /// Event that triggered this poll
+    /// Event that triggered this poll.
     event: PollEvent,
-    /// Core Registry
+    /// Core Registry.
     registry: Registry,
 }
 impl PollContext {
-    /// Create a context for a `PollEvent` with the global `Registry`
+    /// Create a context for a `PollEvent` with the global `Registry`.
     pub(crate) fn from(event: &PollEvent, registry: &Registry) -> Self {
         Self {
             event: event.clone(),
             registry: registry.clone(),
         }
     }
-    /// Get a reference to the core registry
+    /// Get a reference to the core registry.
     pub(crate) fn registry(&self) -> &Registry {
         &self.registry
     }
-    /// Get a reference to the locked resource specs object
+    /// Get a reference to the locked resource specs object.
     pub(crate) fn specs(&self) -> &ResourceSpecsLocked {
         self.registry.specs()
     }
 
-    #[allow(dead_code)]
-    /// Get a reference to the event that triggered this poll
+    /// Get a reference to the event that triggered this poll.
     pub(crate) fn event(&self) -> &PollEvent {
         &self.event
     }
 }
 
-/// Trait used by all reconciliation loops
+/// Trait used by all reconciliation loops.
 #[async_trait::async_trait]
 pub(crate) trait TaskPoller: Send + Sync + std::fmt::Debug {
-    /// Attempts to poll this poller, which will poll itself depending on the `PollEvent`
+    /// Attempts to poll this poller, which will poll itself depending on the `PollEvent`.
     #[tracing::instrument(skip(context), level = "trace")]
     async fn try_poll(&mut self, context: &PollContext) -> PollResult {
         tracing::trace!("Entering trace call");
@@ -129,10 +130,10 @@ pub(crate) trait TaskPoller: Send + Sync + std::fmt::Debug {
         result
     }
 
-    /// Force poll the poller
+    /// Force poll the poller.
     async fn poll(&mut self, context: &PollContext) -> PollResult;
 
-    /// Polls the ready state and returns true if ready
+    /// Polls the ready state and returns true if ready.
     async fn poll_ready(&mut self, context: &PollContext) -> bool {
         match context.event() {
             PollEvent::TimedRun => self.poll_timer(context).await,
@@ -140,12 +141,12 @@ pub(crate) trait TaskPoller: Send + Sync + std::fmt::Debug {
         }
     }
 
-    /// Polls the `PollTimer` and returns true if ready
+    /// Polls the `PollTimer` and returns true if ready.
     async fn poll_timer(&mut self, _context: &PollContext) -> bool {
         true
     }
 
-    /// Determine if self should be polled for this `PollEvent`
+    /// Determine if self should be polled for this `PollEvent`.
     async fn poll_event(&mut self, context: &PollContext) -> bool {
         match context.event() {
             PollEvent::TimedRun => true,
@@ -154,7 +155,7 @@ pub(crate) trait TaskPoller: Send + Sync + std::fmt::Debug {
         }
     }
 
-    /// Convert from a vector of results to a single result
+    /// Convert from a vector of results to a single result.
     fn squash_results(results: Vec<PollResult>) -> PollResult
     where
         Self: Sized,
@@ -163,7 +164,7 @@ pub(crate) trait TaskPoller: Send + Sync + std::fmt::Debug {
     }
 }
 
-/// Convert from a vector of results to a single result
+/// Convert from a vector of results to a single result.
 pub(crate) fn squash_results(results: Vec<PollResult>) -> PollResult {
     let mut results = results.into_iter();
     match results.find(|r| r.is_err()) {

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -365,6 +365,9 @@ impl Service {
 
         let spec = guarded_node.drain(&self.registry, label.clone()).await?;
         let state = self.registry.node_state(&id).await.ok();
+
+        self.registry.notify(PollTriggerEvent::NodeDrain).await;
+
         Ok(Node::new(id, Some(spec), state))
     }
 }

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -131,6 +131,7 @@ fn test_deserialization_v1_to_v2() {
                 )),
                 publish_context: None,
                 affinity_group: None,
+                runtime_info: Default::default(),
             }),
         },
         TestEntry {

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -179,6 +179,9 @@ impl ResourceLifecycleWithLifetime for OperationGuardArc<VolumeSnapshot> {
             });
         }
 
+        // Try to prune 1 stale transaction, if present..
+        snapshot.prune(registry, Some(1)).await.ok();
+
         let prepare_snapshot = snapshot.snapshot_params(&replica)?;
         snapshot
             .start_create_update(

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -288,6 +288,7 @@ impl TryFrom<volume::VolumeDefinition> for VolumeSpec {
                 .publish_context
                 .map(|map_wrapper| map_wrapper.map),
             affinity_group: volume_spec.affinity_group.into_opt(),
+            runtime_info: Default::default(),
         };
         Ok(volume_spec)
     }

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -582,13 +582,13 @@ impl SpecTransaction<NodeOperation> for NodeSpec {
 
     fn log_op(&self, operation: &NodeOperation) -> (bool, bool) {
         match operation {
-            NodeOperation::Cordon(_) => (false, false),
-            NodeOperation::Uncordon(_) => (false, false),
-            NodeOperation::Drain(_) => (false, false),
-            NodeOperation::AddDrainingVolumes(_) => (false, false),
-            NodeOperation::RemoveDrainingVolumes(_) => (false, false),
-            NodeOperation::RemoveAllDrainingVolumes() => (false, false),
-            NodeOperation::SetDrained() => (false, false),
+            NodeOperation::Cordon(_) => (false, true),
+            NodeOperation::Uncordon(_) => (false, true),
+            NodeOperation::Drain(_) => (false, true),
+            NodeOperation::AddDrainingVolumes(_) => (false, true),
+            NodeOperation::RemoveDrainingVolumes(_) => (false, true),
+            NodeOperation::RemoveAllDrainingVolumes() => (false, true),
+            NodeOperation::SetDrained() => (false, true),
         }
     }
 

--- a/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/snapshots/volume.rs
@@ -6,7 +6,10 @@ use crate::types::v0::{
 use chrono::{DateTime, Utc};
 use pstor::{ApiVersion, ObjectKey, StorableObject, StorableObjectType};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 /// User specification of a volume snapshot.
 /// todo: is e-derivations a better way of doing this?
@@ -374,7 +377,21 @@ impl StorableObject for VolumeSnapshot {
 /// List of all volume snapshots and related information.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct VolumeSnapshotList {
-    snapshots: HashMap<SnapshotId, VolumeSnapshot>,
+    snapshots: HashSet<SnapshotId>,
+}
+impl VolumeSnapshotList {
+    /// Insert snapshot into the list.
+    pub fn insert(&mut self, snapshot: SnapshotId) {
+        self.snapshots.insert(snapshot);
+    }
+    /// Remove snapshot from the list.
+    pub fn remove(&mut self, snapshot: &SnapshotId) {
+        self.snapshots.remove(snapshot);
+    }
+    /// Check if there's any snapshot.
+    pub fn is_empty(&self) -> bool {
+        self.snapshots.is_empty()
+    }
 }
 
 impl PartialEq<()> for VolumeSnapshot {

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -60,6 +60,10 @@ impl Nexus {
         self.device_uri = add_query(self.device_uri, name, value);
         self
     }
+    /// Check if the nexus is able to process IO.
+    pub fn io_online(&self) -> bool {
+        matches!(self.status, NexusStatus::Online | NexusStatus::Degraded)
+    }
 }
 
 impl From<Nexus> for models::Nexus {


### PR DESCRIPTION
    feat(snapshot): add runtime snapshot list to volume
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(drain): notify reconciler when a node drain command is received
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(drain-cordon): missing pstor flush after refactoring
    
    This would cause drain and cordon operations not to log writes to pstor.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(snapshot/timeouts): enhance snapshot create timeout testing
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(snapshot/create): handle create errors
    
    When snapshot creation fail, attempt to undo it to pstor. This can happen when creating snapshot
    through nexus and nexus crashes but replica snapshot is created.
    Potentially we could accept this scenario as a success, but for now let's start on the safe side.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(snapshot/cleanup): destroy transactions
    
    Rework transaction cleanup to wa potential order issue.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>