### PR TITLE
Cargo upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,18 +21,18 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
+checksum = "a92ef85799cba03f76e4f7c10f533e66d87c9a7e7055f3391f09000ad8351bc9"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.8.3",
+ "ahash",
  "base64 0.21.2",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -123,20 +123,23 @@ dependencies = [
 
 [[package]]
 name = "actix-tls"
-version = "3.0.3"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
+checksum = "72616e7fbec0aa99c6f3164677fa48ff5a60036d0799c98cab894a44f3e0efc3"
 dependencies = [
- "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "futures-core",
  "http",
- "log",
+ "impl-more",
  "pin-project-lite",
+ "rustls 0.21.6",
+ "rustls-webpki",
+ "tokio",
  "tokio-rustls 0.23.4",
  "tokio-util",
+ "tracing",
  "webpki-roots",
 ]
 
@@ -152,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.3.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
+checksum = "0e4a5b5e29603ca8c94a77c65cf874718ceb60292c5a5c3e5f4ace041af462b9"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -166,7 +169,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.7.6",
+ "ahash",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -175,7 +178,6 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http",
  "itoa",
  "language-tags",
  "log",
@@ -187,8 +189,8 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.4.9",
- "time 0.3.25",
+ "socket2 0.5.3",
+ "time",
  "url",
 ]
 
@@ -220,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -280,17 +282,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -342,16 +333,15 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
@@ -381,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -391,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "async-nats"
@@ -421,7 +411,7 @@ dependencies = [
  "serde_nanos",
  "serde_repr",
  "thiserror",
- "time 0.3.25",
+ "time",
  "tokio",
  "tokio-retry",
  "tokio-rustls 0.24.1",
@@ -453,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.72"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -470,9 +460,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "awc"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ef547a81796eb2dfe9b345aba34c2e08391a0502493711395b36dd64052b69"
+checksum = "7fa3c705a9c7917ac0f41c0757a0a747b43bbc29b0b364b081bd7c5fc67fb223"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -480,7 +470,6 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.7.6",
  "base64 0.21.2",
  "bytes",
  "cfg-if",
@@ -560,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -714,9 +703,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
  "serde",
 ]
@@ -757,18 +746,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -784,20 +772,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.21"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.21"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -807,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -860,7 +847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.25",
+ "time",
  "version_check",
 ]
 
@@ -1622,14 +1609,14 @@ checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "git-version-macro"
@@ -1718,6 +1705,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "http"
@@ -1816,7 +1812,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.4",
@@ -1898,6 +1894,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "impl-more"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
 
 [[package]]
 name = "indexmap"
@@ -2198,7 +2200,7 @@ version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7995aaf15656bf3694cd455578d59119acc3ca55f71e9a1b579a34a47d17ecce"
 dependencies = [
- "ahash 0.8.3",
+ "ahash",
  "backoff",
  "derivative",
  "futures",
@@ -2236,9 +2238,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libloading"
@@ -2277,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
 
 [[package]]
 name = "local-channel"
@@ -2347,9 +2349,9 @@ checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "mime"
@@ -2403,7 +2405,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -2442,14 +2444,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
  "libc",
- "static_assertions",
 ]
 
 [[package]]
@@ -2566,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -2597,7 +2598,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-jaeger",
  "pin-project",
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "rustls-pemfile",
  "serde",
  "serde_derive",
@@ -3159,14 +3160,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.6",
- "regex-syntax 0.7.4",
+ "regex-automata 0.3.9",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -3180,13 +3181,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -3197,15 +3198,15 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -3229,6 +3230,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -3259,7 +3261,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "opentelemetry",
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3354,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -3367,9 +3369,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
  "ring",
@@ -3412,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.3"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -3443,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -3455,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3528,9 +3530,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -3547,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3569,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -3644,7 +3646,7 @@ dependencies = [
  "indexmap 1.9.3",
  "serde",
  "serde_json",
- "time 0.3.25",
+ "time",
 ]
 
 [[package]]
@@ -3764,7 +3766,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.25",
+ "time",
 ]
 
 [[package]]
@@ -3859,12 +3861,6 @@ checksum = "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b"
 dependencies = [
  "loom",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stor-port"
@@ -3969,6 +3965,27 @@ name = "sysfs"
 version = "1.0.0"
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,17 +4063,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
@@ -4110,9 +4116,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.30.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3ce25f50619af8b0aec2eb23deebe84249e19e2ddd393a6e16e3300a6dadfd"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4187,7 +4193,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "tokio",
  "webpki",
 ]
@@ -4573,9 +4579,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4654,12 +4660,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -4745,9 +4745,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
  "ring",
  "untrusted",
@@ -4768,13 +4768,14 @@ version = "0.1.0"
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -4876,11 +4877,12 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio 0.8.8",
+ "mio",
  "num_cpus",
  "socket2 0.4.9",
  "tokio",
@@ -134,10 +134,10 @@ dependencies = [
  "http",
  "impl-more",
  "pin-project-lite",
- "rustls 0.21.6",
+ "rustls",
  "rustls-webpki",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "webpki-roots",
@@ -208,15 +208,15 @@ dependencies = [
 
 [[package]]
 name = "actix-web-opentelemetry"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa592a5b9b3d96101434bca1024c6da6c23630163aec485428e613cd7100dcf"
+checksum = "bdbeb48a7523926c2e555044ace1c3715956be38b8d34fc27484c8a1d9642de6"
 dependencies = [
  "actix-http",
  "actix-web",
  "futures-util",
- "opentelemetry",
  "opentelemetry-semantic-conventions",
+ "opentelemetry_api",
  "serde",
 ]
 
@@ -253,14 +253,14 @@ dependencies = [
  "http",
  "humantime",
  "hyper",
- "indexmap 1.9.3",
- "itertools",
+ "indexmap 2.0.2",
+ "itertools 0.11.0",
  "nix",
  "nvmeadm",
  "once_cell",
  "opentelemetry",
  "parking_lot",
- "prost-types",
+ "prost-types 0.11.9",
  "reqwest",
  "rpc",
  "serde",
@@ -271,7 +271,7 @@ dependencies = [
  "stor-port",
  "tokio",
  "tokio-udev",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "tracing",
  "url",
@@ -315,6 +315,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -387,15 +393,14 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "async-nats"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8257238e2a3629ee5618502a75d1b91f8017c24638c75349fc8d2d80cf1f7c4c"
+checksum = "0e45b67ea596bb94741ef15ba1d90b72c92bdc07553d8033734cb620a2b39f1c"
 dependencies = [
  "base64 0.21.2",
  "bytes",
  "futures",
  "http",
- "itoa",
  "memchr",
  "nkeys",
  "nuid",
@@ -403,6 +408,7 @@ dependencies = [
  "rand",
  "regex",
  "ring",
+ "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-webpki",
@@ -414,7 +420,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-retry",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tracing",
  "url",
 ]
@@ -588,23 +594,24 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
+ "prettyplease 0.2.12",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn 2.0.28",
  "which",
 ]
 
@@ -631,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af254ed2da4936ef73309e9597180558821cb16ae9bba4cb24ce6b612d8d80ed"
+checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
 dependencies = [
  "base64 0.21.2",
  "bollard-stubs",
@@ -660,11 +667,12 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.42.0-rc.7"
+version = "1.43.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602bda35f33aeb571cef387dcd4042c643a8bf689d8aaac2cc47ea24cb7bc7e0"
+checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
  "serde",
+ "serde_repr",
  "serde_with",
 ]
 
@@ -943,10 +951,10 @@ dependencies = [
  "nix",
  "nvmeadm",
  "once_cell",
- "prost",
- "prost-build",
- "prost-derive",
- "prost-types",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "prost-derive 0.11.9",
+ "prost-types 0.11.9",
  "regex",
  "rpc",
  "serde_json",
@@ -958,11 +966,11 @@ dependencies = [
  "sys-mount",
  "sysfs",
  "tokio",
- "tonic",
- "tonic-build",
+ "tonic 0.9.2",
+ "tonic-build 0.9.2",
  "tower",
  "tracing",
- "udev 0.7.0",
+ "udev 0.8.0",
  "url",
  "utils",
  "uuid",
@@ -1053,19 +1061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.0",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,7 +1084,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -1114,7 +1109,7 @@ dependencies = [
  "rpc",
  "stor-port",
  "tokio",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "tracing",
  "tracing-opentelemetry",
@@ -1203,7 +1198,7 @@ version = "1.0.0"
 dependencies = [
  "bindgen",
  "snafu",
- "udev 0.7.0",
+ "udev 0.8.0",
  "url",
  "uuid",
 ]
@@ -1363,16 +1358,16 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319dc0fb739a6e84cb8678b8cf50c9bcfa4712ae826b33ecf00cc0850550a58"
+checksum = "3d982a3b3088a5f95d19882d298b352a2e0be20703e3080c1e6767731d5dec79"
 dependencies = [
  "http",
- "prost",
+ "prost 0.12.1",
  "tokio",
  "tokio-stream",
- "tonic",
- "tonic-build",
+ "tonic 0.10.2",
+ "tonic-build 0.10.2",
  "tower",
  "tower-service",
 ]
@@ -1398,14 +1393,14 @@ dependencies = [
  "chrono",
  "futures",
  "once_cell",
- "prost",
+ "prost 0.11.9",
  "prost-wkt-types",
  "serde",
  "serde_json",
  "snafu",
  "tokio",
- "tonic",
- "tonic-build",
+ "tonic 0.9.2",
+ "tonic-build 0.9.2",
  "tracing",
  "uuid",
 ]
@@ -1624,7 +1619,7 @@ version = "0.3.5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1643,15 +1638,15 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "prost-types 0.11.9",
  "rpc",
  "serde_json",
  "stor-port",
  "tokio",
- "tonic",
- "tonic-build",
+ "tonic 0.9.2",
+ "tonic-build 0.9.2",
  "tower",
  "tracing",
  "tracing-opentelemetry",
@@ -1684,9 +1679,13 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1805,17 +1804,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "log",
- "rustls 0.20.9",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1914,12 +1914,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
+ "serde",
 ]
 
 [[package]]
@@ -1954,6 +1955,17 @@ dependencies = [
  "stor-port",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1998,6 +2010,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.3.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
+checksum = "4f7765dccf8c39c3a470fc694efe322969d791e713ca46bc7b5c506886157572"
 dependencies = [
  "serde",
  "serde_json",
@@ -2060,11 +2081,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1985030683a2bac402cbda61222195de80d3f66b4c87ab56e5fea379bd98c3"
+checksum = "95578de7d6eac4fba42114bc751e38c59a739968769df1be56feba6f17fd148e"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.2",
  "bytes",
  "chrono",
  "http",
@@ -2098,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.78.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ee2ba94546e32a5aef943e5831c6ac25592ff8dcfa8b2a06e0aaea90c69188"
+checksum = "a189cb8721a47de68d883040713bbb9c956763d784fcf066828018d32c180b96"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2111,16 +2132,16 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.78.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9ca1f597bd48ed26f45f601bf2fa3aaa0933b8d1652d883b8444519b72af4a"
+checksum = "98989b6e1f27695afe22aa29c94136fa06be5e8d28b91222e6dfbe5a460c803f"
 dependencies = [
  "base64 0.20.0",
  "bytes",
  "chrono",
- "dirs-next",
  "either",
  "futures",
+ "home",
  "http",
  "http-body",
  "hyper",
@@ -2136,7 +2157,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -2148,9 +2169,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.78.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f2c6d1a2d1584859499eb05a41c5a44713818041621fa7515cfdbdf4769ea7"
+checksum = "c24d23bf764ec9a5652f943442ff062b91fd52318ea6d2fc11115f19d8c84d13"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2166,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.78.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1dfe288fd87029f87c5713ddf585a4221e1b5be8f8c7c02ba28f5211f2a6d7"
+checksum = "0bbec4da219dcb02bb32afd762a7ac4dffd47ed92b7e35ac9a7b961d21327117"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2196,14 +2217,16 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.78.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7995aaf15656bf3694cd455578d59119acc3ca55f71e9a1b579a34a47d17ecce"
+checksum = "381224caa8a6fc16f8251cf1fd6d8678cdf5366f33000a923e4c54192e4b25b5"
 dependencies = [
  "ahash",
+ "async-trait",
  "backoff",
  "derivative",
  "futures",
+ "hashbrown 0.14.1",
  "json-patch",
  "k8s-openapi",
  "kube-client",
@@ -2386,19 +2409,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
@@ -2407,15 +2417,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2480,15 +2481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,11 +2492,10 @@ dependencies = [
 
 [[package]]
 name = "nuid"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c1bb65186718d348306bf1afdeb20d9ab45b2ab80fb793c0fdcf59ffbb4f38"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
 dependencies = [
- "lazy_static",
  "rand",
 ]
 
@@ -2598,7 +2589,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-jaeger",
  "pin-project",
- "rustls 0.20.9",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_derive",
@@ -2662,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -2672,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc79add46364183ece1a4542592ca593e6421c60807232f5b8f7a31703825d"
+checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2684,37 +2675,34 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-jaeger"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e785d273968748578931e4dc3b4f5ec86b26e09d9e0d66b55adda7fce742f7a"
+checksum = "876958ba9084f390f913fcf04ddf7bbbb822898867bb0a51cc28f2b9e5c1b515"
 dependencies = [
  "async-trait",
- "futures",
- "futures-executor",
- "once_cell",
+ "futures-core",
+ "futures-util",
  "opentelemetry",
  "opentelemetry-semantic-conventions",
- "thiserror",
  "thrift",
  "tokio",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b02e0230abb0ab6636d18e2ba8fa02903ea63772281340ccac18e0af3ec9eeb"
+checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
 dependencies = [
  "opentelemetry",
 ]
 
 [[package]]
 name = "opentelemetry_api"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
 dependencies = [
- "fnv",
  "futures-channel",
  "futures-util",
  "indexmap 1.9.3",
@@ -2722,25 +2710,26 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "dashmap",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "once_cell",
  "opentelemetry_api",
+ "ordered-float 3.9.1",
  "percent-encoding",
  "rand",
+ "regex",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2748,18 +2737,18 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "1.1.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
 dependencies = [
  "num-traits",
 ]
@@ -2926,6 +2915,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "prettytable-rs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,7 +2954,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.1",
 ]
 
 [[package]]
@@ -2966,16 +2975,38 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.11.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.12",
+ "prost 0.12.1",
+ "prost-types 0.12.1",
+ "regex",
+ "syn 2.0.28",
  "tempfile",
  "which",
 ]
@@ -2987,10 +3018,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2999,7 +3043,16 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
+dependencies = [
+ "prost 0.12.1",
 ]
 
 [[package]]
@@ -3010,7 +3063,7 @@ checksum = "562788060bcf2bfabe055194bd991ed2442457661744c88e0a0828ff9a08c08b"
 dependencies = [
  "chrono",
  "inventory",
- "prost",
+ "prost 0.11.9",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3024,9 +3077,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4dca8bcead3b728a6a7da017cc95e7f4cb2320ec4f6896bc593a1c4700f7328"
 dependencies = [
  "heck",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "prost-types 0.11.9",
  "quote",
 ]
 
@@ -3037,9 +3090,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2377c5680f2342871823045052e791b4487f7c90aae17e0feaee24cf59578a34"
 dependencies = [
  "chrono",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "prost-types 0.11.9",
  "prost-wkt",
  "prost-wkt-build",
  "regex",
@@ -3065,7 +3118,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "url",
  "uuid",
@@ -3080,12 +3133,12 @@ dependencies = [
  "clap",
  "deployer-cluster",
  "etcd-client",
- "itertools",
+ "itertools 0.11.0",
  "openapi",
  "parse-size",
  "prettytable-rs",
  "serde",
- "serde_yaml 0.9.25",
+ "serde_yaml",
  "tokio",
  "utils",
 ]
@@ -3261,11 +3314,11 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "opentelemetry",
- "rustls 0.20.9",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
- "serde_yaml 0.9.25",
+ "serde_yaml",
  "snafu",
  "stor-port",
  "tinytemplate",
@@ -3292,7 +3345,7 @@ dependencies = [
  "prettytable-rs",
  "serde",
  "serde_json",
- "serde_yaml 0.9.25",
+ "serde_yaml",
  "shutdown_hooks",
  "strum",
  "strum_macros",
@@ -3320,17 +3373,17 @@ name = "rpc"
 version = "1.0.0"
 dependencies = [
  "bytes",
- "prost",
- "prost-build",
- "prost-derive",
- "prost-types",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "prost-derive 0.11.9",
+ "prost-types 0.11.9",
  "serde",
  "serde_derive",
  "serde_json",
  "strum",
  "strum_macros",
- "tonic",
- "tonic-build",
+ "tonic 0.9.2",
+ "tonic-build 0.9.2",
 ]
 
 [[package]]
@@ -3369,21 +3422,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -3575,7 +3616,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "itoa",
  "ryu",
  "serde",
@@ -3636,29 +3677,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "chrono",
  "hex",
  "indexmap 1.9.3",
+ "indexmap 2.0.2",
  "serde",
  "serde_json",
  "time",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]
@@ -3667,7 +3697,7 @@ version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "itoa",
  "ryu",
  "serde",
@@ -3855,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b"
+checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
 dependencies = [
  "loom",
 ]
@@ -3872,7 +3902,7 @@ dependencies = [
  "openapi",
  "percent-encoding",
  "platform",
- "prost-types",
+ "prost-types 0.11.9",
  "pstor",
  "rand",
  "serde",
@@ -3882,7 +3912,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "url",
  "uuid",
@@ -3896,21 +3926,21 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3949,9 +3979,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sys-mount"
-version = "1.5.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1af10c09a6d1f65753e52772a4621e00da8b1d772d0f24595b60ccd36d6b51"
+checksum = "ab6b8b397ed1fa2364625189a004d532b5d58f772943c57aa144feb1966142bd"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -4050,14 +4080,14 @@ dependencies = [
 
 [[package]]
 name = "thrift"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09678c4cdbb4eed72e18b7c2af1329c69825ed16fcbac62d083fc3e2b0590ff0"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
  "log",
- "ordered-float 1.1.1",
+ "ordered-float 2.10.0",
  "threadpool",
 ]
 
@@ -4123,7 +4153,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 0.8.8",
+ "mio",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
@@ -4189,22 +4219,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.6",
+ "rustls",
  "tokio",
 ]
 
@@ -4221,9 +4240,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -4233,14 +4252,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-udev"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246ffebae60acd93eb0056bac967cad807c7aa09916fabceac50479ad1f53e64"
+checksum = "f25418da261774ef3dcae985951bc138cf5fd49b3f4bd7450124ca75af8ed142"
 dependencies = [
  "futures-core",
- "mio 0.7.14",
  "tokio",
- "udev 0.6.3",
+ "udev 0.7.0",
 ]
 
 [[package]]
@@ -4260,14 +4278,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4278,29 +4295,66 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.11.9",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.2",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.12.1",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.1.25",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.11.9",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+dependencies = [
+ "prettyplease 0.2.12",
+ "proc-macro2",
+ "prost-build 0.12.1",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -4325,18 +4379,19 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64 0.21.2",
+ "bitflags 2.4.0",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-range-header",
+ "mime",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -4390,16 +4445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4412,12 +4457,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.18.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
+checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
 dependencies = [
  "once_cell",
  "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4459,13 +4506,13 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",
@@ -4508,22 +4555,22 @@ dependencies = [
 
 [[package]]
 name = "udev"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c960764f7e816eed851a96c364745d37f9fe71a2e7dba79fbd40104530b5dd0"
+checksum = "4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a"
 dependencies = [
  "libc",
  "libudev-sys",
- "mio 0.8.8",
  "pkg-config",
 ]
 
 [[package]]
 name = "udev"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a"
+checksum = "50051c6e22be28ee6f217d50014f3bc29e81c20dc66ff7ca0d5c5226e1dcc5a1"
 dependencies = [
+ "io-lifetimes",
  "libc",
  "libudev-sys",
  "pkg-config",
@@ -4588,6 +4635,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -4755,12 +4808,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "weighted-scoring"
@@ -4883,15 +4933,6 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,6 +93,9 @@ pipeline {
   triggers {
     cron(cronSchedule())
   }
+  environment {
+    CARGO_INCREMENTAL = "1"
+  }
 
   stages {
     stage('init') {

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -30,21 +30,21 @@ path = "src/bin/jsongrpc/main.rs"
  path = "src/bin/ha/cluster/main.rs"
 
 [dependencies]
-anyhow = "1.0.72"
+anyhow = "1.0.75"
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
-chrono = "0.4.26"
-clap = { version = "4.3.21", features = ["color", "derive", "env", "string"] }
-tokio = { version = "1.30.0", features = ["full"] }
+chrono = "0.4.31"
+clap = { version = "4.4.6", features = ["color", "derive", "env", "string"] }
+tokio = { version = "1.32.0", features = ["full"] }
 tonic = "0.8.3"
 futures = "0.3.28"
-serde_json = "1.0.104"
-async-trait = "0.1.72"
+serde_json = "1.0.107"
+async-trait = "0.1.73"
 dyn-clonable = "0.9.0"
 snafu = "0.7.5"
 humantime = "2.1.0"
 state = "0.5.3"
 http = "0.2.9"
-reqwest = "0.11.18"
+reqwest = "0.11.20"
 parking_lot = "0.12.1"
 itertools = "0.10.5"
 once_cell = "1.18.0"
@@ -55,9 +55,9 @@ tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ] }
 opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread"] }
 tracing = "0.1.37"
-nix = { version = "0.26.2", default-features = false }
+nix = { version = "0.27.1", default-features = false }
 prost-types = "0.11.9"
-url = "2.4.0"
+url = "2.4.1"
 
 grpc = { path = "../grpc" }
 shutdown = { path = "../../utils/shutdown" }
@@ -73,9 +73,9 @@ tokio-udev = { version = "0.8.0" }
 [dev-dependencies]
 deployer-cluster = { path = "../../utils/deployer-cluster" }
 events-api = { path = "../../utils/dependencies/events-api" }
-url = "2.4.0"
+url = "2.4.1"
 once_cell = "1.18.0"
 
 [dependencies.serde]
 features = ["derive"]
-version = "1.0.183"
+version = "1.0.188"

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -35,25 +35,25 @@ uuid = { version = "1.4.1", features = ["serde", "v4"] }
 chrono = "0.4.31"
 clap = { version = "4.4.6", features = ["color", "derive", "env", "string"] }
 tokio = { version = "1.32.0", features = ["full"] }
-tonic = "0.8.3"
+tonic = "0.9.2"
 futures = "0.3.28"
 serde_json = "1.0.107"
 async-trait = "0.1.73"
 dyn-clonable = "0.9.0"
 snafu = "0.7.5"
 humantime = "2.1.0"
-state = "0.5.3"
+state = "0.6.0"
 http = "0.2.9"
-reqwest = "0.11.20"
+reqwest = "0.11.22"
 parking_lot = "0.12.1"
-itertools = "0.10.5"
+itertools = "0.11.0"
 once_cell = "1.18.0"
-indexmap = "1.9.3"
+indexmap = "2.0.2"
 futures-util = { version = "0.3.28" }
 crossbeam-queue = "0.3.8"
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ] }
-opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread"] }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
 tracing = "0.1.37"
 nix = { version = "0.27.1", default-features = false }
 prost-types = "0.11.9"
@@ -68,7 +68,7 @@ nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
 weighted-scoring = { path = "../../utils/weighted-scoring" }
 
 [target.'cfg(target_os="linux")'.dependencies]
-tokio-udev = { version = "0.8.0" }
+tokio-udev = { version = "0.9.1" }
 
 [dev-dependencies]
 deployer-cluster = { path = "../../utils/deployer-cluster" }

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -180,6 +180,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
             utils::tracing_telemetry::global::tracer_provider().versioned_tracer(
                 "core-agent",
                 Some(env!("CARGO_PKG_VERSION")),
+                None::<std::borrow::Cow<'static, str>>,
                 None,
             ),
         )

--- a/control-plane/agents/src/bin/core/pool/wrapper.rs
+++ b/control-plane/agents/src/bin/core/pool/wrapper.rs
@@ -171,7 +171,7 @@ impl From<&PoolWrapper> for Vec<Replica> {
 // are not active)
 impl PartialOrd for PoolWrapper {
     // todo: change code to support using cmp
-    #[allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
+    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self.state.status.partial_cmp(&other.state.status) {
             Some(Ordering::Greater) => Some(Ordering::Greater),

--- a/control-plane/agents/src/lib.rs
+++ b/control-plane/agents/src/lib.rs
@@ -8,7 +8,7 @@
 use futures::Future;
 use grpc::tracing::OpenTelServer;
 use snafu::Snafu;
-use state::Container;
+use state::TypeMap;
 use std::{net::SocketAddr, sync::Arc};
 use stor_port::transport_api::ErrorChain;
 
@@ -27,7 +27,7 @@ pub enum ServiceError {
 type LayerStack = tower::layer::util::Stack<OpenTelServer, tower::layer::util::Identity>;
 /// An agent service with shareable state and a tonic server for gRPC services.
 pub struct Service<S = tonic::transport::server::Router<LayerStack>> {
-    shared_state: Arc<Container![Send + Sync]>,
+    shared_state: Arc<TypeMap![Send + Sync]>,
     tonic_server: S,
 }
 /// A `Service` that has not yet been added any routes.
@@ -62,7 +62,7 @@ impl Service {
     /// Setup default service with an opentelemetry layer configured on the tonic server.
     pub fn builder() -> Service<tonic::transport::Server<LayerStack>> {
         Service::<tonic::transport::Server<LayerStack>> {
-            shared_state: Arc::new(<Container![Send + Sync]>::new()),
+            shared_state: Arc::new(<TypeMap![Send + Sync]>::new()),
             tonic_server: tonic::transport::Server::builder().layer(OpenTelServer::new(vec![
                 // This is a bit of hack, but tonic doesn't seem to provide access to this uri
                 // path in any way.

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -15,14 +15,14 @@ name = "csi-node"
 path = "src/bin/node/main.rs"
 
 [build-dependencies]
-tonic-build = "0.8.4"
+tonic-build = "0.9.2"
 prost-build = "0.11.9"
 
 [dependencies]
 prost = "0.11.9"
 prost-derive = "0.11.9"
 prost-types = "0.11.9"
-tonic = "0.8.3"
+tonic = "0.9.2"
 
 anyhow = "1.0.75"
 async-stream = "0.3.5"
@@ -35,8 +35,8 @@ grpc = { path = "../grpc" }
 tokio = { version = "1.32.0", features = ["full"] }
 clap =  { version = "4.4.6", features = ["color", "env", "string"] }
 nix = { version = "0.27.1", default-features = false, features = [ "ioctl", "fs" ] }
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 heck = "0.4.1"
 tracing = "0.1.37"
 glob = "0.3.1"
@@ -47,8 +47,8 @@ tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 url = "2.4.1"
 uuid = { version = "1.4.1", features = ["v4"] }
 which = "4.4.2"
-k8s-openapi = { version = "0.17.0", features = ["v1_20"] }
-kube = { version = "0.78.0", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
+kube = { version = "0.85.0", features = ["runtime", "derive"] }
 nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
 sysfs = { path = "../../utils/dependencies/sysfs" }
 stor-port = { path = "../stor-port" }
@@ -56,7 +56,6 @@ utils = { path = "../../utils/utils-lib" }
 shutdown = { path = "../../utils/shutdown" }
 
 [target.'cfg(target_os="linux")'.dependencies]
-udev = "0.7.0"
+udev = "0.8.0"
 devinfo = { path = "../../utils/dependencies/devinfo" }
-sys-mount = { version = "1.5.1", default-features = false }
-#sys-mount = { version = "2.0.2", default-features = false }
+sys-mount = { version = "2.1.0", default-features = false }

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -24,29 +24,29 @@ prost-derive = "0.11.9"
 prost-types = "0.11.9"
 tonic = "0.8.3"
 
-anyhow = "1.0.72"
+anyhow = "1.0.75"
 async-stream = "0.3.5"
 futures = { version = "0.3.28", default-features = false }
 humantime = "2.1.0"
 once_cell = "1.18.0"
-regex = "1.9.3"
+regex = "1.9.6"
 rpc = { path = "../../rpc" }
 grpc = { path = "../grpc" }
-tokio = { version = "1.30.0", features = ["full"] }
-clap =  { version = "4.3.21", features = ["color", "env", "string"] }
-nix = { version = "0.26.2", default-features = false, features = [ "ioctl", "fs" ] }
+tokio = { version = "1.32.0", features = ["full"] }
+clap =  { version = "4.4.6", features = ["color", "env", "string"] }
+nix = { version = "0.27.1", default-features = false, features = [ "ioctl", "fs" ] }
 strum = "0.24.1"
 strum_macros = "0.24.3"
 heck = "0.4.1"
 tracing = "0.1.37"
 glob = "0.3.1"
 lazy_static = "1.4.0"
-serde_json = "1.0.104"
+serde_json = "1.0.107"
 snafu = "0.7.5"
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
-url = "2.4.0"
+url = "2.4.1"
 uuid = { version = "1.4.1", features = ["v4"] }
-which = "4.4.0"
+which = "4.4.2"
 k8s-openapi = { version = "0.17.0", features = ["v1_20"] }
 kube = { version = "0.78.0", features = ["runtime", "derive"] }
 nvmeadm = { path = "../../utils/dependencies/nvmeadm" }

--- a/control-plane/csi-driver/src/bin/controller/pvwatcher.rs
+++ b/control-plane/csi-driver/src/bin/controller/pvwatcher.rs
@@ -1,8 +1,7 @@
 use futures::TryStreamExt;
 use k8s_openapi::api::core::v1::PersistentVolume;
-
 use kube::{
-    api::{Api, ListParams},
+    api::Api,
     runtime::{watcher, WatchStreamExt},
     Client, ResourceExt,
 };
@@ -35,7 +34,7 @@ impl PvGarbageCollector {
         tokio::spawn(async move {
             cloned_self.handle_missed_events().await;
         });
-        watcher(self.pv_handle.clone(), ListParams::default())
+        watcher(self.pv_handle.clone(), watcher::Config::default())
             .touched_objects()
             .try_for_each(|pvol| async {
                 self.process_object(pvol).await;

--- a/control-plane/csi-driver/src/bin/node/mount.rs
+++ b/control-plane/csi-driver/src/bin/node/mount.rs
@@ -119,8 +119,8 @@ fn parse(options: &[String]) -> (bool, String) {
 fn show(options: &[String]) -> String {
     let list: Vec<String> = options
         .iter()
+        .filter(|value| value.as_str() != "rw")
         .cloned()
-        .filter(|value| value != "rw")
         .collect();
 
     if list.is_empty() {

--- a/control-plane/csi-driver/src/bin/node/mount.rs
+++ b/control-plane/csi-driver/src/bin/node/mount.rs
@@ -115,16 +115,6 @@ fn parse(options: &[String]) -> (bool, String) {
     (readonly, list.join(","))
 }
 
-// Utility function to wrap a string in an Option.
-// Note that, in particular, the empty string is mapped to None.
-fn option(value: &str) -> Option<&str> {
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
-}
-
 // Utility function used for displaying a list of options.
 fn show(options: &[String]) -> String {
     let list: Vec<String> = options
@@ -155,13 +145,15 @@ pub(crate) fn filesystem_mount(
         flags.insert(MountFlags::RDONLY);
     }
 
-    let mount = Mount::new(
-        device,
-        target,
-        FilesystemType::Manual(fstype.as_ref()),
-        flags,
-        option(&value),
-    )?;
+    // I'm not certain if it's fine to pass "" so keep existing behaviour
+    let mount = if value.is_empty() {
+        Mount::builder()
+    } else {
+        Mount::builder().data(&value)
+    }
+    .fstype(FilesystemType::Manual(fstype.as_ref()))
+    .flags(flags)
+    .mount(device, target)?;
 
     debug!(
         "Filesystem ({}) on device {} mounted onto target {} (options: {})",
@@ -197,7 +189,10 @@ pub(crate) fn bind_mount(source: &str, target: &str, file: bool) -> Result<Mount
         flags.insert(MountFlags::RDONLY);
     }
 
-    let mount = Mount::new(source, target, FilesystemType::Manual("none"), flags, None)?;
+    let mount = Mount::builder()
+        .fstype(FilesystemType::Manual("none"))
+        .flags(flags)
+        .mount(source, target)?;
 
     debug!("Source {} bind mounted onto target {}", source, target);
 
@@ -219,13 +214,14 @@ pub(crate) fn bind_remount(target: &str, options: &[String]) -> Result<Mount, Er
 
     flags.insert(MountFlags::REMOUNT);
 
-    let mount = Mount::new(
-        "none",
-        target,
-        FilesystemType::Manual("none"),
-        flags,
-        option(&value),
-    )?;
+    let mount = if value.is_empty() {
+        Mount::builder()
+    } else {
+        Mount::builder().data(&value)
+    }
+    .fstype(FilesystemType::Manual("none"))
+    .flags(flags)
+    .mount("none", target)?;
 
     debug!(
         "Target {} bind remounted (options: {})",
@@ -257,7 +253,10 @@ pub(crate) fn remount(target: &str, ro: bool) -> Result<Mount, Error> {
         flags.insert(MountFlags::RDONLY);
     }
 
-    let mount = Mount::new("", target, FilesystemType::Manual("none"), flags, None)?;
+    let mount = Mount::builder()
+        .fstype(FilesystemType::Manual("none"))
+        .flags(flags)
+        .mount("", target)?;
 
     debug!("Target {} remounted with {:?}", target, flags);
 
@@ -275,15 +274,21 @@ pub(crate) fn blockdevice_mount(
     let mut flags = MountFlags::empty();
     flags.insert(MountFlags::BIND);
 
-    let mount = Mount::new(source, target, FilesystemType::Manual("none"), flags, None)?;
+    let mount = Mount::builder()
+        .fstype(FilesystemType::Manual("none"))
+        .flags(flags)
+        .mount(source, target)?;
     info!("Block device {} mounted to {}", source, target,);
 
     if readonly {
         flags.insert(MountFlags::REMOUNT);
         flags.insert(MountFlags::RDONLY);
 
-        let mount = Mount::new("", target, FilesystemType::Manual(""), flags, None)?;
-        info!("Remounted block device {} (readonly) to {}", source, target,);
+        let mount = Mount::builder()
+            .fstype(FilesystemType::Manual(""))
+            .flags(flags)
+            .mount("", target)?;
+        info!("Remounted block device {} (readonly) to {}", source, target);
         return Ok(mount);
     }
 

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -11,11 +11,11 @@ name = "grpc"
 path = "src/lib.rs"
 
 [build-dependencies]
-tonic-build = "0.8.4"
+tonic-build = "0.9.2"
 prost-build = "0.11.9"
 
 [dependencies]
-tonic = "0.8.3"
+tonic = "0.9.2"
 prost = "0.11.9"
 prost-types = "0.11.9"
 
@@ -25,10 +25,10 @@ humantime = "2.1.0"
 utils = { path = "../../utils/utils-lib" }
 rpc = { path = "../../rpc"}
 uuid = { version = "1.4.1", features = ["v4"] }
-tracing-opentelemetry = "0.18.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread"] }
-opentelemetry-http = { version = "0.7.0" }
-opentelemetry-semantic-conventions = "0.10.0"
+tracing-opentelemetry = "0.21.0"
+opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
+opentelemetry-http = { version = "0.9.0" }
+opentelemetry-semantic-conventions = "0.12.0"
 tracing = "0.1.37"
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 serde_json = "1.0.107"

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -19,7 +19,7 @@ tonic = "0.8.3"
 prost = "0.11.9"
 prost-types = "0.11.9"
 
-tokio = { version = "1.30.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 stor-port = { path = "../stor-port" }
 humantime = "2.1.0"
 utils = { path = "../../utils/utils-lib" }
@@ -31,7 +31,7 @@ opentelemetry-http = { version = "0.7.0" }
 opentelemetry-semantic-conventions = "0.10.0"
 tracing = "0.1.37"
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
-serde_json = "1.0.104"
+serde_json = "1.0.107"
 events-api = { path = "../../utils/dependencies/events-api" }
 
 [dev-dependencies]

--- a/control-plane/grpc/src/tracing.rs
+++ b/control-plane/grpc/src/tracing.rs
@@ -1,16 +1,18 @@
 use opentelemetry::{
     global,
     trace::{FutureExt, SpanKind, TraceContextExt, Tracer, TracerProvider},
-    KeyValue,
+    Key, KeyValue,
 };
 use opentelemetry_http::HeaderInjector;
-use opentelemetry_semantic_conventions::trace::{HTTP_STATUS_CODE, RPC_GRPC_STATUS_CODE};
+use opentelemetry_semantic_conventions::trace::RPC_GRPC_STATUS_CODE;
 use std::{future::Future, pin::Pin};
 use tonic::{
     codegen::http::{Request, Response},
     transport::Channel,
 };
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+const HTTP_STATUS_CODE: Key = Key::from_static_str("http.status_code");
 
 /// Add OpenTelemetry Span to the Http Headers
 #[derive(Default)]
@@ -141,6 +143,7 @@ where
         let tracer = global::tracer_provider().versioned_tracer(
             "grpc-server",
             Some(env!("CARGO_PKG_VERSION")),
+            None::<std::borrow::Cow<'static, str>>,
             None,
         );
         let extractor = opentelemetry_http::HeaderExtractor(request.headers());

--- a/control-plane/plugin/Cargo.toml
+++ b/control-plane/plugin/Cargo.toml
@@ -21,8 +21,8 @@ tls = [ "openapi/tower-client-tls" ]
 [dependencies]
 openapi = { path = "../../openapi", default-features = false, features = [ "tower-trace" ] }
 utils = { path = "../../utils/utils-lib" }
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 tokio = { version = "1.32.0" }
 anyhow = "1.0.75"
 async-trait = "0.1.73"

--- a/control-plane/plugin/Cargo.toml
+++ b/control-plane/plugin/Cargo.toml
@@ -23,18 +23,18 @@ openapi = { path = "../../openapi", default-features = false, features = [ "towe
 utils = { path = "../../utils/utils-lib" }
 strum = "0.24.1"
 strum_macros = "0.24.3"
-tokio = { version = "1.30.0" }
-anyhow = "1.0.72"
-async-trait = "0.1.72"
+tokio = { version = "1.32.0" }
+anyhow = "1.0.75"
+async-trait = "0.1.73"
 once_cell = "1.18.0"
-clap = { version = "4.3.21", features = ["color", "derive", "string"] }
+clap = { version = "4.4.6", features = ["color", "derive", "string"] }
 prettytable-rs = "0.10.0"
 lazy_static = "1.4.0"
-serde = "1.0.183"
-serde_json = "1.0.104"
+serde = "1.0.188"
+serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 humantime = "2.1.0"
-chrono = "0.4.26"
+chrono = "0.4.31"
 
 [dev-dependencies]
 # Test dependencies

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -17,12 +17,12 @@ path = "./src/lib.rs"
 
 [dependencies]
 # Actix Server, telemetry
-rustls = "0.20.9"
+rustls = "0.21.7"
 rustls-pemfile = "1.0.3"
-actix-web = { version = "4.4.0", features = ["rustls"] }
+actix-web = { version = "4.4.0", features = ["rustls-0_21"] }
 actix-service = "2.0.2"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread"] }
-actix-web-opentelemetry = "0.13.0"
+opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
+actix-web-opentelemetry = "0.15.0"
 tracing = "0.1.37"
 once_cell = "1.18.0"
 async-trait = "0.1.73"

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -17,22 +17,22 @@ path = "./src/lib.rs"
 
 [dependencies]
 # Actix Server, telemetry
-rustls = "0.20.8"
+rustls = "0.20.9"
 rustls-pemfile = "1.0.3"
-actix-web = { version = "4.3.1", features = ["rustls"] }
+actix-web = { version = "4.4.0", features = ["rustls"] }
 actix-service = "2.0.2"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread"] }
 actix-web-opentelemetry = "0.13.0"
 tracing = "0.1.37"
 once_cell = "1.18.0"
-async-trait = "0.1.72"
-serde_json = { version = "1.0.104", features = ["preserve_order"] }
+async-trait = "0.1.73"
+serde_json = { version = "1.0.107", features = ["preserve_order"] }
 serde_yaml = "0.9.25"
-clap = { version = "4.3.21", features = ["color", "derive", "env", "string"] }
+clap = { version = "4.4.6", features = ["color", "derive", "env", "string"] }
 futures = "0.3.28"
-anyhow = "1.0.72"
+anyhow = "1.0.75"
 snafu = "0.7.5"
-url = "2.4.0"
+url = "2.4.1"
 http = "0.2.9"
 tinytemplate = "1.2.1"
 jsonwebtoken = "8.3.0"
@@ -43,10 +43,10 @@ grpc = { path = "../grpc" }
 num_cpus = "1.16.0"
 
 [dev-dependencies]
-tokio = { version = "1.30.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 composer = { path = "../../utils/dependencies/composer", default-features = false }
 deployer-cluster = { path = "../../utils/deployer-cluster" }
 
 [dependencies.serde]
 features = ["derive"]
-version = "1.0.183"
+version = "1.0.188"

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -233,7 +233,8 @@ async fn main() -> anyhow::Result<()> {
             .expect("Expect to be initialised only once");
     }
 
-    let server = HttpServer::new(app).bind_rustls(CliArgs::args().https, get_certificates()?)?;
+    let server =
+        HttpServer::new(app).bind_rustls_021(CliArgs::args().https, get_certificates()?)?;
     let result = if let Some(http) = CliArgs::args().http {
         server.bind(http).map_err(anyhow::Error::from)?
     } else {

--- a/control-plane/stor-port/Cargo.toml
+++ b/control-plane/stor-port/Cargo.toml
@@ -9,8 +9,8 @@ description = "Persistent store and transport associated information for the con
 [dependencies]
 url = "2.4.1"
 uuid = { version = "1.4.1", features = ["v4"] }
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 serde_json = "1.0.107"
 percent-encoding = "2.3.0"
 tokio = { version = "1.32.0", features = [ "full" ] }
@@ -20,7 +20,7 @@ serde_tuple = "0.5.0"
 async-trait = "0.1.73"
 dyn-clonable = "0.9.0"
 rand = "0.8.5"
-tonic = "0.8.3"
+tonic = "0.9.2"
 chrono = { version = "0.4.31", features = ["serde"] }
 tracing = "0.1.37"
 prost-types = "0.11.9"

--- a/control-plane/stor-port/Cargo.toml
+++ b/control-plane/stor-port/Cargo.toml
@@ -7,21 +7,21 @@ description = "Persistent store and transport associated information for the con
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-url = "2.4.0"
+url = "2.4.1"
 uuid = { version = "1.4.1", features = ["v4"] }
 strum = "0.24.1"
 strum_macros = "0.24.3"
-serde_json = "1.0.104"
+serde_json = "1.0.107"
 percent-encoding = "2.3.0"
-tokio = { version = "1.30.0", features = [ "full" ] }
+tokio = { version = "1.32.0", features = [ "full" ] }
 snafu = "0.7.5"
-serde = { version = "1.0.183", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_tuple = "0.5.0"
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 dyn-clonable = "0.9.0"
 rand = "0.8.5"
 tonic = "0.8.3"
-chrono = { version = "0.4.26", features = ["serde"] }
+chrono = { version = "0.4.31", features = ["serde"] }
 tracing = "0.1.37"
 prost-types = "0.11.9"
 

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -21,15 +21,15 @@ stor-port = { path = "../control-plane/stor-port" }
 rpc = { path = "../rpc" }
 utils = { path = "../utils/utils-lib" }
 grpc = { path = "../control-plane/grpc" }
-clap = { version = "4.3.21", features = ["color", "derive", "env", "string"] }
-tokio = { version = "1.30.0", features = ["full"] }
+clap = { version = "4.4.6", features = ["color", "derive", "env", "string"] }
+tokio = { version = "1.32.0", features = ["full"] }
 tonic = "0.8.3"
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 strum = "0.24.1"
 strum_macros = "0.24.3"
 paste = "1.0.14"
 humantime = "2.1.0"
-reqwest = { version = "0.11.18", features = ["multipart"] }
+reqwest = { version = "0.11.20", features = ["multipart"] }
 futures = "0.3.28"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -23,13 +23,13 @@ utils = { path = "../utils/utils-lib" }
 grpc = { path = "../control-plane/grpc" }
 clap = { version = "4.4.6", features = ["color", "derive", "env", "string"] }
 tokio = { version = "1.32.0", features = ["full"] }
-tonic = "0.8.3"
+tonic = "0.9.2"
 async-trait = "0.1.73"
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 paste = "1.0.14"
 humantime = "2.1.0"
-reqwest = { version = "0.11.20", features = ["multipart"] }
+reqwest = { version = "0.11.22", features = ["multipart"] }
 futures = "0.3.28"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }

--- a/k8s/forward/Cargo.toml
+++ b/k8s/forward/Cargo.toml
@@ -9,13 +9,13 @@ edition = "2021"
 [dependencies]
 kube = { version = "0.78.0", features = [ "ws" ] }
 k8s-openapi = { version = "0.17.0", default-features = false, features = ["v1_20"] }
-tokio = { version = "1.30.0", features = [ "full" ] }
+tokio = { version = "1.32.0", features = [ "full" ] }
 tokio-stream = { version = "0.1.14", features = ["net"] }
 futures = "0.3.28"
-anyhow = "1.0.72"
+anyhow = "1.0.75"
 tracing = "0.1.37"
 shutdown = { path = "../../utils/shutdown" }
-serde_json = "1.0.104"
+serde_json = "1.0.107"
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ] }
 
 [dev-dependencies]

--- a/k8s/forward/Cargo.toml
+++ b/k8s/forward/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kube = { version = "0.78.0", features = [ "ws" ] }
-k8s-openapi = { version = "0.17.0", default-features = false, features = ["v1_20"] }
+kube = { version = "0.85.0", features = [ "ws" ] }
+k8s-openapi = { version = "0.19.0", default-features = false, features = ["v1_20"] }
 tokio = { version = "1.32.0", features = [ "full" ] }
 tokio-stream = { version = "0.1.14", features = ["net"] }
 futures = "0.3.28"

--- a/k8s/operators/Cargo.toml
+++ b/k8s/operators/Cargo.toml
@@ -27,8 +27,8 @@ anyhow = "1.0.75"
 chrono = "0.4.31"
 clap =  { version = "4.4.6", features = ["color", "env", "string"] }
 futures = "0.3.28"
-k8s-openapi = { version = "0.17.0", features = ["v1_20"] }
-kube = { version = "0.78.0", features = ["derive", "runtime"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
+kube = { version = "0.85.0", features = ["derive", "runtime"] }
 schemars = "0.8.15"
 serde = "1.0.188"
 serde_json = "1.0.107"

--- a/k8s/operators/Cargo.toml
+++ b/k8s/operators/Cargo.toml
@@ -23,16 +23,16 @@ tls = [ "openapi/tower-client-tls" ]
 [dependencies]
 openapi = { path = "../../openapi", default-features = false, features = [ "tower-client", "tower-trace" ] }
 utils = { path = "../../utils/utils-lib" }
-anyhow = "1.0.72"
-chrono = "0.4.26"
-clap =  { version = "4.3.21", features = ["color", "env", "string"] }
+anyhow = "1.0.75"
+chrono = "0.4.31"
+clap =  { version = "4.4.6", features = ["color", "env", "string"] }
 futures = "0.3.28"
 k8s-openapi = { version = "0.17.0", features = ["v1_20"] }
 kube = { version = "0.78.0", features = ["derive", "runtime"] }
-schemars = "0.8.12"
-serde = "1.0.183"
-serde_json = "1.0.104"
+schemars = "0.8.15"
+serde = "1.0.188"
+serde_json = "1.0.107"
 snafu = "0.7.5"
-tokio = { version = "1.30.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 humantime = "2.1.0"
 tracing = "0.1.37"

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -8,8 +8,8 @@ in
 rec {
   inherit makeRustTarget;
   rust_default = { override ? { } }: rec {
-    nightly_pkg = pkgs.rust-bin.nightly."2023-08-10";
-    stable_pkg = pkgs.rust-bin.stable."1.71.1";
+    nightly_pkg = pkgs.rust-bin.nightly."2023-10-05";
+    stable_pkg = pkgs.rust-bin.stable."1.72.1";
 
     nightly = nightly_pkg.default.override (override);
     stable = stable_pkg.default.override (override);

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -19,7 +19,7 @@ let
       inherit tag;
       created = "now";
       name = "openebs/mayastor-${name}${image_suffix.${buildType}}";
-      contents = [ tini busybox package ];
+      copyToRoot = [ tini busybox package ];
       config = {
         Entrypoint = [ "tini" "--" package.binary ];
       } // config;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "48f3d76f512c7267d82d84c5d3d156ad2b9a8d12",
-        "sha256": "1xivbqbixnk96pacb6ihcbhsmcm0cly7xbgpq2g8kwqf4sgxk2hi",
+        "rev": "c0df7f2a856b5ff27a3ce314f6d7aacf5fda546f",
+        "sha256": "0hm2yznc083bys92h6zrx5lsar5nqphx1h27p7pxz4x7hmilxpsy",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/48f3d76f512c7267d82d84c5d3d156ad2b9a8d12.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/c0df7f2a856b5ff27a3ce314f6d7aacf5fda546f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -31,28 +31,28 @@ serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 url = { version = "^2.4", features = ["serde"] }
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 dyn-clonable = "0.9.0"
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
 serde_urlencoded = "0.7"
 
 # actix dependencies
-actix-web = { version = "4.3.1", features = ["rustls"], optional = true }
+actix-web = { version = "4.4.0", features = ["rustls"], optional = true }
 actix-web-opentelemetry = { version = "0.13.0", optional = true }
-awc = { version = "3.1.1", optional = true }
+awc = { version = "3.2.0", optional = true }
 
 # tower and hyper dependencies
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ], optional = true }
 tower = { version = "0.4.13", features = [ "timeout", "util", "limit" ], optional = true }
 tower-http = { version = "0.3.5", features = [ "trace", "map-response-body", "auth" ], optional = true }
-tokio = { version = "1.30.0", features = ["full"], optional = true }
+tokio = { version = "1.32.0", features = ["full"], optional = true }
 http-body = { version = "0.4.5", optional = true }
 futures = { version = "0.3.28", optional = true }
 pin-project = { version = "1.1.3", optional = true }
 # SSL
-rustls = { version = "0.20.8", optional = true, features = [ "dangerous_configuration" ] }
+rustls = { version = "0.20.9", optional = true, features = [ "dangerous_configuration" ] }
 rustls-pemfile = "1.0.3"
-webpki = { version = "0.22.0", optional = true }
+webpki = { version = "0.22.2", optional = true }
 hyper-rustls = { version = "0.23.2", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 tokio-native-tls = { version = "0.3.1", optional = true }

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -37,29 +37,29 @@ uuid = { version = "1.4.1", features = ["serde", "v4"] }
 serde_urlencoded = "0.7"
 
 # actix dependencies
-actix-web = { version = "4.4.0", features = ["rustls"], optional = true }
-actix-web-opentelemetry = { version = "0.13.0", optional = true }
+actix-web = { version = "4.4.0", features = ["rustls-0_21"], optional = true }
+actix-web-opentelemetry = { version = "0.15.0", optional = true }
 awc = { version = "3.2.0", optional = true }
 
 # tower and hyper dependencies
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ], optional = true }
 tower = { version = "0.4.13", features = [ "timeout", "util", "limit" ], optional = true }
-tower-http = { version = "0.3.5", features = [ "trace", "map-response-body", "auth" ], optional = true }
+tower-http = { version = "0.4.4", features = [ "trace", "map-response-body", "auth" ], optional = true }
 tokio = { version = "1.32.0", features = ["full"], optional = true }
 http-body = { version = "0.4.5", optional = true }
 futures = { version = "0.3.28", optional = true }
 pin-project = { version = "1.1.3", optional = true }
 # SSL
-rustls = { version = "0.20.9", optional = true, features = [ "dangerous_configuration" ] }
+rustls = { version = "0.21.7", optional = true, features = [ "dangerous_configuration" ] }
 rustls-pemfile = "1.0.3"
 webpki = { version = "0.22.2", optional = true }
-hyper-rustls = { version = "0.23.2", optional = true }
+hyper-rustls = { version = "0.24.1", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 tokio-native-tls = { version = "0.3.1", optional = true }
 # tracing and telemetry
-opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio-current-thread"], optional = true  }
-tracing-opentelemetry = { version = "0.18.0", optional = true }
-opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread"], optional = true }
-opentelemetry-http = { version = "0.7.0", optional = true }
+opentelemetry-jaeger = { version = "0.19.0", features = ["rt-tokio-current-thread"], optional = true  }
+tracing-opentelemetry = { version = "0.21.0", optional = true }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"], optional = true }
+opentelemetry-http = { version = "0.9.0", optional = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.17", optional = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "rpc"
 version = "1.0.0"
-authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
-tonic-build = "0.8.4"
+tonic-build = "0.9.2"
 prost-build = "0.11.9"
 
 [dependencies]
-tonic = "0.8.3"
+tonic = "0.9.2"
 bytes = "1.5.0"
 prost = "0.11.9"
 prost-derive = "0.11.9"
@@ -17,5 +16,5 @@ prost-types = "0.11.9"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_derive = "1.0.188"
 serde_json = "1.0.107"
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.2"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -10,12 +10,12 @@ prost-build = "0.11.9"
 
 [dependencies]
 tonic = "0.8.3"
-bytes = "1.4.0"
+bytes = "1.5.0"
 prost = "0.11.9"
 prost-derive = "0.11.9"
 prost-types = "0.11.9"
-serde = { version = "1.0.183", features = ["derive"] }
-serde_derive = "1.0.183"
-serde_json = "1.0.104"
+serde = { version = "1.0.188", features = ["derive"] }
+serde_derive = "1.0.188"
+serde_json = "1.0.107"
 strum = "0.24.1"
 strum_macros = "0.24.3"

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,7 @@ in
 mkShell {
   name = "control-plane-shell";
   buildInputs = [
+    llvmPackages.bintools
     clang
     commitlint
     cowsay
@@ -50,6 +51,10 @@ mkShell {
     tini
     udev
   ] ++ pkgs.lib.optional (system == "aarch64-darwin") darwin.apple_sdk.frameworks.Security;
+
+  # Use lld linker to work around issue when building all tests where all ram is gobbled up!
+  # This helps reduce memory usage, though not completely.
+  NIX_CFLAGS_LINK = " -fuse-ld=lld";
 
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
   PROTOC = "${protobuf}/bin/protoc";

--- a/tests/io-engine/Cargo.toml
+++ b/tests/io-engine/Cargo.toml
@@ -12,7 +12,7 @@ name = "testlib"
 path = "src/lib.rs"
 
 [dev-dependencies]
-tokio = { version = "1.30.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 openapi = { path = "../../openapi", features = [ "tower-client", "tower-trace" ] }
 deployer-cluster = { path = "../../utils/deployer-cluster" }
 stor-port = { path = "../../control-plane/stor-port" }

--- a/utils/deployer-cluster/Cargo.toml
+++ b/utils/deployer-cluster/Cargo.toml
@@ -8,17 +8,17 @@ description = "Create and Manage local deployer clusters"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.30.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 openapi = { path = "../../openapi", features = [ "tower-client", "tower-trace" ] }
 composer = { path = "../../utils/dependencies/composer", default-features = false }
 deployer = { path = "../../deployer" }
 rpc = { path = "../../rpc" }
 csi-driver = { path = "../../control-plane/csi-driver" }
 utils = { path = "../../utils/utils-lib" }
-anyhow = "1.0.72"
+anyhow = "1.0.75"
 stor-port = { path = "../../control-plane/stor-port" }
-clap = { version = "4.3.21", features = ["derive", "env", "string"] }
-backtrace = "0.3.68"
+clap = { version = "4.4.6", features = ["derive", "env", "string"] }
+backtrace = "0.3.69"
 etcd-client = "0.10.4"
 grpc = { path = "../../control-plane/grpc" }
 tonic = "0.8.3"

--- a/utils/deployer-cluster/Cargo.toml
+++ b/utils/deployer-cluster/Cargo.toml
@@ -19,13 +19,13 @@ anyhow = "1.0.75"
 stor-port = { path = "../../control-plane/stor-port" }
 clap = { version = "4.4.6", features = ["derive", "env", "string"] }
 backtrace = "0.3.69"
-etcd-client = "0.10.4"
+etcd-client = "0.12.1"
 grpc = { path = "../../control-plane/grpc" }
-tonic = "0.8.3"
+tonic = "0.9.2"
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 # Tracing
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
-opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio-current-thread"] }
-tracing-opentelemetry = "0.18.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.19.0", features = ["rt-tokio-current-thread"] }
+tracing-opentelemetry = "0.21.0"
+opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }

--- a/utils/platform/Cargo.toml
+++ b/utils/platform/Cargo.toml
@@ -7,7 +7,7 @@ description = "A library used to identify which platfrom we're running under."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.30.0", features = [ "full" ] }
+tokio = { version = "1.32.0", features = [ "full" ] }
 k8s-openapi = { version = "0.17.0", features = ["v1_20"] }
 kube = { version = "0.78.0", features = ["derive"] }
 tracing = "0.1.37"

--- a/utils/platform/Cargo.toml
+++ b/utils/platform/Cargo.toml
@@ -8,6 +8,7 @@ description = "A library used to identify which platfrom we're running under."
 
 [dependencies]
 tokio = { version = "1.32.0", features = [ "full" ] }
-k8s-openapi = { version = "0.17.0", features = ["v1_20"] }
-kube = { version = "0.78.0", features = ["derive"] }
+# Version 0.20.0 brings support for 1_28 but removes support from 1_20 and 1_21..
+k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
+kube = { version = "0.85.0", features = ["derive"] }
 tracing = "0.1.37"

--- a/utils/pstor-usage/Cargo.toml
+++ b/utils/pstor-usage/Cargo.toml
@@ -16,8 +16,8 @@ anyhow = "1.0.75"
 clap = { version = "4.4.6", features = ["color", "derive", "env", "string"] }
 parse-size = { version = "1.0.0", features = [ "std" ] }
 async-trait = "0.1.73"
-etcd-client = "0.10.4"
+etcd-client = "0.12.1"
 prettytable-rs = "0.10.0"
 serde = "1.0.188"
 serde_yaml = "0.9.25"
-itertools = "0.10.5"
+itertools = "0.11.0"

--- a/utils/pstor-usage/Cargo.toml
+++ b/utils/pstor-usage/Cargo.toml
@@ -8,16 +8,16 @@ authors = ["Tiago Castro <tiago.castro@mayadata.io>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.30.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 openapi = { path = "../../openapi", default-features = false, features = [ "tower-client", "tower-trace" ] }
 deployer-cluster = { path = "../../utils/deployer-cluster" }
 utils = { path = "../utils-lib" }
-anyhow = "1.0.72"
-clap = { version = "4.3.21", features = ["color", "derive", "env", "string"] }
+anyhow = "1.0.75"
+clap = { version = "4.4.6", features = ["color", "derive", "env", "string"] }
 parse-size = { version = "1.0.0", features = [ "std" ] }
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 etcd-client = "0.10.4"
 prettytable-rs = "0.10.0"
-serde = "1.0.183"
+serde = "1.0.188"
 serde_yaml = "0.9.25"
 itertools = "0.10.5"

--- a/utils/pstor-usage/Cargo.toml
+++ b/utils/pstor-usage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pstor-usage"
 description = "Persistent Storage Usage"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Tiago Castro <tiago.castro@mayadata.io>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/utils/pstor/Cargo.toml
+++ b/utils/pstor/Cargo.toml
@@ -8,17 +8,17 @@ edition = "2021"
 [dependencies]
 url = "2.4.1"
 uuid = { version = "1.4.1", features = ["v4"] }
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 serde_json = "1.0.107"
 tokio = { version = "1.32.0", features = [ "full" ] }
 snafu = "0.7.5"
-etcd-client = "0.10.4"
+etcd-client = "0.12.1"
 serde = { version = "1.0.188", features = ["derive"] }
 async-trait = "0.1.73"
 dyn-clonable = "0.9.0"
 rand = "0.8.5"
-tonic = "0.8.3"
+tonic = "0.9.2"
 tracing = "0.1.37"
 parking_lot = "0.12.1"
 

--- a/utils/pstor/Cargo.toml
+++ b/utils/pstor/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-url = "2.4.0"
+url = "2.4.1"
 uuid = { version = "1.4.1", features = ["v4"] }
 strum = "0.24.1"
 strum_macros = "0.24.3"
-serde_json = "1.0.104"
-tokio = { version = "1.30.0", features = [ "full" ] }
+serde_json = "1.0.107"
+tokio = { version = "1.32.0", features = [ "full" ] }
 snafu = "0.7.5"
 etcd-client = "0.10.4"
-serde = { version = "1.0.183", features = ["derive"] }
-async-trait = "0.1.72"
+serde = { version = "1.0.188", features = ["derive"] }
+async-trait = "0.1.73"
 dyn-clonable = "0.9.0"
 rand = "0.8.5"
 tonic = "0.8.3"
@@ -27,4 +27,4 @@ platform = { path = "../platform" }
 
 [dev-dependencies]
 composer = { path = "../dependencies/composer" }
-tokio = { version = "1.30.0", features = [ "full" ] }
+tokio = { version = "1.32.0", features = [ "full" ] }

--- a/utils/shutdown/Cargo.toml
+++ b/utils/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.30.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.37"
 lazy_static = "1.4.0"
-async-trait = "0.1.72"
+async-trait = "0.1.73"

--- a/utils/utils-lib/Cargo.toml
+++ b/utils/utils-lib/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
-tracing-opentelemetry = "0.18.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread"] }
-opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio-current-thread"] }
+tracing-opentelemetry = "0.21.0"
+opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.19.0", features = ["rt-tokio-current-thread"] }
 version-info = { path = "../dependencies/version-info", default-features = false, features = ["git-version-fallback"] }
-git-version-macro = { path = "../dependencies/rust-git-version/git-version-macro" }
+git-version-macro = { path = "../dependencies/git-version-macro" }
 tracing = "0.1.37"
 url = "2.4.1"
 event-publisher = { path = "../dependencies/event-publisher" }

--- a/utils/utils-lib/Cargo.toml
+++ b/utils/utils-lib/Cargo.toml
@@ -11,5 +11,5 @@ opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio-current-threa
 version-info = { path = "../dependencies/version-info", default-features = false, features = ["git-version-fallback"] }
 git-version-macro = { path = "../dependencies/rust-git-version/git-version-macro" }
 tracing = "0.1.37"
-url = "2.4.0"
+url = "2.4.1"
 event-publisher = { path = "../dependencies/event-publisher" }

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -83,7 +83,7 @@ pub const DEFAULT_GRPC_CLIENT_CONCURRENCY: usize = 25;
 
 /// The default quiet filters in addition to `RUST_LOG`.
 pub const RUST_LOG_SILENCE_DEFAULTS: &str =
-    "actix_web=info,actix_server=info,h2=info,hyper=info,tower_buffer=info,tower=info,rustls=info,reqwest=info,tokio_util=info,tokio_tungstenite=info,tungstenite=info,async_io=info,polling=info,tonic=info,want=info,mio=info";
+    "actix_web=info,actix_server=info,async_nats=info,h2=info,hyper=info,tower_buffer=info,tower=info,rustls=info,reqwest=info,tokio_util=info,tokio_tungstenite=info,tungstenite=info,async_io=info,polling=info,tonic=info,want=info,mio=info";
 
 /// The default value to be assigned as cluster agent GRPC server addr if not overridden.
 pub const DEFAULT_CLUSTER_AGENT_SERVER_ADDR: &str = "0.0.0.0:11500";


### PR DESCRIPTION
    chore: use lld in the dev shell
    
    This addresses memory usage issues on CI (though happen locally as well)
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: upgrade rust to 05/10 nightly and 1.72.1 stable
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build(nix): replace deprecated contents with copyToRoot
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    chore: silence async_nats crate debug logs
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: upgrade rust crates
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: update cargo deps
    
    Updates cargo deps from toml file.
    Next set of changes will upgrade versions.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci: disable cargo incremental compilation
    
    There's no benefit to having this on CI and it takes up more space..
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>