### PR TITLE
CI: speedup tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,6 +145,8 @@ pipeline {
             }
             sh 'printenv'
             sh 'nix-shell --run "cargo build --bins"'
+            // builds the tests
+            sh 'nix-shell --run "./scripts/rust/test.sh --no-run"'
             sh 'nix-shell --run "./scripts/rust/test.sh"'
           }
           post {

--- a/control-plane/agents/src/bin/core/controller/io_engine/client.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/client.rs
@@ -55,7 +55,8 @@ impl GrpcContext {
             .unwrap_or_else(|| comms_timeouts.request());
 
         let endpoint = tonic::transport::Endpoint::from(uri)
-            .connect_timeout(comms_timeouts.connect() + Duration::from_millis(500))
+            // todo: why are we adding slack here, connect should be respected?
+            .connect_timeout(comms_timeouts.connect() + Duration::from_millis(250))
             .timeout(timeout);
 
         Ok(Self {
@@ -72,7 +73,8 @@ impl GrpcContext {
         self.endpoint = self
             .endpoint
             .clone()
-            .connect_timeout(self.comms_timeouts.connect() + Duration::from_millis(500))
+            // todo: why are we adding slack here, connect should be respected?
+            .connect_timeout(self.comms_timeouts.connect() + Duration::from_millis(250))
             .timeout(match request {
                 None => self.comms_timeouts.request(),
                 Some(request) => timeout_grpc(request, self.comms_timeouts.opts().clone()),

--- a/control-plane/agents/src/bin/core/controller/reconciler/snapshot/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/snapshot/garbage_collector.rs
@@ -110,6 +110,7 @@ async fn deleting_volume_snapshot_reconciler(
         Err(error) => {
             tracing::error!(
                 snapshot.uuid = %snapshot.uuid(),
+                %error,
                 "Failed to delete volumeSnapshot"
             );
             Err(error)
@@ -150,6 +151,7 @@ async fn creating_orphaned_volume_snapshot_reconciler(
         Err(error) => {
             tracing::error!(
                 snapshot.uuid = %snapshot.uuid(),
+                %error,
                 "Failed to delete volumeSnapshot"
             );
             Err(error)

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
@@ -700,7 +700,7 @@ impl CloneVolumeSnapshot {
                 GetSuitablePoolsContext {
                     registry: registry.clone(),
                     spec: spec.clone(),
-                    allocated_bytes: None,
+                    allocated_bytes: Some(0),
                     move_repl: None,
                     snap_repl: false,
                     ag_restricted_nodes: None,

--- a/control-plane/agents/src/bin/core/tests/node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/node/mod.rs
@@ -30,17 +30,20 @@ fn new_node(
 
 #[tokio::test]
 async fn node() {
+    let rpc_timeout = stor_port::transport_api::TimeoutOptions::default()
+        .with_req_timeout(Duration::from_secs(1))
+        .with_connect_timeout(Duration::from_millis(150))
+        .with_timeout_backoff(Duration::from_millis(150))
+        .with_max_retries(12);
+
     let cluster = ClusterBuilder::builder()
         .with_rest(false)
         .with_agents(vec!["core"])
         .with_node_deadline("2s")
+        .with_req_timeouts(rpc_timeout.connect_timeout(), rpc_timeout.base_timeout())
         .build()
         .await
         .unwrap();
-    let rpc_timeout = stor_port::transport_api::TimeoutOptions::default()
-        .with_req_timeout(Duration::from_secs(1))
-        .with_timeout_backoff(Duration::from_millis(100))
-        .with_max_retries(6);
 
     let maya_name = cluster.node(0);
     let grpc = format!("{}:10124", cluster.node_ip(0));

--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -16,7 +16,7 @@ use utils::{
     package_description, tracing_telemetry::KeyValue, version_info_str,
     DEFAULT_CLUSTER_AGENT_CLIENT_ADDR, DEFAULT_NODE_AGENT_SERVER_ADDR,
     NVME_PATH_AGGREGATION_PERIOD, NVME_PATH_CHECK_PERIOD, NVME_PATH_CONNECTION_PERIOD,
-    NVME_PATH_RETRANSMISSION_PERIOD,
+    NVME_PATH_RETRANSMISSION_PERIOD, NVME_SUBSYS_REFRESH_PERIOD,
 };
 mod detector;
 mod path_provider;
@@ -61,6 +61,10 @@ struct Cli {
     /// Connection timeout for path replacement operation.
     #[clap(short, long, env = "PATH_CONNECTION_TIMEOUT", default_value = NVME_PATH_CONNECTION_PERIOD)]
     path_connection_timeout: humantime::Duration,
+
+    /// NVMe subsystem refresh period when monitoring its state.
+    #[clap(short, long, env = "SUBSYS_REFRESH_PERIOD", default_value = NVME_SUBSYS_REFRESH_PERIOD)]
+    subsys_refresh_period: humantime::Duration,
 
     /// Sends opentelemetry spans to the Jaeger endpoint agent.
     #[clap(long, short)]

--- a/control-plane/stor-port/src/transport_api/mod.rs
+++ b/control-plane/stor-port/src/transport_api/mod.rs
@@ -593,6 +593,10 @@ impl TimeoutOptions {
     pub fn base_timeout(&self) -> Duration {
         self.request_timeout
     }
+    /// Get the base timeout.
+    pub fn backoff_timeout(&self) -> Duration {
+        self.timeout_step
+    }
     /// Default http2 Keep Alive interval.
     pub(crate) fn default_keep_alive_interval() -> std::time::Duration {
         Duration::from_secs(10)

--- a/deployer/src/infra/agents/ha/cluster.rs
+++ b/deployer/src/infra/agents/ha/cluster.rs
@@ -16,6 +16,11 @@ impl ComponentAction for HaClusterAgent {
         )
         .with_portmap("11500", "11500");
 
+        if let Some(env) = &options.agents_env {
+            for kv in env {
+                spec = spec.with_env(kv.key.as_str(), kv.value.as_str().as_ref());
+            }
+        }
         if let Some(period) = options.cluster_fast_requeue {
             spec = spec.with_args(vec!["--fast-requeue", period.to_string().as_str()]);
         }
@@ -48,7 +53,7 @@ impl ComponentAction for HaClusterAgent {
             .await
             {
                 Ok(_) => break,
-                Err(_) => sleep(Duration::from_millis(100)).await,
+                Err(_) => sleep(Duration::from_millis(25)).await,
             }
         }
         Ok(())

--- a/deployer/src/infra/csi-driver/controller.rs
+++ b/deployer/src/infra/csi-driver/controller.rs
@@ -70,7 +70,7 @@ impl ComponentAction for CsiController {
                 .await
             {
                 Ok(channel) => break channel,
-                Err(_) => sleep(Duration::from_millis(100)).await,
+                Err(_) => sleep(Duration::from_millis(25)).await,
             }
         };
 
@@ -83,7 +83,7 @@ impl ComponentAction for CsiController {
                 .await
             {
                 Ok(_) => break,
-                Err(_) => sleep(Duration::from_millis(100)).await,
+                Err(_) => sleep(Duration::from_millis(25)).await,
             }
         }
 

--- a/deployer/src/infra/csi-driver/node.rs
+++ b/deployer/src/infra/csi-driver/node.rs
@@ -166,7 +166,7 @@ impl CsiNode {
                 .await
             {
                 Ok(channel) => break channel,
-                Err(_) => sleep(Duration::from_millis(150)).await,
+                Err(_) => sleep(Duration::from_millis(25)).await,
             }
         };
 
@@ -179,7 +179,7 @@ impl CsiNode {
                 .await
             {
                 Ok(_) => break,
-                Err(_) => sleep(Duration::from_millis(150)).await,
+                Err(_) => sleep(Duration::from_millis(25)).await,
             }
         }
 

--- a/deployer/src/infra/etcd.rs
+++ b/deployer/src/infra/etcd.rs
@@ -15,6 +15,9 @@ impl ComponentAction for Etcd {
                     "http://0.0.0.0:2379",
                     "--listen-client-urls",
                     "http://0.0.0.0:2379",
+                    // these ensure fast startup since it's not a cluster anyway
+                    "--heartbeat-interval=1",
+                    "--election-timeout=5",
                 ]),
             )
             .with_portmap("2379", "2379")

--- a/deployer/src/infra/rest.rs
+++ b/deployer/src/infra/rest.rs
@@ -19,7 +19,8 @@ impl ComponentAction for Rest {
             let binary = Binary::from_dbg("rest")
                 .with_arg("--dummy-certificates")
                 .with_args(vec!["--https", "rest:8080"])
-                .with_args(vec!["--http", "rest:8081"]);
+                .with_args(vec!["--http", "rest:8081"])
+                .with_arg("--workers=1");
             let binary = if let Some(jwk) = &options.rest_jwk {
                 binary.with_arg("--jwk").with_arg(jwk)
             } else {

--- a/scripts/python/test.sh
+++ b/scripts/python/test.sh
@@ -7,6 +7,9 @@
 # For faster test cycle, the env variable FAST can be set to anything, which will skip building certain dependencies.
 # Before using it, make sure they are already built!
 # Eg: FAST=1 scripts/python/test.sh tests/bdd/features/volume/create/test_feature.py -k test_sufficient_suitable_pools
+# To avoid cleanup/teardown of the cluster and resources you can use this:
+# Eg: CLEAN=0 scripts/python/test.sh tests/bdd/features/volume/create/test_feature.py
+# This way the cluster will remain in place, which sometimes can help figure out why it failed.
 
 set -e
 
@@ -36,7 +39,7 @@ fi
 
 # Extra arguments will be provided directly to pytest, otherwise the bdd folder will be tested with default arguments
 if [ $# -eq 0 ]; then
-  pytest "$BDD_TEST_DIR"
+  pytest "$BDD_TEST_DIR" --durations=20
 else
   pytest "$@"
 fi

--- a/scripts/rust/test.sh
+++ b/scripts/rust/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR="$(dirname "$0")"
+ARGS=${1}
 
 cleanup_handler() {
   ERROR=$?
@@ -14,6 +15,8 @@ trap cleanup_handler INT QUIT TERM HUP EXIT
 set -euxo pipefail
 # test dependencies
 cargo build --bins
+cargo_test="cargo test"
 for test in deployer-cluster grpc agents rest io-engine-tests shutdown csi-driver; do
-    cargo test -p ${test} -- --test-threads=1
+    cargo_test="$cargo_test -p $test"
 done
+$cargo_test ${ARGS} -- --test-threads=1

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -19,6 +19,7 @@ class StartOptions:
     io_engine_env: str = ""
     agents_env: str = ""
     node_deadline: str = ""
+    node_conn_timeout: str = ""
     jaeger: bool = True
     cluster_uid: str = "bdd"
     extra_args: [str] = ()
@@ -30,6 +31,8 @@ class StartOptions:
     fio_spdk: bool = False
     io_engine_coreisol: bool = False
     io_engine_devices: [str] = ()
+    request_timeout: str = ""
+    no_min_timeouts: bool = False
 
     def args(self):
         args = [
@@ -53,6 +56,8 @@ class StartOptions:
             args.append(f"--cache-period={self.cache_period}")
         if len(self.node_deadline) > 0:
             args.append(f"--node-deadline={self.node_deadline}")
+        if len(self.node_conn_timeout) > 0:
+            args.append(f"--node-conn-timeout={self.node_conn_timeout}")
         if len(self.io_engine_env) > 0:
             args.append(f"--io-engine-env={self.io_engine_env}")
         if len(self.agents_env) > 0:
@@ -71,6 +76,10 @@ class StartOptions:
             args.append("--io-engine-isolate")
         for device in self.io_engine_devices:
             args.append(f"--io-engine-devices={device}")
+        if len(self.request_timeout) > 0:
+            args.append(f"--request-timeout={self.request_timeout}")
+        if self.no_min_timeouts:
+            args.append(f"--no-min-timeouts")
 
         agent_arg = "--agents=Core"
         if self.ha_node_agent:
@@ -99,6 +108,7 @@ class Deployer(object):
         agents_env="",
         rest_env="",
         node_deadline="",
+        node_conn_timeout="",
         jaeger=True,
         max_rebuilds="",
         cluster_agent=False,
@@ -107,6 +117,8 @@ class Deployer(object):
         fio_spdk=False,
         io_engine_coreisol=False,
         io_engine_devices=[],
+        request_timeout="",
+        no_min_timeouts=False,
     ):
         options = StartOptions(
             io_engines,
@@ -120,6 +132,7 @@ class Deployer(object):
             agents_env=agents_env,
             rest_env=rest_env,
             node_deadline=node_deadline,
+            node_conn_timeout=node_conn_timeout,
             jaeger=jaeger,
             max_rebuilds=max_rebuilds,
             ha_node_agent=node_agent,
@@ -128,6 +141,8 @@ class Deployer(object):
             fio_spdk=fio_spdk,
             io_engine_coreisol=io_engine_coreisol,
             io_engine_devices=io_engine_devices,
+            request_timeout=request_timeout,
+            no_min_timeouts=no_min_timeouts,
         )
         pytest.deployer_options = options
         Deployer.start_with_opts(options)

--- a/tests/bdd/common/operations.py
+++ b/tests/bdd/common/operations.py
@@ -1,8 +1,8 @@
 import http
 import time
 from urllib.parse import urlparse
-
 from retrying import retry
+import sys
 
 import common
 import openapi.exceptions
@@ -53,7 +53,7 @@ class Volume(object):
 
     @staticmethod
     def cleanup(volume):
-        if Cluster.env_cleanup():
+        if Cluster.fixture_cleanup():
             try:
                 if hasattr(volume, "spec"):
                     Volume.__api().del_volume(volume.spec.uuid)
@@ -102,7 +102,7 @@ class Snapshot(object):
 
     @staticmethod
     def cleanup(snapshot):
-        if Cluster.env_cleanup():
+        if Cluster.fixture_cleanup():
             try:
                 if hasattr(snapshot, "definition"):
                     Snapshot.__api().del_snapshot(snapshot.definition.spec.uuid)
@@ -152,6 +152,10 @@ class Cluster(object):
     @staticmethod
     def env_cleanup():
         return common.env_cleanup()
+
+    @staticmethod
+    def fixture_cleanup():
+        return common.env_cleanup() or not hasattr(sys, "last_traceback")
 
     @staticmethod
     def wait_cache_update(slack=0.1):

--- a/tests/bdd/features/ha/node-agent/test_path_replacement.py
+++ b/tests/bdd/features/ha/node-agent/test_path_replacement.py
@@ -35,7 +35,7 @@ TARGET_NODE_1 = "io-engine-1"
 TARGET_NODE_2 = "io-engine-2"
 NEXUS_NQN = "nqn.2019-05.io.openebs:%s" % VOLUME_UUID
 # Interval to wait before HA Node agent classifies broken path as failed
-PATH_DETECTION_TIME = 6
+PATH_DETECTION_TIME = 2
 # FIO should be active long enough to outlive the detection interval.
 FIO_RUNTIME = PATH_DETECTION_TIME * 2
 
@@ -114,6 +114,7 @@ def background():
         csi_node=True,
         cache_period="1s",
         io_engine_coreisol=True,
+        agents_env="DETECTION_PERIOD=100ms,SUBSYS_REFRESH_PERIOD=100ms",
     )
 
     ApiClient.pools_api().put_node_pool(

--- a/tests/bdd/features/ha/test_robustness.py
+++ b/tests/bdd/features/ha/test_robustness.py
@@ -49,14 +49,15 @@ ETCD_CLIENT = Etcd()
 def init():
     Deployer.start(
         2,
-        cache_period="500ms",
-        reconcile_period="600ms",
+        cache_period="100ms",
+        reconcile_period="200ms",
         cluster_agent=True,
-        cluster_agent_fast="1s",
+        cluster_agent_fast="100ms",
         node_agent=True,
         csi_node=True,
         io_engine_coreisol=True,
         io_engine_env="MAYASTOR_HB_INTERVAL_SEC=0",
+        agents_env="DETECTION_PERIOD=100ms,SUBSYS_REFRESH_PERIOD=100ms",
     )
     yield
     Deployer.stop()
@@ -103,7 +104,7 @@ def a_connected_nvme_initiator(connect_to_first_path):
     """a connected nvme initiator."""
     volume = pytest.volume
     device_uri = volume.state["target"]["deviceUri"]
-    nvme_set_reconnect_delay(device_uri, 2)
+    nvme_set_reconnect_delay(device_uri, 1)
 
 
 @given("a deployer cluster")
@@ -116,7 +117,7 @@ def a_reconnect_delay_set_to_15s():
     """a reconnect_delay set to 15s."""
     volume = pytest.volume
     device_uri = volume.state["target"]["deviceUri"]
-    nvme_set_reconnect_delay(device_uri, 15)
+    nvme_set_reconnect_delay(device_uri, 7)
 
 
 @given("a single replica volume")
@@ -187,7 +188,7 @@ def we_uncordon_the_nontarget_node():
 def the_ha_clustering_fails_a_few_times():
     """the ha clustering fails a few times."""
     # we have no way of determining this? maybe through etcd?
-    time.sleep(5)
+    time.sleep(1)
 
 
 @then("the path should be established")
@@ -206,7 +207,7 @@ def we_restart_the_volume_target_node():
 def the_ha_clustering_fails_as_there_is_no_other_node():
     """the ha clustering fails as there is no other node."""
     # we have no way of determining this? maybe through etcd?
-    time.sleep(10)
+    time.sleep(2)
 
 
 @when("the volume target node has io-path broken")
@@ -215,7 +216,7 @@ def the_volume_target_node_has_iopath_broken():
     simulate_network_failure(TARGET_NODE_1, NVME_SVC_PORT)
     # Restart container to speed up the failure
     Docker.stop_container(TARGET_NODE_1)
-    time.sleep(2)
+    time.sleep(1)
     Docker.restart_container(TARGET_NODE_1)
     yield
     remove_network_failure(TARGET_NODE_1, NVME_SVC_PORT, False)

--- a/tests/bdd/features/snapshot/create/test_feature.py
+++ b/tests/bdd/features/snapshot/create/test_feature.py
@@ -57,7 +57,13 @@ def disks(tmp_files):
 
 @pytest.fixture(scope="module")
 def deployer_cluster(disks):
-    Deployer.start(2, cache_period="200ms", reconcile_period="250ms")
+    Deployer.start(
+        2,
+        cache_period="150ms",
+        reconcile_period="150ms",
+        request_timeout="1s",
+        no_min_timeouts=True,
+    )
     ApiClient.pools_api().put_node_pool(NODE_NAME, "pool-1", CreatePoolBody([disks[0]]))
     yield
     Deployer.stop()

--- a/tests/bdd/features/snapshot/delete/test_delete.py
+++ b/tests/bdd/features/snapshot/delete/test_delete.py
@@ -96,10 +96,7 @@ def weve_created_a_snapshot_for_the_volume():
     """we've created a snapshot for the volume."""
     ApiClient.snapshots_api().put_volume_snapshot(VOLUME1_UUID, SNAP1_UUID)
     yield
-    try:
-        ApiClient.snapshots_api().del_snapshot(SNAP1_UUID)
-    except openapi.exceptions.ApiException:
-        pass
+    Snapshot.cleanup(SNAP1_UUID)
 
 
 @when("the snapshot is deleted")

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -116,6 +116,9 @@ pub const NVME_PATH_RETRANSMISSION_PERIOD: &str = "10s";
 /// Period for aggregating multiple failed paths before reporting them.
 pub const NVME_PATH_AGGREGATION_PERIOD: &str = "1s";
 
+/// NVMe subsystem refresh period when monitoring its state.
+pub const NVME_SUBSYS_REFRESH_PERIOD: &str = "500ms";
+
 /// Period for aggregating multiple failed paths before reporting them.
 pub const DEFAULT_HOST_ACCESS_CONTROL: &str = "nexuses,replicas";
 


### PR DESCRIPTION
    ci(python/bdd): speed up tests by reducing request timeout
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci(rust): several improvements
    
    Reduce etcd election timeout in deployer (there's only 1 anyway...)
    Start rest in deployer with a single core for faster startup.
    Fix RpcHandle from rpc from blocking to async.
    ShutdowOrder is completely broken, add our own new type for the composer
    and aim to fix this in another commit. For now simply send sigterms
    concurrently to speed up shutdown.
    Add more tracing information to deployer.
    Reduce "backoff" timeouts in general.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci(rust): build tests in single call
    
    This is faster because when building tests individually we're actually building
    with different deps so it takes longer.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
