### PR TITLE
fix(nexus/replica): check with replica owner before destroying it

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -31,6 +31,7 @@ use stor_port::{
         store::{
             nexus::{NexusSpec, ReplicaUri},
             nexus_child::NexusChild,
+            volume::VolumeSpec,
         },
         transport::{
             Child, ChildUri, CreateNexus, Nexus, NexusChildActionContext, NexusShareProtocol,
@@ -44,7 +45,6 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime},
 };
-
 use tokio::sync::RwLock;
 use tracing::Instrument;
 
@@ -125,9 +125,9 @@ async fn nexus_reconciler(
 
     if reconcile {
         match squash_results(vec![
-            handle_faulted_children(nexus, context).await,
+            handle_faulted_children(nexus, &mut None, context).await,
             unknown_children_remover(nexus, context).await,
-            missing_children_remover(nexus, context).await,
+            missing_children_remover(nexus, &mut None, context).await,
             fixup_nexus_protocol(nexus, context).await,
             enospc_children_onliner(nexus, context).await,
         ]) {
@@ -144,6 +144,7 @@ async fn nexus_reconciler(
 #[tracing::instrument(skip(nexus, context), level = "trace", fields(nexus.uuid = %nexus.uuid(), nexus.node = %nexus.as_ref().node, request.reconcile = true))]
 pub(super) async fn handle_faulted_children(
     nexus: &mut OperationGuardArc<NexusSpec>,
+    volume: &mut Option<&mut OperationGuardArc<VolumeSpec>>,
     context: &PollContext,
 ) -> PollResult {
     let nexus_uuid = nexus.uuid();
@@ -151,7 +152,7 @@ pub(super) async fn handle_faulted_children(
     let child_count = nexus_state.children.len();
     if nexus_state.status == NexusStatus::Degraded && child_count > 1 {
         for child in nexus_state.children.iter().filter(|c| c.state.faulted()) {
-            let _ = handle_faulted_child(nexus, child, &nexus_state, context).await;
+            let _ = handle_faulted_child(nexus, volume, child, &nexus_state, context).await;
         }
     }
     Ok(PollerState::Idle)
@@ -162,6 +163,7 @@ pub(super) async fn handle_faulted_children(
 /// or it opts for a full rebuilding by faulting the child instead.
 async fn handle_faulted_child(
     nexus_spec: &mut OperationGuardArc<NexusSpec>,
+    volume: &mut Option<&mut OperationGuardArc<VolumeSpec>>,
     child: &Child,
     nexus: &Nexus,
     context: &PollContext,
@@ -171,16 +173,16 @@ async fn handle_faulted_child(
 
     let Some(child_uuid) = nexus_spec.as_ref().replica_uri(&child.uri).map(|r| r.uuid()) else {
         tracing::warn!(%child.uri, "Unknown Child found, a full rebuild is required");
-        return faulted_children_remover(nexus_spec, child, context).await;
+        return faulted_children_remover(nexus_spec, volume, child, context).await;
     };
     let Some(faulted_at) = child.faulted_at else {
         tracing::warn!(%child.uri, child.uuid=%child_uuid, "Child faulted without a timestamp set, a full rebuild required");
-        return faulted_children_remover(nexus_spec, child, context).await;
+        return faulted_children_remover(nexus_spec, volume, child, context).await;
     };
 
     if !can_partial_rebuild {
         tracing::warn!(%child.uri, child.uuid=%child_uuid, ?child.state_reason, "No IO log available, this child cannot be partially rebuilt");
-        faulted_children_remover(nexus_spec, child, context).await?;
+        faulted_children_remover(nexus_spec, volume, child, context).await?;
     } else if child_replica_is_online(child_uuid, context).await {
         let child_uuid = child_uuid.clone();
         tracing::info!(%child.uri, child.uuid=%child_uuid, ?child.state_reason, "Child's replica is back online within the partial rebuild window");
@@ -192,13 +194,13 @@ async fn handle_faulted_child(
                 %error,
                 "Failed to online child, a full rebuild is required"
             );
-            faulted_children_remover(nexus_spec, child, context).await?;
+            faulted_children_remover(nexus_spec, volume, child, context).await?;
         }
     } else if let Some(elapsed) =
         wait_duration_elapsed(&child.uri, child_uuid, faulted_at, wait_duration)
     {
         tracing::warn!(%child.uri, child.uuid=%child_uuid, ?child.state_reason, ?elapsed, "Partial rebuild window elapsed, a full rebuild is required");
-        faulted_children_remover(nexus_spec, child, context).await?;
+        faulted_children_remover(nexus_spec, volume, child, context).await?;
     }
     Ok(())
 }
@@ -206,6 +208,7 @@ async fn handle_faulted_child(
 /// Removes child from nexus children list to initiate Full rebuild of child.
 async fn faulted_children_remover(
     nexus: &mut OperationGuardArc<NexusSpec>,
+    volume: &mut Option<&mut OperationGuardArc<VolumeSpec>>,
     child: &Child,
     context: &PollContext,
 ) -> Result<(), SvcError> {
@@ -216,9 +219,8 @@ async fn faulted_children_remover(
         tracing::warn!(%child.uri, %child.state, %child.state_reason, ?faulted_at, "Attempting to remove faulted child")
     });
     nexus
-        .remove_child_by_uri(context.registry(), &nexus_state, &child.uri)
+        .remove_vol_child_by_uri(volume, context.registry(), &nexus_state, &child.uri)
         .await?;
-
     nexus.warn_span(|| {
         tracing::warn!(%child.uri, %child.state, %child.state_reason, ?faulted_at, "Successfully removed faulted child")
     });
@@ -330,6 +332,7 @@ pub(super) async fn unknown_children_remover(
 #[tracing::instrument(skip(nexus, context), level = "trace", fields(nexus.uuid = %nexus.uuid(), request.reconcile = true))]
 pub(super) async fn missing_children_remover(
     nexus: &mut OperationGuardArc<NexusSpec>,
+    volume: &mut Option<&mut OperationGuardArc<VolumeSpec>>,
     context: &PollContext,
 ) -> PollResult {
     let nexus_uuid = nexus.uuid();
@@ -346,7 +349,7 @@ pub(super) async fn missing_children_remover(
         ));
 
         if let Err(error) = nexus
-            .remove_child_by_uri(context.registry(), &nexus_state, &child.uri())
+            .remove_vol_child_by_uri(volume, context.registry(), &nexus_state, &child.uri())
             .await
         {
             nexus.error_span(|| {

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -216,7 +216,7 @@ async fn faulted_children_remover(
         tracing::warn!(%child.uri, %child.state, %child.state_reason, ?faulted_at, "Attempting to remove faulted child")
     });
     nexus
-        .remove_child_by_uri(context.registry(), &nexus_state, &child.uri, true)
+        .remove_child_by_uri(context.registry(), &nexus_state, &child.uri)
         .await?;
 
     nexus.warn_span(|| {
@@ -301,7 +301,7 @@ pub(super) async fn unknown_children_remover(
                     tracing::warn!("Attempting to remove unknown child '{}'", child.uri)
                 });
                 if let Err(error) = nexus
-                    .remove_child_by_uri(context.registry(), &nexus_state, &child.uri, false)
+                    .remove_child_by_uri(context.registry(), &nexus_state, &child.uri)
                     .await
                 {
                     nexus.error(&format!(
@@ -346,7 +346,7 @@ pub(super) async fn missing_children_remover(
         ));
 
         if let Err(error) = nexus
-            .remove_child_by_uri(context.registry(), &nexus_state, &child.uri(), true)
+            .remove_child_by_uri(context.registry(), &nexus_state, &child.uri())
             .await
         {
             nexus.error_span(|| {

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
@@ -17,7 +17,7 @@ use stor_port::types::v0::{
     store::{
         nexus::NexusSpec, nexus_persistence::NexusInfo, replica::ReplicaSpec, volume::VolumeSpec,
     },
-    transport::{DestroyVolume, ReplicaOwners, VolumeStatus},
+    transport::{DestroyVolume, NexusOwners, ReplicaOwners, VolumeStatus},
 };
 use tracing::Instrument;
 
@@ -160,7 +160,8 @@ async fn disown_unused_nexuses(
 
             nexus.warn_span(|| tracing::warn!("Attempting to disown unused nexus"));
             // the nexus garbage collector will destroy the disowned nexuses
-            match nexus.disown(context.registry()).await {
+            let owner = NexusOwners::Volume(volume.uuid().clone());
+            match nexus.remove_owners(context.registry(), &owner, false).await {
                 Ok(_) => {
                     nexus.info_span(|| tracing::info!("Successfully disowned unused nexus"));
                 }

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
@@ -44,12 +44,11 @@ async fn hot_spare_reconcile(
     volume_spec: &mut ResourceMutex<VolumeSpec>,
     context: &PollContext,
 ) -> PollResult {
-    let uuid = volume_spec.uuid();
-    let volume_state = context.registry().volume_state(uuid).await?;
     let mut volume = match volume_spec.operation_guard() {
         Ok(guard) => guard,
         Err(_) => return PollResult::Ok(PollerState::Busy),
     };
+    let volume_state = context.registry().volume_state(volume.uuid()).await?;
 
     if !volume.as_ref().policy.self_heal {
         return PollResult::Ok(PollerState::Idle);

--- a/control-plane/agents/src/bin/core/nexus/specs.rs
+++ b/control-plane/agents/src/bin/core/nexus/specs.rs
@@ -79,7 +79,15 @@ impl SpecOperationsHelper for NexusSpec {
             }
             NexusOperation::RemoveChild(_) => Ok(()),
             NexusOperation::Shutdown => Ok(()),
-            _ => unreachable!(),
+            NexusOperation::OwnerUpdate(owners) => {
+                if !self.would_disown(owners) {
+                    return Err(SvcError::Internal {
+                        details: format!("Nexus {} not owned by {owners:?}", self.uuid),
+                    });
+                }
+                Ok(())
+            }
+            NexusOperation::Create | NexusOperation::Destroy => unreachable!(),
         }?;
         self.start_op(op);
         Ok(())

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -1,9 +1,6 @@
 use crate::controller::{
     registry::Registry,
-    resources::{
-        operations::{ResourceLifecycle, ResourceOwnerUpdate},
-        OperationGuardArc,
-    },
+    resources::{operations::ResourceLifecycle, OperationGuardArc},
 };
 use agents::{errors, errors::SvcError};
 use snafu::OptionExt;
@@ -47,19 +44,6 @@ impl OperationGuardArc<ReplicaSpec> {
             &self.destroy_request(ReplicaOwners::new_disown_all(), &node_id),
         )
         .await
-    }
-
-    /// Disown and destroy the replica from its volume
-    pub(crate) async fn disown_and_destroy_replica(
-        &mut self,
-        registry: &Registry,
-        node: &NodeId,
-    ) -> Result<(), SvcError> {
-        // disown it from the volume first, so at the very least it can be garbage collected
-        // at a later point if the node is not accessible
-        let disowner = ReplicaOwners::new_disown_all();
-        self.remove_owners(registry, &disowner, true).await?;
-        self.destroy_volume_replica(registry, Some(node)).await
     }
 
     /// Return a `DestroyReplica` request based on the provided arguments

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -283,7 +283,7 @@ impl OperationGuardArc<VolumeSpec> {
     /// (that is, replicas which are not used by a nexus).
     /// It must not be the last replica of the volume
     /// (an error will be returned in such case).
-    pub(super) async fn remove_unused_volume_replica(
+    pub(crate) async fn remove_unused_volume_replica(
         &mut self,
         registry: &Registry,
         replica_id: &ReplicaId,

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -434,7 +434,7 @@ impl OperationGuardArc<VolumeSpec> {
                 Some(child) => child.uri.clone(),
             };
             match nexus
-                .remove_child_by_uri(registry, nexus_state, &child_uri, true)
+                .remove_child_by_uri(registry, nexus_state, &child_uri)
                 .await
             {
                 Ok(_) => {


### PR DESCRIPTION
When removing a nexus child, don't attempt to destroy the equivalent replica, let the other reconcilers do this.
Adds a test for this using a fake nexus volume.