### PR TITLE
feat(snapshots, restores): store restores as a part of snap meta, expose counts on rest

### DIFF
--- a/control-plane/agents/src/bin/core/controller/resources/operations.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations.rs
@@ -1,5 +1,6 @@
-use crate::controller::registry::Registry;
+use crate::controller::{registry::Registry, resources::OperationGuardArc};
 use agents::errors::SvcError;
+use stor_port::types::v0::store::volume::VolumeSpec;
 
 /// Resource Cordon Operations.
 #[async_trait::async_trait]
@@ -265,6 +266,7 @@ pub(crate) trait ResourcePruning {
 pub(crate) trait ResourceCloning {
     type Create: Sync + Send;
     type CreateOutput: Sync + Send + Sized;
+    type Destroy: Sync + Send;
 
     /// Create a clone for the `Self` resource.
     async fn create_clone(
@@ -272,4 +274,12 @@ pub(crate) trait ResourceCloning {
         registry: &Registry,
         request: &Self::Create,
     ) -> Result<Self::CreateOutput, SvcError>;
+
+    /// Destroy a clone for the `Self` resource, using the volume life cycle op.
+    async fn destroy_clone(
+        &mut self,
+        registry: &Registry,
+        request: &Self::Destroy,
+        volume: OperationGuardArc<VolumeSpec>,
+    ) -> Result<(), SvcError>;
 }

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -551,7 +551,7 @@ async fn reconciler_missing_pool_state() {
         .with_io_engines(1)
         .with_pool(0, disk.uri())
         .with_cache_period("1s")
-        .with_reconcile_period(Duration::from_secs(1), Duration::from_secs(1))
+        .with_reconcile_period(Duration::from_secs(1), Duration::from_millis(1))
         .build()
         .await
         .unwrap();

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -59,6 +59,8 @@ message VolumeSpec {
   optional AffinityGroup affinity_group = 10;
   // Volume Content Source i.e the snapshot or a volume.
   optional VolumeContentSource content_source  = 11;
+  // Number of snapshots taken on this volume.
+  uint32 num_snapshots = 12;
 
   // Volume Content Source i.e the snapshot or a volume.
   message VolumeContentSource {
@@ -513,6 +515,8 @@ message VolumeSnapshotMeta {
   uint64                             spec_size = 6;
   // Size taken by the snapshot and its predecessors.
   uint64                  total_allocated_size = 7;
+  // Number of restores done from this snapshot.
+  uint32                          num_restores = 8;
 
   message ReplicaSnapshots {
     repeated ReplicaSnapshot         snapshots = 1;

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -156,6 +156,7 @@ impl From<VolumeSpec> for volume::VolumeDefinition {
                 thin: volume_spec.thin,
                 affinity_group: volume_spec.affinity_group.into_opt(),
                 content_source: volume_spec.content_source.into_opt(),
+                num_snapshots: volume_spec.metadata.num_snapshots() as u32,
             }),
             metadata: Some(volume::Metadata {
                 spec_status: spec_status as i32,
@@ -320,6 +321,7 @@ impl TryFrom<volume::VolumeDefinition> for VolumeSpec {
             affinity_group: volume_spec.affinity_group.into_opt(),
             metadata: VolumeMetadata::new(volume_meta.as_thin),
             content_source: volume_spec.content_source.try_into_opt()?,
+            num_snapshots: volume_spec.num_snapshots,
         };
         Ok(volume_spec)
     }

--- a/control-plane/grpc/src/operations/volume/traits_snapshots.rs
+++ b/control-plane/grpc/src/operations/volume/traits_snapshots.rs
@@ -107,6 +107,7 @@ impl From<&stor_port::types::v0::store::snapshots::volume::VolumeSnapshot> for V
                 total_allocated_size: value.metadata().total_allocated_size(),
                 txn_id: value.metadata().txn_id().clone(),
                 transactions,
+                num_restores: value.num_restores(),
             },
         }
     }
@@ -137,7 +138,10 @@ pub struct VolumeSnapshotMeta {
     /// The "actual" snapshots can be accessed by the key `txn_id`.
     /// Failed transactions are any other key.
     transactions: HashMap<String, Vec<ReplicaSnapshot>>,
+    /// The number of restores done from this snapshot.
+    num_restores: u32,
 }
+
 impl VolumeSnapshotMeta {
     /// Get the volume snapshot status.
     pub fn status(&self) -> &SpecStatus<()> {
@@ -166,6 +170,10 @@ impl VolumeSnapshotMeta {
     /// Get the snapshot total allocated size in bytes.
     pub fn total_allocated_size(&self) -> u64 {
         self.total_allocated_size
+    }
+    /// The number of restores done from this snapshot.
+    pub fn num_restores(&self) -> u32 {
+        self.num_restores
     }
 }
 
@@ -468,6 +476,7 @@ impl TryFrom<volume::VolumeSnapshot> for VolumeSnapshot {
                         snapshots.map(|s| (k, s))
                     })
                     .collect::<Result<HashMap<_, _>, _>>()?,
+                num_restores: meta.num_restores,
             },
             state: VolumeSnapshotState {
                 info,
@@ -624,6 +633,7 @@ impl TryFrom<VolumeSnapshot> for volume::VolumeSnapshot {
                 size: value.meta.size,
                 spec_size: value.meta.spec_size,
                 total_allocated_size: value.meta.total_allocated_size,
+                num_restores: value.meta.num_restores,
             }),
             state: Some(volume::VolumeSnapshotState {
                 state: Some(snapshot::SnapshotState {

--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -2,8 +2,8 @@ use clap::Parser;
 use openapi::tower::client::Url;
 use plugin::{
     operations::{
-        Cordoning, Drain, Get, GetBlockDevices, GetSnapshots, List, Operations, RebuildHistory,
-        ReplicaTopology, Scale,
+        Cordoning, Drain, Get, GetBlockDevices, GetSnapshots, List, ListExt, Operations,
+        RebuildHistory, ReplicaTopology, Scale,
     },
     resources::{
         blockdevice, cordon, drain, node, pool, snapshot, volume, CordonResources, DrainResources,
@@ -83,13 +83,15 @@ async fn execute(cli_args: CliArgs) {
                 }
                 GetDrainArgs::Nodes => drain::NodeDrains::list(&cli_args.output).await,
             },
-            GetResources::Volumes => volume::Volumes::list(&cli_args.output).await,
+            GetResources::Volumes(vol_args) => {
+                volume::Volumes::list(&cli_args.output, vol_args).await
+            }
             GetResources::Volume { id } => volume::Volume::get(id, &cli_args.output).await,
             GetResources::RebuildHistory { id } => {
                 volume::Volume::rebuild_history(id, &cli_args.output).await
             }
-            GetResources::VolumeReplicaTopologies => {
-                volume::Volume::topologies(&cli_args.output).await
+            GetResources::VolumeReplicaTopologies(vol_args) => {
+                volume::Volume::topologies(&cli_args.output, vol_args).await
             }
             GetResources::VolumeReplicaTopology { id } => {
                 volume::Volume::topology(id, &cli_args.output).await

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -41,6 +41,14 @@ pub trait List {
     async fn list(output: &utils::OutputFormat);
 }
 
+/// List trait.
+/// To be implemented by resources which support the 'list' operation, with context.
+#[async_trait(?Send)]
+pub trait ListExt {
+    type Context;
+    async fn list(output: &utils::OutputFormat, context: &Self::Context);
+}
+
 /// Get trait.
 /// To be implemented by resources which support the 'get' operation.
 #[async_trait(?Send)]
@@ -62,7 +70,8 @@ pub trait Scale {
 #[async_trait(?Send)]
 pub trait ReplicaTopology {
     type ID;
-    async fn topologies(output: &utils::OutputFormat);
+    type Context;
+    async fn topologies(output: &utils::OutputFormat, context: &Self::Context);
     async fn topology(id: &Self::ID, output: &utils::OutputFormat);
 }
 

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -2,6 +2,7 @@ use crate::resources::{
     blockdevice::BlockDeviceArgs,
     node::{DrainNodeArgs, GetNodeArgs},
     snapshot::VolumeSnapshotArgs,
+    volume::VolumesArgs,
 };
 
 pub mod blockdevice;
@@ -29,13 +30,13 @@ pub enum GetResources {
     #[clap(subcommand)]
     Drain(GetDrainArgs),
     /// Get all volumes.
-    Volumes,
+    Volumes(VolumesArgs),
     /// Get volume with the given ID.
     Volume { id: VolumeId },
     /// Get Rebuild history for the volume with the given ID.
     RebuildHistory { id: VolumeId },
     /// Get the replica topology for all volumes.
-    VolumeReplicaTopologies,
+    VolumeReplicaTopologies(VolumesArgs),
     /// Get the replica topology for the volume with the given ID.
     VolumeReplicaTopology { id: VolumeId },
     /// Get volume snapshots based on input args.

--- a/control-plane/plugin/src/resources/snapshot.rs
+++ b/control-plane/plugin/src/resources/snapshot.rs
@@ -56,7 +56,8 @@ impl CreateRow for openapi::models::VolumeSnapshot {
             ::utils::bytes::into_human(meta.spec_size),
             ::utils::bytes::into_human(state.allocated_size),
             ::utils::bytes::into_human(meta.total_allocated_size),
-            state.source_volume
+            state.source_volume,
+            self.definition.metadata.num_restores
         ]
     }
 }

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -20,7 +20,9 @@ lazy_static! {
         "STATUS",
         "SIZE",
         "THIN-PROVISIONED",
-        "ALLOCATED"
+        "ALLOCATED",
+        "SNAPSHOTS",
+        "SOURCE"
     ];
     pub static ref SNAPSHOT_HEADERS: Row = row![
         "ID",
@@ -28,7 +30,8 @@ lazy_static! {
         "SOURCE-SIZE",
         "ALLOCATED-SIZE",
         "TOTAL-ALLOCATED-SIZE",
-        "SOURCE-VOL"
+        "SOURCE-VOL",
+        "RESTORES"
     ];
     pub static ref POOLS_HEADERS: Row = row![
         "ID",

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3218,6 +3218,11 @@ components:
           $ref: '#/components/schemas/AffinityGroup'
         content_source:
           $ref: '#/components/schemas/VolumeContentSource'
+        num_snapshots:
+          description: Number of snapshots taken on this volume.
+          type: integer
+          format: int32
+          minimum: 0
       required:
         - num_paths
         - num_replicas
@@ -3227,6 +3232,7 @@ components:
         - uuid
         - policy
         - thin
+        - num_snapshots
     VolumeTarget:
       example:
         node: io-engine-1
@@ -3516,6 +3522,11 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/ReplicaSnapshot'
+        num_restores:
+          description: Number of restores done from this snapshot.
+          type: integer
+          format: int32
+          minimum: 0
       required:
         - status
         - size
@@ -3523,6 +3534,7 @@ components:
         - total_allocated_size
         - txn_id
         - transactions
+        - num_restores
     VolumeSnapshotSpec:
       description: |-
         Volume Snapshot Spec information.

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1780,7 +1780,7 @@ paths:
           name: volume_id
           description: The uuid of the snapshots source volume.
           schema:
-            $ref: '#/components/schemas/SnapshotId'
+            $ref: '#/components/schemas/VolumeId'
           required: false
         - in: query
           name: max_entries

--- a/control-plane/rest/service/src/v0/snapshots.rs
+++ b/control-plane/rest/service/src/v0/snapshots.rs
@@ -184,6 +184,7 @@ fn to_models_volume_snapshot(snap: &VolumeSnapshot) -> models::VolumeSnapshot {
                         )
                     })
                     .collect::<HashMap<_, _>>(),
+                snap.meta().num_restores(),
             ),
             models::VolumeSnapshotSpec::new_all(snap.spec().snap_id(), snap.spec().source_id()),
         ),

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -175,6 +175,9 @@ pub struct VolumeSpec {
     /// Affinity Group related information.
     #[serde(default)]
     pub affinity_group: Option<AffinityGroup>,
+    /// Number of snapshots taken on this volume.
+    #[serde(skip)]
+    pub num_snapshots: u32,
     /// Volume metadata information.
     #[serde(default, skip_serializing_if = "super::is_default")]
     pub metadata: VolumeMetadata,
@@ -218,6 +221,10 @@ impl VolumeMetadata {
         self.runtime.snapshots.insert(snapshot);
         // we become thin provisioned!
         self.persisted.snapshot_as_thin = Some(true);
+    }
+    /// Number of snapshots taken on this volume.
+    pub fn num_snapshots(&self) -> usize {
+        self.runtime.snapshots.len()
     }
 }
 
@@ -744,6 +751,7 @@ impl From<VolumeSpec> for models::VolumeSpec {
             src.metadata.persisted.snapshot_as_thin,
             src.affinity_group.into_opt(),
             src.content_source.into_opt(),
+            src.num_snapshots,
         )
     }
 }

--- a/tests/bdd/features/volume/create/test_feature.py
+++ b/tests/bdd/features/volume/create/test_feature.py
@@ -258,6 +258,7 @@ def volume_creation_should_succeed_with_a_returned_volume_object(create_request)
         VOLUME_UUID,
         VolumePolicy(False),
         False,
+        0,
     )
 
     # Check the volume object returned is as expected

--- a/tests/bdd/features/volume/observability/test_feature.py
+++ b/tests/bdd/features/volume/observability/test_feature.py
@@ -37,7 +37,9 @@ VOLUME_SIZE = 10485761
 def init():
     Deployer.start(1)
     ApiClient.pools_api().put_node_pool(
-        NODE_NAME, POOL_UUID, CreatePoolBody(["malloc:///disk?size_mb=50"])
+        NODE_NAME,
+        POOL_UUID,
+        CreatePoolBody(["malloc:///disk?size_mb=50"]),
     )
     ApiClient.volumes_api().put_volume(
         VOLUME_UUID, CreateVolumeBody(VolumePolicy(False), 1, VOLUME_SIZE, False)
@@ -80,6 +82,7 @@ def a_volume_object_representing_the_volume_should_be_returned(volume_ctx):
         VOLUME_UUID,
         VolumePolicy(False),
         False,
+        0,
     )
 
     volume = volume_ctx[VOLUME_CTX_KEY]

--- a/tests/bdd/features/volume/topology/test_feature.py
+++ b/tests/bdd/features/volume/topology/test_feature.py
@@ -474,6 +474,7 @@ def volume_creation_should_succeed_with_a_returned_volume_object_with_topology(
         VOLUME_UUID,
         VolumePolicy(False),
         False,
+        0,
         topology=Topology(
             pool_topology=PoolTopology(
                 labelled=LabelledTopology(
@@ -499,7 +500,13 @@ def volume_creation_should_succeed_with_a_returned_volume_object_without_pool_to
 ):
     """volume creation should succeed with a returned volume object without pool topology."""
     expected_spec = VolumeSpec(
-        1, VOLUME_SIZE, SpecStatus("Created"), VOLUME_UUID, VolumePolicy(False), False
+        1,
+        VOLUME_SIZE,
+        SpecStatus("Created"),
+        VOLUME_UUID,
+        VolumePolicy(False),
+        False,
+        0,
     )
 
     # Check the volume object returned is as expected


### PR DESCRIPTION
```
rest-plugin get volumes              
 ID                                    REPLICAS  TARGET-NODE  ACCESSIBILITY  STATUS  SIZE   THIN-PROVISIONED  ALLOCATED  SNAPSHOTS  SOURCE 
 ec4e66fd-3b33-4439-b504-d49aba53da26  1         <none>       <none>         Online  10MiB  true (snapped)    12MiB      1          <none> 
 ec4e66fd-3b33-4439-b504-d49aba53da27  1         <none>       <none>         Online  10MiB  true              12MiB      0          Snapshot 
 ec4e66fd-3b33-4439-b504-d49aba53da28  1         <none>       <none>         Online  10MiB  true              12MiB      0          Snapshot 
```
```
rest-plugin get volumes --source none
 ID                                    REPLICAS  TARGET-NODE  ACCESSIBILITY  STATUS  SIZE   THIN-PROVISIONED  ALLOCATED  SNAPSHOTS  SOURCE 
 ec4e66fd-3b33-4439-b504-d49aba53da26  1         <none>       <none>         Online  10MiB  true (snapped)    12MiB      1          <none> 
```
```
rest-plugin get volumes --source snapshot
 ID                                    REPLICAS  TARGET-NODE  ACCESSIBILITY  STATUS  SIZE   THIN-PROVISIONED  ALLOCATED  SNAPSHOTS  SOURCE 
 ec4e66fd-3b33-4439-b504-d49aba53da27  1         <none>       <none>         Online  10MiB  true              12MiB      0          Snapshot 
 ec4e66fd-3b33-4439-b504-d49aba53da28  1         <none>       <none>         Online  10MiB  true              12MiB      0          Snapshot
```