### PR TITLE
Snapshot/clone initial rpc

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
@@ -18,9 +18,9 @@ use stor_port::{
         CreateSnapshotClone, DestroyNexus, DestroyPool, DestroyReplica, DestroyReplicaSnapshot,
         FaultNexusChild, GetBlockDevices, GetRebuildRecord, ImportPool, ListRebuildRecord,
         ListReplicaSnapshots, ListSnapshotClones, Nexus, NexusChildAction, NexusChildActionContext,
-        NexusChildActionKind, NexusId, NodeId, PoolState, RebuildHistory, Register,
-        RemoveNexusChild, Replica, ReplicaId, ReplicaSnapshot, ShareNexus, ShareReplica,
-        ShutdownNexus, UnshareNexus, UnshareReplica,
+        NexusChildActionKind, NexusId, PoolState, RebuildHistory, Register, RemoveNexusChild,
+        Replica, ReplicaId, ReplicaSnapshot, ShareNexus, ShareReplica, ShutdownNexus, UnshareNexus,
+        UnshareReplica,
     },
 };
 
@@ -52,7 +52,7 @@ pub(crate) trait NodeApi:
 #[async_trait]
 pub(crate) trait PoolListApi {
     /// List pools based on api version in context.
-    async fn list_pools(&self, node_id: &NodeId) -> Result<Vec<PoolState>, SvcError>;
+    async fn list_pools(&self) -> Result<Vec<PoolState>, SvcError>;
 }
 
 #[async_trait]
@@ -68,7 +68,7 @@ pub(crate) trait PoolApi {
 #[async_trait]
 pub(crate) trait ReplicaListApi {
     /// List all replicas from the node.
-    async fn list_replicas(&self, node_id: &NodeId) -> Result<Vec<Replica>, SvcError>;
+    async fn list_replicas(&self) -> Result<Vec<Replica>, SvcError>;
 
     /// Get the specified replica from the node.
     async fn get_replica(&self, replica_id: &ReplicaId) -> Result<Replica, SvcError>;
@@ -90,9 +90,9 @@ pub(crate) trait ReplicaApi {
 #[async_trait]
 pub(crate) trait NexusListApi {
     /// List all nexuses from the node.
-    async fn list_nexuses(&self, node_id: &NodeId) -> Result<Vec<Nexus>, SvcError>;
+    async fn list_nexuses(&self) -> Result<Vec<Nexus>, SvcError>;
     /// Get the specified nexus from the node.
-    async fn get_nexus(&self, node_id: &NodeId, nexus_id: &NexusId) -> Result<Nexus, SvcError>;
+    async fn get_nexus(&self, nexus_id: &NexusId) -> Result<Nexus, SvcError>;
 }
 
 #[async_trait]

--- a/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
@@ -15,11 +15,12 @@ use stor_port::{
     transport_api::v0::BlockDevices,
     types::v0::transport::{
         AddNexusChild, ApiVersion, CreateNexus, CreatePool, CreateReplica, CreateReplicaSnapshot,
-        DestroyNexus, DestroyPool, DestroyReplica, DestroyReplicaSnapshot, FaultNexusChild,
-        GetBlockDevices, GetRebuildRecord, ImportPool, ListRebuildRecord, ListReplicaSnapshots,
-        Nexus, NexusChildAction, NexusChildActionContext, NexusChildActionKind, NexusId, NodeId,
-        PoolState, RebuildHistory, Register, RemoveNexusChild, Replica, ReplicaId, ReplicaSnapshot,
-        ShareNexus, ShareReplica, ShutdownNexus, UnshareNexus, UnshareReplica,
+        CreateSnapshotClone, DestroyNexus, DestroyPool, DestroyReplica, DestroyReplicaSnapshot,
+        FaultNexusChild, GetBlockDevices, GetRebuildRecord, ImportPool, ListRebuildRecord,
+        ListReplicaSnapshots, ListSnapshotClones, Nexus, NexusChildAction, NexusChildActionContext,
+        NexusChildActionKind, NexusId, NodeId, PoolState, RebuildHistory, Register,
+        RemoveNexusChild, Replica, ReplicaId, ReplicaSnapshot, ShareNexus, ShareReplica,
+        ShutdownNexus, UnshareNexus, UnshareReplica,
     },
 };
 
@@ -189,6 +190,18 @@ pub(crate) trait ReplicaSnapshotApi {
         &self,
         request: &ListReplicaSnapshots,
     ) -> Result<Vec<ReplicaSnapshot>, SvcError>;
+
+    /// Create replica clone from the snapshot.
+    async fn create_snapshot_clone(
+        &self,
+        request: &CreateSnapshotClone,
+    ) -> Result<Replica, SvcError>;
+
+    /// List snapshot clones.
+    async fn list_snapshot_clones(
+        &self,
+        request: &ListSnapshotClones,
+    ) -> Result<Vec<Replica>, SvcError>;
 }
 
 #[async_trait]

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/pool.rs
@@ -3,14 +3,14 @@ use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::io_engine::Null;
 use stor_port::{
     transport_api::ResourceKind,
-    types::v0::transport::{CreatePool, DestroyPool, ImportPool, NodeId, PoolState},
+    types::v0::transport::{CreatePool, DestroyPool, ImportPool, PoolState},
 };
 
 use snafu::ResultExt;
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::PoolListApi for super::RpcClient {
-    async fn list_pools(&self, node_id: &NodeId) -> Result<Vec<PoolState>, SvcError> {
+    async fn list_pools(&self) -> Result<Vec<PoolState>, SvcError> {
         let rpc_pools = self
             .client()
             .list_pools(Null {})
@@ -24,7 +24,7 @@ impl crate::controller::io_engine::PoolListApi for super::RpcClient {
 
         let pools = rpc_pools
             .iter()
-            .map(|p| rpc_pool_to_agent(p, node_id))
+            .map(|p| rpc_pool_to_agent(p, self.context.node()))
             .collect();
 
         Ok(pools)

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/replica.rs
@@ -4,9 +4,9 @@ use rpc::io_engine::Null;
 use stor_port::{
     transport_api::ResourceKind,
     types::v0::transport::{
-        CreateReplica, CreateReplicaSnapshot, DestroyReplica, DestroyReplicaSnapshot,
-        ListReplicaSnapshots, NodeId, Replica, ReplicaId, ReplicaSnapshot, ShareReplica,
-        UnshareReplica,
+        CreateReplica, CreateReplicaSnapshot, CreateSnapshotClone, DestroyReplica,
+        DestroyReplicaSnapshot, ListReplicaSnapshots, ListSnapshotClones, NodeId, Replica,
+        ReplicaId, ReplicaSnapshot, ShareReplica, UnshareReplica,
     },
 };
 
@@ -136,6 +136,28 @@ impl crate::controller::io_engine::ReplicaSnapshotApi for super::RpcClient {
         Err(SvcError::GrpcRequestError {
             resource: ResourceKind::Replica,
             request: "list_snapshots".to_string(),
+            source: tonic::Status::unimplemented(""),
+        })
+    }
+
+    async fn create_snapshot_clone(
+        &self,
+        _request: &CreateSnapshotClone,
+    ) -> Result<Replica, SvcError> {
+        Err(SvcError::GrpcRequestError {
+            resource: ResourceKind::Replica,
+            request: "create_snapshot_clone".to_string(),
+            source: tonic::Status::unimplemented(""),
+        })
+    }
+
+    async fn list_snapshot_clones(
+        &self,
+        _request: &ListSnapshotClones,
+    ) -> Result<Vec<Replica>, SvcError> {
+        Err(SvcError::GrpcRequestError {
+            resource: ResourceKind::Replica,
+            request: "create_snapshot_clone".to_string(),
             source: tonic::Status::unimplemented(""),
         })
     }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/replica.rs
@@ -5,8 +5,8 @@ use stor_port::{
     transport_api::ResourceKind,
     types::v0::transport::{
         CreateReplica, CreateReplicaSnapshot, CreateSnapshotClone, DestroyReplica,
-        DestroyReplicaSnapshot, ListReplicaSnapshots, ListSnapshotClones, NodeId, Replica,
-        ReplicaId, ReplicaSnapshot, ShareReplica, UnshareReplica,
+        DestroyReplicaSnapshot, ListReplicaSnapshots, ListSnapshotClones, Replica, ReplicaId,
+        ReplicaSnapshot, ShareReplica, UnshareReplica,
     },
 };
 
@@ -14,7 +14,7 @@ use snafu::ResultExt;
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::ReplicaListApi for super::RpcClient {
-    async fn list_replicas(&self, node_id: &NodeId) -> Result<Vec<Replica>, SvcError> {
+    async fn list_replicas(&self) -> Result<Vec<Replica>, SvcError> {
         let rpc_replicas =
             self.client()
                 .list_replicas_v2(Null {})
@@ -28,7 +28,7 @@ impl crate::controller::io_engine::ReplicaListApi for super::RpcClient {
 
         let replicas = rpc_replicas
             .iter()
-            .filter_map(|p| match rpc_replica_to_agent(p, node_id) {
+            .filter_map(|p| match rpc_replica_to_agent(p, self.context.node()) {
                 Ok(r) => Some(r),
                 Err(error) => {
                     tracing::error!(error=%error, "Could not convert rpc replica");

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -10,7 +10,7 @@ use stor_port::{
         transport::{
             self, ChildState, ChildStateReason, Nexus, NexusId, NexusNvmePreemption,
             NexusNvmfConfig, NexusStatus, NodeId, NvmeReservation, PoolState, Protocol, Replica,
-            ReplicaId, ReplicaName, ReplicaStatus,
+            ReplicaId, ReplicaKind, ReplicaName, ReplicaStatus,
         },
     },
 };
@@ -125,6 +125,7 @@ impl TryIoEngineToAgent for v0::ReplicaV2 {
                         .unwrap_or(transport::HostNqn::Invalid { nqn: n.to_string() })
                 })
                 .collect(),
+            kind: ReplicaKind::Regular,
         })
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
@@ -3,14 +3,14 @@ use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::v1::pool::ListPoolOptions;
 use stor_port::{
     transport_api::ResourceKind,
-    types::v0::transport::{CreatePool, DestroyPool, ImportPool, NodeId, PoolState},
+    types::v0::transport::{CreatePool, DestroyPool, ImportPool, PoolState},
 };
 
 use snafu::ResultExt;
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::PoolListApi for super::RpcClient {
-    async fn list_pools(&self, id: &NodeId) -> Result<Vec<PoolState>, SvcError> {
+    async fn list_pools(&self) -> Result<Vec<PoolState>, SvcError> {
         let rpc_pools = self
             .pool()
             .list_pools(ListPoolOptions::default())
@@ -20,7 +20,10 @@ impl crate::controller::io_engine::PoolListApi for super::RpcClient {
                 request: "list_pools",
             })?;
         let rpc_pools = &rpc_pools.get_ref().pools;
-        let pools = rpc_pools.iter().map(|p| rpc_pool_to_agent(p, id)).collect();
+        let pools = rpc_pools
+            .iter()
+            .map(|p| rpc_pool_to_agent(p, self.context.node()))
+            .collect();
         Ok(pools)
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
@@ -8,9 +8,9 @@ use rpc::v1::{
 use stor_port::{
     transport_api::ResourceKind,
     types::v0::transport::{
-        CreateReplica, CreateReplicaSnapshot, DestroyReplica, DestroyReplicaSnapshot,
-        ListReplicaSnapshots, NodeId, Replica, ReplicaId, ReplicaSnapshot, ShareReplica,
-        UnshareReplica,
+        CreateReplica, CreateReplicaSnapshot, CreateSnapshotClone, DestroyReplica,
+        DestroyReplicaSnapshot, ListReplicaSnapshots, ListSnapshotClones, NodeId, Replica,
+        ReplicaId, ReplicaSnapshot, ShareReplica, UnshareReplica,
     },
 };
 
@@ -183,5 +183,19 @@ impl crate::controller::io_engine::ReplicaSnapshotApi for super::RpcClient {
 
         let ret = response.into_inner();
         ret.snapshots.iter().map(|s| s.try_to_agent()).collect()
+    }
+
+    async fn create_snapshot_clone(
+        &self,
+        _request: &CreateSnapshotClone,
+    ) -> Result<Replica, SvcError> {
+        todo!()
+    }
+
+    async fn list_snapshot_clones(
+        &self,
+        _request: &ListSnapshotClones,
+    ) -> Result<Vec<Replica>, SvcError> {
+        todo!()
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
@@ -9,8 +9,8 @@ use stor_port::{
     transport_api::ResourceKind,
     types::v0::transport::{
         CreateReplica, CreateReplicaSnapshot, CreateSnapshotClone, DestroyReplica,
-        DestroyReplicaSnapshot, ListReplicaSnapshots, ListSnapshotClones, NodeId, Replica,
-        ReplicaId, ReplicaSnapshot, ShareReplica, UnshareReplica,
+        DestroyReplicaSnapshot, ListReplicaSnapshots, ListSnapshotClones, Replica, ReplicaId,
+        ReplicaSnapshot, ShareReplica, UnshareReplica,
     },
 };
 
@@ -18,7 +18,7 @@ use snafu::ResultExt;
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::ReplicaListApi for super::RpcClient {
-    async fn list_replicas(&self, id: &NodeId) -> Result<Vec<Replica>, SvcError> {
+    async fn list_replicas(&self) -> Result<Vec<Replica>, SvcError> {
         let rpc_replicas = self
             .replica()
             .list_replicas(ListReplicaOptions::default())
@@ -32,7 +32,7 @@ impl crate::controller::io_engine::ReplicaListApi for super::RpcClient {
 
         let replicas = rpc_replicas
             .iter()
-            .filter_map(|p| match rpc_replica_to_agent(p, id) {
+            .filter_map(|p| match rpc_replica_to_agent(p, self.context.node()) {
                 Ok(r) => Some(r),
                 Err(error) => {
                     tracing::error!(error=%error, "Could not convert rpc replica");

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -273,7 +273,7 @@ impl NodeWrapper {
 
     /// Get the `NodeStateFetcher` to fetch information from the data-plane.
     pub(crate) fn fetcher(&self) -> NodeStateFetcher {
-        NodeStateFetcher::new(self.node_state.clone(), self.rebuild_since_timestamp())
+        NodeStateFetcher::new(self.rebuild_since_timestamp())
     }
 
     /// Whether the watchdog deadline has expired.
@@ -849,22 +849,16 @@ impl NodeWrapper {
 /// Fetches node state from the dataplane.
 #[derive(Debug, Clone)]
 pub(crate) struct NodeStateFetcher {
-    /// Inner Node state.
-    node_state: NodeState,
     /// Fetch rebuild history since end_time timestamp.
     rebuild_since_timestamp: Option<prost_types::Timestamp>,
 }
 
 impl NodeStateFetcher {
     /// Get new `Self` from the `NodeState`.
-    fn new(node_state: NodeState, rebuild_since_timestamp: Option<prost_types::Timestamp>) -> Self {
+    fn new(rebuild_since_timestamp: Option<prost_types::Timestamp>) -> Self {
         Self {
-            node_state,
             rebuild_since_timestamp,
         }
-    }
-    fn id(&self) -> &NodeId {
-        self.node_state.id()
     }
     async fn ignore_unimplemented<T: Default, F: Future<Output = Result<T, SvcError>>>(
         fetch: F,
@@ -941,15 +935,15 @@ impl NodeStateFetcher {
     }
     /// Fetch all replicas from this node via gRPC.
     async fn fetch_replicas(&self, client: &mut GrpcClient) -> Result<Vec<Replica>, SvcError> {
-        client.list_replicas(self.id()).await
+        client.list_replicas().await
     }
     /// Fetch all pools from this node via gRPC.
     async fn fetch_pools(&self, client: &mut GrpcClient) -> Result<Vec<PoolState>, SvcError> {
-        client.list_pools(self.id()).await
+        client.list_pools().await
     }
     /// Fetch all nexuses from the node via gRPC.
     async fn fetch_nexuses(&self, client: &mut GrpcClient) -> Result<Vec<Nexus>, SvcError> {
-        client.list_nexuses(self.id()).await
+        client.list_nexuses().await
     }
 }
 

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -23,13 +23,13 @@ use stor_port::{
         store::{nexus::NexusState, replica::ReplicaState},
         transport::{
             AddNexusChild, ApiVersion, Child, CreateNexus, CreatePool, CreateReplica,
-            CreateReplicaSnapshot, DestroyNexus, DestroyPool, DestroyReplica,
+            CreateReplicaSnapshot, CreateSnapshotClone, DestroyNexus, DestroyPool, DestroyReplica,
             DestroyReplicaSnapshot, FaultNexusChild, GetRebuildRecord, ImportPool,
-            ListRebuildRecord, ListReplicaSnapshots, MessageIdVs, Nexus, NexusChildAction,
-            NexusChildActionContext, NexusChildActionKind, NexusId, NodeId, NodeState, NodeStatus,
-            PoolId, PoolState, RebuildHistory, Register, RemoveNexusChild, Replica, ReplicaId,
-            ReplicaName, ReplicaSnapshot, ShareNexus, ShareReplica, ShutdownNexus, SnapshotId,
-            UnshareNexus, UnshareReplica, VolumeId,
+            ListRebuildRecord, ListReplicaSnapshots, ListSnapshotClones, MessageIdVs, Nexus,
+            NexusChildAction, NexusChildActionContext, NexusChildActionKind, NexusId, NodeId,
+            NodeState, NodeStatus, PoolId, PoolState, RebuildHistory, Register, RemoveNexusChild,
+            Replica, ReplicaId, ReplicaName, ReplicaSnapshot, ShareNexus, ShareReplica,
+            ShutdownNexus, SnapshotId, UnshareNexus, UnshareReplica, VolumeId,
         },
     },
 };
@@ -1616,6 +1616,25 @@ impl ReplicaSnapshotApi for Arc<tokio::sync::RwLock<NodeWrapper>> {
     ) -> Result<Vec<ReplicaSnapshot>, SvcError> {
         let dataplane = self.grpc_client_locked(request.id()).await?;
         dataplane.list_repl_snapshots(request).await
+    }
+
+    async fn create_snapshot_clone(
+        &self,
+        request: &CreateSnapshotClone,
+    ) -> Result<Replica, SvcError> {
+        let dataplane = self.grpc_client_locked(request.id()).await?;
+        let clone = dataplane.create_snapshot_clone(request).await?;
+        self.update_replica_state(Either::Insert(clone.clone()))
+            .await;
+        Ok(clone)
+    }
+
+    async fn list_snapshot_clones(
+        &self,
+        request: &ListSnapshotClones,
+    ) -> Result<Vec<Replica>, SvcError> {
+        let dataplane = self.grpc_client_locked(request.id()).await?;
+        dataplane.list_snapshot_clones(request).await
     }
 }
 

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -114,7 +114,8 @@ async fn pool() {
             share: Protocol::None,
             uri,
             status: ReplicaStatus::Online,
-            allowed_hosts: vec![]
+            allowed_hosts: vec![],
+            kind: Default::default(),
         }
     );
 

--- a/control-plane/grpc/proto/v1/replica/replica.proto
+++ b/control-plane/grpc/proto/v1/replica/replica.proto
@@ -29,6 +29,8 @@ message Replica {
   optional google.protobuf.StringValue pool_uuid = 10;
   // space usage information.
   ReplicaSpaceUsage space = 11;
+  // kind of the replica, eg: regular or clone.
+  ReplicaKind kind = 12;
 }
 
 // Multiple replicas
@@ -57,6 +59,16 @@ enum ReplicaStatus {
   Degraded = 2;
   // the replica is unable to be used
   Faulted = 3;
+}
+
+// Kind of the Replica.
+enum ReplicaKind {
+  // A regular data-replica.
+  Regular = 0;
+  // A replica which is another replica's snapshot.
+  Snapshot = 1;
+  // A replica which is a clone of another replica's snapshot.
+  SnapshotClone = 2;
 }
 
 // Create Replica Request

--- a/control-plane/grpc/src/operations/replica/traits.rs
+++ b/control-plane/grpc/src/operations/replica/traits.rs
@@ -18,8 +18,8 @@ use stor_port::{
         transport,
         transport::{
             CreateReplica, DestroyReplica, Filter, HostNqn, NexusId, NodeId, PoolId, PoolUuid,
-            Replica, ReplicaId, ReplicaName, ReplicaOwners, ReplicaSpaceUsage, ShareReplica,
-            UnshareReplica, VolumeId,
+            Replica, ReplicaId, ReplicaKind, ReplicaName, ReplicaOwners, ReplicaSpaceUsage,
+            ShareReplica, UnshareReplica, VolumeId,
         },
     },
     IntoOption, IntoVec,
@@ -72,6 +72,25 @@ impl From<Replica> for replica::Replica {
             uri: replica.uri,
             status: status as i32,
             space: replica.space.into_opt(),
+            kind: replica::ReplicaKind::from(replica.kind).into(),
+        }
+    }
+}
+impl From<ReplicaKind> for replica::ReplicaKind {
+    fn from(value: ReplicaKind) -> Self {
+        match value {
+            ReplicaKind::Regular => Self::Regular,
+            ReplicaKind::Snapshot => Self::Snapshot,
+            ReplicaKind::SnapshotClone => Self::SnapshotClone,
+        }
+    }
+}
+impl From<replica::ReplicaKind> for ReplicaKind {
+    fn from(value: replica::ReplicaKind) -> Self {
+        match value {
+            replica::ReplicaKind::Regular => Self::Regular,
+            replica::ReplicaKind::Snapshot => Self::Snapshot,
+            replica::ReplicaKind::SnapshotClone => Self::SnapshotClone,
         }
     }
 }
@@ -135,6 +154,9 @@ impl TryFrom<replica::Replica> for Replica {
                 }
             },
             allowed_hosts: vec![],
+            kind: replica::ReplicaKind::from_i32(replica.kind)
+                .unwrap_or_default()
+                .into(),
         })
     }
 }

--- a/control-plane/stor-port/src/transport_api/v0.rs
+++ b/control-plane/stor-port/src/transport_api/v0.rs
@@ -42,6 +42,8 @@ impl_message!(UnshareReplica);
 impl_message!(CreateReplicaSnapshot);
 impl_message!(DestroyReplicaSnapshot);
 impl_message!(ListReplicaSnapshots);
+impl_message!(CreateSnapshotClone);
+impl_message!(ListSnapshotClones);
 
 impl_vector_request!(Nexuses, Nexus);
 impl_message!(GetNexuses);

--- a/control-plane/stor-port/src/types/v0/store/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/replica.rs
@@ -9,7 +9,7 @@ use crate::{
         },
         transport::{
             self, CreateReplica, HostNqn, NodeId, PoolId, PoolUuid, Protocol, ReplicaId,
-            ReplicaName, ReplicaOwners, ReplicaShareProtocol, VolumeId,
+            ReplicaKind, ReplicaName, ReplicaOwners, ReplicaShareProtocol, VolumeId,
         },
     },
     IntoOption, IntoVec,
@@ -365,6 +365,7 @@ impl From<&ReplicaSpec> for transport::Replica {
             uri: "".to_string(),
             status: transport::ReplicaStatus::Unknown,
             allowed_hosts: replica.allowed_hosts.clone().into_vec(),
+            kind: ReplicaKind::Regular,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/mod.rs
+++ b/control-plane/stor-port/src/types/v0/transport/mod.rs
@@ -89,6 +89,10 @@ pub enum MessageIdVs {
     DestroyReplicaSnapshot,
     /// List Replica Snapshots.
     ListReplicaSnapshots,
+    /// Create a Snapshot Clone.
+    CreateSnapshotClone,
+    /// List all clones from snapshot.
+    ListSnapshotClones,
     /// Volume Service
     ///
     /// Get nexuses with filter.

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -82,12 +82,27 @@ pub struct Replica {
     pub status: ReplicaStatus,
     /// Host nqn's allowed to connect to the target.
     pub allowed_hosts: Vec<HostNqn>,
+    /// Type of replica, example regular or snapshot.
+    pub kind: ReplicaKind,
 }
 impl Replica {
     /// Check if the replica is online.
     pub fn online(&self) -> bool {
         self.status.online()
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, EnumString, Display, Default, Eq, PartialEq)]
+#[strum(serialize_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
+pub enum ReplicaKind {
+    /// A regular data-replica.
+    #[default]
+    Regular,
+    /// A replica which is another replica's snapshot.
+    Snapshot,
+    /// A replica which is a clone of another replica's snapshot.
+    SnapshotClone,
 }
 
 /// The request type to create a replica's snapshot.

--- a/control-plane/stor-port/src/types/v0/transport/snapshot.rs
+++ b/control-plane/stor-port/src/types/v0/transport/snapshot.rs
@@ -2,6 +2,7 @@ use super::*;
 use serde::Serialize;
 
 rpc_impl_string_uuid!(SnapshotId, "UUID of a snapshot");
+rpc_impl_string_uuid!(SnapshotCloneId, "UUID of a snapshot clone");
 
 /// The entity if of a snapshot.
 pub type SnapshotEntId = String;
@@ -9,6 +10,8 @@ pub type SnapshotEntId = String;
 pub type SnapshotTxId = String;
 /// The name of a snapshot.
 pub type SnapshotName = String;
+/// The name of a snapshot clone.
+pub type SnapshotCloneName = String;
 
 /// Common set of snapshot parameters used for snapshot creation against `TargetId`.
 #[derive(Debug)]
@@ -118,5 +121,39 @@ pub enum ListReplicaSnapshots {
     /// All snapshots from the given source.
     ReplicaSnapshots(ReplicaId),
     /// The specific snapshot.
+    Snapshot(SnapshotId),
+}
+
+/// The request type to create a snapshot's clone.
+pub type CreateSnapshotClone = SnapshotCloneParameters;
+
+/// Common set of parameters used for snapshot clone creation.
+#[derive(Debug, Clone)]
+pub struct SnapshotCloneParameters {
+    /// Unique identification of the source snapshot.
+    snapshot_uuid: SnapshotId,
+    /// Name of the snapshot clone.
+    name: SnapshotCloneName,
+    /// Unique identification of the snapshot clone.
+    uuid: SnapshotCloneId,
+}
+impl SnapshotCloneParameters {
+    /// Get a reference to the snapshot uuid.
+    pub fn snapshot_uuid(&self) -> &SnapshotId {
+        &self.snapshot_uuid
+    }
+    /// Get a reference to the clone name.
+    pub fn name(&self) -> &SnapshotCloneName {
+        &self.name
+    }
+    /// Get a reference to the clone uuid.
+    pub fn uuid(&self) -> &SnapshotCloneId {
+        &self.uuid
+    }
+}
+
+/// List all clones from the given snapshot.
+#[derive(Debug, Clone)]
+pub enum ListSnapshotClones {
     Snapshot(SnapshotId),
 }

--- a/control-plane/stor-port/src/types/v0/transport/snapshot.rs
+++ b/control-plane/stor-port/src/types/v0/transport/snapshot.rs
@@ -155,5 +155,15 @@ impl SnapshotCloneParameters {
 /// List all clones from the given snapshot.
 #[derive(Debug, Clone)]
 pub enum ListSnapshotClones {
+    All,
     Snapshot(SnapshotId),
+}
+impl ListSnapshotClones {
+    /// Get a reference to the snapshot uuid.
+    pub fn uuid(&self) -> Option<&SnapshotId> {
+        match self {
+            ListSnapshotClones::All => None,
+            ListSnapshotClones::Snapshot(uuid) => Some(uuid),
+        }
+    }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -476,7 +476,8 @@ pub mod v1 {
     pub mod snapshot {
         pub use super::pb::{
             destroy_snapshot_request, snapshot_rpc_client, CreateReplicaSnapshotRequest,
-            CreateReplicaSnapshotResponse, DestroySnapshotRequest, ListSnapshotsRequest,
+            CreateReplicaSnapshotResponse, CreateSnapshotCloneRequest, DestroySnapshotRequest,
+            ListSnapshotCloneRequest, ListSnapshotCloneResponse, ListSnapshotsRequest,
             ListSnapshotsResponse, Nexus, NexusCreateSnapshotReplicaDescriptor,
             NexusCreateSnapshotReplicaStatus, NexusCreateSnapshotRequest,
             NexusCreateSnapshotResponse, SnapshotInfo,


### PR DESCRIPTION
    fix(snapshot/clone): implement create & list clone dataplane rpc api
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(snapshot/clone): add scaffolding for dataplane rpc
    
    todo: add actual gRPC call implementation and type conversion.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
