### PR TITLE
fix(bins): improve errors when server fails

### DIFF
--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -177,7 +177,7 @@ impl Registry {
                 .await
                 .map_err(|error| StoreError::Generic {
                     source: Box::new(error),
-                    description: "Deletetion of the v1 nexus_info failed".to_string(),
+                    description: "Deletion of the v1 nexus_info failed".to_string(),
                 })?;
             // Disable the v1 compat mode.
             registry

--- a/control-plane/agents/src/bin/ha/cluster/main.rs
+++ b/control-plane/agents/src/bin/ha/cluster/main.rs
@@ -92,12 +92,12 @@ async fn main() -> anyhow::Result<()> {
     let mover = volume::VolumeMover::new(store, cli.fast_requeue, node_list.clone());
     mover.send_switchover_req(entries).await?;
 
-    info!("starting cluster-agent server");
-    server::ClusterAgent::new(cli.grpc_endpoint, node_list, mover)
+    info!("Starting cluster-agent server");
+    let result = server::ClusterAgent::new(cli.grpc_endpoint, node_list, mover)
         .run()
-        .await
-        .map_err(|e| anyhow::anyhow!("Error running server: {e}"))?;
-
+        .await;
     utils::tracing_telemetry::flush_traces();
+    result?;
+
     Ok(())
 }

--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -94,7 +94,7 @@ impl Cli {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     let cli_args = Cli::args();
 
     utils::print_package_info!();
@@ -140,11 +140,15 @@ async fn main() {
 
     // Start gRPC server and path failure detection loop.
     tokio::select! {
-        _ = detector.start() => {
-            tracing::info!("Path failure detector stopped")
+        result = detector.start() => {
+            tracing::info!("Path failure detector stopped");
+            result?;
+            Ok(())
         },
-        _ = server.serve() => {
+        result = server.serve() => {
             tracing::info!("gRPC server stopped");
+            result?;
+            Ok(())
         },
     }
 }

--- a/control-plane/agents/src/lib.rs
+++ b/control-plane/agents/src/lib.rs
@@ -10,6 +10,7 @@ use grpc::tracing::OpenTelServer;
 use snafu::Snafu;
 use state::Container;
 use std::{net::SocketAddr, sync::Arc};
+use stor_port::transport_api::ErrorChain;
 
 mod common;
 
@@ -94,7 +95,7 @@ impl Service {
     /// Runs this server as a future until a shutdown signal is received.
     pub async fn run(self, socket: SocketAddr) {
         if let Err(error) = self.run_err(socket).await {
-            tracing::error!(error=?error, "Error running service thread");
+            tracing::error!(error = error.full_string(), "Error running service thread");
         }
     }
 

--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -112,5 +112,5 @@ async fn main() -> anyhow::Result<()> {
     )
     .await;
     utils::tracing_telemetry::flush_traces();
-    result.map_err(|error| anyhow::anyhow!("error: {}", error))
+    result
 }

--- a/control-plane/csi-driver/src/bin/node/nodeplugin_grpc.rs
+++ b/control-plane/csi-driver/src/bin/node/nodeplugin_grpc.rs
@@ -99,8 +99,9 @@ impl NodePluginGrpcServer {
             .serve_with_shutdown(endpoint, Shutdown::wait())
             .await
             .map_err(|error| {
-                error!(?error, "gRPC server failed");
-                anyhow::anyhow!("gRPC server failed with error: {}", error)
+                use stor_port::transport_api::ErrorChain;
+                error!(error = error.full_string(), "NodePluginGrpcServer failed");
+                error.into()
             })
     }
 }

--- a/tests/bdd/features/csi/node/test_parameters.py
+++ b/tests/bdd/features/csi/node/test_parameters.py
@@ -135,7 +135,7 @@ def start_csi_plugin(setup, io_queues, staging_target_path):
             "sudo",
             os.environ["WORKSPACE_ROOT"] + "/target/debug/csi-node",
             "--csi-socket=/var/tmp/csi-node.sock",
-            "--grpc-endpoint=0.0.0.0",
+            "--grpc-endpoint=0.0.0.0:50050",
             "--node-name=msn-test",
             f"--nvme-nr-io-queues={io_queues}",
             "-v",


### PR DESCRIPTION
Example output:
Error: GrpcServer error

Caused by:
    0: transport error
    1: error creating server listener: Address already in use (os error 98)
    2: Address already in use (os error 98