### PR TITLE
feat(ha): csi node should label nodes with nvme ana capability, node agent should not report failed paths if ana is not supported

### DIFF
--- a/control-plane/agents/src/bin/ha/node/detector.rs
+++ b/control-plane/agents/src/bin/ha/node/detector.rs
@@ -136,6 +136,15 @@ impl PathRecord {
     }
 
     fn report_live(&mut self) {
+        if self.state != PathState::Good {
+            tracing::info!(
+                from=%self.state,
+                to=%PathState::Good,
+                target=self.nqn,
+                path=self.path,
+                "Target path has been fixed",
+            );
+        }
         self.state = PathState::Good;
     }
 }
@@ -216,11 +225,12 @@ pub struct PathFailureDetector {
 
 impl PathFailureDetector {
     /// Return a new `Self`.
-    pub(crate) fn new(args: &Cli) -> Self {
+    pub(crate) fn new(args: &Cli, ana_enabled: bool) -> Self {
         let reporter = PathReporter::new(
             args.node_name.clone(),
             *args.retransmission_period,
             *args.aggregation_period,
+            ana_enabled,
         );
 
         let (tx, rx) = channel(64);

--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -139,8 +139,10 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
+    // Check whether ana is enabled or not.
+    let ana_enabled: bool = utils::check_nvme_core_ana().unwrap_or_default();
     // Instantiate path failure detector along with Nvme cache object.
-    let detector = PathFailureDetector::new(&cli_args);
+    let detector = PathFailureDetector::new(&cli_args, ana_enabled);
 
     let cache = detector.get_cache();
 

--- a/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
@@ -273,6 +273,13 @@ impl Detach for NvmfDetach {
     }
 }
 
+/// Check for the presence of nvme tcp kernel module.
+pub(crate) fn check_nvme_tcp_module() -> Result<(), std::io::Error> {
+    let path = "/sys/module/nvme_tcp";
+    std::fs::metadata(path)?;
+    Ok(())
+}
+
 /// Set the nvme_core module IO timeout
 /// (note, this is a system-wide parameter)
 pub(crate) fn set_nvmecore_iotimeout(io_timeout_secs: u32) -> Result<(), std::io::Error> {

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -128,3 +128,6 @@ pub const SNAPSHOT_TRANSACTION_PRUNE_LIMIT: usize = 10;
 
 /// Maximum number of snapshot transactions allowed.
 pub const SNAPSHOT_MAX_TRANSACTION_LIMIT: usize = 5;
+
+/// Label for the csi-node nvme ana multi-path.
+pub const CSI_NODE_NVME_ANA: &str = "openebs.io/csi-node.nvme-ana";

--- a/utils/utils-lib/src/lib.rs
+++ b/utils/utils-lib/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod constants;
+
 pub use constants::*;
 
 pub mod tracing_telemetry;
@@ -12,3 +13,20 @@ pub use version_info::{version_info as version_info_inner, VersionInfo};
 
 /// Byte conversion helpers.
 pub mod bytes;
+
+use std::fs;
+/// Check for the presence of nvme ana multipath.
+pub fn check_nvme_core_ana() -> Result<bool, std::io::Error> {
+    match fs::read_to_string("/sys/module/nvme_core/parameters/multipath")?
+        .trim()
+        .to_uppercase()
+        .as_str()
+    {
+        "Y" => Ok(true),
+        "N" => Ok(false),
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Invalid value in NVMe multipath file",
+        )),
+    }
+}


### PR DESCRIPTION
- When CSI nodes start up it will detect the presence of `nvme_tcp` kernel modules and exit with a message.
- When CSI nodes startup it will label the k8s node with the nvme-ana capability.
- If nvme-ana is not supported HA nodes will not report failed paths, it will just log.