### PR TITLE
chore(deps): update k8s-openapi lib version to v1_25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ __pycache__
 /terraform/cluster/current_user.txt
 /rust-toolchain.toml
 /.rust-toolchain
-/rpc/mayastor-api
+/rpc/api
 /local-fio-0-verify.state

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -47,7 +47,7 @@ tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 url = "2.4.1"
 uuid = { version = "1.4.1", features = ["v4"] }
 which = "4.4.2"
-k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 kube = { version = "0.85.0", features = ["runtime", "derive"] }
 nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
 sysfs = { path = "../../utils/dependencies/sysfs" }

--- a/k8s/forward/Cargo.toml
+++ b/k8s/forward/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 kube = { version = "0.85.0", features = [ "ws" ] }
-k8s-openapi = { version = "0.19.0", default-features = false, features = ["v1_20"] }
+k8s-openapi = { version = "0.19.0", default-features = false, features = ["v1_25"] }
 tokio = { version = "1.32.0", features = [ "full" ] }
 tokio-stream = { version = "0.1.14", features = ["net"] }
 futures = "0.3.28"

--- a/k8s/operators/Cargo.toml
+++ b/k8s/operators/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = "1.0.75"
 chrono = "0.4.31"
 clap =  { version = "4.4.6", features = ["color", "env", "string"] }
 futures = "0.3.28"
-k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 kube = { version = "0.85.0", features = ["derive", "runtime"] }
 schemars = "0.8.15"
 serde = "1.0.188"

--- a/utils/platform/Cargo.toml
+++ b/utils/platform/Cargo.toml
@@ -9,6 +9,6 @@ description = "A library used to identify which platfrom we're running under."
 [dependencies]
 tokio = { version = "1.32.0", features = [ "full" ] }
 # Version 0.20.0 brings support for 1_28 but removes support from 1_20 and 1_21..
-k8s-openapi = { version = "0.19.0", features = ["v1_20"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 kube = { version = "0.85.0", features = ["derive"] }
 tracing = "0.1.37"


### PR DESCRIPTION
Updates the kubernetes openapi libraries to those compatible with kubernetes v1.25