### PR TITLE
Snapshot/restore/bdd

### DIFF
--- a/control-plane/agents/src/bin/core/volume/clone_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/clone_operations.rs
@@ -142,8 +142,10 @@ impl SnapshotCloneOp<'_> {
             Some(pool) if pools.is_empty() => Ok(pool),
             // todo: support more than 1 replica snapshots
             Some(_) => Err(SvcError::NReplSnapshotNotAllowed {}),
-            None => Err(SvcError::NoHealthyReplicas {
-                id: new_volume.uuid_str(),
+            // todo: filtering should keep invalid pools/resources and tag them with a reason
+            //   why they cannot be used!
+            None => Err(SvcError::NoSnapshotPools {
+                id: snapshot.spec().uuid().to_string(),
             }),
         }?;
 

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -236,6 +236,8 @@ pub enum SvcError {
     NoOnlineReplicas { id: String },
     #[snafu(display("No healthy replicas are available for Volume '{}'", id))]
     NoHealthyReplicas { id: String },
+    #[snafu(display("Pool not ready to take clone of snapshot '{}'", id))]
+    NoSnapshotPools { id: String },
     #[snafu(display(
         "Replica Count of {} is not attainable for {}",
         count,
@@ -735,6 +737,12 @@ impl From<SvcError> for ReplyError {
             SvcError::NoHealthyReplicas { .. } => ReplyError {
                 kind: ReplyErrorKind::VolumeNoReplicas,
                 resource: ResourceKind::Volume,
+                source,
+                extra,
+            },
+            SvcError::NoSnapshotPools { .. } => ReplyError {
+                kind: ReplyErrorKind::FailedPrecondition,
+                resource: ResourceKind::VolumeSnapshotClone,
                 source,
                 extra,
             },

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -167,14 +167,22 @@ message VolumeState {
 message VolumeUsage {
   // Capacity of the volume in bytes.
   uint64 capacity = 1;
-  // Allocated size in bytes, related to a single healthy replica.
+  // Allocated size in bytes, related the largest healthy replica, including snapshots.
   // For example, if a volume has 2 replicas, each with 1MiB allocated space, then
   // this field will be 1MiB.
   uint64 allocated = 2;
-  // Allocated size in bytes, accrued from all the replica.
+  // Allocated size in bytes, accrued from all the replicas, including snapshots.
   // For example, if a volume has 2 replicas, each with 1MiB allocated space, then
   // this field will be 2MiB.
   uint64 total_allocated = 3;
+  // Allocated size in bytes, related the largest healthy replica, excluding snapshots.
+  uint64 allocated_replica = 4;
+  // Allocated size in bytes, related the healthy replica with the highest snapshot usage.
+  uint64 allocated_snapshots = 5;
+  // Allocated size in bytes, accrued from all the replicas, excluding snapshots.
+  uint64 total_allocated_replicas = 7;
+  // Allocated size in bytes, accrued from all the replica's snapshots.
+  uint64 total_allocated_snapshots = 8;
 }
 
 message ReplicaTopology {

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -191,7 +191,15 @@ impl From<Volume> for volume::Volume {
 
 impl From<volume::VolumeUsage> for VolumeUsage {
     fn from(value: volume::VolumeUsage) -> Self {
-        Self::new(value.capacity, value.allocated, value.total_allocated)
+        Self::new(
+            value.capacity,
+            value.allocated,
+            value.allocated_replica,
+            value.allocated_snapshots,
+            value.total_allocated,
+            value.total_allocated_replicas,
+            value.total_allocated_snapshots,
+        )
     }
 }
 impl From<VolumeUsage> for volume::VolumeUsage {
@@ -200,6 +208,10 @@ impl From<VolumeUsage> for volume::VolumeUsage {
             capacity: value.capacity(),
             allocated: value.allocated(),
             total_allocated: value.total_allocated(),
+            allocated_replica: value.allocated_replica(),
+            allocated_snapshots: value.allocated_snapshots(),
+            total_allocated_replicas: value.total_allocated_replicas(),
+            total_allocated_snapshots: value.total_allocated_snapshots(),
         }
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3352,34 +3352,56 @@ components:
         capacity:
           description: Capacity of the volume in bytes.
           type: integer
-          example: 80241024
           format: int64
           minimum: 0
         allocated:
           description: -|
-             Allocated size in bytes, related to a single healthy replica.
-             For example, if a volume has 2 replicas, each with 1MiB allocated space, then
-             this field will be 1MiB.
-          example: 80241024
+            Allocated size in bytes, related the largest healthy replica, including snapshots.
+            For example, if a volume has 2 replicas, each with 1MiB allocated space, then
+            this field will be 1MiB.
+          type: integer
+          format: int64
+          minimum: 0
+        allocated_replica:
+          description: -|
+            Allocated size in bytes, related to the largest healthy replica, excluding snapshots.
+          type: integer
+          format: int64
+          minimum: 0
+        allocated_snapshots:
+          description: -|
+            Allocated size in bytes, related the healthy replica with the highest snapshot usage.
           type: integer
           format: int64
           minimum: 0
         total_allocated:
           description: -|
-            Allocated size in bytes, accrued from all the replica.
+            Allocated size in bytes, accrued from all the replicas, including snapshots.
             For example, if a volume has 2 replicas, each with 1MiB allocated space, then
             this field will be 2MiB.
-          example: 80241024
+          type: integer
+          format: int64
+          minimum: 0
+        total_allocated_replicas:
+          description: -|
+            Allocated size in bytes, accrued from all the replicas, excluding snapshots.
+        total_allocated_snapshots:
+          description: -|
+            Allocated size in bytes, accrued from all the replica's snapshots.
           type: integer
           format: int64
           minimum: 0
       required:
         - capacity
         - allocated
+        - allocated_replica
+        - allocated_snapshots
         - total_allocated
+        - total_allocated_replicas
+        - total_allocated_snapshots
     Volumes:
       description: |-
-        Array of volumes plus the next token for subsequent get requests when using pagination
+        Array of volumes plus the next token for subsequent get requests when using pagination.
       type: object
       properties:
         entries:
@@ -3405,7 +3427,7 @@ components:
         - state
     VolumeSnapshots:
       description: |-
-        Array of volume snapshots plus the next token for subsequent get requests when using pagination
+        Array of volume snapshots plus the next token for subsequent get requests when using pagination.
       type: object
       properties:
         entries:

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -76,23 +76,41 @@ pub struct VolumeState {
 pub struct VolumeUsage {
     /// Capacity of the volume in bytes.
     capacity: u64,
-    /// Allocated size in bytes, related to a single healthy replica.
+    /// Allocated size in bytes, related the largest healthy replica, including snapshots.
     /// For example, if a volume has 2 replicas, each with 1MiB allocated space, then
     /// this field will be 1MiB.
     allocated: u64,
-    /// Allocated size in bytes, accrued from all the replica.
-    /// For example, if a volume has 2 replicas, each with 1MiB allocated space, then
-    /// this field will be 2MiB.
+    /// Allocated size in bytes, related the largest healthy replica, excluding snapshots.
+    allocated_replica: u64,
+    /// Allocated size in bytes, related the healthy replica with the highest snapshot usage.
+    allocated_snapshots: u64,
+    /// Allocated size in bytes, accrued from all the replicas, including snapshots.
     total_allocated: u64,
+    /// Allocated size in bytes, accrued from all the replicas, excluding snapshots.
+    total_allocated_replicas: u64,
+    /// Allocated size in bytes, accrued from all the replica's snapshots.
+    total_allocated_snapshots: u64,
 }
 
 impl VolumeUsage {
     /// Return a new `Self` from the given parameters.
-    pub fn new(capacity: u64, allocated: u64, total_allocated: u64) -> Self {
+    pub fn new(
+        capacity: u64,
+        allocated: u64,
+        allocated_replica: u64,
+        allocated_snapshots: u64,
+        total_allocated: u64,
+        total_allocated_replicas: u64,
+        total_allocated_snapshots: u64,
+    ) -> Self {
         Self {
             capacity,
             allocated,
+            allocated_replica,
+            allocated_snapshots,
             total_allocated,
+            total_allocated_replicas,
+            total_allocated_snapshots,
         }
     }
     /// Get the volume capacity.
@@ -103,9 +121,25 @@ impl VolumeUsage {
     pub fn allocated(&self) -> u64 {
         self.allocated
     }
+    /// Allocated size in bytes, related the largest healthy replica, excluding snapshots.
+    pub fn allocated_replica(&self) -> u64 {
+        self.allocated_replica
+    }
+    /// Allocated size in bytes, related the healthy replica with the highest snapshot usage.
+    pub fn allocated_snapshots(&self) -> u64 {
+        self.allocated_snapshots
+    }
     /// Get the volume total allocated bytes across all replicas.
     pub fn total_allocated(&self) -> u64 {
         self.total_allocated
+    }
+    /// Allocated size in bytes, accrued from all the replicas, excluding snapshots.
+    pub fn total_allocated_replicas(&self) -> u64 {
+        self.total_allocated_replicas
+    }
+    /// Allocated size in bytes, accrued from all the replica's snapshots.
+    pub fn total_allocated_snapshots(&self) -> u64 {
+        self.total_allocated_snapshots
     }
 }
 
@@ -127,7 +161,15 @@ impl From<VolumeState> for models::VolumeState {
 }
 impl From<VolumeUsage> for models::VolumeUsage {
     fn from(value: VolumeUsage) -> Self {
-        Self::new(value.capacity, value.allocated, value.total_allocated)
+        Self::new(
+            value.capacity,
+            value.allocated,
+            value.allocated_replica,
+            value.allocated_snapshots,
+            value.total_allocated,
+            value.total_allocated_replicas,
+            value.total_allocated_snapshots,
+        )
     }
 }
 

--- a/tests/bdd/common/__init__.py
+++ b/tests/bdd/common/__init__.py
@@ -1,0 +1,26 @@
+import os
+import re
+import time
+
+
+# Converts humantime to float seconds
+# Example: 100ms -> 0.1
+def human_time_to_float(human_time) -> float:
+    conv = {"s": 1, "ms": 100, "us": 1000}
+    m = re.match("(?P<num>\\d+)(?P<unit>.*)", human_time)
+    matches = m.groupdict()
+    num = int(matches["num"])
+    unit = matches["unit"]
+    assert unit in conv
+    return num / float(conv[unit])
+
+
+def human_sleep(human_time):
+    time.sleep(human_time_to_float(human_time))
+
+
+def env_cleanup():
+    clean = os.getenv("CLEAN")
+    if clean is not None and clean.lower() in ("no", "false", "f", "0"):
+        return False
+    return True

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
-
+import pytest
 from dataclasses import dataclass
+
+import common
 
 
 @dataclass
@@ -126,6 +128,7 @@ class Deployer(object):
             io_engine_coreisol=io_engine_coreisol,
             io_engine_devices=io_engine_devices,
         )
+        pytest.deployer_options = options
         Deployer.start_with_opts(options)
 
     # Start containers with the provided options.
@@ -165,3 +168,12 @@ class Deployer(object):
         for disk in disks:
             if os.path.exists(disk):
                 os.remove(disk)
+
+    @staticmethod
+    def cleanup_disks(len=1):
+        if common.env_cleanup():
+            Deployer.delete_disks(len)
+
+    @staticmethod
+    def cache_period():
+        return pytest.deployer_options.cache_period

--- a/tests/bdd/common/fio.py
+++ b/tests/bdd/common/fio.py
@@ -19,7 +19,7 @@ class Fio(object):
         direct=True,
         size=None,
         norandommap=True,
-        offset=0,
+        offset="0",
         extra_args="",
     ):
         self.name = name

--- a/tests/bdd/features/snapshot/restore/delete.feature
+++ b/tests/bdd/features/snapshot/restore/delete.feature
@@ -1,0 +1,24 @@
+Feature: Deleting Restored Snapshot Volume
+
+  Background:
+    Given a deployer cluster
+    And a single replica volume
+    And a snapshot
+    And a single replica volume from the snapshot
+
+  Scenario: Deleting in reverse creation order
+    When we delete the restored volume
+    Then the snapshot should still exist
+    And we delete the snapshot
+    And the pool space usage should reflect the original volume
+    When we delete the original volume
+    Then the pool space usage should be zero
+
+  Scenario: Deleting in creation order
+    When we delete the original volume
+    Then the snapshot and the restored volume should still exist
+    And the pool space usage should reflect the snapshot and restored volume
+    And we delete the snapshot
+    And the pool space usage should reflect the snapshot and restored volume
+    When we delete the restored volume
+    Then the pool space usage should be zero

--- a/tests/bdd/features/snapshot/restore/test_delete.py
+++ b/tests/bdd/features/snapshot/restore/test_delete.py
@@ -1,0 +1,180 @@
+"""Deleting Restored Snapshot Volume feature tests."""
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+import uuid
+
+from common.deployer import Deployer
+from common.apiclient import ApiClient
+from common.docker import Docker
+from common.operations import Volume, Snapshot, wait_node_online
+
+from openapi.model.create_pool_body import CreatePoolBody
+from openapi.model.create_volume_body import CreateVolumeBody
+from openapi.model.volume_policy import VolumePolicy
+
+POOL = "pool"
+NODE = Deployer.node_name(0)
+
+
+@pytest.fixture(scope="module")
+def volume_uuids():
+    return list(map(lambda x: str(uuid.uuid4()), range(10)))
+
+
+@pytest.fixture(scope="module")
+def snapshot_uuids():
+    return list(map(lambda x: str(uuid.uuid4()), range(10)))
+
+
+@pytest.fixture(scope="module")
+def disks():
+    yield Deployer.create_disks(1, size=300 * 1024 * 1024)
+    Deployer.cleanup_disks(1)
+
+
+@pytest.fixture(scope="module")
+def deployer_cluster(disks):
+    Deployer.start(1, cache_period="100ms", reconcile_period="150ms", fio_spdk=True)
+    ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(0), POOL, CreatePoolBody([disks[0]])
+    )
+    yield
+    Deployer.stop()
+
+
+@scenario("delete.feature", "Deleting in creation order")
+def test_deleting_in_creation_order():
+    """Deleting in creation order."""
+
+
+@scenario("delete.feature", "Deleting in reverse creation order")
+def test_deleting_in_reverse_creation_order():
+    """Deleting in reverse creation order."""
+
+
+@given("a deployer cluster")
+def a_deployer_cluster(deployer_cluster):
+    """a deployer cluster."""
+
+
+@given("a single replica volume from the snapshot", target_fixture="restored_volume")
+def a_single_replica_volume_from_the_snapshot(
+    original_snapshot, volume_uuids, snapshot_uuids
+):
+    """a single replica volume from the snapshot."""
+    volume = ApiClient.volumes_api().put_snapshot_volume(
+        original_snapshot.definition.spec.uuid,
+        volume_uuids[1],
+        CreateVolumeBody(
+            VolumePolicy(True),
+            replicas=1,
+            size=original_snapshot.definition.metadata.size,
+            thin=True,
+        ),
+    )
+    # allocate 1 cluster worth of data
+    volume = Volume.fio(volume, offset="7M", size="4096B")
+    yield volume
+    Volume.cleanup(volume)
+
+
+@given("a snapshot", target_fixture="original_snapshot")
+def a_snapshot(original_volume, snapshot_uuids):
+    """a snapshot."""
+    snapshot = ApiClient.snapshots_api().put_volume_snapshot(
+        original_volume.spec.uuid, snapshot_uuids[0]
+    )
+    # Why 3M you ask? Well because we know that we have 5M of unused partition at the start of the replica
+    # so if we write before, we might span 2 clusters instead of 1, which could be confusing
+    volume = Volume.fio(original_volume, offset="3M", size="4096B")
+    snapshot = Snapshot.update(snapshot, original_volume, cached=False)
+    yield snapshot
+    Snapshot.cleanup(snapshot)
+
+
+@given("a single replica volume", target_fixture="original_volume")
+def a_single_replica_volume(volume_uuids):
+    """a single replica volume."""
+    volume = ApiClient.volumes_api().put_volume(
+        volume_uuids[0],
+        CreateVolumeBody(
+            VolumePolicy(True),
+            replicas=1,
+            size=88 * 1024 * 1024,
+            thin=True,
+        ),
+    )
+    yield volume
+    Volume.cleanup(volume)
+
+
+@when("we delete the original volume")
+def we_delete_the_original_volume(original_volume):
+    """we delete the original volume."""
+    ApiClient.volumes_api().del_volume(original_volume.spec.uuid)
+
+
+@when("we delete the restored volume")
+def we_delete_the_restored_volume(restored_volume):
+    """we delete the restored volume."""
+    ApiClient.volumes_api().del_volume(restored_volume.spec.uuid)
+
+
+@then("the pool space usage should be zero")
+def the_pool_space_usage_should_be_zero():
+    """the pool space usage should be zero."""
+    pool = ApiClient.pools_api().get_pool(POOL)
+    assert pool.state.used == 0
+
+
+@then("the pool space usage should reflect the original volume")
+def the_pool_space_usage_should_reflect_the_original_volume(original_volume):
+    """the pool space usage should reflect the original volume."""
+    pool = ApiClient.pools_api().get_pool(POOL)
+    # Bug, dataplane caches allocated, requires a restart until fixed
+    Docker.restart_container(NODE)
+    wait_node_online(NODE)
+    volume = Volume.update(original_volume, cached=False)
+    assert pool.state.used == volume.state.usage.allocated
+
+
+@then("the pool space usage should reflect the snapshot and restored volume")
+def the_pool_space_usage_should_reflect_the_snapshot_and_restored_volume(
+    restored_volume, original_snapshot
+):
+    """the pool space usage should reflect the snapshot and restored volume."""
+    pool = ApiClient.pools_api().get_pool(POOL)
+    # todo: use retry pattern instead
+    restored_volume = Volume.update(restored_volume, cached=False)
+
+    restored_usage = 4 * 1024 * 1024
+    snapshot_usage = 8 * 1024 * 1024
+    assert restored_volume.state.usage.allocated_replica == restored_usage
+    assert original_snapshot.state.allocated_size == snapshot_usage
+    assert pool.state.used == snapshot_usage + restored_usage
+
+
+@then("the snapshot and the restored volume should still exist")
+def the_snapshot_and_the_restored_volume_should_still_exist(
+    original_volume, original_snapshot, restored_volume
+):
+    """the snapshot and the restored volume should still exist."""
+    ApiClient.snapshots_api().get_volume_snapshot(
+        original_volume.spec.uuid, original_snapshot.definition.spec.uuid
+    )
+    ApiClient.volumes_api().get_volume(restored_volume.spec.uuid)
+
+
+@then("the snapshot should still exist")
+def the_snapshot_should_still_exist(original_volume, original_snapshot):
+    """the snapshot should still exist."""
+    ApiClient.snapshots_api().get_volume_snapshot(
+        original_volume.spec.uuid, original_snapshot.definition.spec.uuid
+    )
+
+
+@then("we delete the snapshot")
+def we_delete_the_snapshot(original_snapshot):
+    """we delete the snapshot."""
+    ApiClient.snapshots_api().del_snapshot(original_snapshot.definition.spec.uuid)


### PR DESCRIPTION
    test(snapshot/bdd): add initial restore delete
    
    A bug was found where after snapshot delete the parent volume needs to have
    ts allocation cache deleted.
    ( The WA for now is to restart the io-engine container and force update )
    
    todo: add multiple layers of snapshots and restores
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(snapshot/volume): split allocation counters
    
    Splits allocation counters into replicas, snapshots and both.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(snapshot/pool): add specific error when pool cannot be used
    
    todo: enhance filtering of resources to include reasons why a certain
    resource could not be used.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
