### PR TITLE
chore: set size_bytes to source volume size

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -241,6 +241,7 @@ impl TryIoEngineToAgent for v1::snapshot::SnapshotInfo {
             self.txn_id.clone(),
             self.valid_snapshot,
             self.ready_as_source,
+            self.referenced_bytes,
         ))
     }
 }

--- a/control-plane/agents/src/bin/core/volume/registry.rs
+++ b/control-plane/agents/src/bin/core/volume/registry.rs
@@ -236,13 +236,13 @@ impl Registry {
     /// Get the snapshot state for the specified volume.
     pub(crate) async fn snapshot_state(&self, snapshot: &VolumeSnapshot) -> VolumeSnapshotState {
         let mut replica_snaps = vec![];
-        let mut size = None;
+        let mut allocated_size = None;
         if let Some(meta_snapshots) = snapshot.metadata().replica_snapshots() {
             replica_snaps = Vec::with_capacity(meta_snapshots.len());
             for replica_snap in meta_snapshots {
                 replica_snaps.push(
                     if let Ok(state) = self.snapshot_replica(replica_snap.spec()).await {
-                        size = Some(state.snap_size());
+                        allocated_size = Some(state.allocated_size());
                         VolumeReplicaSnapshotState::new_online(replica_snap.spec(), state)
                     } else {
                         VolumeReplicaSnapshotState::new_offline(replica_snap.spec())
@@ -251,7 +251,7 @@ impl Registry {
             }
         }
 
-        VolumeSnapshotState::new(snapshot, size, replica_snaps)
+        VolumeSnapshotState::new(snapshot, allocated_size, replica_snaps)
     }
 
     /// Return a single snapshot object corresponding, either matching (vol_id + snap_id)

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -818,7 +818,8 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
 fn snapshot_to_csi(snapshot: models::VolumeSnapshot) -> Snapshot {
     Snapshot {
-        size_bytes: snapshot.state.size as i64,
+        // TODO: Revisit this once restoreSize is decided properly.
+        size_bytes: snapshot.definition.metadata.spec_size as i64,
         snapshot_id: snapshot.definition.spec.uuid.to_string(),
         source_volume_id: snapshot.definition.spec.source_volume.to_string(),
         creation_time: snapshot

--- a/control-plane/grpc/proto/v1/snapshot/snapshot.proto
+++ b/control-plane/grpc/proto/v1/snapshot/snapshot.proto
@@ -14,8 +14,8 @@ message SnapshotState {
   SnapshotStatus               status = 2;
   // Creation timestamp of the snapshot.
   google.protobuf.Timestamp timestamp = 3;
-  // Size of the snapshot (typically follows source size).
-  uint64                         size = 4;
+  // Size allocated to the snapshot.
+  uint64               allocated_size = 4;
   string                    source_id = 5;
 }
 
@@ -34,27 +34,29 @@ message ReplicaSnapshotSourceState {
 }
 
 message ReplicaSnapshotState {
-  string                         uuid = 1;
-  string                   replica_id = 2;
-  string                    pool_uuid = 3;
-  string                      pool_id = 4;
-  SnapshotStatus               status = 5;
+  string                          uuid = 1;
+  string                    replica_id = 2;
+  string                     pool_uuid = 3;
+  string                       pool_id = 4;
+  SnapshotStatus                status = 5;
   // Creation timestamp of the snapshot.
-  google.protobuf.Timestamp timestamp = 6;
+  google.protobuf.Timestamp  timestamp = 6;
   // Size of the snapshot (typically follows source size).
-  uint64                         size = 7;
-  // Runtime size taken by the snapshot.
-  uint64              size_referenced = 8;
+  uint64                  replica_size = 7;
+  // Size allocated to the snapshot.
+  uint64                allocated_size = 8;
+  // Predecessor allocated size of the snapshot.
+  uint64        predecessor_alloc_size = 9;
   /// Number of clones created from this snapshot.
-  uint64                   num_clones = 9;
+  uint64                   num_clones = 10;
   // Transaction Id that defines this snapshot when it is created.
-  string                       txn_id = 10;
+  string                       txn_id = 11;
   // Whether this replica snapshot is valid w.r.t all attributes.
-  bool                          valid = 11;
+  bool                          valid = 12;
   // Name of the snapshot.
-  string                         name = 12;
+  string                         name = 13;
   // id of the entity for which snapshot is taken.
-  string                    entity_id = 13;
+  string                    entity_id = 14;
   // ready for usage, i,e source for another volume.
-  bool                ready_as_source = 14;
+  bool                ready_as_source = 15;
 }

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -478,6 +478,13 @@ message VolumeSnapshotMeta {
   // Failed transactions are any other key.
   map<string, ReplicaSnapshots>   transactions = 4;
 
+  // Size of the snapshot in bytes.
+  uint64                                  size = 5;
+  // Spec size of the snapshot in bytes.
+  uint64                             spec_size = 6;
+  // Size taken by the snapshot and its predecessors.
+  uint64                  total_allocated_size = 7;
+
   message ReplicaSnapshots {
     repeated ReplicaSnapshot         snapshots = 1;
   }

--- a/control-plane/plugin/src/resources/snapshot.rs
+++ b/control-plane/plugin/src/resources/snapshot.rs
@@ -39,6 +39,7 @@ impl VolumeSnapshotArgs {
 
 impl CreateRow for openapi::models::VolumeSnapshot {
     fn row(&self) -> Row {
+        let meta = &self.definition.metadata;
         let state = &self.state;
         let timestamp =
             state
@@ -52,7 +53,9 @@ impl CreateRow for openapi::models::VolumeSnapshot {
         row![
             state.uuid,
             optional_cell(timestamp),
-            ::utils::bytes::into_human(state.size),
+            ::utils::bytes::into_human(meta.spec_size),
+            ::utils::bytes::into_human(state.allocated_size),
+            ::utils::bytes::into_human(meta.total_allocated_size),
             state.source_volume
         ]
     }

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -22,7 +22,14 @@ lazy_static! {
         "THIN-PROVISIONED",
         "ALLOCATED"
     ];
-    pub static ref SNAPSHOT_HEADERS: Row = row!["ID", "TIMESTAMP", "SIZE", "SOURCE-VOL"];
+    pub static ref SNAPSHOT_HEADERS: Row = row![
+        "ID",
+        "TIMESTAMP",
+        "SOURCE-SIZE",
+        "ALLOCATED-SIZE",
+        "TOTAL-ALLOCATED-SIZE",
+        "SOURCE-VOL"
+    ];
     pub static ref POOLS_HEADERS: Row = row![
         "ID",
         "DISKS",

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3379,6 +3379,24 @@ components:
           description: Timestamp when snapshot is taken on the storage system.
           type: string
           format: date-time
+        size:
+          description: |-
+            Size in bytes of the snapshot (which is equivalent to its source size).
+          type: integer
+          format: int64
+          minimum: 0
+        spec_size:
+          description: |-
+            Spec size in bytes of the snapshot (which is equivalent to its source spec size).
+          type: integer
+          format: int64
+          minimum: 0
+        total_allocated_size:
+          description: |-
+            Size in bytes taken by the snapshot and its predecessors.
+          type: integer
+          format: int64
+          minimum: 0
         txn_id:
           type: string
         transactions:
@@ -3389,6 +3407,9 @@ components:
               $ref: '#/components/schemas/ReplicaSnapshot'
       required:
         - status
+        - size
+        - spec_size
+        - total_allocated_size
         - txn_id
         - transactions
     VolumeSnapshotSpec:
@@ -3410,9 +3431,10 @@ components:
       properties:
         uuid:
           $ref: '#/components/schemas/SnapshotId'
-        size:
+        allocated_size:
           description: |-
-            Size in bytes of the snapshot (which is equivalent to its source size).
+            Runtime size in bytes of the snapshot. Equal to the volume allocation at the time of the snapshot creation.
+            It may grow larger if any of its predecessors are deleted.
           type: integer
           format: int64
           minimum: 0
@@ -3433,7 +3455,7 @@ components:
             $ref: '#/components/schemas/ReplicaSnapshotState'
       required:
         - uuid
-        - size
+        - allocated_size
         - source_volume
         - ready_as_source
         - replica_snapshots
@@ -3488,10 +3510,19 @@ components:
           description: Replica snapshot size.
           type: integer
           format: int64
-        referenced_size:
-          description: Replica snapshot referenced size.
+          minimum: 0
+        allocated_size:
+          description: |-
+            Runtime size in bytes of the snapshot. Equal to the volume allocation at the time of the snapshot creation.
+            It may grow larger if any of its predecessors are deleted.
           type: integer
           format: int64
+          minimum: 0
+        predecessor_alloc_size:
+          description: Total allocated size of all the snapshot predecessors.
+          type: integer
+          format: int64
+          minimum: 0
       required:
         - uuid
         - source_id
@@ -3499,7 +3530,8 @@ components:
         - pool_id
         - timestamp
         - size
-        - referenced_size
+        - allocated_size
+        - predecessor_alloc_size
     OfflineReplicaSnapshotState:
       description: |-
         Offline ReplicaSnapshotState representation.

--- a/control-plane/rest/service/src/v0/snapshots.rs
+++ b/control-plane/rest/service/src/v0/snapshots.rs
@@ -170,6 +170,9 @@ fn to_models_volume_snapshot(snap: &VolumeSnapshot) -> models::VolumeSnapshot {
             models::VolumeSnapshotMetadata::new_all(
                 snap.meta().status().clone(),
                 snap.meta().timestamp().map(|t| t.to_string()),
+                snap.meta().size(),
+                snap.meta().spec_size(),
+                snap.meta().total_allocated_size(),
                 snap.meta().txn_id(),
                 snap.meta()
                     .transactions()
@@ -186,7 +189,7 @@ fn to_models_volume_snapshot(snap: &VolumeSnapshot) -> models::VolumeSnapshot {
         ),
         state: models::VolumeSnapshotState::new_all(
             snap.state().uuid(),
-            snap.state().size().unwrap_or_default(),
+            snap.state().allocated_size().unwrap_or_default(),
             snap.state().source_id(),
             snap.state().timestamp().map(|t| t.to_string()),
             snap.state().ready_as_source(),
@@ -218,8 +221,9 @@ fn to_models_replica_snapshot_state(
                 pool_id: pool_id.to_string(),
                 pool_uuid: state.pool_uuid().uuid().to_owned(),
                 timestamp: Timestamp::from(state.timestamp()).to_string(),
-                size: state.source_size() as i64,
-                referenced_size: state.snap_size() as i64,
+                size: state.replica_size(),
+                allocated_size: state.allocated_size(),
+                predecessor_alloc_size: state.predecessor_alloc_size(),
             })
         }
         VolumeReplicaSnapshotState::Offline {

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -136,8 +136,8 @@ pub struct ReplicaSnapshotDescr {
     snap_uuid: SnapshotId,
     /// Name of the snapshot.
     snap_name: String,
-    /// Amount of bytes referenced by snapshot.
-    snap_size: u64,
+    /// Amount of bytes allocated to snapshot.
+    allocated_size: u64,
     /// Number of clones created from this snapshot.
     num_clones: u64,
     /// Snapshot timestamp.
@@ -148,7 +148,7 @@ pub struct ReplicaSnapshotDescr {
     pool_uuid: PoolUuid,
     /// Name of the pool where the snapshot resides.
     pool_id: PoolId,
-    /// Amount of bytes referenced by replica.
+    /// Amount of bytes allocated to replica.
     replica_size: u64,
     /// Identity of the entity under which snapshot is taken.
     entity_id: String,
@@ -158,6 +158,8 @@ pub struct ReplicaSnapshotDescr {
     valid: bool,
     /// Snapshot is ready as source.
     ready_as_source: bool,
+    /// The amount of bytes allocated to all predecessor snapshots.
+    predecessor_alloc_size: u64,
 }
 impl ReplicaSnapshotDescr {
     #[allow(clippy::too_many_arguments)]
@@ -165,7 +167,7 @@ impl ReplicaSnapshotDescr {
     pub fn new(
         snap_uuid: SnapshotId,
         snap_name: String,
-        snap_size: u64,
+        allocated_size: u64,
         num_clones: u64,
         snap_time: SystemTime,
         replica_uuid: ReplicaId,
@@ -176,11 +178,12 @@ impl ReplicaSnapshotDescr {
         txn_id: String,
         valid: bool,
         ready_as_source: bool,
+        predecessor_alloc_size: u64,
     ) -> Self {
         Self {
             snap_uuid,
             snap_name,
-            snap_size,
+            allocated_size,
             num_clones,
             snap_time,
             replica_uuid,
@@ -191,6 +194,7 @@ impl ReplicaSnapshotDescr {
             txn_id,
             valid,
             ready_as_source,
+            predecessor_alloc_size,
         }
     }
 
@@ -228,13 +232,13 @@ impl ReplicaSnapshotDescr {
     }
 
     /// Get the size of snapshot source.
-    pub fn source_size(&self) -> u64 {
+    pub fn replica_size(&self) -> u64 {
         self.replica_size
     }
 
-    /// Get the size of snapshot referenced data.
-    pub fn snap_size(&self) -> u64 {
-        self.snap_size
+    /// Get the size of snapshot allocated data.
+    pub fn allocated_size(&self) -> u64 {
+        self.allocated_size
     }
 
     /// Get the snapshot name.
@@ -265,6 +269,11 @@ impl ReplicaSnapshotDescr {
     /// Get the replica snapshot's replica uuid.
     pub fn replica_uuid(&self) -> &ReplicaId {
         &self.replica_uuid
+    }
+
+    /// The amount of bytes allocated to all predecessor snapshots.
+    pub fn predecessor_alloc_size(&self) -> u64 {
+        self.predecessor_alloc_size
     }
 }
 

--- a/tests/bdd/features/snapshot/create/test_feature.py
+++ b/tests/bdd/features/snapshot/create/test_feature.py
@@ -350,13 +350,13 @@ def the_snapshot_should_not_be_listed():
 @then("the snapshot size should be equal to the volume size")
 def the_snapshot_size_should_be_equal_to_the_volume_size(volume, snapshot):
     """the snapshot size should be equal to the volume size."""
-    assert snapshot.state.size == volume.spec.size
+    assert snapshot.state.allocated_size == volume.spec.size
 
 
 @then("the snapshot source size should be equal to the volume size")
 def the_snapshot_source_size_should_be_equal_to_the_volume_size(volume, snapshot):
     """the snapshot source size should be equal to the volume size."""
-    assert snapshot.state.size == volume.spec.size
+    assert snapshot.state.allocated_size == volume.spec.size
 
 
 @then("the snapshot status ready as source should be false")


### PR DESCRIPTION
UPDATED VOLUME SNAPSHOT CONTROL PLANE STRUCTURE
```{
      "definition": {
        "metadata": {
          "status": "Created",
          "timestamp": "2023-07-07T11:02:22.763863691Z",
          "size": 12582912,
          "spec_size": 10485761,
          "total_allocated_size": 12582912,
          "txn_id": "1",
          "transactions": {
            "1": [
              {
                "uuid": "5ed4c683-045a-4658-ae69-9e062ef8439c",
                "source_id": "71df671c-e28c-4e29-9c96-87d4f5cc3238",
                "status": "Created"
              }
            ]
          }
        },
        "spec": {
          "uuid": "95bbb623-fa74-4521-9d91-af4f7f1a0b26",
          "source_volume": "ec4e66fd-3b33-4439-b504-d49aba53da26"
        }
      },
      "state": {
        "uuid": "95bbb623-fa74-4521-9d91-af4f7f1a0b26",
        "allocated_size": 12582912,
        "source_volume": "ec4e66fd-3b33-4439-b504-d49aba53da26",
        "timestamp": "2023-07-07T11:02:22.763863691Z",
        "ready_as_source": false,
        "replica_snapshots": [
          {
            "online": {
              "uuid": "5ed4c683-045a-4658-ae69-9e062ef8439c",
              "source_id": "71df671c-e28c-4e29-9c96-87d4f5cc3238",
              "pool_id": "pool-1",
              "pool_uuid": "2c9674b2-10de-4171-b9e0-0b9a9fea04b9",
              "timestamp": "2023-07-07T11:02:22.763863691Z",
              "size": 12582912,
              "allocated_size": 12582912,
              "predecessor_alloc_size": 0
            }
          }
        ]
      }
```
REST PLUGIN CHANGES
```
nix ➜  mayastor-control-plane git:(fix-csi-cp) ✗ rest-plugin get volume-snapshots
 ID                                    TIMESTAMP             SOURCE-SIZE  ALLOCATED-SIZE  TOTAL-ALLOCATED-SIZE  SOURCE-VOL 
 95bbb623-fa74-4521-9d91-af4f7f1a0b25  2023-07-07T12:01:48Z  10MiB        12MiB           12MiB                 ec4e66fd-3b33-4439-b504-d49aba53da26 
 95bbb623-fa74-4521-9d91-af4f7f1a0b24  2023-07-07T12:01:52Z  10MiB        0 B             12MiB                 ec4e66fd-3b33-4439-b504-d49aba53da26 

```