### PR TITLE
fix(snapshot/timeout): increase nexus and replica snapshot timeout

### DIFF
--- a/control-plane/grpc/src/context.rs
+++ b/control-plane/grpc/src/context.rs
@@ -55,11 +55,14 @@ pub fn timeout_grpc(op_id: MessageId, timeout_opts: TimeoutOptions) -> Duration 
                 MessageIdVs::RepublishVolume => min_timeouts.nexus() * 2,
 
                 MessageIdVs::CreateNexus => min_timeouts.nexus(),
+                MessageIdVs::CreateNexusSnapshot => min_timeouts.nexus_snapshot(),
                 MessageIdVs::DestroyNexus => min_timeouts.nexus(),
                 MessageIdVs::ShutdownNexus => min_timeouts.nexus_shutdown(),
 
                 MessageIdVs::CreateReplica => min_timeouts.replica(),
+                MessageIdVs::CreateReplicaSnapshot => min_timeouts.replica_snapshot(),
                 MessageIdVs::DestroyReplica => min_timeouts.replica(),
+                MessageIdVs::DestroyReplicaSnapshot => min_timeouts.replica_snapshot(),
 
                 MessageIdVs::CreatePool => min_timeouts.pool(),
                 MessageIdVs::DestroyPool => min_timeouts.pool(),

--- a/control-plane/stor-port/src/transport_api/mod.rs
+++ b/control-plane/stor-port/src/transport_api/mod.rs
@@ -503,19 +503,23 @@ pub struct TimeoutOptions {
 #[derive(Debug, Clone)]
 pub struct RequestMinTimeout {
     replica: Duration,
+    replica_snapshot: Duration,
     nexus: Duration,
     pool: Duration,
     nexus_shutdown: Duration,
+    nexus_snapshot: Duration,
     nvme_reconnect: Duration,
 }
 
 impl Default for RequestMinTimeout {
     fn default() -> Self {
         Self {
-            replica: Duration::from_secs(10),
+            replica: Duration::from_secs(15),
+            replica_snapshot: Duration::from_secs(10),
             nexus: Duration::from_secs(30),
             pool: Duration::from_secs(20),
             nexus_shutdown: Duration::from_secs(15),
+            nexus_snapshot: Duration::from_secs(30),
             nvme_reconnect: Duration::from_secs(12),
         }
     }
@@ -525,9 +529,17 @@ impl RequestMinTimeout {
     pub fn replica(&self) -> Duration {
         self.replica
     }
+    /// Minimum timeout for a replica snapshot operation.
+    pub fn replica_snapshot(&self) -> Duration {
+        self.replica_snapshot
+    }
     /// Minimum timeout for a nexus operation.
     pub fn nexus(&self) -> Duration {
         self.nexus
+    }
+    /// Minimum timeout for a nexus snapshot operation.
+    pub fn nexus_snapshot(&self) -> Duration {
+        self.nexus_snapshot
     }
     /// Minimum timeout for a pool operation.
     pub fn pool(&self) -> Duration {


### PR DESCRIPTION
Increase timeouts for nexus and replica snapshots as it seems sometimes the subsystem pause can take a few seconds. On a particular test it took 11s to pause.
If we increase the IO timeout this might take even longer? So we probably need a way to undo snapshot creation because when we timeout the snapshot might not be created yet so the control-plane can't undo it!