### PR TITLE
feat(dsp_versioning): allows dsp operator to work with v1beta1 schema

### DIFF
--- a/k8s/operators/src/lib.rs
+++ b/k8s/operators/src/lib.rs
@@ -2,6 +2,6 @@
 pub mod diskpool {
     /// The DiskPool custom resource definition.
     pub mod crd {
-        include!("pool/diskpool/crd.rs");
+        include!("pool/diskpool/v1beta1.rs");
     }
 }

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -1,29 +1,65 @@
-use super::crd::{DiskPool, DiskPoolSpec};
+use super::{
+    v1alpha1::DiskPool as AlphaDiskPool,
+    v1beta1::{DiskPool, DiskPoolSpec},
+};
 use crate::error::Error;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
-use kube::{api::PostParams, Api, Client, CustomResourceExt, ResourceExt};
+use kube::{
+    api::{ListParams, Patch, PatchParams, PostParams},
+    core::crd::merge_crds,
+    Api, Client, CustomResourceExt, ResourceExt,
+};
 use openapi::apis::StatusCode;
-use tracing::info;
+use tracing::{error, info};
 
-/// Get the DiskPool api.
-pub(crate) fn api(client: &Client, namespace: &str) -> Api<DiskPool> {
+/// Get the DiskPool v1beta1 api.
+pub(crate) fn v1beta1_api(client: &Client, namespace: &str) -> Api<DiskPool> {
     Api::namespaced(client.clone(), namespace)
 }
 
-/// Create a disk pool CR, with the given name and spec.
-pub(crate) async fn create(
+/// Create a v1beta1 disk pool CR, with the given name and spec.
+pub(crate) async fn create_v1beta_cr(
     client: &Client,
     namespace: &str,
     name: &str,
     spec: DiskPoolSpec,
 ) -> Result<(), Error> {
     let post_params = PostParams::default();
-    let api = api(client, namespace);
+    let api = v1beta1_api(client, namespace);
     let new_disk_pool: DiskPool = DiskPool::new(name, spec);
     match api.create(&post_params, &new_disk_pool).await {
         Ok(_) => Ok(()),
         Err(kube::Error::Api(e)) if e.code == StatusCode::CONFLICT => Ok(()),
         Err(error) => Err(error.into()),
+    }
+}
+
+/// Replaces a given disk pool CR with v1beta1 schema CR.
+pub(crate) async fn replace_with_v1beta1(
+    client: &Client,
+    cr_name: &str,
+    namespace: &str,
+    res_ver: Option<String>,
+    spec: DiskPoolSpec,
+) -> Result<(), Error> {
+    let post_params = PostParams::default();
+    let api = v1beta1_api(client, namespace);
+    let mut new_disk_pool: DiskPool = DiskPool::new(cr_name, spec);
+    new_disk_pool.metadata.resource_version = res_ver;
+    info!(
+        pool.cr_name = cr_name,
+        "Patching existing pool with v1beta1 schema"
+    );
+    match api.replace(cr_name, &post_params, &new_disk_pool).await {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            error!(
+                ?error,
+                pool.cr_name = cr_name,
+                "Failed to patch pool with v1beta 1schema"
+            );
+            Err(error.into())
+        }
     }
 }
 
@@ -35,33 +71,165 @@ pub(crate) async fn create(
 /// is wrong would be to consult the logs.
 pub(crate) async fn ensure_crd(k8s: &Client) -> Result<CustomResourceDefinition, Error> {
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
-
     // Check if there is an existing dsp diskpool. If yes, Replace it with new generated one.
     // Create new if it doesnt exist.
-    let mut crd = DiskPool::crd();
+    let mut crd = AlphaDiskPool::crd();
     let crd_name = crd.metadata.name.as_ref().ok_or(Error::InvalidCRField {
         field: "diskpool.metadata.name".to_string(),
     })?;
+    crd.spec.versions[0].served = false;
+    let new_crd = DiskPool::crd();
+    let all_crds = vec![crd.clone(), new_crd.clone()];
+    let new_crd =
+        merge_crds(all_crds, "v1beta1").map_err(|source| Error::CrdMergeError { source })?;
 
-    // Ensure the diskpool.
-    let result = if let Ok(existing) = crd_api.get(crd_name).await {
-        crd.metadata.resource_version = existing.resource_version();
+    // Ensure if diskpool crd exist to determine api verb.
+    let result = if crd_api.get(crd_name).await.is_ok() {
         info!(
             "Replacing CRD: {}",
-            serde_json::to_string_pretty(&crd).unwrap()
+            serde_json::to_string_pretty(&new_crd).unwrap_or_default()
         );
-
-        let pp = PostParams::default();
-        crd_api.replace(crd_name, &pp, &crd).await
+        let param = PatchParams::apply("merge_v1alpha1_v1beta1").force();
+        crd_api
+            .patch("diskpools.openebs.io", &param, &Patch::Apply(&new_crd))
+            .await
     } else {
         info!(
             "Creating CRD: {}",
-            serde_json::to_string_pretty(&crd).unwrap()
+            serde_json::to_string_pretty(&new_crd).unwrap_or_default()
         );
 
         let pp = PostParams::default();
-        crd_api.create(&pp, &crd).await
+        crd_api.create(&pp, &new_crd).await
     };
     let crd = result.map_err(|e| Error::Kube { source: e })?;
     Ok(crd)
+}
+
+/// This discards older unserved schema from the crd.
+pub(crate) async fn discard_older_schema(k8s: &Client, new_version: &str) -> Result<(), Error> {
+    let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
+    let mut new_crd = DiskPool::crd();
+    let crd_name = new_crd
+        .metadata
+        .name
+        .as_ref()
+        .ok_or(Error::InvalidCRField {
+            field: "diskpool.metadata.name".to_string(),
+        })?;
+    if crd_api.get(crd_name).await.is_ok() {
+        info!(
+            "Replacing CRD: {}",
+            serde_json::to_string_pretty(&new_crd).unwrap()
+        );
+        update_stored_version(k8s, crd_name, new_version).await?;
+        if let Ok(modified_crd) = crd_api.get(crd_name).await {
+            new_crd.metadata.resource_version = modified_crd.resource_version();
+            let pp = PostParams::default();
+            crd_api.replace(crd_name, &pp, &new_crd).await?;
+        }
+    } else {
+        info!(
+            "Creating CRD: {}",
+            serde_json::to_string_pretty(&new_crd).unwrap()
+        );
+        let pp = PostParams::default();
+        if let Err(e) = crd_api.create(&pp, &new_crd).await {
+            error!("Failed to create v1beta1 CRD: {:?}", e);
+        }
+    }
+    Ok(())
+}
+
+/// Lists existing v1alpha1 CR in cluster and replaces them with v1beta1 CR.
+/// This ensures that there is no v1alpha1 stored objects in cluster.
+pub(crate) async fn migrate_to_v1beta1(
+    k8s: Client,
+    ns: &str,
+    pagination_limit: u32,
+) -> Result<(), Error> {
+    if let Ok(mut v1_alpha1_pools) = list_existing_cr(&k8s, ns, pagination_limit).await {
+        for dsp in v1_alpha1_pools.iter_mut() {
+            if let Some(res_ver) = dsp.resource_version() {
+                let name = dsp.name_any();
+                let node = dsp.spec.node();
+                let disk = dsp.spec.disks();
+                replace_with_v1beta1(
+                    &k8s,
+                    &name,
+                    ns,
+                    Some(res_ver.clone()),
+                    DiskPoolSpec::new(node, disk),
+                )
+                .await?;
+                info!(crd = ?dsp.name_any(), "CR creation successful");
+            } else {
+                return Err(Error::CrdFieldMissing {
+                    name: dsp.name_any(),
+                    field: "resource_version".to_string(),
+                });
+            }
+        }
+    } else {
+        return Err(Error::Generic {
+            message: "Error in listing v1alpha1 CR".to_string(),
+        });
+    };
+    Ok(())
+}
+
+/// Updates stored version in CRD status to the new version passed as arg,
+/// Please ensure that older versions are served:false, stored:false before calling this method,
+/// This would allow us to remove older schema from CRD versions.
+async fn update_stored_version(
+    k8s: &Client,
+    crd_name: &str,
+    new_version: &str,
+) -> Result<(), Error> {
+    let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
+    if let Ok(mut crd) = crd_api.get_status(crd_name).await {
+        let param = PatchParams::apply("status_patch").force();
+        if let Some(mut status) = crd.status.as_mut() {
+            status.stored_versions = Some(vec![new_version.to_string()]);
+        } else {
+            return Err(Error::CrdFieldMissing {
+                name: crd_name.to_string(),
+                field: "status".to_string(),
+            });
+        }
+        crd.metadata.managed_fields = None;
+        let _ = crd_api
+            .patch_status(crd_name, &param, &Patch::Apply(&crd))
+            .await?;
+    }
+    Ok(())
+}
+
+/// Fetch list of all mayastor pools.
+pub(crate) async fn list_existing_cr(
+    client: &Client,
+    namespace: &str,
+    pagination_limit: u32,
+) -> Result<Vec<DiskPool>, Error> {
+    // Create the list params with pagination limit.
+    let mut list_params = ListParams::default().limit(pagination_limit);
+    // Since v1alpha1 is not served at this stage we cannot use v1alpha1 api client
+    // to list existing CRs. Existing CRs which were created and stored as v1alpha1 can
+    // be retrieved using v1beta1 client. Kube api server performs the required conversions and
+    // returns us the resources.
+    let pools_api: Api<DiskPool> = v1beta1_api(client, namespace);
+    let mut pools: Vec<DiskPool> = vec![];
+    loop {
+        let mut result = pools_api.list(&list_params).await?;
+        pools.append(&mut result.items);
+        // Check for the token, if valid then continue.
+        match result.metadata.continue_ {
+            Some(token) if !token.is_empty() => {
+                list_params = list_params.continue_token(token.as_str())
+            }
+            _ => break,
+        }
+    }
+
+    Ok(pools)
 }

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -189,7 +189,7 @@ async fn update_stored_version(
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
     if let Ok(mut crd) = crd_api.get_status(crd_name).await {
         let param = PatchParams::apply("status_patch").force();
-        if let Some(mut status) = crd.status.as_mut() {
+        if let Some(status) = crd.status.as_mut() {
             status.stored_versions = Some(vec![new_version.to_string()]);
         } else {
             return Err(Error::CrdFieldMissing {

--- a/k8s/operators/src/pool/diskpool/mod.rs
+++ b/k8s/operators/src/pool/diskpool/mod.rs
@@ -4,4 +4,5 @@
 /// DiskPool client operations.
 pub(crate) mod client;
 /// The DiskPool custom resource definition.
-pub mod crd;
+pub(crate) mod v1alpha1;
+pub(crate) mod v1beta1;

--- a/k8s/operators/src/pool/diskpool/v1beta1.rs
+++ b/k8s/operators/src/pool/diskpool/v1beta1.rs
@@ -1,0 +1,184 @@
+use kube::CustomResource;
+use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    CustomResource, Serialize, Deserialize, Default, Debug, Eq, PartialEq, Clone, JsonSchema,
+)]
+#[kube(
+group = "openebs.io",
+version = "v1beta1",
+kind = "DiskPool",
+plural = "diskpools",
+// The name of the struct that gets created that represents a resource
+namespaced,
+status = "DiskPoolStatus",
+derive = "PartialEq",
+derive = "Default",
+shortname = "dsp",
+printcolumn = r#"{ "name":"node", "type":"string", "description":"node the pool is on", "jsonPath":".spec.node"}"#,
+printcolumn = r#"{ "name":"state", "type":"string", "description":"dsp cr state", "jsonPath":".status.cr_state"}"#,
+printcolumn = r#"{ "name":"pool_status", "type":"string", "description":"Control plane pool status", "jsonPath":".status.pool_status"}"#,
+printcolumn = r#"{ "name":"capacity", "type":"integer", "format": "int64", "minimum" : "0", "description":"total bytes", "jsonPath":".status.capacity"}"#,
+printcolumn = r#"{ "name":"used", "type":"integer", "format": "int64", "minimum" : "0", "description":"used bytes", "jsonPath":".status.used"}"#,
+printcolumn = r#"{ "name":"available", "type":"integer", "format": "int64", "minimum" : "0", "description":"available bytes", "jsonPath":".status.available"}"#
+)]
+
+/// The pool spec which contains the parameters we use when creating the pool
+pub struct DiskPoolSpec {
+    /// The node the pool is placed on
+    node: String,
+    /// The disk device the pool is located on
+    disks: Vec<String>,
+}
+
+impl DiskPoolSpec {
+    /// Create a new DiskPoolSpec from the node and the disks.
+    pub fn new(node: String, disks: Vec<String>) -> Self {
+        Self { node, disks }
+    }
+    /// The node the pool is placed on.
+    pub fn node(&self) -> String {
+        self.node.clone()
+    }
+    /// The disk devices that compose the pool.
+    pub fn disks(&self) -> Vec<String> {
+        self.disks.clone()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema, Default)]
+/// PoolState represents operator specific states for DSP CR.
+pub enum CrPoolState {
+    /// The pool is a new OR missing resource, and it has not been created or
+    /// imported yet by the operator. The pool spec MAY be but DOES
+    /// NOT have a status field.
+    #[default]
+    Creating,
+    /// The resource spec has been created, and the pool is getting created by
+    /// the control plane.
+    Created,
+    /// This state is set when we receive delete event on the dsp cr.
+    Terminating,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+/// PoolStatus is Control plane status of a given DSP CR.
+pub enum PoolStatus {
+    /// State is Unknown.
+    Unknown,
+    /// The pool is in normal working order.
+    Online,
+    /// The pool has experienced a failure but can still function.
+    Degraded,
+    /// The pool is completely inaccessible.
+    Faulted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+/// Status of the pool which is driven and changed by the controller loop.
+pub struct DiskPoolStatus {
+    #[serde(default)]
+    pub cr_state: CrPoolState,
+    /// Pool status from respective control plane object.
+    pub pool_status: Option<PoolStatus>,
+    /// Capacity as number of bytes.
+    capacity: u64,
+    /// Used number of bytes.
+    used: u64,
+    /// Available number of bytes.
+    available: u64,
+}
+
+impl Default for DiskPoolStatus {
+    fn default() -> Self {
+        Self {
+            cr_state: CrPoolState::Creating,
+            pool_status: None,
+            capacity: 0,
+            used: 0,
+            available: 0,
+        }
+    }
+}
+
+impl DiskPoolStatus {
+    /// Set when Pool is not found for some reason.
+    pub fn not_found() -> Self {
+        Self {
+            pool_status: None,
+            ..Default::default()
+        }
+    }
+
+    /// Set when operator is attempting delete on pool.
+    pub fn terminating(p: Pool) -> Self {
+        let state = p.state.unwrap_or_default();
+        let free = if state.capacity > state.used {
+            state.capacity - state.used
+        } else {
+            0
+        };
+        Self {
+            cr_state: CrPoolState::Terminating,
+            pool_status: Some(state.status.into()),
+            capacity: state.capacity,
+            used: state.used,
+            available: free,
+        }
+    }
+
+    /// Set when deleting a Pool which is not accessible.
+    pub fn terminating_when_unknown() -> Self {
+        Self {
+            cr_state: CrPoolState::Terminating,
+            pool_status: Some(PoolStatus::Unknown),
+            ..Default::default()
+        }
+    }
+
+    pub fn mark_unknown() -> Self {
+        Self {
+            cr_state: CrPoolState::Created,
+            pool_status: Some(PoolStatus::Unknown),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<RestPoolStatus> for PoolStatus {
+    fn from(p: RestPoolStatus) -> Self {
+        match p {
+            RestPoolStatus::Unknown => Self::Unknown,
+            RestPoolStatus::Online => Self::Online,
+            RestPoolStatus::Degraded => Self::Degraded,
+            RestPoolStatus::Faulted => Self::Faulted,
+        }
+    }
+}
+
+/// Returns DiskPoolStatus from Control plane pool object.
+impl From<Pool> for DiskPoolStatus {
+    fn from(p: Pool) -> Self {
+        if let Some(state) = p.state {
+            let free = if state.capacity > state.used {
+                state.capacity - state.used
+            } else {
+                0
+            };
+            Self {
+                cr_state: CrPoolState::Created,
+                pool_status: Some(state.status.into()),
+                capacity: state.capacity,
+                used: state.used,
+                available: free,
+            }
+        } else {
+            Self {
+                cr_state: CrPoolState::Created,
+                ..Default::default()
+            }
+        }
+    }
+}

--- a/k8s/operators/src/pool/error.rs
+++ b/k8s/operators/src/pool/error.rs
@@ -1,3 +1,4 @@
+use kube::core::crd::MergeError;
 use openapi::{clients, models::RestJsonError};
 use snafu::Snafu;
 
@@ -42,6 +43,15 @@ pub enum Error {
     },
     Generic {
         message: String,
+    },
+    #[snafu(display("CRD merge failed"))]
+    CrdMergeError {
+        source: MergeError,
+    },
+    #[snafu(display("{} for CRD : {}", field, name))]
+    CrdFieldMissing {
+        name: String,
+        field: String,
     },
 }
 


### PR DESCRIPTION
With this PR we are adding new schema (v1beta1) to the diskpools.openebs.io CRD.

All the existing DSP objects in the cluster which would have got created using v1alpha1 spec will get converted to v1beta1 automatically.

We are removing v1alpha1 schema from CRD versions after the existing CR migration completes. So new DSP CR creation will have to happen using v1beta1 object. v1alpha1 will be unsupported henceforth.