### PR TITLE
feat(topology): add topology in dsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "prost-types",
  "regex",
  "rpc",
+ "serde",
  "serde_json",
  "shutdown",
  "snafu",

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
@@ -52,6 +52,8 @@ impl PoolBaseFilters {
     }
     /// Should only attempt to use pools having specific creation label if topology has it.
     pub(crate) fn topology(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        tracing::info!("Aashvi in topology  {:?}", request.topology.clone());
+        tracing::info!("Aashvi in item  {:?}", item);
         let volume_pool_topology_labels: HashMap<String, String>;
         match request.topology.clone() {
             None => return true,
@@ -70,6 +72,7 @@ impl PoolBaseFilters {
                 },
             },
         };
+        tracing::info!("volume_pool_topology_labels Alpha {:?}", volume_pool_topology_labels);
         // We will reach this part of code only if the volume has pool topology labels.
         match request.registry().specs().pool(&item.pool.id) {
             Ok(spec) => match spec.labels {
@@ -77,6 +80,8 @@ impl PoolBaseFilters {
                 Some(label) => volume_pool_topology_labels
                     .iter()
                     .all(|(vol_key, vol_val)| {
+                        tracing::info!("Durga mata  Alpha {:?}", vol_key);
+                        tracing::info!("Durga mata  Alpha {:?}", vol_val);
                         // See `InclusiveLabel` doc comment.
                         // todo: add exclusion
                         label

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -490,7 +490,7 @@ impl OperationGuardArc<VolumeSpec> {
     ) -> Result<Vec<ReplicaId>, SvcError> {
         let mut created_replicas = Vec::with_capacity(count);
         let mut candidate_error = None;
-
+        tracing::info!(" Inside create_volume_replicas");
         for iter in 0 .. count {
             let candidates = match volume_replica_candidates(registry, self.as_ref()).await {
                 Ok(candidates) => candidates,

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -54,6 +54,7 @@ sysfs = { path = "../../utils/dependencies/sysfs" }
 stor-port = { path = "../stor-port" }
 utils = { path = "../../utils/utils-lib" }
 shutdown = { path = "../../utils/shutdown" }
+serde = { version = "1.0.188", features = ["derive"] }
 
 [target.'cfg(target_os="linux")'.dependencies]
 udev = "0.8.0"

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -262,7 +262,17 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
         let mut inclusive_label_topology: HashMap<String, String> = HashMap::new();
 
+        tracing::info!("Aashivi  one {:#?}", context);
+
         inclusive_label_topology.insert(String::from(CREATED_BY_KEY), String::from(DSP_OPERATOR));
+
+        if let Some(pool_topology_inclusion) = context.publish_params().pool_topology_inclusion() {
+            for (key, value) in pool_topology_inclusion.iter() {
+                println!("{} {}", key, value);
+                inclusive_label_topology.insert(key.to_string(), value.to_string());
+             }
+        }
+        tracing::info!("inclusive_label_topology one two three {:#?}", inclusive_label_topology);
 
         let parsed_vol_uuid = Uuid::parse_str(&volume_uuid).map_err(|_e| {
             Status::invalid_argument(format!("Malformed volume UUID: {volume_uuid}"))

--- a/k8s/operators/src/pool/diskpool/v1beta1.rs
+++ b/k8s/operators/src/pool/diskpool/v1beta1.rs
@@ -2,6 +2,7 @@ use kube::CustomResource;
 use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(
     CustomResource, Serialize, Deserialize, Default, Debug, Eq, PartialEq, Clone, JsonSchema,
@@ -31,12 +32,26 @@ pub struct DiskPoolSpec {
     node: String,
     /// The disk device the pool is located on
     disks: Vec<String>,
+    /// The topology for data placement.
+    topology: Option<Topology>,
+}
+
+/// Placement pool topology used by volume operations.
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
+pub struct Topology {
+    /// Label for topology
+    #[serde(default)]
+    pub labelled: HashMap<String, String>,
 }
 
 impl DiskPoolSpec {
     /// Create a new DiskPoolSpec from the node and the disks.
-    pub fn new(node: String, disks: Vec<String>) -> Self {
-        Self { node, disks }
+    pub fn new(node: String, disks: Vec<String>, topology: Option<Topology>) -> Self {
+        Self {
+            node,
+            disks,
+            topology,
+        }
     }
     /// The node the pool is placed on.
     pub fn node(&self) -> String {


### PR DESCRIPTION
Run command 
```
cat <<EOF | kubectl create -f -
apiVersion: "openebs.io/v1beta1"
kind: DiskPool
metadata:
  name: pool-1
  namespace: mayastor
spec:
  node: node-0-128039
  disks: ["/dev/sdb"]
  topology:
    labelled:
        type: hot
EOF
```

The DSP object looks like 
```
root@ashish-dev:~/code/rust/mayastor-extensions(develop)$ k get dsp pool-ashish -oyaml
apiVersion: openebs.io/v1beta1
kind: DiskPool
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openebs.io/v1beta1","kind":"DiskPool","metadata":{"annotations":{},"name":"pool-ashish","namespace":"mayastor"},"spec":{"disks":["/dev/sdb"],"node":"node-0-128039","topology":{"labelled":{"ashish":"sinha"}}}}
  creationTimestamp: "2023-11-17T04:16:51Z"
  finalizers:
  - openebs.io/diskpool-protection
  generation: 1
  name: pool-1
  namespace: mayastor
  resourceVersion: "248393"
  uid: a1fa9f9d-2198-4802-bafb-6a82eeb1016d
spec:
  disks:
  - /dev/sdb
  node: node-0-128039
  topology:
    labelled:
      type: hot
status:
  available: 10724835328
  capacity: 10724835328
  cr_state: Created
  pool_status: Online
  used: 0
```

This PR also patches the old CRD with the new CRD which has topology field.

Question : 
- Do the old cr need to be migrated.