### PR TITLE
Fixup correct nvme controller and make child add v1 idempotent

### DIFF
--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -78,7 +78,7 @@ impl ComponentAction for IoEngine {
                 spec = spec.with_env("DEVELOPER_DELAYED", "1");
             }
 
-            if !options.no_etcd {
+            if !options.no_etcd && !options.io_engine_no_pstor {
                 let etcd = format!("etcd.{}:2379", options.cluster_label.name());
                 spec = spec.with_args(vec!["-p", &etcd]);
             }

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -183,6 +183,10 @@ pub struct StartOptions {
     )]
     io_engine_api_versions: Vec<IoEngineApiVersion>,
 
+    /// Don't configure the persistent store with the io-engine.
+    #[clap(long)]
+    io_engine_no_pstor: bool,
+
     /// Set the developer delayed env flag of the io_engine reactor.
     #[clap(short, long)]
     pub developer_delayed: bool,
@@ -435,6 +439,11 @@ impl StartOptions {
     #[must_use]
     pub fn with_isolated_io_engine(mut self, isolate: bool) -> Self {
         self.io_engine_isolate = isolate;
+        self
+    }
+    #[must_use]
+    pub fn with_io_engine_no_pstor(mut self, no_pstor: bool) -> Self {
+        self.io_engine_no_pstor = no_pstor;
         self
     }
     #[must_use]

--- a/tests/bdd/features/csi/node/test_parameters.py
+++ b/tests/bdd/features/csi/node/test_parameters.py
@@ -63,6 +63,10 @@ def the_nvme_device_should_report_total_queues(total):
     # max io queues is cpu_count
     # admin q is 1
     assert queue_count == min(total, os.cpu_count() + 1)
+    file = f"/sys/block/nvme2c2n1/queue/io_timeout"
+    io_timoout = int(subprocess.run(["sudo", "cat", file], capture_output=True).stdout)
+    print(f"io_timeout: {io_timoout}")
+    assert io_timoout == 33000
 
 
 @pytest.fixture
@@ -137,6 +141,7 @@ def start_csi_plugin(setup, io_queues, staging_target_path):
             "--csi-socket=/var/tmp/csi-node.sock",
             "--grpc-endpoint=0.0.0.0:50050",
             "--node-name=msn-test",
+            "--nvme-io-timeout=33s",
             f"--nvme-nr-io-queues={io_queues}",
             "-v",
         ],

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -288,7 +288,7 @@ impl Cluster {
         Ok(CsiNodeClient { csi, internal })
     }
 
-    /// restart the core agent
+    /// Restart the core agent.
     pub async fn restart_core(&self) {
         self.remove_store_lock(ControlPlaneService::CoreAgent).await;
         self.composer.restart("core").await.unwrap();


### PR DESCRIPTION
    feat(csi/node/timeout): add nvme-io-engine timeout and parse humantime
    
    Adds new parameter "--nvme-io-timeout".
    This is used to set the timeout per nvme block device.
    TODO: Check if this is enough to avoid setting the global timeout..
    Also let's parse the "--nvme-core-io-timeout" as humantime as well..
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(nexus/add-child/v1): make add child v1 idempotent
    
    When v1 nexus add child was added, it was not made idempotent.
    Even though this is not an issue per se, as the child eventually gets
    GCd and re-added it can cause strange logging..
    TODO: should we have different behaviour depending on the state?
    Example if faulted should we remove/readd?
    Bonus: Fixes old test which stopped working a long time ago when
    pstor was enabled for the data-plane by not enabling it for that
    particular test only..
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(csi-node/nvmf/fixup): fixup correct nvme controller
    
    When we replace an existing path, the new path has a different controller number. And so
    the controller number and device number now mismatch, meaning we can not safely deref
    /sys/class/nvme/nvme{major}
    Instead, we can simply deref
    /sys/class/block/nvme{major}c*n1/queue
    The major ensures we use the original device number, and the glob ensures we modify the
    timeout for all controllers.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
