### PR TITLE
fix: use relative url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "utils/dependencies"]
 	path = utils/dependencies
-	url = https://github.com/openebs/mayastor-dependencies.git
+	url = ../mayastor-dependencies.git
 	branch = develop


### PR DESCRIPTION
Use a relative URL for importing the dependencies submodule.
The top-level part of the URL is the same between repos, so need not be duplicated,
and can be inferred from the URL of the parent repo.
Tested by building locally and via CI.