### PR TITLE
build: upgrade tonic/prost crate deps

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[env]
+# Use lld linker to work around issue when building all tests where all ram is gobbled up!
+# This helps reduce memory usage, though not completely.
+NIX_CFLAGS_LINK = " -fuse-ld=lld"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,8 +31,8 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "ahash",
- "base64 0.21.2",
- "bitflags 2.4.0",
+ "base64 0.21.4",
+ "bitflags 2.4.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -66,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -254,13 +254,13 @@ dependencies = [
  "humantime",
  "hyper",
  "indexmap 2.0.2",
- "itertools 0.11.0",
+ "itertools",
  "nix",
  "nvmeadm",
  "once_cell",
  "opentelemetry",
  "parking_lot",
- "prost-types 0.11.9",
+ "prost-types",
  "reqwest",
  "rpc",
  "serde",
@@ -271,7 +271,7 @@ dependencies = [
  "stor-port",
  "tokio",
  "tokio-udev",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "tracing",
  "url",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.3"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8f9420f797f2d9e935edf629310eb938a0d839f984e25327f3c7eed22300c"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -397,7 +397,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e45b67ea596bb94741ef15ba1d90b72c92bdc07553d8033734cb620a2b39f1c"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "futures",
  "http",
@@ -444,18 +444,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -476,7 +476,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "cfg-if",
  "cookie",
@@ -582,9 +582,9 @@ checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -598,20 +598,20 @@ version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
- "prettyplease 0.2.12",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.28",
+ "syn 2.0.38",
  "which",
 ]
 
@@ -623,9 +623,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block-buffer"
@@ -642,7 +642,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
  "libc",
@@ -809,7 +809,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -951,10 +951,10 @@ dependencies = [
  "nix",
  "nvmeadm",
  "once_cell",
- "prost 0.11.9",
- "prost-build 0.11.9",
- "prost-derive 0.11.9",
- "prost-types 0.11.9",
+ "prost",
+ "prost-build",
+ "prost-derive",
+ "prost-types",
  "regex",
  "rpc",
  "serde_json",
@@ -966,8 +966,8 @@ dependencies = [
  "sys-mount",
  "sysfs",
  "tokio",
- "tonic 0.9.2",
- "tonic-build 0.9.2",
+ "tonic",
+ "tonic-build",
  "tower",
  "tracing",
  "udev 0.8.0",
@@ -1022,7 +1022,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -1109,7 +1109,7 @@ dependencies = [
  "rpc",
  "stor-port",
  "tokio",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "tracing",
  "tracing-opentelemetry",
@@ -1327,33 +1327,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da96524cc884f6558f1769b6c46686af2fe8e8b4cd253bd5a3cdba8181b8e070"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1363,11 +1343,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d982a3b3088a5f95d19882d298b352a2e0be20703e3080c1e6767731d5dec79"
 dependencies = [
  "http",
- "prost 0.12.1",
+ "prost",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
- "tonic-build 0.10.2",
+ "tonic",
+ "tonic-build",
  "tower",
  "tower-service",
 ]
@@ -1393,23 +1373,23 @@ dependencies = [
  "chrono",
  "futures",
  "once_cell",
- "prost 0.11.9",
- "prost-wkt-types",
+ "prost",
+ "prost-extend",
  "serde",
  "serde_json",
  "snafu",
  "tokio",
- "tonic 0.9.2",
- "tonic-build 0.9.2",
+ "tonic",
+ "tonic-build",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fiat-crypto"
@@ -1530,7 +1510,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1619,7 +1599,7 @@ version = "0.3.5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1638,15 +1618,15 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
- "prost 0.11.9",
- "prost-build 0.11.9",
- "prost-types 0.11.9",
+ "prost",
+ "prost-build",
+ "prost-types",
  "rpc",
  "serde_json",
  "stor-port",
  "tokio",
- "tonic 0.9.2",
- "tonic-build 0.9.2",
+ "tonic",
+ "tonic-build",
  "tower",
  "tracing",
  "tracing-opentelemetry",
@@ -1695,9 +1675,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -1750,9 +1730,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -1939,12 +1919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
-name = "inventory"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53088c87cf71c9d4f3372a2cb9eea1e7b8a0b1bf8b7f7d23fe5b76dbb07e63b"
-
-[[package]]
 name = "io-engine-tests"
 version = "1.0.0"
 dependencies = [
@@ -2002,15 +1976,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -2026,9 +1991,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
@@ -2071,7 +2036,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "pem",
  "ring",
  "serde",
@@ -2085,7 +2050,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95578de7d6eac4fba42114bc751e38c59a739968769df1be56feba6f17fd148e"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "chrono",
  "http",
@@ -2261,9 +2226,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -2302,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "local-channel"
@@ -2336,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "loom"
@@ -2449,7 +2414,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
 ]
@@ -2630,7 +2595,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2851,14 +2816,14 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -2906,22 +2871,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
-dependencies = [
- "proc-macro2",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2940,21 +2895,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -2964,29 +2909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
 dependencies = [
  "bytes",
- "prost-derive 0.12.1",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease 0.1.25",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2997,31 +2920,18 @@ checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.11.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.12",
- "prost 0.12.1",
- "prost-types 0.12.1",
+ "prettyplease",
+ "prost",
+ "prost-types",
  "regex",
- "syn 2.0.28",
+ "syn 2.0.38",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3031,19 +2941,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+name = "prost-extend"
+version = "0.1.0"
 dependencies = [
- "prost 0.11.9",
+ "chrono",
+ "prost",
+ "serde",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -3052,53 +2964,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
 dependencies = [
- "prost 0.12.1",
-]
-
-[[package]]
-name = "prost-wkt"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562788060bcf2bfabe055194bd991ed2442457661744c88e0a0828ff9a08c08b"
-dependencies = [
- "chrono",
- "inventory",
- "prost 0.11.9",
- "serde",
- "serde_derive",
- "serde_json",
- "typetag",
-]
-
-[[package]]
-name = "prost-wkt-build"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4dca8bcead3b728a6a7da017cc95e7f4cb2320ec4f6896bc593a1c4700f7328"
-dependencies = [
- "heck",
- "prost 0.11.9",
- "prost-build 0.11.9",
- "prost-types 0.11.9",
- "quote",
-]
-
-[[package]]
-name = "prost-wkt-types"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2377c5680f2342871823045052e791b4487f7c90aae17e0feaee24cf59578a34"
-dependencies = [
- "chrono",
- "prost 0.11.9",
- "prost-build 0.11.9",
- "prost-types 0.11.9",
- "prost-wkt",
- "prost-wkt-build",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
+ "prost",
 ]
 
 [[package]]
@@ -3118,7 +2984,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic 0.9.2",
+ "tonic",
  "tracing",
  "url",
  "uuid",
@@ -3133,7 +2999,7 @@ dependencies = [
  "clap",
  "deployer-cluster",
  "etcd-client",
- "itertools 0.11.0",
+ "itertools",
  "openapi",
  "parse-size",
  "prettytable-rs",
@@ -3145,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -3213,14 +3079,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.6"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.9",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3234,13 +3100,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.9"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3251,9 +3117,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
@@ -3261,7 +3127,7 @@ version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3373,17 +3239,17 @@ name = "rpc"
 version = "1.0.0"
 dependencies = [
  "bytes",
- "prost 0.11.9",
- "prost-build 0.11.9",
- "prost-derive 0.11.9",
- "prost-types 0.11.9",
+ "prost",
+ "prost-build",
+ "prost-derive",
+ "prost-types",
  "serde",
  "serde_derive",
  "serde_json",
  "strum",
  "strum_macros",
- "tonic 0.9.2",
- "tonic-build 0.9.2",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -3409,11 +3275,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.17"
+version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3450,7 +3316,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -3571,9 +3437,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -3590,13 +3456,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3639,7 +3505,7 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3681,7 +3547,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3801,18 +3667,18 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smart-default"
@@ -3902,7 +3768,7 @@ dependencies = [
  "openapi",
  "percent-encoding",
  "platform",
- "prost-types 0.11.9",
+ "prost-types",
  "pstor",
  "rand",
  "serde",
@@ -3912,7 +3778,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic 0.9.2",
+ "tonic",
  "tracing",
  "url",
  "uuid",
@@ -3940,7 +3806,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3962,9 +3828,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4017,9 +3883,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4056,7 +3922,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4146,9 +4012,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4181,7 +4047,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4278,34 +4144,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.21.2",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
@@ -4313,7 +4151,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "h2",
  "http",
@@ -4322,26 +4160,13 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.1",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
-dependencies = [
- "prettyplease 0.1.25",
- "proc-macro2",
- "prost-build 0.11.9",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4350,11 +4175,11 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
 dependencies = [
- "prettyplease 0.2.12",
+ "prettyplease",
  "proc-macro2",
- "prost-build 0.12.1",
+ "prost-build",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4383,8 +4208,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "base64 0.21.2",
- "bitflags 2.4.0",
+ "base64 0.21.4",
+ "bitflags 2.4.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4412,11 +4237,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -4425,20 +4249,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4530,30 +4354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "typetag"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec6850cc671cd0cfb3ab285465e48a3b927d9de155051c35797446b32f9169f"
-dependencies = [
- "erased-serde",
- "inventory",
- "once_cell",
- "serde",
- "typetag-impl",
-]
-
-[[package]]
-name = "typetag-impl"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c49a6815b4f8379c36f06618bc1b80ca77aaf8a3fd4d8549dca6fdb016000f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "udev"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4593,9 +4393,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -4741,7 +4541,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -4775,7 +4575,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -35,7 +35,7 @@ uuid = { version = "1.4.1", features = ["serde", "v4"] }
 chrono = "0.4.31"
 clap = { version = "4.4.6", features = ["color", "derive", "env", "string"] }
 tokio = { version = "1.32.0", features = ["full"] }
-tonic = "0.9.2"
+tonic = "0.10.2"
 futures = "0.3.28"
 serde_json = "1.0.107"
 async-trait = "0.1.73"
@@ -56,7 +56,7 @@ hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "
 opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
 tracing = "0.1.37"
 nix = { version = "0.27.1", default-features = false }
-prost-types = "0.11.9"
+prost-types = "0.12.1"
 url = "2.4.1"
 
 grpc = { path = "../grpc" }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -144,7 +144,7 @@ impl TryIoEngineToAgent for v0::NexusV2 {
                 kind: ResourceKind::Nexus,
             })?,
             size: self.size,
-            status: ExternalType(v0::NexusState::from_i32(self.state).unwrap_or_default()).into(),
+            status: ExternalType(v0::NexusState::try_from(self.state).unwrap_or_default()).into(),
             children: self.children.iter().map(|c| c.to_agent()).collect(),
             device_uri: self.device_uri.clone(),
             rebuilds: self.rebuilds,
@@ -173,7 +173,7 @@ impl TryIoEngineToAgent for v0::Nexus {
             name: self.uuid.clone(),
             uuid: Default::default(),
             size: self.size,
-            status: ExternalType(v0::NexusState::from_i32(self.state).unwrap_or_default()).into(),
+            status: ExternalType(v0::NexusState::try_from(self.state).unwrap_or_default()).into(),
             children: self.children.iter().map(|c| c.to_agent()).collect(),
             device_uri: self.device_uri.clone(),
             rebuilds: self.rebuilds,
@@ -243,10 +243,10 @@ impl IoEngineToAgent for v0::Child {
         Self::AgentMessage {
             uri: self.uri.clone().into(),
             state: ChildState::from(ExternalType(
-                v0::ChildState::from_i32(self.state).unwrap_or(v0::ChildState::ChildUnknown),
+                v0::ChildState::try_from(self.state).unwrap_or(v0::ChildState::ChildUnknown),
             )),
             rebuild_progress: u8::try_from(self.rebuild_progress).ok(),
-            state_reason: v0::ChildStateReason::from_i32(self.reason)
+            state_reason: v0::ChildStateReason::try_from(self.reason)
                 .map(|f| From::from(ExternalType(f)))
                 .unwrap_or(ChildStateReason::Unknown),
             faulted_at: None,

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -65,18 +65,14 @@ impl IoEngineToAgent for v0::BlockDevice {
             devpath: self.devpath.clone(),
             devlinks: self.devlinks.clone(),
             size: self.size,
-            partition: match &self.partition {
-                Some(partition) => partition.to_agent(),
-                None => transport::Partition {
-                    ..Default::default()
-                },
-            },
-            filesystem: match &self.filesystem {
-                Some(filesystem) => filesystem.to_agent(),
-                None => transport::Filesystem {
-                    ..Default::default()
-                },
-            },
+            partition: self
+                .partition
+                .as_ref()
+                .map(|partition| partition.to_agent()),
+            filesystem: self
+                .filesystem
+                .as_ref()
+                .map(|filesystem| filesystem.to_agent()),
             available: self.available,
         }
     }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/host.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/host.rs
@@ -57,7 +57,7 @@ impl crate::controller::io_engine::HostApi for super::RpcClient {
                     .map(|v| {
                         // Get the list of supported api versions from dataplane
                         registration::traits::ApiVersion(
-                            rpc::v1::registration::ApiVersion::from_i32(v).unwrap_or_default(),
+                            rpc::v1::registration::ApiVersion::try_from(v).unwrap_or_default(),
                         )
                         .into()
                     })

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -67,18 +67,14 @@ impl IoEngineToAgent for v1::host::BlockDevice {
             devpath: self.devpath.clone(),
             devlinks: self.devlinks.clone(),
             size: self.size,
-            partition: match &self.partition {
-                Some(partition) => partition.to_agent(),
-                None => transport::Partition {
-                    ..Default::default()
-                },
-            },
-            filesystem: match &self.filesystem {
-                Some(filesystem) => filesystem.to_agent(),
-                None => transport::Filesystem {
-                    ..Default::default()
-                },
-            },
+            partition: self
+                .partition
+                .as_ref()
+                .map(|partition| partition.to_agent()),
+            filesystem: self
+                .filesystem
+                .as_ref()
+                .map(|filesystem| filesystem.to_agent()),
             available: self.available,
         }
     }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -333,7 +333,7 @@ impl TryIoEngineToAgent for v1::nexus::Nexus {
                 kind: ResourceKind::Nexus,
             })?,
             size: self.size,
-            status: ExternalType(v1::nexus::NexusState::from_i32(self.state).unwrap_or_default())
+            status: ExternalType(v1::nexus::NexusState::try_from(self.state).unwrap_or_default())
                 .into(),
             children: self.children.iter().map(|c| c.to_agent()).collect(),
             device_uri: self.device_uri.clone(),
@@ -404,11 +404,11 @@ impl IoEngineToAgent for v1::nexus::Child {
         Self::AgentMessage {
             uri: self.uri.clone().into(),
             state: ChildState::from(ExternalType(
-                v1::nexus::ChildState::from_i32(self.state)
+                v1::nexus::ChildState::try_from(self.state)
                     .unwrap_or(v1::nexus::ChildState::Unknown),
             )),
             rebuild_progress: u8::try_from(self.rebuild_progress).ok(),
-            state_reason: v1::nexus::ChildStateReason::from_i32(self.state_reason)
+            state_reason: v1::nexus::ChildStateReason::try_from(self.state_reason)
                 .map(|f| From::from(ExternalType(f)))
                 .unwrap_or(ChildStateReason::Unknown),
             faulted_at: self
@@ -710,7 +710,7 @@ impl TryFrom<ExternalType<v1::nexus::RebuildHistoryRecord>> for transport::Rebui
                 .map_err(|_| SvcError::InvalidArguments {})?,
             src_uri: transport::ChildUri::try_from(value.0.src_uri)
                 .map_err(|_| SvcError::InvalidArguments {})?,
-            state: v1::nexus::RebuildJobState::from_i32(value.0.state)
+            state: v1::nexus::RebuildJobState::try_from(value.0.state)
                 .map(|f| From::from(ExternalType(f)))
                 .unwrap_or_default(),
             blocks_total: value.0.blocks_total,

--- a/control-plane/agents/src/bin/core/tests/event/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/event/mod.rs
@@ -20,7 +20,7 @@ use tokio::time::timeout;
 const CHILD_WAIT: Duration = Duration::from_millis(1);
 
 async fn build_cluster(num_ioe: u32, pool_size: u64) -> Cluster {
-    let reconcile_period = Duration::from_millis(300);
+    let reconcile_period = Duration::from_millis(100);
     ClusterBuilder::builder()
         .with_rest(true)
         .with_io_engines(num_ioe)
@@ -154,6 +154,18 @@ async fn pool_deletion_event_test(sub: &mut BusSubscription<EventMessage>) {
 }
 
 async fn volume_creation_event_test(sub: &mut BusSubscription<EventMessage>) {
+    let replica_creation_message = timeout(Duration::from_millis(10), sub.next())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(replica_creation_message.category(), EventCategory::Replica);
+    assert_eq!(replica_creation_message.action(), EventAction::Create);
+    let replica_creation_message = timeout(Duration::from_millis(10), sub.next())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(replica_creation_message.category(), EventCategory::Replica);
+    assert_eq!(replica_creation_message.action(), EventAction::Create);
     let vol_creation_message = timeout(Duration::from_millis(10), sub.next())
         .await
         .unwrap()
@@ -163,6 +175,18 @@ async fn volume_creation_event_test(sub: &mut BusSubscription<EventMessage>) {
 }
 
 async fn volume_deletion_event_test(sub: &mut BusSubscription<EventMessage>) {
+    let replica_deletion_message = timeout(Duration::from_millis(10), sub.next())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(replica_deletion_message.category(), EventCategory::Replica);
+    assert_eq!(replica_deletion_message.action(), EventAction::Delete);
+    let replica_deletion_message = timeout(Duration::from_millis(10), sub.next())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(replica_deletion_message.category(), EventCategory::Replica);
+    assert_eq!(replica_deletion_message.action(), EventAction::Delete);
     let vol_deletion_message = timeout(Duration::from_millis(10), sub.next())
         .await
         .unwrap()
@@ -190,6 +214,12 @@ async fn nexus_deletion_event_test(sub: &mut BusSubscription<EventMessage>) {
 }
 
 async fn rebuild_begin_event_test(sub: &mut BusSubscription<EventMessage>) {
+    let replica_creation_message = timeout(Duration::from_millis(300), sub.next())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(replica_creation_message.category(), EventCategory::Replica);
+    assert_eq!(replica_creation_message.action(), EventAction::Create);
     let rebuid_start_event_message = timeout(Duration::from_millis(300), sub.next())
         .await
         .unwrap()

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -15,14 +15,14 @@ name = "csi-node"
 path = "src/bin/node/main.rs"
 
 [build-dependencies]
-tonic-build = "0.9.2"
-prost-build = "0.11.9"
+tonic-build = "0.10.2"
+prost-build = "0.12.1"
 
 [dependencies]
-prost = "0.11.9"
-prost-derive = "0.11.9"
-prost-types = "0.11.9"
-tonic = "0.9.2"
+prost = "0.12.1"
+prost-derive = "0.12.1"
+prost-types = "0.12.1"
+tonic = "0.10.2"
 
 anyhow = "1.0.75"
 async-stream = "0.3.5"

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -94,8 +94,8 @@ fn check_access_mode(
 ) -> Result<(), String> {
     match volume_capability {
         Some(capability) => match &capability.access_mode {
-            Some(access) => match Mode::from_i32(access.mode) {
-                Some(mode) => match mode {
+            Some(access) => match Mode::try_from(access.mode) {
+                Ok(mode) => match mode {
                     Mode::SingleNodeWriter | Mode::MultiNodeSingleWriter => Ok(()),
                     Mode::SingleNodeReaderOnly | Mode::MultiNodeReaderOnly => {
                         if readonly {
@@ -108,7 +108,7 @@ fn check_access_mode(
                         "volume capability: unsupported access mode: {mode:?}"
                     )),
                 },
-                None => Err(format!(
+                Err(_) => Err(format!(
                     "volume capability: invalid access mode: {}",
                     access.mode
                 )),

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -11,13 +11,13 @@ name = "grpc"
 path = "src/lib.rs"
 
 [build-dependencies]
-tonic-build = "0.9.2"
-prost-build = "0.11.9"
+tonic-build = "0.10.2"
+prost-build = "0.12.1"
 
 [dependencies]
-tonic = "0.9.2"
-prost = "0.11.9"
-prost-types = "0.11.9"
+tonic = "0.10.2"
+prost = "0.12.1"
+prost-types = "0.12.1"
 
 tokio = { version = "1.32.0", features = ["full"] }
 stor-port = { path = "../stor-port" }

--- a/control-plane/grpc/src/misc/traits.rs
+++ b/control-plane/grpc/src/misc/traits.rs
@@ -155,10 +155,10 @@ impl From<ReplyError> for crate::common::ReplyError {
 impl From<crate::common::ReplyError> for ReplyError {
     fn from(err: crate::common::ReplyError) -> Self {
         ReplyError {
-            kind: common::ReplyErrorKind::from_i32(err.clone().kind)
+            kind: common::ReplyErrorKind::try_from(err.clone().kind)
                 .unwrap_or(common::ReplyErrorKind::Aborted)
                 .into(),
-            resource: common::ResourceKind::from_i32(err.clone().resource)
+            resource: common::ResourceKind::try_from(err.clone().resource)
                 .unwrap_or(common::ResourceKind::Unknown)
                 .into(),
             source: err.clone().source,

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -334,19 +334,19 @@ impl From<BlockDevice> for blockdevice::BlockDevice {
             devpath: bd.devpath,
             devlinks: bd.devlinks,
             size: bd.size,
-            partition: Some(blockdevice::Partition {
-                parent: bd.partition.parent,
-                number: bd.partition.number,
-                name: bd.partition.name,
-                scheme: bd.partition.scheme,
-                typeid: bd.partition.typeid,
-                uuid: bd.partition.uuid,
+            partition: bd.partition.map(|bd| blockdevice::Partition {
+                parent: bd.parent,
+                number: bd.number,
+                name: bd.name,
+                scheme: bd.scheme,
+                typeid: bd.typeid,
+                uuid: bd.uuid,
             }),
-            filesystem: Some(blockdevice::Filesystem {
-                fstype: bd.filesystem.fstype,
-                label: bd.filesystem.label,
-                uuid: bd.filesystem.uuid,
-                mountpoint: bd.filesystem.mountpoint,
+            filesystem: bd.filesystem.map(|bd| blockdevice::Filesystem {
+                fstype: bd.fstype,
+                label: bd.label,
+                uuid: bd.uuid,
+                mountpoint: bd.mountpoint,
             }),
             available: bd.available,
         }
@@ -365,38 +365,20 @@ impl TryFrom<blockdevice::BlockDevice> for BlockDevice {
             devpath: bd.devpath,
             devlinks: bd.devlinks,
             size: bd.size,
-            partition: match bd.partition {
-                Some(partition) => Partition {
-                    parent: partition.parent,
-                    number: partition.number,
-                    name: partition.name,
-                    scheme: partition.scheme,
-                    typeid: partition.typeid,
-                    uuid: partition.uuid,
-                },
-                None => {
-                    return Err(ReplyError::invalid_argument(
-                        ResourceKind::Block,
-                        "bd.partition",
-                        "".to_string(),
-                    ))
-                }
-            },
-            filesystem: match bd.filesystem {
-                Some(filesystem) => Filesystem {
-                    fstype: filesystem.fstype,
-                    label: filesystem.label,
-                    uuid: filesystem.uuid,
-                    mountpoint: filesystem.mountpoint,
-                },
-                None => {
-                    return Err(ReplyError::invalid_argument(
-                        ResourceKind::Block,
-                        "bd.partition",
-                        "".to_string(),
-                    ))
-                }
-            },
+            partition: bd.partition.map(|partition| Partition {
+                parent: partition.parent,
+                number: partition.number,
+                name: partition.name,
+                scheme: partition.scheme,
+                typeid: partition.typeid,
+                uuid: partition.uuid,
+            }),
+            filesystem: bd.filesystem.map(|filesystem| Filesystem {
+                fstype: filesystem.fstype,
+                label: filesystem.label,
+                uuid: filesystem.uuid,
+                mountpoint: filesystem.mountpoint,
+            }),
             available: bd.available,
         })
     }

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -90,12 +90,12 @@ impl TryFrom<node::Node> for Node {
         };
         let node_state = match node_grpc_type.state {
             Some(state) => {
-                let status: NodeStatus = match node::NodeStatus::from_i32(state.status) {
-                    Some(status) => Ok(status.into()),
-                    None => Err(Self::Error::invalid_argument(
+                let status: NodeStatus = match node::NodeStatus::try_from(state.status) {
+                    Ok(status) => Ok(status.into()),
+                    Err(error) => Err(Self::Error::invalid_argument(
                         ResourceKind::Node,
                         "node.state.status",
-                        "".to_string(),
+                        error,
                     )),
                 }?;
                 // todo: pass proper apiversion on the upper layer once openapi has the changes

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -59,7 +59,7 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
                 ))
             }
         };
-        let pool_spec_status = match common::SpecStatus::from_i32(pool_meta.spec_status) {
+        let pool_spec_status = match common::SpecStatus::try_from(pool_meta.spec_status).ok() {
             Some(status) => status.into(),
             None => {
                 return Err(ReplyError::invalid_argument(
@@ -92,13 +92,13 @@ impl TryFrom<pool::PoolState> for PoolState {
             node: pool_state.node_id.into(),
             id: pool_state.pool_id.into(),
             disks: pool_state.disks_uri.iter().map(|i| i.into()).collect(),
-            status: match pool::PoolStatus::from_i32(pool_state.status) {
-                Some(status) => status.into(),
-                None => {
+            status: match pool::PoolStatus::try_from(pool_state.status) {
+                Ok(status) => status.into(),
+                Err(error) => {
                     return Err(ReplyError::invalid_argument(
                         ResourceKind::Pool,
                         "pool.state.status",
-                        "".to_string(),
+                        error,
                     ))
                 }
             },

--- a/control-plane/grpc/src/operations/registration/traits.rs
+++ b/control-plane/grpc/src/operations/registration/traits.rs
@@ -79,7 +79,7 @@ impl RegisterInfo for RegisterRequest {
                 .clone()
                 .into_iter()
                 .map(|v| {
-                    ApiVersion(rpc::v1::registration::ApiVersion::from_i32(v).unwrap_or_default())
+                    ApiVersion(rpc::v1::registration::ApiVersion::try_from(v).unwrap_or_default())
                         .into()
                 })
                 .collect(),

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -252,13 +252,13 @@ impl TryFrom<volume::VolumeDefinition> for VolumeSpec {
             }
         };
 
-        let volume_spec_status = match common::SpecStatus::from_i32(volume_meta.spec_status) {
-            Some(status) => status.into(),
-            None => {
+        let volume_spec_status = match common::SpecStatus::try_from(volume_meta.spec_status) {
+            Ok(status) => status.into(),
+            Err(error) => {
                 return Err(ReplyError::invalid_argument(
                     ResourceKind::Volume,
                     "volume.metadata.spec_status",
-                    "".to_string(),
+                    error.to_string(),
                 ))
             }
         };
@@ -368,13 +368,13 @@ impl TryFrom<volume::Volume> for Volume {
         let volume_state = VolumeState {
             uuid: VolumeId::try_from(StringValue(grpc_state.uuid))?,
             size: grpc_state.size,
-            status: match nexus::NexusStatus::from_i32(grpc_state.status) {
-                Some(status) => status.into(),
-                None => {
+            status: match nexus::NexusStatus::try_from(grpc_state.status) {
+                Ok(status) => status.into(),
+                Err(error) => {
                     return Err(ReplyError::invalid_argument(
                         ResourceKind::Volume,
                         "volume.state.status",
-                        "".to_string(),
+                        error,
                     ))
                 }
             },
@@ -456,10 +456,10 @@ impl TryFrom<volume::ReplicaTopology> for ReplicaTopology {
             topology.usage.into_opt(),
             topology
                 .child_status
-                .and_then(|s| nexus::ChildState::from_i32(s).into_opt()),
+                .and_then(|s| nexus::ChildState::try_from(s).ok().into_opt()),
             topology
                 .child_status_reason
-                .and_then(|s| nexus::ChildStateReason::from_i32(s).into_opt()),
+                .and_then(|s| nexus::ChildStateReason::try_from(s).ok().into_opt()),
             topology.rebuild_progress.and_then(|r| u8::try_from(r).ok()),
         ))
     }
@@ -702,13 +702,13 @@ impl TryFrom<volume::VolumeTarget> for VolumeTarget {
             target.node_id.into(),
             NexusId::try_from(StringValue(target.nexus_id))?,
             match target.protocol {
-                Some(i) => match volume::VolumeShareProtocol::from_i32(i) {
-                    Some(protocol) => Some(protocol.into()),
-                    None => {
+                Some(i) => match volume::VolumeShareProtocol::try_from(i) {
+                    Ok(protocol) => Some(protocol.into()),
+                    Err(error) => {
                         return Err(ReplyError::invalid_argument(
                             ResourceKind::Volume,
                             "target.protocol",
-                            "is empty".to_string(),
+                            error,
                         ))
                     }
                 },
@@ -1140,13 +1140,13 @@ impl ValidateRequestTypes for ShareVolumeRequest {
     fn validated(self) -> Result<Self::Validated, ReplyError> {
         Ok(ValidatedShareVolumeRequest {
             uuid: VolumeId::try_from(StringValue(self.uuid))?,
-            share: match volume::VolumeShareProtocol::from_i32(self.share) {
-                Some(share) => share.into(),
-                None => {
+            share: match volume::VolumeShareProtocol::try_from(self.share) {
+                Ok(share) => share.into(),
+                Err(error) => {
                     return Err(ReplyError::invalid_argument(
                         ResourceKind::Volume,
                         "share_volume_request.share",
-                        "".to_string(),
+                        error,
                     ))
                 }
             },
@@ -1321,13 +1321,13 @@ impl ValidateRequestTypes for PublishVolumeRequest {
         Ok(ValidatedPublishVolumeRequest {
             uuid: VolumeId::try_from(StringValue(self.uuid.clone()))?,
             share: match self.share {
-                Some(share) => match volume::VolumeShareProtocol::from_i32(share) {
-                    Some(share) => Some(share.into()),
-                    None => {
+                Some(share) => match volume::VolumeShareProtocol::try_from(share) {
+                    Ok(share) => Some(share.into()),
+                    Err(error) => {
                         return Err(ReplyError::invalid_argument(
                             ResourceKind::Volume,
                             "publish_volume_request.share",
-                            "".to_string(),
+                            error,
                         ))
                     }
                 },
@@ -1481,13 +1481,13 @@ impl ValidateRequestTypes for RepublishVolumeRequest {
     fn validated(self) -> Result<Self::Validated, ReplyError> {
         Ok(ValidatedRepublishVolumeRequest {
             uuid: VolumeId::try_from(StringValue(self.uuid.clone()))?,
-            share: match volume::VolumeShareProtocol::from_i32(self.share) {
-                Some(share) => share.into(),
-                None => {
+            share: match volume::VolumeShareProtocol::try_from(self.share) {
+                Ok(share) => share.into(),
+                Err(error) => {
                     return Err(ReplyError::invalid_argument(
                         ResourceKind::Volume,
                         "republish_volume_request.share",
-                        "".to_string(),
+                        error,
                     ))
                 }
             },

--- a/control-plane/grpc/src/operations/volume/traits_snapshots.rs
+++ b/control-plane/grpc/src/operations/volume/traits_snapshots.rs
@@ -456,7 +456,7 @@ impl TryFrom<volume::VolumeSnapshot> for VolumeSnapshot {
         Ok(Self {
             spec: info.clone(),
             meta: VolumeSnapshotMeta {
-                status: common::SpecStatus::from_i32(meta.spec_status)
+                status: common::SpecStatus::try_from(meta.spec_status)
                     .unwrap_or_default()
                     .into(),
                 timestamp: meta.timestamp,
@@ -507,7 +507,7 @@ impl TryFrom<volume::VolumeSnapshot> for VolumeSnapshot {
                                 );
                                 let spec = ReplicaSnapshotSpec::new(&source, snapshot_id);
                                 let status =
-                                    crate::snapshot::SnapshotStatus::from_i32(state.status)
+                                    crate::snapshot::SnapshotStatus::try_from(state.status)
                                         .unwrap_or_default();
                                 Ok(match status {
                                     crate::snapshot::SnapshotStatus::Unknown => {
@@ -583,7 +583,7 @@ impl TryFrom<volume::ReplicaSnapshot> for ReplicaSnapshot {
     type Error = ReplyError;
     fn try_from(value: volume::ReplicaSnapshot) -> Result<Self, Self::Error> {
         Ok(ReplicaSnapshot {
-            status: common::SpecStatus::from_i32(value.spec_status)
+            status: common::SpecStatus::try_from(value.spec_status)
                 .unwrap_or_default()
                 .into(),
             uuid: value

--- a/control-plane/grpc/src/operations/watch/traits.rs
+++ b/control-plane/grpc/src/operations/watch/traits.rs
@@ -200,9 +200,13 @@ impl TryFrom<watch::Watch> for Watch {
                     ))
                 }
             },
-            watch_type: watch::WatchType::from_i32(value.watch_type)
-                .ok_or_else(|| {
-                    ReplyError::invalid_argument(ResourceKind::Watch, "watch_type", "".to_string())
+            watch_type: watch::WatchType::try_from(value.watch_type)
+                .map_err(|error| {
+                    ReplyError::invalid_argument(
+                        ResourceKind::Watch,
+                        "watch_type",
+                        error.to_string(),
+                    )
                 })?
                 .into(),
         })
@@ -306,13 +310,13 @@ impl ValidateRequestTypes for watch::Watch {
                     ))
                 }
             })?,
-            watch_type: match watch::WatchType::from_i32(self.watch_type) {
-                Some(watch_type) => watch_type.into(),
-                None => {
+            watch_type: match watch::WatchType::try_from(self.watch_type) {
+                Ok(watch_type) => watch_type.into(),
+                Err(error) => {
                     return Err(ReplyError::invalid_argument(
                         ResourceKind::Watch,
                         "watch_type",
-                        "".to_string(),
+                        error,
                     ))
                 }
             },

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1953,29 +1953,6 @@ components:
       type: string
       format: uuid
     BlockDevice:
-      example:
-        available: false
-        devlinks:
-          - ''
-        devmajor: 0
-        devminor: 0
-        devname: ''
-        devpath: ''
-        devtype: ''
-        filesystem:
-          fstype: ''
-          label: ''
-          mountpoint: ''
-          uuid: ''
-        model: ''
-        partition:
-          name: ''
-          number: 0
-          parent: ''
-          scheme: ''
-          typeid: ''
-          uuid: ''
-        size: 0
       description: Block device information
       type: object
       properties:
@@ -2036,13 +2013,6 @@ components:
           description: device model - useful for identifying devices
           type: string
         partition:
-          example:
-            name: ''
-            number: 0
-            parent: ''
-            scheme: ''
-            typeid: ''
-            uuid: ''
           description: partition information in case where device represents a partition
           type: object
           properties:
@@ -2085,9 +2055,7 @@ components:
         - devname
         - devpath
         - devtype
-        - filesystem
         - model
-        - partition
         - size
     ChildState:
       example: Online

--- a/control-plane/stor-port/Cargo.toml
+++ b/control-plane/stor-port/Cargo.toml
@@ -20,10 +20,10 @@ serde_tuple = "0.5.0"
 async-trait = "0.1.73"
 dyn-clonable = "0.9.0"
 rand = "0.8.5"
-tonic = "0.9.2"
+tonic = "0.10.2"
 chrono = { version = "0.4.31", features = ["serde"] }
 tracing = "0.1.37"
-prost-types = "0.11.9"
+prost-types = "0.12.1"
 
 openapi = { path = "../../openapi", features = [ "actix-server", "tower-client", "tower-trace" ] }
 platform = { path = "../../utils/platform" }

--- a/control-plane/stor-port/src/types/v0/transport/blockdevice.rs
+++ b/control-plane/stor-port/src/types/v0/transport/blockdevice.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::IntoOption;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -71,9 +72,9 @@ pub struct BlockDevice {
     /// size of device in (512 byte) blocks
     pub size: u64,
     /// partition information in case where device represents a partition
-    pub partition: Partition,
+    pub partition: Option<Partition>,
     /// filesystem information in case where a filesystem is present
-    pub filesystem: Filesystem,
+    pub filesystem: Option<Filesystem>,
     /// identifies if device is available for use (ie. is not "currently" in
     /// use)
     pub available: bool,
@@ -81,7 +82,7 @@ pub struct BlockDevice {
 
 impl From<BlockDevice> for models::BlockDevice {
     fn from(src: BlockDevice) -> Self {
-        models::BlockDevice::new(
+        models::BlockDevice::new_all(
             src.available,
             src.devlinks,
             src.devmajor as i32,
@@ -89,9 +90,9 @@ impl From<BlockDevice> for models::BlockDevice {
             src.devname,
             src.devpath,
             src.devtype,
-            src.filesystem,
+            src.filesystem.into_opt(),
             src.model,
-            src.partition,
+            src.partition.into_opt(),
             src.size,
         )
     }

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -23,7 +23,7 @@ utils = { path = "../utils/utils-lib" }
 grpc = { path = "../control-plane/grpc" }
 clap = { version = "4.4.6", features = ["color", "derive", "env", "string"] }
 tokio = { version = "1.32.0", features = ["full"] }
-tonic = "0.9.2"
+tonic = "0.10.2"
 async-trait = "0.1.73"
 strum = "0.25.0"
 strum_macros = "0.25.2"

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -12,7 +12,7 @@
 , gitVersions
 , openapi-generator
 , which
-, udev
+, systemdMinimal
 , utillinux
   # with allInOne set to true all components are built as part of the same "cargo build" derivation
   # this allows for a quicker build of all components but slower single components
@@ -56,6 +56,7 @@ let
   src_list = [
     "Cargo.lock"
     "Cargo.toml"
+    ".cargo"
     "common"
     "control-plane"
     "deployer"
@@ -77,8 +78,8 @@ let
     GIT_VERSION = "${gitVersions.tag_or_long}";
 
     inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE;
-    nativeBuildInputs = [ clang pkg-config openapi-generator which git ];
-    buildInputs = [ llvmPackages.libclang protobuf openssl udev utillinux ];
+    nativeBuildInputs = [ clang pkg-config openapi-generator which git llvmPackages.bintools ];
+    buildInputs = [ llvmPackages.libclang protobuf openssl.dev systemdMinimal.dev utillinux.dev ];
     doCheck = false;
   };
   release_build = { "release" = true; "debug" = false; };

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -4,15 +4,15 @@ version = "1.0.0"
 edition = "2021"
 
 [build-dependencies]
-tonic-build = "0.9.2"
-prost-build = "0.11.9"
+tonic-build = "0.10.2"
+prost-build = "0.12.1"
 
 [dependencies]
-tonic = "0.9.2"
+tonic = "0.10.2"
 bytes = "1.5.0"
-prost = "0.11.9"
-prost-derive = "0.11.9"
-prost-types = "0.11.9"
+prost = "0.12.1"
+prost-derive = "0.12.1"
+prost-types = "0.12.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_derive = "1.0.188"
 serde_json = "1.0.107"

--- a/shell.nix
+++ b/shell.nix
@@ -52,10 +52,6 @@ mkShell {
     udev
   ] ++ pkgs.lib.optional (system == "aarch64-darwin") darwin.apple_sdk.frameworks.Security;
 
-  # Use lld linker to work around issue when building all tests where all ram is gobbled up!
-  # This helps reduce memory usage, though not completely.
-  NIX_CFLAGS_LINK = " -fuse-ld=lld";
-
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";

--- a/utils/deployer-cluster/Cargo.toml
+++ b/utils/deployer-cluster/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4.4.6", features = ["derive", "env", "string"] }
 backtrace = "0.3.69"
 etcd-client = "0.12.1"
 grpc = { path = "../../control-plane/grpc" }
-tonic = "0.9.2"
+tonic = "0.10.2"
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 # Tracing
 tracing = "0.1.37"

--- a/utils/pstor/Cargo.toml
+++ b/utils/pstor/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 async-trait = "0.1.73"
 dyn-clonable = "0.9.0"
 rand = "0.8.5"
-tonic = "0.9.2"
+tonic = "0.10.2"
 tracing = "0.1.37"
 parking_lot = "0.12.1"
 


### PR DESCRIPTION
    build: use lld linker globally
    
    Previously it was only set for the nix shell, let's set this for images too by
    using the cargo config build settings.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(rest/openapi): block-device filesystem and partition are optional
    
    For some reason the openapi was marking them as required...
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: upgrade tonic/prost crate deps
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
