### PR TITLE
Volume Snapshot Commitment

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/capacity.rs
@@ -95,6 +95,8 @@ pub(super) async fn child_enospc_onlineable(
     for r in children.flat_map(|c| c.as_replica()) {
         replicas.push(registry.replica(r.uuid()).await?);
     }
+    // todo: this won't work for volumes with snapshots
+    //  we need to figure out which blocks would require rebuild
     let min_allocated_bytes = replicas
         .into_iter()
         .flat_map(|r| r.space)

--- a/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
@@ -42,14 +42,6 @@ impl GetPersistedNexusChildren {
     pub(crate) fn new_snapshot(spec: &VolumeSpec) -> Self {
         Self::Snapshot(spec.clone())
     }
-    /// Check if the snapshotting volume is published.
-    pub(crate) fn snapshot_target_published(&self) -> bool {
-        match self {
-            Self::Create(_) => false,
-            Self::ReCreate(_) => false,
-            Self::Snapshot(vol) => vol.target().is_some(),
-        }
-    }
     /// Get the optional volume spec (used for nexus creation).
     pub(crate) fn vol_spec(&self) -> Option<&VolumeSpec> {
         match self {

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -9,7 +9,7 @@ use stor_port::types::v0::{
         nexus_persistence::{ChildInfo, NexusInfo},
         replica::ReplicaSpec,
     },
-    transport::{Child, ChildUri, PoolId, Replica},
+    transport::{Child, ChildUri, NodeId, PoolId, Replica},
 };
 
 /// Item for pool scheduling logic.
@@ -87,6 +87,15 @@ impl PoolItemLister {
             })
             .collect();
         pools
+    }
+    /// Get a list of pool items.
+    pub(crate) async fn list_for_snaps(registry: &Registry, item: &ChildItem) -> Vec<PoolItem> {
+        let nodes = Self::nodes(registry).await;
+
+        match nodes.iter().find(|n| n.id() == item.node()) {
+            Some(node) => vec![PoolItem::new(node.clone(), item.pool().clone(), None)],
+            None => vec![],
+        }
     }
 }
 
@@ -245,6 +254,10 @@ impl ChildItem {
     /// Get the pool wrapper.
     pub(crate) fn pool(&self) -> &PoolWrapper {
         &self.pool_state
+    }
+    /// Get a reference to the node id.
+    pub(crate) fn node(&self) -> &NodeId {
+        &self.pool_state.node
     }
     /// Check if we can rebuild this child.
     pub(crate) fn rebuildable(&self) -> &Option<bool> {

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
@@ -1,5 +1,8 @@
 use super::ResourceFilter;
-use crate::controller::scheduling::{volume::AddVolumeReplica, NodeFilters};
+use crate::controller::scheduling::{
+    volume::{AddVolumeReplica, SnapshotVolumeReplica},
+    NodeFilters,
+};
 
 mod affinity_group;
 pub(crate) mod pool;
@@ -27,5 +30,19 @@ impl DefaultBasePolicy {
             .filter(pool::PoolBaseFilters::capacity)
             .filter(pool::PoolBaseFilters::min_free_space)
             .filter(pool::PoolBaseFilters::topology)
+    }
+    fn filter_snapshot(request: SnapshotVolumeReplica) -> SnapshotVolumeReplica {
+        Self::filter_snapshot_pools(Self::filter_snapshot_nodes(request))
+    }
+    fn filter_snapshot_nodes(request: SnapshotVolumeReplica) -> SnapshotVolumeReplica {
+        request
+            .filter(NodeFilters::cordoned_for_pool)
+            .filter(NodeFilters::online_for_pool)
+    }
+    fn filter_snapshot_pools(request: SnapshotVolumeReplica) -> SnapshotVolumeReplica {
+        request
+            .filter(pool::PoolBaseFilters::usable)
+            .filter(pool::PoolBaseFilters::capacity)
+            .filter(pool::PoolBaseFilters::min_free_space)
     }
 }

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/thick.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/thick.rs
@@ -1,6 +1,6 @@
 use crate::controller::scheduling::{
     resources::PoolItem,
-    volume::{AddVolumeReplica, GetSuitablePoolsContext},
+    volume::{AddVolumeReplica, GetSuitablePoolsContext, SnapshotVolumeReplica},
     volume_policy::{affinity_group, pool::PoolBaseFilters, DefaultBasePolicy},
     ResourceFilter, ResourcePolicy, SortBuilder, SortCriteria,
 };
@@ -24,6 +24,13 @@ impl ResourcePolicy<AddVolumeReplica> for ThickPolicy {
             .filter(affinity_group::SingleReplicaPolicy::replica_anti_affinity)
             // sort pools in order of preference (from least to most number of replicas)
             .sort_ctx(ThickPolicy::sort_by_weights)
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ResourcePolicy<SnapshotVolumeReplica> for ThickPolicy {
+    fn apply(self, to: SnapshotVolumeReplica) -> SnapshotVolumeReplica {
+        DefaultBasePolicy::filter_snapshot(to)
     }
 }
 

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -120,6 +120,12 @@ pub(crate) struct ThinArgs {
     /// to be created on the pool is 100GiB.
     #[clap(long, env = "VOLUME_COMMITMENT_%", value_parser = value_parse_percent, default_value = "40%")]
     volume_commitment: u64,
+    /// When creating snapshots for an existing volume, each replica pool must have at least
+    /// this much free space percentage of the volume size.
+    /// Example: if this value is 40, the pool has 40GiB free, then the max volume size allowed
+    /// to be snapped on the pool is 100GiB.
+    #[clap(long, env = "SNAPSHOT_COMMITMENT_%", value_parser = value_parse_percent, default_value = "40%")]
+    snapshot_commitment: u64,
     /// Same as the `volume_commitment` argument, but applicable only when creating replicas for
     /// a new volume.
     #[clap(long, env = "VOLUME_COMMITMENT_%_INITIAL", value_parser = value_parse_percent, default_value = "40%")]

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -2,16 +2,17 @@ use crate::volume::helpers::wait_node_online;
 use deployer_cluster::{Cluster, ClusterBuilder};
 use grpc::operations::{
     pool::traits::PoolOperations,
+    replica::traits::ReplicaOperations,
     volume::traits::{CreateVolumeSnapshot, DeleteVolumeSnapshot, VolumeOperations},
 };
+use std::time::Duration;
 use stor_port::{
     transport_api::{ReplyErrorKind, TimeoutOptions},
     types::v0::transport::{
-        CreateVolume, DestroyPool, DestroyVolume, Filter, PublishVolume, SnapshotId,
+        CreateReplica, CreateVolume, DestroyPool, DestroyReplica, DestroyVolume, Filter,
+        PublishVolume, ReplicaId, SnapshotId, Volume,
     },
 };
-
-use std::time::Duration;
 
 #[tokio::test]
 async fn snapshot() {
@@ -32,7 +33,7 @@ async fn snapshot() {
         .create(
             &CreateVolume {
                 uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
-                size: 5242880,
+                size: 60 * 1024 * 1024,
                 replicas: 1,
                 thin: false,
                 ..Default::default()
@@ -95,13 +96,7 @@ async fn snapshot() {
     assert!(!snaps.entries().is_empty());
 
     vol_cli
-        .delete_snapshot(
-            &DeleteVolumeSnapshot::new(
-                &Some(replica_snapshot.spec().source_id.clone()),
-                replica_snapshot.spec().snap_id.clone(),
-            ),
-            None,
-        )
+        .delete_snapshot(&DeleteVolumeSnapshot::from(&replica_snapshot), None)
         .await
         .unwrap();
 
@@ -147,8 +142,100 @@ async fn snapshot() {
         .unwrap();
 
     tracing::info!("Nexus Snapshot: {nexus_snapshot:?}");
+    vol_cli
+        .delete_snapshot(&DeleteVolumeSnapshot::from(&nexus_snapshot), None)
+        .await
+        .unwrap();
 
     pool_destroy_validation(&cluster).await;
+    thin_provisioning(&cluster, volume).await;
+}
+
+async fn thin_provisioning(cluster: &Cluster, volume: Volume) {
+    let vol_cli = cluster.grpc_client().volume();
+    let pool_cli = cluster.grpc_client().pool();
+
+    let pools = pool_cli
+        .get(Filter::Pool(cluster.pool(0, 0)), None)
+        .await
+        .unwrap();
+    let pool = pools.0.get(0).unwrap();
+    let pool_state = pool.state().unwrap();
+    let watermark = 16 * 1024 * 1024;
+    let free_space = pool_state.capacity - pool_state.used - watermark;
+
+    // Take up the entire pool free space
+    let repl_cli = cluster.grpc_client().replica();
+    let mut req = CreateReplica {
+        node: cluster.node(0),
+        uuid: ReplicaId::new(),
+        pool_id: cluster.pool(0, 0),
+        size: free_space,
+        thin: false,
+        ..Default::default()
+    };
+    let replica = repl_cli.create(&req, None).await.unwrap();
+
+    // Try to take a snapshot now, should fail!
+    let error = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .expect_err("No free space");
+    assert_eq!(error.kind, ReplyErrorKind::ResourceExhausted);
+
+    repl_cli
+        .destroy(&DestroyReplica::from(replica), None)
+        .await
+        .unwrap();
+
+    req.size = free_space / 2;
+    let replica = repl_cli.create(&req, None).await.unwrap();
+
+    let snapshot = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    repl_cli
+        .destroy(&DestroyReplica::from(replica), None)
+        .await
+        .unwrap();
+    vol_cli
+        .delete_snapshot(&DeleteVolumeSnapshot::from(&snapshot), None)
+        .await
+        .unwrap();
+
+    // create 2 replicas of pool cap, exceeding pool commitment of 2.5x
+    req.thin = true;
+    req.size = pool_state.capacity - watermark;
+    let _replica = repl_cli.create(&req, None).await.unwrap();
+
+    // 2x the pool capacity is ok
+    let _snapshot = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    req.uuid = ReplicaId::new();
+    let _replica = repl_cli.create(&req, None).await.unwrap();
+
+    let error = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .expect_err("Pool over-committed");
+    assert_eq!(error.kind, ReplyErrorKind::ResourceExhausted);
 }
 
 async fn pool_destroy_validation(cluster: &Cluster) {
@@ -189,13 +276,7 @@ async fn pool_destroy_validation(cluster: &Cluster) {
     assert_eq!(del_error.kind, ReplyErrorKind::InUse);
 
     vol_cli
-        .delete_snapshot(
-            &DeleteVolumeSnapshot::new(
-                &Some(replica_snapshot.spec().source_id.clone()),
-                replica_snapshot.spec().snap_id.clone(),
-            ),
-            None,
-        )
+        .delete_snapshot(&DeleteVolumeSnapshot::from(&replica_snapshot), None)
         .await
         .unwrap();
 }

--- a/control-plane/agents/src/bin/core/volume/scheduling.rs
+++ b/control-plane/agents/src/bin/core/volume/scheduling.rs
@@ -72,13 +72,15 @@ pub(crate) async fn healthy_volume_replicas(
 }
 
 /// Return healthy replicas for volume snapshotting.
+/// todo: need to refactor to filter with dedicated scheduler.
 pub(crate) async fn snapshoteable_replica(
-    request: &GetPersistedNexusChildren,
+    volume: &VolumeSpec,
     registry: &Registry,
 ) -> Result<HealthyChildItems, SvcError> {
-    let published = request.snapshot_target_published();
+    let published = volume.target().is_some();
 
-    let builder = nexus::CreateVolumeNexus::builder_with_defaults(request, registry).await?;
+    let request = GetPersistedNexusChildren::new_snapshot(volume);
+    let builder = nexus::CreateVolumeNexus::builder_with_defaults(&request, registry).await?;
     let info = builder.context().nexus_info().clone();
 
     if let Some(info_inner) = &builder.context().nexus_info() {

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -155,10 +155,6 @@ impl ResourceLifecycleWithLifetime for OperationGuardArc<VolumeSnapshot> {
         let volume = &request.volume;
         let request = &request.request;
 
-        if volume.as_ref().num_replicas != 1 {
-            return Err(SvcError::NReplSnapshotNotAllowed {});
-        }
-
         let replica = snapshoteable_replica(volume.as_ref(), registry).await?;
         let target_node = if let Some(target) = volume.as_ref().target() {
             registry.node_wrapper(target.node()).await

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -531,6 +531,7 @@ impl From<SvcError> for ReplyError {
                     NotEnough::OfReplicas { .. } => ResourceKind::Replica,
                     NotEnough::OfNexuses { .. } => ResourceKind::Nexus,
                     NotEnough::OfNodes { .. } => ResourceKind::Node,
+                    NotEnough::PoolFree {} => ResourceKind::Pool,
                 },
                 source: desc.to_string(),
                 extra: error.full_string(),
@@ -919,4 +920,6 @@ pub enum NotEnough {
     OfNexuses { have: u64, need: u64 },
     #[snafu(display("Not enough nodes available, {}/{}", have, need))]
     OfNodes { have: u64, need: u64 },
+    #[snafu(display("Not enough free space in the pool"))]
+    PoolFree {},
 }

--- a/control-plane/grpc/src/operations/volume/traits_snapshots.rs
+++ b/control-plane/grpc/src/operations/volume/traits_snapshots.rs
@@ -37,7 +37,6 @@ pub trait DeleteVolumeSnapshotInfo: Send + Sync + std::fmt::Debug {
 
 /// A volume snapshot.
 #[derive(Debug)]
-#[allow(unused)]
 pub struct VolumeSnapshot {
     spec: VolumeSnapshotSpec,
     meta: VolumeSnapshotMeta,
@@ -64,6 +63,15 @@ impl VolumeSnapshot {
     /// Get the volume snapshot state.
     pub fn state(&self) -> &VolumeSnapshotState {
         &self.state
+    }
+}
+
+impl From<&VolumeSnapshot> for DeleteVolumeSnapshot {
+    fn from(snapshot: &VolumeSnapshot) -> Self {
+        Self::new(
+            &Some(snapshot.spec().source_id.clone()),
+            snapshot.spec().snap_id.clone(),
+        )
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -41,6 +41,18 @@ pub struct ReplicaSpaceUsage {
     /// Number of actually used clusters for this replica's snapshots.
     pub allocated_clusters_snapshots: u64,
 }
+impl ReplicaSpaceUsage {
+    /// Get the total allocated bytes, including from snapshots.
+    pub fn total_allocated(&self) -> u64 {
+        self.allocated_bytes + self.allocated_bytes_snapshots
+    }
+    /// Get the distinct allocated bytes from the replica and its snapshots.
+    /// This would signify how much data of the replica range is allocated.
+    /// Not supported at the moment so cap replica+snapshots up to capacity.
+    pub fn allocated_distinct(&self) -> u64 {
+        self.total_allocated().min(self.capacity_bytes)
+    }
+}
 
 /// Replica information.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
    feat(snapshot/commitment): use commitment when creating a snapshot
    
    The snapshot create now uses the same rules as volume/replica creation.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci: fix test race condition
    
    Make cache reload period too high so we don't try to refresh whilst testing
    a timeout condition.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>