### PR TITLE
feat(multi-replica-snapshot): Handle multireplica snapshot in control-plane

### DIFF
--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -93,14 +93,18 @@ impl PoolItemLister {
         pools
     }
     /// Get a list of pool items to create a snapshot on.
-    /// todo: support multi-replica snapshot.
-    pub(crate) async fn list_for_snaps(registry: &Registry, item: &ChildItem) -> Vec<PoolItem> {
+    pub(crate) async fn list_for_snaps(registry: &Registry, items: &[ChildItem]) -> Vec<PoolItem> {
         let nodes = Self::nodes(registry).await;
-
-        match nodes.iter().find(|n| n.id() == item.node()) {
-            Some(node) => vec![PoolItem::new(node.clone(), item.pool().clone(), None)],
-            None => vec![],
-        }
+        let pool_items = items
+            .iter()
+            .filter_map(|item| {
+                nodes
+                    .iter()
+                    .find(|node| node.id() == item.node())
+                    .map(|node| PoolItem::new(node.clone(), item.pool().clone(), None))
+            })
+            .collect();
+        pool_items
     }
     /// Get a list of replicas wrapped as ChildItem, for resize.
     pub(crate) async fn list_for_resize(registry: &Registry, spec: &VolumeSpec) -> Vec<ChildItem> {

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
@@ -636,7 +636,7 @@ pub(crate) struct SnapshotVolumeReplica {
 }
 
 impl SnapshotVolumeReplica {
-    async fn builder(registry: &Registry, volume: &VolumeSpec, item: &ChildItem) -> Self {
+    async fn builder(registry: &Registry, volume: &VolumeSpec, items: &[ChildItem]) -> Self {
         let allocated_bytes = AddVolumeReplica::allocated_bytes(registry, volume).await;
 
         Self {
@@ -649,7 +649,7 @@ impl SnapshotVolumeReplica {
                     snap_repl: true,
                     ag_restricted_nodes: None,
                 },
-                PoolItemLister::list_for_snaps(registry, item).await,
+                PoolItemLister::list_for_snaps(registry, items).await,
             ),
         }
     }
@@ -670,8 +670,7 @@ impl SnapshotVolumeReplica {
     pub(crate) async fn builder_with_defaults(
         registry: &Registry,
         volume: &VolumeSpec,
-        // todo: only 1 replica snapshot supported atm
-        items: &ChildItem,
+        items: &[ChildItem],
     ) -> Self {
         Self::builder(registry, volume, items)
             .await

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -811,14 +811,14 @@ impl ResourceLifecycleExt<CreateVolumeSource<'_>> for OperationGuardArc<VolumeSp
         request_src: &CreateVolumeSource,
     ) -> Result<Self::CreateOutput, SvcError> {
         request_src.pre_flight_check()?;
-        let request = request_src.source();
-
         let specs = registry.specs();
         let mut volume = specs
             .get_or_create_volume(request_src)?
             .operation_guard_wait()
             .await?;
-        let volume_clone = volume.start_create_update(registry, request).await?;
+        let volume_clone = volume
+            .start_create_update(registry, request_src.source())
+            .await?;
 
         // If the volume is a part of the ag, create or update accordingly.
         registry.specs().get_or_create_affinity_group(&volume_clone);

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -1059,7 +1059,6 @@ impl SpecOperationsHelper for VolumeSpec {
                     }
                 }
             }
-
             VolumeOperation::RemoveUnusedReplica(uuid) => {
                 let last_replica = !registry
                     .specs()
@@ -1111,10 +1110,6 @@ impl SpecOperationsHelper for VolumeSpec {
             }
             VolumeOperation::Create => unreachable!(),
             VolumeOperation::Destroy => unreachable!(),
-
-            VolumeOperation::CreateSnapshot(_) if self.num_replicas != 1 => {
-                Err(SvcError::NReplSnapshotNotAllowed {})
-            }
             VolumeOperation::CreateSnapshot(_) => Ok(()),
             VolumeOperation::DestroySnapshot(_) => Ok(()),
             VolumeOperation::Resize(_) => Ok(()),

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -214,6 +214,7 @@ impl IoEngineApiClient {
     /// Create a volume of target size and provision storage resources for it.
     /// This operation is not idempotent, so the caller is responsible for taking
     /// all actions with regards to idempotency.
+    #[allow(clippy::too_many_arguments)]
     #[instrument(fields(volume.uuid = %volume_id), skip(self, volume_id))]
     pub(crate) async fn create_volume(
         &self,
@@ -223,6 +224,7 @@ impl IoEngineApiClient {
         volume_topology: CreateVolumeTopology,
         thin: bool,
         affinity_group: Option<AffinityGroup>,
+        max_snapshots: Option<u32>,
     ) -> Result<Volume, ApiClientError> {
         let topology =
             Topology::new_all(volume_topology.node_topology, volume_topology.pool_topology);
@@ -235,6 +237,7 @@ impl IoEngineApiClient {
             policy: VolumePolicy::new_all(true),
             labels: None,
             affinity_group,
+            max_snapshots,
         };
 
         let result = self
@@ -259,6 +262,7 @@ impl IoEngineApiClient {
         volume_topology: CreateVolumeTopology,
         thin: bool,
         affinity_group: Option<AffinityGroup>,
+        max_snapshots: Option<u32>,
     ) -> Result<Volume, ApiClientError> {
         let topology =
             Topology::new_all(volume_topology.node_topology, volume_topology.pool_topology);
@@ -271,8 +275,8 @@ impl IoEngineApiClient {
             policy: VolumePolicy::new_all(true),
             labels: None,
             affinity_group,
+            max_snapshots,
         };
-
         let result = self
             .rest_client
             .volumes_api()

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -315,6 +315,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                 );
 
                 let sts_affinity_group_name = context.sts_affinity_group();
+                let max_snapshots = context.max_snapshots();
 
                 let volume = match volume_content_source {
                     Some(snapshot_uuid) => {
@@ -327,6 +328,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                                 volume_topology,
                                 thin,
                                 sts_affinity_group_name.clone().map(AffinityGroup::new),
+                                max_snapshots,
                             )
                             .await?
                     }
@@ -339,6 +341,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                                 volume_topology,
                                 thin,
                                 sts_affinity_group_name.clone().map(AffinityGroup::new),
+                                max_snapshots,
                             )
                             .await?
                     }

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -61,6 +61,8 @@ message VolumeSpec {
   optional VolumeContentSource content_source  = 11;
   // Number of snapshots taken on this volume.
   uint32 num_snapshots = 12;
+  // Max snapshots limit per volume.
+  optional uint32 max_snapshots = 13;
 
   // Volume Content Source i.e the snapshot or a volume.
   message VolumeContentSource {
@@ -265,6 +267,8 @@ message CreateVolumeRequest {
   optional AffinityGroup affinity_group = 9;
   // maximum total volume size
   optional uint64 cluster_capacity_limit = 10;
+  // Max snapshots limit per volume.
+  optional uint32 max_snapshots = 11;
 }
 
 // Publish a volume on a node

--- a/control-plane/grpc/src/operations/volume/client.rs
+++ b/control-plane/grpc/src/operations/volume/client.rs
@@ -22,7 +22,6 @@ use crate::{
         volume_grpc_client::VolumeGrpcClient, GetSnapshotsRequest, GetVolumesRequest, ProbeRequest,
     },
 };
-
 use stor_port::{
     transport_api::{v0::Volumes, ReplyError, ResourceKind, TimeoutOptions},
     types::v0::transport::{Filter, MessageIdVs, Volume},

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -161,6 +161,7 @@ impl From<VolumeSpec> for volume::VolumeDefinition {
                 affinity_group: volume_spec.affinity_group.into_opt(),
                 content_source: volume_spec.content_source.into_opt(),
                 num_snapshots: volume_spec.metadata.num_snapshots() as u32,
+                max_snapshots: volume_spec.max_snapshots,
             }),
             metadata: Some(volume::Metadata {
                 spec_status: spec_status as i32,
@@ -345,6 +346,7 @@ impl TryFrom<volume::VolumeDefinition> for VolumeSpec {
             metadata: VolumeMetadata::new(volume_meta.as_thin),
             content_source: volume_spec.content_source.try_into_opt()?,
             num_snapshots: volume_spec.num_snapshots,
+            max_snapshots: volume_spec.max_snapshots,
         };
         Ok(volume_spec)
     }
@@ -892,6 +894,8 @@ pub trait CreateVolumeInfo: Send + Sync + std::fmt::Debug {
     fn affinity_group(&self) -> Option<AffinityGroup>;
     /// Capacity Limit.
     fn cluster_capacity_limit(&self) -> Option<u64>;
+    /// Max snapshot limit per volume.
+    fn max_snapshots(&self) -> Option<u32>;
 }
 
 impl CreateVolumeInfo for CreateVolume {
@@ -929,6 +933,10 @@ impl CreateVolumeInfo for CreateVolume {
 
     fn cluster_capacity_limit(&self) -> Option<u64> {
         self.cluster_capacity_limit
+    }
+
+    fn max_snapshots(&self) -> Option<u32> {
+        self.max_snapshots
     }
 }
 
@@ -982,6 +990,10 @@ impl CreateVolumeInfo for ValidatedCreateVolumeRequest {
     fn cluster_capacity_limit(&self) -> Option<u64> {
         self.inner.cluster_capacity_limit
     }
+
+    fn max_snapshots(&self) -> Option<u32> {
+        self.inner.max_snapshots
+    }
 }
 
 impl ValidateRequestTypes for CreateVolumeRequest {
@@ -1019,6 +1031,7 @@ impl From<&dyn CreateVolumeInfo> for CreateVolume {
             thin: data.thin(),
             affinity_group: data.affinity_group(),
             cluster_capacity_limit: data.cluster_capacity_limit(),
+            max_snapshots: data.max_snapshots(),
         }
     }
 }
@@ -1037,6 +1050,7 @@ impl From<&dyn CreateVolumeInfo> for CreateVolumeRequest {
             thin: data.thin(),
             affinity_group: data.affinity_group().map(|ag| ag.into()),
             cluster_capacity_limit: data.cluster_capacity_limit(),
+            max_snapshots: data.max_snapshots(),
         }
     }
 }

--- a/control-plane/grpc/src/operations/volume/traits_snapshots.rs
+++ b/control-plane/grpc/src/operations/volume/traits_snapshots.rs
@@ -175,6 +175,14 @@ impl VolumeSnapshotMeta {
     pub fn num_restores(&self) -> u32 {
         self.num_restores
     }
+    /// The number of replica snapshots for the current transaction.
+    pub fn num_snapshot_replicas(&self) -> u32 {
+        if let Some(replica_snap_list) = self.transactions().get(self.txn_id()) {
+            replica_snap_list.len() as u32
+        } else {
+            0
+        }
+    }
 }
 
 /// Volume replica snapshot information.

--- a/control-plane/plugin/src/resources/error.rs
+++ b/control-plane/plugin/src/resources/error.rs
@@ -74,6 +74,12 @@ pub enum Error {
         id: String,
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,
     },
+    /// Error when set volume property request fails.
+    #[snafu(display("Failed to set volume {id} property, Error {source}"))]
+    ScaleVolumePropertyError {
+        id: String,
+        source: openapi::tower::client::Error<openapi::models::RestJsonError>,
+    },
     /// Error when list snapshots request fails.
     #[snafu(display("Failed to list volume snapshots. Error {source}"))]
     ListSnapshotsError {

--- a/control-plane/plugin/src/resources/snapshot.rs
+++ b/control-plane/plugin/src/resources/snapshot.rs
@@ -57,7 +57,8 @@ impl CreateRow for openapi::models::VolumeSnapshot {
             ::utils::bytes::into_human(state.allocated_size),
             ::utils::bytes::into_human(meta.total_allocated_size),
             state.source_volume,
-            self.definition.metadata.num_restores
+            self.definition.metadata.num_restores,
+            self.definition.metadata.num_snapshot_replicas
         ]
     }
 }

--- a/control-plane/plugin/src/resources/tests.rs
+++ b/control-plane/plugin/src/resources/tests.rs
@@ -36,6 +36,7 @@ async fn setup() {
                 labels: None,
                 thin: false,
                 affinity_group: None,
+                max_snapshots: None,
             },
         )
         .await
@@ -108,6 +109,7 @@ async fn get_volumes_paginated() {
                     topology: None,
                     labels: None,
                     affinity_group: None,
+                    max_snapshots: None,
                 },
             )
             .await

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -22,7 +22,7 @@ lazy_static! {
         "THIN-PROVISIONED",
         "ALLOCATED",
         "SNAPSHOTS",
-        "SOURCE"
+        "SOURCE",
     ];
     pub static ref SNAPSHOT_HEADERS: Row = row![
         "ID",
@@ -31,7 +31,8 @@ lazy_static! {
         "ALLOCATED-SIZE",
         "TOTAL-ALLOCATED-SIZE",
         "SOURCE-VOL",
-        "RESTORES"
+        "RESTORES",
+        "SNAPSHOT_REPLICAS"
     ];
     pub static ref POOLS_HEADERS: Row = row![
         "ID",

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2521,6 +2521,7 @@ components:
         thin: false
         topology: null
         affinity_group: null
+        max_snapshots: 10
       description: Create Volume Body
       type: object
       properties:
@@ -2551,6 +2552,11 @@ components:
           description: Affinity Group related information.
           allOf:
             - $ref: '#/components/schemas/AffinityGroup'
+        max_snapshots:
+          description: Max Snapshots limit per volume.
+          type: integer
+          format: int32
+          minimum: 0
       required:
         - policy
         - replicas
@@ -3356,6 +3362,7 @@ components:
         target_node: io-engine-1
         uuid: 514ed1c8-7174-49ac-b9cd-ad44ef670a67
         thin: false
+        max_snapshots: 10
       description: User specification of a volume.
       type: object
       properties:
@@ -3427,6 +3434,11 @@ components:
           $ref: '#/components/schemas/VolumeContentSource'
         num_snapshots:
           description: Number of snapshots taken on this volume.
+          type: integer
+          format: int32
+          minimum: 0
+        max_snapshots:
+          description: Max snapshots to limit per volume.
           type: integer
           format: int32
           minimum: 0
@@ -3754,6 +3766,11 @@ components:
           type: integer
           format: int32
           minimum: 0
+        num_snapshot_replicas:
+          description: Number of snapshot replicas for a volumesnapshot.
+          type: integer
+          format: int32
+          minimum: 0
       required:
         - status
         - size
@@ -3762,6 +3779,7 @@ components:
         - txn_id
         - transactions
         - num_restores
+        - num_snapshot_replicas
     VolumeSnapshotSpec:
       description: |-
         Volume Snapshot Spec information.

--- a/control-plane/rest/service/src/v0/snapshots.rs
+++ b/control-plane/rest/service/src/v0/snapshots.rs
@@ -185,6 +185,7 @@ fn to_models_volume_snapshot(snap: &VolumeSnapshot) -> models::VolumeSnapshot {
                     })
                     .collect::<HashMap<_, _>>(),
                 snap.meta().num_restores(),
+                snap.meta().num_snapshot_replicas(),
             ),
             models::VolumeSnapshotSpec::new_all(snap.spec().snap_id(), snap.spec().source_id()),
         ),

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -192,6 +192,8 @@ pub struct CreateVolumeBody {
     pub thin: bool,
     /// Affinity Group related information.
     pub affinity_group: Option<AffinityGroup>,
+    /// Max snapshot limit per volume.
+    pub max_snapshots: Option<u32>,
 }
 impl From<models::CreateVolumeBody> for CreateVolumeBody {
     fn from(src: models::CreateVolumeBody) -> Self {
@@ -203,6 +205,7 @@ impl From<models::CreateVolumeBody> for CreateVolumeBody {
             labels: src.labels,
             thin: src.thin,
             affinity_group: src.affinity_group.map(|ag| ag.into()),
+            max_snapshots: src.max_snapshots,
         }
     }
 }
@@ -216,6 +219,7 @@ impl From<CreateVolume> for CreateVolumeBody {
             labels: create.labels,
             thin: create.thin,
             affinity_group: create.affinity_group,
+            max_snapshots: create.max_snapshots,
         }
     }
 }
@@ -232,6 +236,7 @@ impl CreateVolumeBody {
             thin: self.thin,
             affinity_group: self.affinity_group.clone(),
             cluster_capacity_limit: None,
+            max_snapshots: self.max_snapshots,
         }
     }
     /// Convert into rpc request type.

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -18,6 +18,17 @@ use crate::{
 use pstor::ApiVersion;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use strum_macros::{EnumCount as EnumCountMacro, EnumIter, EnumString};
+
+/// Volume properties.
+#[derive(
+    Serialize, Deserialize, EnumString, Debug, EnumCountMacro, EnumIter, PartialEq, Clone, Copy,
+)]
+pub enum VolumeAttr {
+    /// Max number of snapshots allowed per volume.
+    #[strum(serialize = "max_snapshots")]
+    MaxSnapshots,
+}
 
 /// Key used by the store to uniquely identify a VolumeState structure.
 pub struct VolumeStateKey(VolumeId);
@@ -205,6 +216,9 @@ pub struct VolumeSpec {
     /// Volume metadata information.
     #[serde(default, skip_serializing_if = "super::is_default")]
     pub metadata: VolumeMetadata,
+    /// Max snapshots limit per volume.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_snapshots: Option<u32>,
 }
 
 /// Volume Content Source i.e the snapshot or a volume.
@@ -725,6 +739,7 @@ impl From<&CreateVolume> for VolumeSpec {
             target_config: None,
             publish_context: None,
             affinity_group: request.affinity_group.clone(),
+            max_snapshots: request.max_snapshots,
             ..Default::default()
         }
     }
@@ -781,6 +796,7 @@ impl From<VolumeSpec> for models::VolumeSpec {
             src.affinity_group.into_opt(),
             src.content_source.into_opt(),
             src.num_snapshots,
+            src.max_snapshots,
         )
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -457,6 +457,8 @@ pub struct CreateVolume {
     pub affinity_group: Option<AffinityGroup>,
     /// Maximum total system volume size.
     pub cluster_capacity_limit: Option<u64>,
+    /// Max Snapshots to limit per volume.
+    pub max_snapshots: Option<u32>,
 }
 
 /// Resize volume request.


### PR DESCRIPTION
1. Add multi-replica snapshot capability in control-plane.
2. Limit snapshot creation based on new environment variable. (max_snapshots)
