### PR TITLE
refactor(nix/build): replace builtins.filterSource and builtins.path

### DIFF
--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -1,12 +1,14 @@
 { lib, stdenv, git, tag ? "" }:
 let
   whitelistSource = src: allowedPrefixes:
-    builtins.filterSource
-      (path: type:
+    builtins.path {
+      filter = (path: type:
         lib.any
           (allowedPrefix: lib.hasPrefix (toString (src + "/${allowedPrefix}")) path)
-          allowedPrefixes)
-      src;
+          allowedPrefixes);
+      path = src;
+      name = "controller-git";
+    };
 in
 stdenv.mkDerivation {
   name = "git-version";

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -40,15 +40,17 @@ let
     cargo = stable_channel.cargo;
   };
   whitelistSource = src: allowedPrefixes:
-    builtins.filterSource
-      (path: type:
+    builtins.path {
+      filter = (path: type:
         lib.any
           (allowedPrefix:
             (lib.hasPrefix (toString (src + "/${allowedPrefix}")) path) ||
             (type == "directory" && lib.hasPrefix path (toString (src + "/${allowedPrefix}")))
           )
-          allowedPrefixes)
-      src;
+          allowedPrefixes);
+      path = src;
+      name = "controller";
+    };
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";


### PR DESCRIPTION
Not only is filterSource deprecated but also path is compatible with nix-illegal characters in their names, like @.