### PR TITLE
Handle discarded snapshots

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
@@ -21,7 +21,13 @@ impl crate::controller::io_engine::ReplicaListApi for super::RpcClient {
     async fn list_replicas(&self) -> Result<Vec<Replica>, SvcError> {
         let rpc_replicas = self
             .replica()
-            .list_replicas(ListReplicaOptions::default())
+            .list_replicas(ListReplicaOptions {
+                name: None,
+                poolname: None,
+                uuid: None,
+                pooluuid: None,
+                replicatype: ReplicaType::AllReplicasExceptSnapshots as i32,
+            })
             .await
             .context(GrpcRequestError {
                 resource: ResourceKind::Replica,

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -252,6 +252,7 @@ impl TryIoEngineToAgent for v1::snapshot::SnapshotInfo {
             self.valid_snapshot,
             self.ready_as_source,
             self.referenced_bytes,
+            self.discarded_snapshot,
         ))
     }
 }
@@ -576,7 +577,8 @@ impl AgentToIoEngine for transport::ListReplicaSnapshots {
         v1::snapshot::ListSnapshotsRequest {
             source_uuid: source.map(ToString::to_string),
             snapshot_uuid: snapshot.map(ToString::to_string),
-            snapshot_query_type: v1::snapshot::SnapshotQueryType::AllSnapshots as i32,
+            snapshot_query_type:
+                v1::snapshot::SnapshotQueryType::AllSnapshotsExceptDiscardedSnapshots as i32,
         }
     }
 }

--- a/control-plane/grpc/proto/v1/snapshot/snapshot.proto
+++ b/control-plane/grpc/proto/v1/snapshot/snapshot.proto
@@ -59,4 +59,7 @@ message ReplicaSnapshotState {
   string                    entity_id = 14;
   // ready for usage, i,e source for another volume.
   bool                ready_as_source = 15;
+  // A discarded snapshot has been "deleted" by the control-plane and will be deleted by
+  // the dataplane when last reference to it (clone) is also deleted.
+  bool                      discarded = 16;
 }

--- a/control-plane/grpc/src/operations/volume/traits_snapshots.rs
+++ b/control-plane/grpc/src/operations/volume/traits_snapshots.rs
@@ -573,6 +573,7 @@ impl TryFrom<&snapshot::ReplicaSnapshotState> for ReplicaSnapshotState {
                 val.valid,
                 val.ready_as_source,
                 val.predecessor_alloc_size,
+                val.discarded,
             ),
         })
     }
@@ -638,7 +639,7 @@ impl TryFrom<VolumeSnapshot> for volume::VolumeSnapshot {
             state: Some(volume::VolumeSnapshotState {
                 state: Some(snapshot::SnapshotState {
                     uuid: value.state().uuid().to_string(),
-                    status: 0,
+                    status: snapshot::SnapshotStatus::Online as i32,
                     timestamp: value.state().timestamp().cloned(),
                     allocated_size: value.state().allocated_size().unwrap_or_default(),
                     source_id: value.state().source_id().to_string(),
@@ -667,6 +668,7 @@ impl TryFrom<VolumeSnapshot> for volume::VolumeSnapshot {
                                         valid: state.valid(),
                                         ready_as_source: state.ready_as_source(),
                                         predecessor_alloc_size: state.predecessor_alloc_size(),
+                                        discarded: state.discarded(),
                                     },
                                 )
                             }
@@ -770,6 +772,7 @@ impl TryFrom<snapshot::ReplicaSnapshotState> for transport::ReplicaSnapshot {
             value.valid,
             value.ready_as_source,
             value.predecessor_alloc_size,
+            value.discarded,
         ))
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -179,10 +179,13 @@ pub struct ReplicaSnapshotDescr {
     ready_as_source: bool,
     /// The amount of bytes allocated to all predecessor snapshots.
     predecessor_alloc_size: u64,
+    /// A discarded snapshot has been "deleted" by the control-plane and will be deleted by
+    /// the dataplane when last reference to it (clone) is also deleted.
+    discarded: bool,
 }
 impl ReplicaSnapshotDescr {
     #[allow(clippy::too_many_arguments)]
-    // Creates a new descriptor from given input values.
+    /// Creates a new descriptor from given input values.
     pub fn new(
         snap_uuid: SnapshotId,
         snap_name: String,
@@ -198,6 +201,7 @@ impl ReplicaSnapshotDescr {
         valid: bool,
         ready_as_source: bool,
         predecessor_alloc_size: u64,
+        discarded: bool,
     ) -> Self {
         Self {
             snap_uuid,
@@ -214,6 +218,7 @@ impl ReplicaSnapshotDescr {
             valid,
             ready_as_source,
             predecessor_alloc_size,
+            discarded,
         }
     }
 
@@ -238,6 +243,12 @@ impl ReplicaSnapshotDescr {
     /// Get a reference to the pool uuid.
     pub fn pool_uuid(&self) -> &PoolUuid {
         &self.pool_uuid
+    }
+
+    /// A discarded snapshot has been "deleted" by the control-plane and will be deleted by
+    /// the dataplane when last reference to it (clone) is also deleted.
+    pub fn discarded(&self) -> bool {
+        self.discarded
     }
 
     /// Get a reference to the pool id.

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -4,6 +4,7 @@ import pytest
 from dataclasses import dataclass
 
 import common
+from common.docker import Docker
 
 
 @dataclass
@@ -177,3 +178,7 @@ class Deployer(object):
     @staticmethod
     def cache_period():
         return pytest.deployer_options.cache_period
+
+    @staticmethod
+    def restart_node(node_name):
+        Docker.restart_container(node_name)

--- a/tests/bdd/common/operations.py
+++ b/tests/bdd/common/operations.py
@@ -55,7 +55,10 @@ class Volume(object):
     def cleanup(volume):
         if Cluster.env_cleanup():
             try:
-                Volume.__api().del_volume(volume.spec.uuid)
+                if hasattr(volume, "spec"):
+                    Volume.__api().del_volume(volume.spec.uuid)
+                else:
+                    Volume.__api().del_volume(volume)
             except NotFoundException:
                 pass
 
@@ -101,7 +104,10 @@ class Snapshot(object):
     def cleanup(snapshot):
         if Cluster.env_cleanup():
             try:
-                Snapshot.__api().del_snapshot(snapshot.definition.spec.uuid)
+                if hasattr(snapshot, "definition"):
+                    Snapshot.__api().del_snapshot(snapshot.definition.spec.uuid)
+                else:
+                    Snapshot.__api().del_snapshot(snapshot)
             except NotFoundException:
                 pass
 
@@ -151,6 +157,10 @@ class Cluster(object):
     def wait_cache_update(slack=0.1):
         cache = common.human_time_to_float(Deployer.cache_period())
         time.sleep(cache + slack)
+
+    @staticmethod
+    def restart_node(node_name):
+        Deployer.restart_node(node_name)
 
 
 @retry(wait_fixed=10, stop_max_attempt_number=200)

--- a/tests/bdd/features/snapshot/delete/delete.feature
+++ b/tests/bdd/features/snapshot/delete/delete.feature
@@ -57,3 +57,14 @@ Feature: Volume Snapshot deletion
       | publish_status |
       | published      |
       | unpublished    |
+
+  Scenario: Delete Snapshots in Order
+    Given we have a single replica unpublished volume
+    And we've created a snapshot for the volume
+    And we've created a snapshot 2 for the volume
+    And we've deleted the volume
+    And the snapshot is deleted
+    When the io-engine node where snapshot 2 resides on is restarted
+    Then the snapshot 2 should still be online
+    When the snapshot 2 is deleted
+    Then the pool usage should be zero

--- a/tests/bdd/features/snapshot/restore/delete.feature
+++ b/tests/bdd/features/snapshot/restore/delete.feature
@@ -63,6 +63,5 @@ Feature: Deleting Restored Snapshot Volume
     Then the pool space usage should reflect the snapshot 2, restored volume 2, and deleted snapshot and deleted restored volume 1 (16MiB)
     When we delete the restored volume 1 snapshot 2
     Then the pool space usage should reflect the restored volume 2, and deleted snapshot 1,2 and deleted restored volume 1 (16MiB)
-    # BUG: dataplane bug where snapshots become replicas..
-    #When we delete the restored volume 2
-    #Then the pool space usage should be zero
+    When we delete the restored volume 2
+    Then the pool space usage should be zero


### PR DESCRIPTION
    test(snapshot/bdd): add ordered deletion test
    
    Ensures a snapshot is still present when it's parents are deleted and
    the dataplane is restarted.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(snapshot/discarded): ignore discarded snapshots during Unknown GC
    
    Also, don't bother keeping these in the registry state..
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>