### PR TITLE
Pin volume target to replicas for 1 replica volumes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/scheduling/affinity_group.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/affinity_group.rs
@@ -28,7 +28,7 @@ pub(crate) fn get_restricted_nodes(
             // Fetch the list of nodes where the volume replicas are placed. If some
             // volume doesn't exist yet, this list will be empty
             // for that volume.
-            let node_ids = specs.get_volume_replica_nodes(volume);
+            let node_ids = specs.volume_replica_nodes(volume);
             // Add a new node in the list if it doesn't already exist.
             let filtered_nodes: Vec<NodeId> = node_ids
                 .into_iter()

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -467,7 +467,8 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                     Ok(node) if node.state.as_ref().map(|n| n.status).unwrap_or(NodeStatus::Unknown) != NodeStatus::Online || cordon_check(node.spec.as_ref()) => {
                         Ok(None)
                     },
-                    Ok(_) => Ok(Some(node_id.as_str()))
+                    Ok(_) if volume.spec.num_replicas > 1 => Ok(Some(node_id.as_str())),
+                    Ok(_) => Ok(None),
                 }?;
 
                 // Volume is not published.

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -467,8 +467,10 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                     Ok(node) if node.state.as_ref().map(|n| n.status).unwrap_or(NodeStatus::Unknown) != NodeStatus::Online || cordon_check(node.spec.as_ref()) => {
                         Ok(None)
                     },
-                    Ok(_) if volume.spec.num_replicas > 1 => Ok(Some(node_id.as_str())),
-                    Ok(_) => Ok(None),
+                    // For 1-replica volumes, don't pre-select the target node. This will allow the
+                    // control-plane to pin the target to the replica node.
+                    Ok(_) if volume.spec.num_replicas == 1 => Ok(None),
+                    Ok(_) => Ok(Some(node_id.as_str())),
                 }?;
 
                 // Volume is not published.

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -81,7 +81,7 @@ message Metadata {
   common.SpecStatus spec_status = 1;
   // Persistent Configuration of the target (current/last)
   TargetConfig target_config = 2;
-  // Publish Context of the volme.
+  // Publish Context of the volume.
   optional common.MapWrapper publish_context = 3;
   // A volume may get temporarily converted into thin-provisioned
   optional bool as_thin = 4;
@@ -95,9 +95,23 @@ message AffinityGroup {
 
 message TargetConfig {
   // Persistent Configuration of the target (current/last)
-  VolumeTarget target = 1;
+  VolumeTarget target              = 1;
   // The nvmf configuration
-  nexus.NexusNvmfConfig config = 2;
+  nexus.NexusNvmfConfig     config = 2;
+  // Frontend configuration.
+  optional FrontendConfig frontend = 3;
+}
+
+message FrontendConfig {
+  // List of allowed frontend nodes.
+  repeated FrontendNode nodes = 1;
+}
+
+message FrontendNode {
+  // The node name.
+  string name = 1;
+  // The node Nvme NQN.
+  string nqn  = 2;
 }
 
 message VolumeTarget {

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3245,8 +3245,28 @@ components:
           type: string
         protocol:
           $ref: '#/components/schemas/VolumeShareProtocol'
+        frontend_nodes:
+          description: |-
+            The nodes where the front-end workload resides.
+            If the workload moves then the volume must be republished.
+          type: array
+          items:
+            $ref: '#/components/schemas/NodeAccessInfo'
       required:
         - node
+    NodeAccessInfo:
+      description: Frontend Node access information.
+      type: object
+      properties:
+        name:
+          description: The nodename of the node.
+          type: string
+        nqn:
+          description: The Nvme Nqn of the node's initiator.
+          type: string
+      required:
+        - name
+        - nqn
     SpecStatus:
       description: Common base state for a resource
       type: string

--- a/scripts/rust/test.sh
+++ b/scripts/rust/test.sh
@@ -11,7 +11,7 @@ while [ "$#" -gt 0 ]; do
       DO_ARGS="y"
       shift;;
     *)
-      if [ -n "$DO_ARGS" ]; then
+      if [ "$DO_ARGS" == "y" ]; then
         ARGS="$ARGS $1"
       else
         OPTS="$OPTS $1"
@@ -35,8 +35,8 @@ set -euxo pipefail
 cargo build --bins
 
 cargo_test="cargo test"
-for test in deployer-cluster grpc agents rest io-engine-tests shutdown csi-driver; do
-    cargo_test="$cargo_test -p $test"
+for package in deployer-cluster grpc agents rest io-engine-tests shutdown csi-driver; do
+    cargo_test="$cargo_test -p $package"
 done
 
 $cargo_test ${OPTS} -- ${ARGS} --test-threads=1

--- a/scripts/rust/test.sh
+++ b/scripts/rust/test.sh
@@ -1,11 +1,28 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR="$(dirname "$0")"
-ARGS=${1}
+
+ARGS=""
+OPTS=""
+DO_ARGS=
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    --)
+      DO_ARGS="y"
+      shift;;
+    *)
+      if [ -n "$DO_ARGS" ]; then
+        ARGS="$ARGS $1"
+      else
+        OPTS="$OPTS $1"
+      fi
+      shift;;
+  esac
+done
 
 cleanup_handler() {
   ERROR=$?
-  "$SCRIPT_DIR"/deployer-cleanup.sh || true
+  RUST_LOG="error" "$SCRIPT_DIR"/deployer-cleanup.sh || true
   if [ $ERROR != 0 ]; then exit $ERROR; fi
 }
 
@@ -13,10 +30,13 @@ cleanup_handler >/dev/null
 trap cleanup_handler INT QUIT TERM HUP EXIT
 
 set -euxo pipefail
-# test dependencies
+
+# build test dependencies
 cargo build --bins
+
 cargo_test="cargo test"
 for test in deployer-cluster grpc agents rest io-engine-tests shutdown csi-driver; do
     cargo_test="$cargo_test -p $test"
 done
-$cargo_test ${ARGS} -- --test-threads=1
+
+$cargo_test ${OPTS} -- ${ARGS} --test-threads=1


### PR DESCRIPTION
    fix(csi/controller): publish idempotency with 1r volumes
    
    With 1r volumes the target node may not be the same as app node. Moreover this could
    already happen if HA kicked in after publish (though probaboly not likely).
    Add frontend configuration to the volume target config, which allows us to check
    if a given node is allowed access. If it is then we can allow idempotent publish.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(node/drain): delete shutdown targets on timeout
    
    For deployer clusters, if the drain operation times out, delete the shutdown targets.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(volume/drain): during node drain don't move target away from replicas
    
    For 1-r volumes, don't move the target away from their replicas.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix: pin volume target to replicas (1-r volumes)
    
    Pin the nexus together with the replica for 1-r volumes.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(rust): allow specifying options and arguments
    
    Now we can run like so for example:
    ./scripts/rust/test.sh -- -Zunstable-options --report-time
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>