### PR TITLE
refactor(plugin get nodes): include cordon, drain status as well in node status

### DIFF
--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -44,7 +44,7 @@ lazy_static! {
         "AVAILABLE",
         "COMMITTED"
     ];
-    pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS", "CORDONED"];
+    pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS"];
     pub static ref REPLICA_TOPOLOGIES_PREFIX: Row = row!["VOLUME-ID"];
     pub static ref REPLICA_TOPOLOGY_HEADERS: Row = row![
         "ID",


### PR DESCRIPTION
### What does this PR do?
- This PR adds the Cordon or Drain related statuses to plugin get nodes.

### Previous Output
```
 ID          GRPC ENDPOINT  STATUS CORDONED
 io-engine-1 10.1.0.8:10124 Online true
 io-engine-2 10.1.0.9:10124 Online false
```


### Current Output
```
 ID           GRPC ENDPOINT   STATUS 
 io-engine-3  10.1.0.7:10124  Online, Cordoned, Drained 
 io-engine-1  10.1.0.5:10124  Online 
 io-engine-2  10.1.0.6:10124  Online, Cordoned
```