### PR TITLE
feat(pstor-proxy): add pstor proxy create, add frontend registration backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap",
+ "clap 4.4.13",
  "crossbeam-queue",
  "deployer-cluster",
  "dyn-clonable",
@@ -335,6 +335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -456,6 +465,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -780,9 +800,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "4.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -790,23 +825,23 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.38",
@@ -814,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
@@ -938,12 +973,12 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "clap",
+ "clap 4.4.13",
  "devinfo",
  "futures",
  "glob",
  "grpc",
- "heck",
+ "heck 0.4.1",
  "humantime",
  "k8s-openapi",
  "kube",
@@ -1045,7 +1080,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1071,7 +1106,7 @@ name = "deployer"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "clap",
+ "clap 4.4.13",
  "composer",
  "events-api",
  "futures",
@@ -1097,7 +1132,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
- "clap",
+ "clap 4.4.13",
  "composer",
  "csi-driver",
  "deployer",
@@ -1669,9 +1704,27 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1937,7 +1990,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "libc",
  "windows-sys",
 ]
@@ -1969,7 +2022,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "rustix",
  "windows-sys",
 ]
@@ -2067,7 +2120,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap",
+ "clap 4.4.13",
  "futures",
  "humantime",
  "k8s-openapi",
@@ -2500,7 +2553,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
@@ -2894,6 +2947,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,7 +2996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools",
  "log",
  "multimap",
@@ -2990,12 +3067,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pstor-proxy"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "clap 4.4.13",
+ "humantime",
+ "indexmap 2.0.2",
+ "parking_lot",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "pstor",
+ "serde",
+ "serde_json",
+ "shutdown",
+ "snafu",
+ "structopt",
+ "strum_macros",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "url",
+ "utils",
+ "uuid",
+]
+
+[[package]]
 name = "pstor-usage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap",
+ "clap 4.4.13",
  "deployer-cluster",
  "etcd-client",
  "itertools",
@@ -3168,7 +3273,7 @@ dependencies = [
  "actix-web-opentelemetry",
  "anyhow",
  "async-trait",
- "clap",
+ "clap 4.4.13",
  "composer",
  "deployer-cluster",
  "futures",
@@ -3200,7 +3305,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap",
+ "clap 4.4.13",
  "deployer-cluster",
  "gag",
  "humantime",
@@ -3707,7 +3812,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3786,9 +3891,39 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "strum"
@@ -3802,7 +3937,7 @@ version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3903,6 +4038,15 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -4414,6 +4558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,6 +4648,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-info"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "control-plane/csi-driver",
     "control-plane/grpc",
     "control-plane/stor-port",
+    "control-plane/pstor-proxy",
     "control-plane/plugin",
     "k8s/operators",
     "k8s/forward",

--- a/control-plane/pstor-proxy/Cargo.toml
+++ b/control-plane/pstor-proxy/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "pstor-proxy"
+description = "Grpc Proxy layer for the pstor"
+version = "1.0.0"
+edition = "2021"
+
+[build-dependencies]
+prost-build = "0.12.1"
+tonic-build = "0.10.2"
+
+[dependencies]
+anyhow = "1.0.75"
+clap = { version = "4.4.13", features = ["derive"] }
+humantime = { version = "2.1.0", features = [] }
+indexmap = "2.0.2"
+parking_lot = "0.12.1"
+prost = "0.12.1"
+prost-types = "0.12.1"
+pstor = { path = "../../utils/pstor" }
+serde = { version = "1.0.189", features = ["derive"] }
+serde_json = { version = "1.0.107", features = [] }
+shutdown = { path = "../../utils/shutdown" }
+snafu = "0.7.5"
+structopt = "0.3.26"
+strum_macros = "0.25.2"
+tokio = { version = "1.32.0", features = ["full"] }
+tonic = "0.10.2"
+tracing = { version = "0.1.40", features = [] }
+url = "2.4.1"
+utils = { path = "../../utils/utils-lib" }
+uuid = { version = "1.4.1", features = ["serde", "v4"] }

--- a/control-plane/pstor-proxy/build.rs
+++ b/control-plane/pstor-proxy/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    tonic_build::configure()
+        .compile(
+            &[
+                "proto/v1/frontend_node/registration.proto",
+                "proto/v1/frontend_node/frontend_node.proto",
+                "proto/v1/misc/common.proto",
+            ],
+            &["proto/"],
+        )
+        .unwrap();
+}

--- a/control-plane/pstor-proxy/proto/v1/frontend_node/frontend_node.proto
+++ b/control-plane/pstor-proxy/proto/v1/frontend_node/frontend_node.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
+import "v1/misc/common.proto";
+
+package pstor_proxy.v1;
+
+// Frontend Node information
+message FrontendNode {
+  // Frontend Node identification
+  string id = 1;
+  // Specification of the frontend node.
+  FrontendNodeSpec spec = 2;
+  // Runtime state of the frontend node.
+  FrontendNodeState state = 3;
+}
+
+// Frontend Node spec
+message FrontendNodeSpec {
+  // Id of the frontend node instance
+  string id = 1;
+  // Grpc endpoint of the frontend node instance
+  string grpc_endpoint = 2;
+  // Frontend node labels
+  optional StringMapValue labels = 3;
+}
+
+// Frontend Node state
+message FrontendNodeState {
+}
+
+// Multiple frontend nodes
+message FrontendNodes {
+  repeated FrontendNode entries = 1;
+  // This token allows you to get the next page of entries for
+  // `GetFrontendNodes` request. If the number of entries is larger than
+  // `max_entries`, use the `next_token` as a value for the
+  // `starting_token` field in the next `GetFrontendNodes` request.
+  optional uint64 next_token = 3;
+}
+
+// Request type for a GetFrontendNodes request
+message GetFrontendNodesRequest {
+  // Filter frontend nodes
+  oneof filter {
+    FrontendNodeFilter frontend_node = 1;
+  }
+  // Pagination to allow for multiple requests to get all frontend nodes
+  Pagination pagination = 2;
+  // Ignore 404 not found errors
+  bool ignore_notfound = 3;
+}
+
+// Reply type for a GetFrontendNodes request
+message GetFrontendNodesReply {
+  oneof reply {
+    FrontendNodes frontend_nodes = 1;
+    ReplyError error = 2;
+  }
+}
+
+service FrontendNodeGrpc {
+  rpc GetFrontendNodes (GetFrontendNodesRequest) returns (GetFrontendNodesReply) {}
+}

--- a/control-plane/pstor-proxy/proto/v1/frontend_node/registration.proto
+++ b/control-plane/pstor-proxy/proto/v1/frontend_node/registration.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
+import "v1/misc/common.proto";
+
+package pstor_proxy.v1;
+
+// Register the frontend node with control-plane
+message RegisterRequest {
+  // Id of the frontend node instance
+  string id = 1;
+  // Grpc endpoint of the frontend node instance
+  string grpc_endpoint = 2;
+  // Frontend node labels
+  optional StringMapValue labels = 3;
+}
+
+// Deregister a frontend node from the control-plane
+message DeregisterRequest {
+  // Id of the frontend node instance
+  string id = 1;
+}
+
+service Registration {
+  rpc Register (RegisterRequest) returns (google.protobuf.Empty) {}
+  rpc Deregister (DeregisterRequest) returns (google.protobuf.Empty) {}
+}

--- a/control-plane/pstor-proxy/proto/v1/misc/common.proto
+++ b/control-plane/pstor-proxy/proto/v1/misc/common.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package pstor_proxy.v1;
+
+// StringMapValue is the type having a hashmap
+message StringMapValue {
+  map<string, string> value = 1;
+}
+
+// ReplyError to be used for all error propagation to and from grpc calls
+message ReplyError {
+  ReplyErrorKind kind = 1;
+  ResourceKind resource = 2;
+  string source = 3;
+  string extra = 4;
+}
+
+// ReplyErrorKind for the kind of the occurred error
+enum ReplyErrorKind {
+  WithMessage = 0;
+  DeserializeReq = 1;
+  Internal = 2;
+  Timeout = 3;
+  InvalidArgument = 4;
+  DeadlineExceeded = 5;
+  NotFound = 6;
+  AlreadyExists = 7;
+  PermissionDenied = 8;
+  ResourceExhausted = 9;
+  FailedPrecondition = 10;
+  Aborted = 11;
+  OutOfRange = 12;
+  Unimplemented = 13;
+  Unavailable = 14;
+  Unauthenticated = 15;
+  Unauthorized = 16;
+  Conflict = 17;
+  FailedPersist = 18;
+  NotShared = 19;
+  AlreadyShared = 20;
+  NotPublished = 21;
+  AlreadyPublished = 22;
+  IsDeleting = 23;
+  ReplicaCountAchieved = 24;
+  ReplicaChangeCount = 25;
+  ReplicaIncrease = 26;
+  ReplicaCreateNumber = 27;
+  VolumeNoReplicas = 28;
+  InUse = 29;
+}
+
+// Filter by Frontend node id
+message FrontendNodeFilter {
+  string frontend_node_id = 1;
+}
+
+// ResourceKind for the resource which has undergone this error
+enum ResourceKind {
+  // Unknown or unspecified resource
+  Unknown = 0;
+  // FrontendNode resource
+  FrontendNodeKind = 1;
+}
+
+// Pagination related parameters.
+// This allows a large response to be split over multiple requests to prevent timeouts.
+message Pagination {
+  // If specified (non-zero value), this is the maximum number of entries to return.
+  uint64 max_entries = 1;
+  // A token to specify where to start paginating. Set this field to `next_token` returned by a
+  // previous `GetResources` call to get the next page of entries.
+  uint64 starting_token = 2;
+}

--- a/control-plane/pstor-proxy/src/bin/pstor-proxy/error.rs
+++ b/control-plane/pstor-proxy/src/bin/pstor-proxy/error.rs
@@ -1,0 +1,71 @@
+use pstor::error::Error as StoreError;
+use pstor_proxy::{
+    types::misc::Filter,
+    v1::common::{ReplyError, ReplyErrorKind, ResourceKind},
+};
+
+#[derive(Debug, snafu::Snafu)]
+#[snafu(visibility(pub), context(suffix(false)))]
+pub(crate) enum SvcError {
+    #[snafu(display("Storage Error: {source}"))]
+    Store { source: StoreError },
+    #[snafu(display("Failed to deserialize specs from pstor, {source}"))]
+    SpecDeserialize { source: serde_json::Error },
+    #[snafu(display("GrpcServer error, {source}"))]
+    GrpcServer { source: tonic::transport::Error },
+    #[snafu(display("Frontend node not found: {resource_id}"))]
+    FrontendNodeNotFound { resource_id: String },
+    #[snafu(display("Not a valid filter: {filter}"))]
+    InvalidFilter { filter: Filter },
+}
+
+impl From<SvcError> for tonic::Status {
+    fn from(value: SvcError) -> Self {
+        let error_str = value.to_string();
+        match value {
+            SvcError::Store { .. } => tonic::Status::failed_precondition(error_str),
+            SvcError::SpecDeserialize { .. } => tonic::Status::internal(error_str),
+            SvcError::GrpcServer { .. } => tonic::Status::internal(error_str),
+            SvcError::FrontendNodeNotFound { .. } => tonic::Status::not_found(error_str),
+            SvcError::InvalidFilter { .. } => tonic::Status::invalid_argument(error_str),
+        }
+    }
+}
+
+impl From<SvcError> for ReplyError {
+    fn from(value: SvcError) -> Self {
+        let error_str = value.to_string();
+        match value {
+            SvcError::Store { .. } => ReplyError {
+                kind: ReplyErrorKind::FailedPersist as i32,
+                resource: 0,
+                source: "pstor".to_string(),
+                extra: error_str,
+            },
+            SvcError::SpecDeserialize { .. } => ReplyError {
+                kind: ReplyErrorKind::DeserializeReq as i32,
+                resource: 0,
+                source: "spec deserialize".to_string(),
+                extra: error_str,
+            },
+            SvcError::GrpcServer { .. } => ReplyError {
+                kind: ReplyErrorKind::Internal as i32,
+                resource: 0,
+                source: "grpc server".to_string(),
+                extra: error_str,
+            },
+            SvcError::FrontendNodeNotFound { .. } => ReplyError {
+                kind: ReplyErrorKind::NotFound as i32,
+                resource: ResourceKind::FrontendNodeKind as i32,
+                source: "frontend node".to_string(),
+                extra: error_str,
+            },
+            SvcError::InvalidFilter { .. } => ReplyError {
+                kind: ReplyErrorKind::InvalidArgument as i32,
+                resource: 0,
+                source: "pstor".to_string(),
+                extra: error_str,
+            },
+        }
+    }
+}

--- a/control-plane/pstor-proxy/src/bin/pstor-proxy/frontend_node/mod.rs
+++ b/control-plane/pstor-proxy/src/bin/pstor-proxy/frontend_node/mod.rs
@@ -1,0 +1,4 @@
+// Module for frontend node grpc server constructs.
+pub(crate) mod server;
+// Module for the frontend node service.
+pub(crate) mod service;

--- a/control-plane/pstor-proxy/src/bin/pstor-proxy/frontend_node/server.rs
+++ b/control-plane/pstor-proxy/src/bin/pstor-proxy/frontend_node/server.rs
@@ -1,0 +1,117 @@
+use crate::frontend_node::service::Service;
+use pstor_proxy::{
+    types::{
+        frontend_node::{DeregisterFrontendNode, RegisterFrontendNode},
+        misc::{Filter, Pagination},
+    },
+    v1::{
+        frontend_node::{
+            get_frontend_nodes_reply, FrontendNodeGrpc, FrontendNodeGrpcServer,
+            GetFrontendNodesReply, GetFrontendNodesRequest,
+        },
+        registration::{DeregisterRequest, RegisterRequest, Registration, RegistrationServer},
+    },
+};
+use std::net::AddrParseError;
+use tonic::{Request, Response, Status};
+
+/// RPC Frontend Node Registration Server
+#[derive(Clone)]
+pub(crate) struct FrontendNodeRegistrationServer {
+    /// Service which executes the operations.
+    service: Service,
+}
+
+impl FrontendNodeRegistrationServer {
+    /// Returns a new FrontendNodeRegistrationServer with the service implementing FrontendNode
+    /// operations.
+    pub(crate) fn new(service: Service) -> Self {
+        Self { service }
+    }
+    /// Converts the FrontendNodeRegistrationServer to its corresponding grpc server type.
+    pub(crate) fn into_grpc_server(self) -> RegistrationServer<FrontendNodeRegistrationServer> {
+        RegistrationServer::new(self)
+    }
+}
+
+#[tonic::async_trait]
+impl Registration for FrontendNodeRegistrationServer {
+    async fn register(&self, request: Request<RegisterRequest>) -> Result<Response<()>, Status> {
+        let req = request.into_inner();
+        self.service
+            .register_frontend_node(&RegisterFrontendNode::new(
+                req.id.into(),
+                req.grpc_endpoint
+                    .parse()
+                    .map_err(|error: AddrParseError| Status::invalid_argument(error.to_string()))?,
+            ))
+            .await?;
+        Ok(Response::new(()))
+    }
+
+    async fn deregister(
+        &self,
+        request: Request<DeregisterRequest>,
+    ) -> Result<Response<()>, Status> {
+        let req = request.into_inner();
+        self.service
+            .deregister_frontend_node(&DeregisterFrontendNode::new(req.id.into()))
+            .await?;
+        Ok(Response::new(()))
+    }
+}
+
+/// RPC Frontend Node Server
+#[derive(Clone)]
+pub(crate) struct FrontendNodeServer {
+    /// Service which executes the operations.
+    service: Service,
+}
+
+impl FrontendNodeServer {
+    /// Returns a new FrontendNodeServer with the service implementing FrontendNode operations.
+    pub(crate) fn new(service: Service) -> Self {
+        Self { service }
+    }
+    /// Converts the FrontendNodeServer to its corresponding grpc server type.
+    pub(crate) fn into_grpc_server(self) -> FrontendNodeGrpcServer<FrontendNodeServer> {
+        FrontendNodeGrpcServer::new(self)
+    }
+}
+
+#[tonic::async_trait]
+impl FrontendNodeGrpc for FrontendNodeServer {
+    async fn get_frontend_nodes(
+        &self,
+        request: Request<GetFrontendNodesRequest>,
+    ) -> Result<Response<GetFrontendNodesReply>, Status> {
+        let req: GetFrontendNodesRequest = request.into_inner();
+        let filter = match req.filter {
+            Some(filter) => match Filter::try_from(filter) {
+                Ok(filter) => filter,
+                Err(err) => {
+                    return Ok(Response::new(GetFrontendNodesReply {
+                        reply: Some(get_frontend_nodes_reply::Reply::Error(err)),
+                    }))
+                }
+            },
+            None => Filter::None,
+        };
+
+        let pagination: Option<Pagination> = req.pagination.map(|p| p.into());
+        match self
+            .service
+            .get_frontend_nodes(filter, req.ignore_notfound, pagination)
+            .await
+        {
+            Ok(frontend_nodes) => Ok(Response::new(GetFrontendNodesReply {
+                reply: Some(get_frontend_nodes_reply::Reply::FrontendNodes(
+                    frontend_nodes.into(),
+                )),
+            })),
+            Err(err) => Ok(Response::new(GetFrontendNodesReply {
+                reply: Some(get_frontend_nodes_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+}

--- a/control-plane/pstor-proxy/src/bin/pstor-proxy/frontend_node/service.rs
+++ b/control-plane/pstor-proxy/src/bin/pstor-proxy/frontend_node/service.rs
@@ -1,0 +1,73 @@
+use crate::{error::SvcError, registry::Registry};
+use pstor_proxy::types::{
+    frontend_node::{DeregisterFrontendNode, FrontendNodes, RegisterFrontendNode},
+    misc::{Filter, Pagination},
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct Service {
+    registry: Registry,
+}
+
+impl Service {
+    pub(crate) fn new(registry: Registry) -> Self {
+        Self { registry }
+    }
+
+    /// Register a frontend node.
+    pub(crate) async fn register_frontend_node(
+        &self,
+        frontend_node_spec: &RegisterFrontendNode,
+    ) -> Result<(), SvcError> {
+        self.registry
+            .register_frontend_node(frontend_node_spec)
+            .await
+    }
+
+    /// Deregister a frontend node.
+    pub(crate) async fn deregister_frontend_node(
+        &self,
+        frontend_node_spec: &DeregisterFrontendNode,
+    ) -> Result<(), SvcError> {
+        self.registry
+            .deregister_frontend_node(frontend_node_spec)
+            .await
+    }
+
+    /// Register one or multiple frontend node.
+    pub(super) async fn get_frontend_nodes(
+        &self,
+        filter: Filter,
+        ignore_notfound: bool,
+        pagination: Option<Pagination>,
+    ) -> Result<FrontendNodes, SvcError> {
+        // The last result can only ever be false if using pagination.
+        let mut last_result = true;
+
+        let filtered_frontend_nodes = match filter {
+            Filter::None => match &pagination {
+                Some(p) => {
+                    let paginated_frontend_nodes = self.registry.paginated_frontend_nodes(p).await;
+                    last_result = paginated_frontend_nodes.last();
+                    paginated_frontend_nodes.result()
+                }
+                None => self.registry.frontend_nodes().await,
+            },
+            Filter::FrontendNode(frontend_node_id) => {
+                match self.registry.frontend_node(&frontend_node_id).await {
+                    Ok(frontend_node) => Ok(vec![frontend_node]),
+                    Err(SvcError::FrontendNodeNotFound { .. }) if ignore_notfound => Ok(vec![]),
+                    Err(error) => Err(error),
+                }?
+            }
+        };
+
+        Ok(FrontendNodes {
+            entries: filtered_frontend_nodes,
+            next_token: match last_result {
+                true => None,
+                false => pagination.map(|p| p.starting_token() + p.max_entries()),
+            },
+        })
+    }
+}

--- a/control-plane/pstor-proxy/src/bin/pstor-proxy/main.rs
+++ b/control-plane/pstor-proxy/src/bin/pstor-proxy/main.rs
@@ -1,0 +1,82 @@
+use crate::{
+    error::SvcError,
+    frontend_node::{
+        server::{FrontendNodeRegistrationServer, FrontendNodeServer},
+        service::Service,
+    },
+    registry::Registry,
+};
+use clap::Parser;
+use std::net::SocketAddr;
+use utils::{version_info_str, DEFAULT_GRPC_SERVER_ADDR};
+
+mod error;
+pub(crate) mod frontend_node;
+pub(crate) mod registry;
+pub(crate) mod resource_map;
+
+/// The Cli arguments for this binary.
+#[derive(Debug, Parser)]
+#[structopt(name = utils::package_description!(), version = version_info_str!())]
+pub(crate) struct CliArgs {
+    /// The Persistent Store URLs to connect to.
+    /// (supports the http/https schema)
+    #[clap(long, short, default_value = "http://localhost:2379")]
+    pub(crate) store: String,
+
+    /// The timeout for store operations.
+    #[clap(long, default_value = utils::STORE_OP_TIMEOUT)]
+    pub(crate) store_timeout: humantime::Duration,
+
+    /// The lease lock ttl for the persistent store after which we'll lose the exclusive access.
+    #[clap(long, default_value = utils::STORE_LEASE_LOCK_TTL)]
+    pub(crate) store_lease_ttl: humantime::Duration,
+
+    // The GRPC Server URLs to connect to.
+    /// (supports the http/https schema)
+    #[clap(long, short, default_value = DEFAULT_GRPC_SERVER_ADDR)]
+    pub(crate) grpc_server_addr: SocketAddr,
+}
+impl CliArgs {
+    fn args() -> Self {
+        CliArgs::parse()
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli_args = CliArgs::args();
+    utils::print_package_info!();
+
+    let _ = server(cli_args).await;
+
+    Ok(())
+}
+
+async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
+    let registry = Registry::new(
+        cli_args.store.clone(),
+        cli_args.store_timeout.into(),
+        cli_args.store_lease_ttl.into(),
+    )
+    .await?;
+
+    let frontend_node_registration_service =
+        FrontendNodeRegistrationServer::new(Service::new(registry.clone())).into_grpc_server();
+    let frontend_node_service =
+        FrontendNodeServer::new(Service::new(registry.clone())).into_grpc_server();
+    tonic::transport::Server::builder()
+        .add_service(frontend_node_registration_service)
+        .add_service(frontend_node_service)
+        .serve_with_shutdown(cli_args.grpc_server_addr, shutdown_signal())
+        .await
+        .map_err(|error| SvcError::GrpcServer { source: error })?;
+
+    registry.stop().await;
+    Ok(())
+}
+
+/// Waits until the process receives a shutdown: either TERM or INT.
+pub async fn shutdown_signal() {
+    shutdown::Shutdown::wait().await;
+}

--- a/control-plane/pstor-proxy/src/bin/pstor-proxy/registry.rs
+++ b/control-plane/pstor-proxy/src/bin/pstor-proxy/registry.rs
@@ -1,0 +1,397 @@
+use crate::{error::SvcError, resource_map::ResourceMutexMap};
+use parking_lot::RwLock;
+use pstor::{
+    etcd::Etcd, key_prefix_obj, ObjectKey, StorableObject, StorableObjectType, Store, StoreKey,
+    StoreKv, StoreObj, API_VERSION,
+};
+use pstor_proxy::types::{
+    frontend_node::{
+        DeregisterFrontendNode, FrontendNode, FrontendNodeId, FrontendNodeKey, FrontendNodeSpec,
+        RegisterFrontendNode,
+    },
+    misc::{PaginatedResult, Pagination},
+};
+use serde::de::DeserializeOwned;
+use std::{
+    future::Future,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+use tokio::sync::Mutex;
+
+const PSTOR_PROXY_SERVICE_NAME: &str = "pstor-proxy";
+
+/// Registry containing all io-engine instances (aka nodes).
+#[derive(Clone, Debug)]
+pub(crate) struct Registry {
+    inner: Arc<RegistryInner<Etcd>>,
+}
+
+impl Deref for Registry {
+    type Target = Arc<RegistryInner<Etcd>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Locked Resource Specs.
+#[derive(Default, Clone, Debug)]
+pub(crate) struct ResourceSpecsLocked(Arc<RwLock<ResourceSpecs>>);
+
+impl Deref for ResourceSpecsLocked {
+    type Target = Arc<RwLock<ResourceSpecs>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Resource Specs.
+#[derive(Default, Debug)]
+pub(crate) struct ResourceSpecs {
+    pub(crate) frontend_nodes: ResourceMutexMap<FrontendNodeId, FrontendNodeSpec>,
+}
+
+/// Generic Registry Inner with a Store trait.
+#[derive(Debug)]
+pub(crate) struct RegistryInner<S: Store> {
+    /// spec (aka desired state) of the various resources.
+    specs: ResourceSpecsLocked,
+    store: Arc<Mutex<S>>,
+    /// store gRPC operation timeout.
+    store_timeout: std::time::Duration,
+}
+
+impl Registry {
+    pub(crate) async fn new(
+        store_url: String,
+        store_timeout: std::time::Duration,
+        store_lease_tll: std::time::Duration,
+    ) -> Result<Self, SvcError> {
+        let store_endpoint = Self::format_store_endpoint(&store_url);
+        tracing::info!("Connecting to persistent store at {}", store_endpoint);
+        let store = Etcd::new_leased(
+            [&store_url],
+            PSTOR_PROXY_SERVICE_NAME.into(),
+            store_lease_tll,
+        )
+        .await
+        .map_err(|error| SvcError::Store { source: error })?;
+        tracing::info!("Connected to persistent store at {}", store_endpoint);
+
+        let registry = Self {
+            inner: Arc::new(RegistryInner {
+                specs: ResourceSpecsLocked::new(),
+                store: Arc::new(Mutex::new(store.clone())),
+                store_timeout,
+            }),
+        };
+
+        registry.init().await?;
+
+        Ok(registry)
+    }
+
+    /// Formats the store endpoint with a default port if one isn't supplied.
+    fn format_store_endpoint(endpoint: &str) -> String {
+        match endpoint.contains(':') {
+            true => endpoint.to_string(),
+            false => format!("{}:{}", endpoint, "2379"),
+        }
+    }
+
+    /// Initialise the registry with the content of the persistent store.
+    async fn init(&self) -> Result<(), SvcError> {
+        let mut store = self.store.lock().await;
+        self.specs.init(store.deref_mut()).await?;
+        Ok(())
+    }
+
+    /// Stops the pstor-proxy registry, which revokes the persistent store lease.
+    pub(crate) async fn stop(&self) {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async move {
+            let store = self.store.lock().await;
+            store.revoke().await
+        })
+        .await
+        .ok();
+    }
+
+    /// Get a reference to the locked resource specs object.
+    fn specs(&self) -> &ResourceSpecsLocked {
+        &self.specs
+    }
+
+    /// Serialized write to the persistent store.
+    async fn store_obj<O: StorableObject>(&self, object: &O) -> Result<(), SvcError> {
+        let store = self.store.clone();
+        match tokio::time::timeout(self.store_timeout, async move {
+            let mut store = store.lock().await;
+            Self::op_with_threshold(async move { store.put_obj(object).await }).await
+        })
+        .await
+        {
+            Ok(result) => result.map_err(|error| SvcError::Store { source: error }),
+            Err(_) => Err(SvcError::Store {
+                source: pstor::error::Error::Timeout {
+                    operation: "Put".to_string(),
+                    timeout: self.store_timeout,
+                },
+            }),
+        }
+    }
+
+    /// Serialized delete to the persistent store.
+    async fn delete_kv<K: StoreKey>(&self, key: &K) -> Result<(), SvcError> {
+        let store = self.store.clone();
+        match tokio::time::timeout(self.store_timeout, async move {
+            let mut store = store.lock().await;
+            Self::op_with_threshold(async move { store.delete_kv(key).await }).await
+        })
+        .await
+        {
+            Ok(result) => match result {
+                Ok(_) => Ok(()),
+                Err(pstor::Error::MissingEntry { .. }) => {
+                    tracing::warn!("Entry with key {} missing from store.", key.to_string());
+                    Ok(())
+                }
+                Err(error) => Err(SvcError::Store { source: error }),
+            },
+            Err(_) => Err(SvcError::Store {
+                source: pstor::error::Error::Timeout {
+                    operation: "Delete".to_string(),
+                    timeout: self.store_timeout,
+                },
+            }),
+        }
+    }
+
+    async fn op_with_threshold<F, O>(future: F) -> O
+    where
+        F: Future<Output = O>,
+    {
+        let start = std::time::Instant::now();
+        let result = future.await;
+        let warn_threshold = std::time::Duration::from_secs(1);
+        if start.elapsed() > warn_threshold {
+            tracing::warn!("Store operation took longer than {:?}", warn_threshold);
+        }
+        result
+    }
+
+    /// Register a frontend node
+    pub(crate) async fn register_frontend_node(
+        &self,
+        frontend_node_spec: &RegisterFrontendNode,
+    ) -> Result<(), SvcError> {
+        self.specs().register_node(self, frontend_node_spec).await?;
+        Ok(())
+    }
+
+    /// Deregister a frontend node.
+    pub(crate) async fn deregister_frontend_node(
+        &self,
+        frontend_node_spec: &DeregisterFrontendNode,
+    ) -> Result<(), SvcError> {
+        self.specs()
+            .deregister_node(self, frontend_node_spec)
+            .await?;
+        Ok(())
+    }
+
+    /// Get the frontend node by id.
+    pub(crate) async fn frontend_node(
+        &self,
+        id: &FrontendNodeId,
+    ) -> Result<FrontendNode, SvcError> {
+        let spec = self.specs().frontend_node_spec(id);
+        let Some(spec) = spec else {
+            return Err(SvcError::FrontendNodeNotFound {
+                resource_id: id.to_string(),
+            });
+        };
+        Ok(FrontendNode::new(spec, None))
+    }
+
+    /// Get all frontend nodes.
+    pub(crate) async fn frontend_nodes(&self) -> Vec<FrontendNode> {
+        let volume_specs = self.specs().frontend_nodes();
+        let mut frontend_nodes = Vec::with_capacity(volume_specs.len());
+        for spec in volume_specs {
+            frontend_nodes.push(FrontendNode::new(spec, None));
+        }
+        frontend_nodes
+    }
+
+    /// Get a paginated subset of volumes.
+    pub(super) async fn paginated_frontend_nodes(
+        &self,
+        pagination: &Pagination,
+    ) -> PaginatedResult<FrontendNode> {
+        let frontend_node_specs = self.specs().paginated_frontend_nodes(pagination);
+        let mut frontend_nodes = Vec::with_capacity(frontend_node_specs.len());
+        let last = frontend_node_specs.last();
+        for spec in frontend_node_specs.result() {
+            frontend_nodes.push(FrontendNode::new(spec, None));
+        }
+        PaginatedResult::new(frontend_nodes, last)
+    }
+}
+
+impl ResourceSpecsLocked {
+    pub(crate) fn new() -> Self {
+        ResourceSpecsLocked::default()
+    }
+
+    /// Initialise the resource specs with the content from the persistent store.
+    async fn init<S: Store>(&self, store: &mut S) -> Result<(), SvcError> {
+        let spec_types = [StorableObjectType::FrontendNodeSpec];
+        for spec in &spec_types {
+            self.populate_specs(store, *spec).await?;
+        }
+        Ok(())
+    }
+
+    /// Get the frontend spec.
+    fn frontend_node_spec(&self, id: &FrontendNodeId) -> Option<FrontendNodeSpec> {
+        let specs = self.read();
+        match specs.frontend_nodes.get(id) {
+            None => None,
+            Some(frontend_node_spec) => {
+                let resource = frontend_node_spec.lock().clone();
+                Some(resource)
+            }
+        }
+    }
+
+    /// Remove the frontend spec from registry.
+    fn remove_frontend_node_spec(&self, id: &FrontendNodeId) {
+        let mut specs = self.write();
+        specs.frontend_nodes.remove(id);
+    }
+
+    async fn populate_specs<S: Store>(
+        &self,
+        store: &mut S,
+        spec_type: StorableObjectType,
+    ) -> Result<(), SvcError> {
+        let prefix = key_prefix_obj(spec_type, API_VERSION);
+        let store_entries = store
+            .get_values_prefix(&prefix)
+            .await
+            .map_err(|error| SvcError::Store { source: error })?;
+        let store_values = store_entries.iter().map(|e| e.1.clone()).collect();
+
+        let mut resource_specs = self.0.write();
+        if let StorableObjectType::FrontendNodeSpec = spec_type {
+            let specs = Self::deserialise_specs::<FrontendNodeSpec>(store_values)
+                .map_err(|error| SvcError::SpecDeserialize { source: error })?;
+            resource_specs.frontend_nodes.populate(specs);
+        }
+
+        Ok(())
+    }
+
+    /// Deserialise a vector of serde_json values into specific spec types.
+    /// If deserialisation fails for any object, return an error.
+    fn deserialise_specs<T>(values: Vec<serde_json::Value>) -> Result<Vec<T>, serde_json::Error>
+    where
+        T: DeserializeOwned,
+    {
+        let specs: Vec<Result<T, serde_json::Error>> = values
+            .iter()
+            .map(|v| serde_json::from_value(v.clone()))
+            .collect();
+
+        let mut result = vec![];
+        for spec in specs {
+            match spec {
+                Ok(s) => {
+                    result.push(s);
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// Create a node spec for the register request
+    async fn register_node(
+        &self,
+        registry: &Registry,
+        frontend_node: &RegisterFrontendNode,
+    ) -> Result<FrontendNodeSpec, SvcError> {
+        let (changed, spec_to_persist) = {
+            let mut specs = self.write();
+            match specs.frontend_nodes.get(&frontend_node.id) {
+                Some(frontend_node_rsc) => {
+                    let mut frontend_node_spec = frontend_node_rsc.lock();
+                    let changed = frontend_node_spec.endpoint != frontend_node.endpoint;
+
+                    frontend_node_spec.endpoint = frontend_node.endpoint;
+                    (changed, frontend_node_spec.clone())
+                }
+                None => {
+                    let node = FrontendNodeSpec::new(
+                        frontend_node.id.clone(),
+                        frontend_node.endpoint,
+                        Default::default(),
+                    );
+                    specs.frontend_nodes.insert(node.clone());
+                    (true, node)
+                }
+            }
+        };
+        if changed {
+            registry.store_obj(&spec_to_persist).await?;
+        }
+        Ok(spec_to_persist)
+    }
+
+    /// Create a node spec for the register request
+    async fn deregister_node(
+        &self,
+        registry: &Registry,
+        node: &DeregisterFrontendNode,
+    ) -> Result<(), SvcError> {
+        registry
+            .delete_kv(&<DeregisterFrontendNode as Into<FrontendNodeKey>>::into(node.clone()).key())
+            .await?;
+        self.remove_frontend_node_spec(&node.id);
+        Ok(())
+    }
+
+    fn frontend_nodes(&self) -> Vec<FrontendNodeSpec> {
+        let specs = self.read();
+        specs
+            .frontend_nodes
+            .values()
+            .map(|v| v.lock().clone())
+            .collect()
+    }
+
+    /// Get a subset of volumes based on the pagination argument.
+    fn paginated_frontend_nodes(
+        &self,
+        pagination: &Pagination,
+    ) -> PaginatedResult<FrontendNodeSpec> {
+        let specs = self.read();
+
+        let num_frontend_nodes = specs.frontend_nodes.len() as u64;
+        let max_entries = pagination.max_entries();
+        let offset = std::cmp::min(pagination.starting_token(), num_frontend_nodes);
+        let mut last_result = false;
+        let length = match offset + max_entries >= num_frontend_nodes {
+            true => {
+                last_result = true;
+                num_frontend_nodes - offset
+            }
+            false => pagination.max_entries(),
+        };
+
+        PaginatedResult::new(specs.frontend_nodes.paginate(offset, length), last_result)
+    }
+}

--- a/control-plane/pstor-proxy/src/bin/pstor-proxy/resource_map.rs
+++ b/control-plane/pstor-proxy/src/bin/pstor-proxy/resource_map.rs
@@ -1,0 +1,207 @@
+use indexmap::{map::Values, IndexMap};
+use parking_lot::Mutex;
+use pstor_proxy::types::frontend_node::{FrontendNodeId, FrontendNodeSpec, IntoVec};
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+    ops::Deref,
+    sync::Arc,
+};
+
+/// Trait which exposes a resource Uid for various types of resources.
+pub(crate) trait ResourceUid {
+    /// The associated type for Id.
+    type Uid: Clone + Display;
+    /// The id of the resource.
+    fn uid(&self) -> &Self::Uid;
+    fn uid_str(&self) -> String {
+        self.uid().to_string()
+    }
+}
+
+/// Ref-counted resource wrapped with a mutex.
+#[derive(Debug, Clone)]
+pub(crate) struct ResourceMutex<T> {
+    inner: Arc<ResourceMutexInner<T>>,
+}
+impl<T: Clone + ResourceUid> ResourceUid for ResourceMutex<T> {
+    type Uid = T::Uid;
+
+    fn uid(&self) -> &Self::Uid {
+        self.immutable_ref().uid()
+    }
+}
+impl<T: Clone + ResourceUid> ResourceUid for Resource<T> {
+    type Uid = T::Uid;
+
+    fn uid(&self) -> &Self::Uid {
+        self.inner.uid()
+    }
+}
+/// Inner Resource which holds the mutex and an immutable value for peeking
+/// into immutable fields such as identification fields.
+#[derive(Debug)]
+pub(crate) struct ResourceMutexInner<T> {
+    resource: Mutex<T>,
+    immutable_peek: Arc<T>,
+}
+impl<T: Clone> From<T> for ResourceMutex<T> {
+    fn from(resource: T) -> Self {
+        let immutable_peek = Arc::new(resource.clone());
+        let resource = Mutex::new(resource);
+        Self {
+            inner: Arc::new(ResourceMutexInner {
+                resource,
+                immutable_peek,
+            }),
+        }
+    }
+}
+impl<T> Deref for ResourceMutex<T> {
+    type Target = Mutex<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner.resource
+    }
+}
+impl<T: Clone> ResourceMutex<T> {
+    /// Peek the initial resource value without locking.
+    /// # Note:
+    /// This is only useful for immutable fields, such as the resource identifier.
+    pub(crate) fn immutable_ref(&self) -> &Arc<T> {
+        &self.inner.immutable_peek
+    }
+}
+
+/// Ref-counted resource.
+#[derive(Debug, Clone)]
+pub(crate) struct Resource<T> {
+    inner: Arc<T>,
+}
+impl<T> Deref for Resource<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<T: Clone> From<T> for Resource<T> {
+    fn from(resource: T) -> Self {
+        Self {
+            inner: Arc::new(resource),
+        }
+    }
+}
+
+/// ResourceMap for mutable resources.
+pub(crate) type ResourceMutexMap<I, S> = ResourceBaseMap<I, ResourceMutex<S>>;
+
+/// Base Resource Map.
+#[derive(Debug)]
+pub(crate) struct ResourceBaseMap<I, S: Clone> {
+    map: IndexMap<I, S>,
+}
+
+impl<I, S> Default for ResourceBaseMap<I, ResourceMutex<S>>
+where
+    I: Eq + Hash + Clone,
+    S: Clone + ResourceUid<Uid = I> + Debug,
+{
+    fn default() -> Self {
+        Self {
+            map: IndexMap::new(),
+        }
+    }
+}
+
+impl<I, S> ResourceBaseMap<I, ResourceMutex<S>>
+where
+    I: Eq + Hash + Clone,
+    S: Clone + ResourceUid<Uid = I> + Debug,
+{
+    /// Get the resource with the given key.
+    pub(crate) fn get(&self, key: &I) -> Option<&ResourceMutex<S>> {
+        self.map.get(key)
+    }
+
+    /// Insert an element or update an existing entry in the map.
+    pub(crate) fn insert(&mut self, value: S) -> ResourceMutex<S> {
+        match self.map.get(value.uid()) {
+            Some(entry) => {
+                let mut e = entry.lock();
+                *e = value;
+                entry.clone()
+            }
+            None => {
+                let key = value.uid().clone();
+                let resource: ResourceMutex<S> = value.into();
+                self.map.insert(key, resource.clone());
+                resource
+            }
+        }
+    }
+
+    /// Remove an element from the map.
+    pub(crate) fn remove(&mut self, key: &I) {
+        self.map.remove(key);
+    }
+
+    /// Populate the resource map.
+    /// Should only be called if the map is empty because a new Arc is created thereby invalidating
+    /// any references to the previous value.
+    pub(crate) fn populate(&mut self, values: impl IntoVec<S>) {
+        assert!(self.map.is_empty());
+        for value in values.into_vec() {
+            self.map.insert(value.uid().clone(), value.into());
+        }
+    }
+
+    /// Return the maps values.
+    pub(crate) fn values(&self) -> Values<'_, I, ResourceMutex<S>> {
+        self.map.values()
+    }
+
+    /// Return the length of the map.
+    pub(crate) fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Return a subset of the map (i.e. a paginated result).
+    pub(crate) fn paginate(&self, offset: u64, len: u64) -> Vec<S> {
+        self.paginate_filter(offset, len, |_| true)
+    }
+
+    /// Apply the closure on the elements and return a subset of the map (i.e. a paginated result),
+    /// containing the elements for which closure returns true.
+    pub(crate) fn paginate_filter<F: Fn(&&ResourceMutex<S>) -> bool>(
+        &self,
+        offset: u64,
+        len: u64,
+        seive: F,
+    ) -> Vec<S> {
+        self.map
+            .values()
+            .filter(seive)
+            .skip(offset as usize)
+            .take(len as usize)
+            .map(|v| v.lock().clone())
+            .collect()
+    }
+}
+
+impl<I, S> Default for ResourceBaseMap<I, Resource<S>>
+where
+    I: Eq + Hash + Clone,
+    S: Clone + ResourceUid<Uid = I> + Debug,
+{
+    fn default() -> Self {
+        Self {
+            map: IndexMap::new(),
+        }
+    }
+}
+
+impl ResourceUid for FrontendNodeSpec {
+    type Uid = FrontendNodeId;
+    fn uid(&self) -> &Self::Uid {
+        &self.id
+    }
+}

--- a/control-plane/pstor-proxy/src/lib.rs
+++ b/control-plane/pstor-proxy/src/lib.rs
@@ -1,0 +1,34 @@
+/// Type definitions.
+pub mod types;
+
+/// Pstor-proxy v1 types
+pub mod v1 {
+    mod all {
+        tonic::include_proto!("pstor_proxy.v1");
+    }
+
+    /// Pstor-proxy frontend node registration grpc module.
+    pub mod registration {
+        pub use super::all::{
+            registration_server::{Registration, RegistrationServer},
+            DeregisterRequest, RegisterRequest,
+        };
+    }
+
+    /// Pstor-proxy frontend node grpc module.
+    pub mod frontend_node {
+        pub use super::all::{
+            frontend_node_grpc_server::{FrontendNodeGrpc, FrontendNodeGrpcServer},
+            get_frontend_nodes_reply, get_frontend_nodes_request, FrontendNode, FrontendNodeSpec,
+            FrontendNodeState, FrontendNodes, GetFrontendNodesReply, GetFrontendNodesRequest,
+        };
+    }
+
+    /// Pstor-proxy commmon grpc module.
+    pub mod common {
+        pub use super::all::{
+            FrontendNodeFilter, Pagination, ReplyError, ReplyErrorKind, ResourceKind,
+            StringMapValue,
+        };
+    }
+}

--- a/control-plane/pstor-proxy/src/types/frontend_node.rs
+++ b/control-plane/pstor-proxy/src/types/frontend_node.rs
@@ -1,0 +1,249 @@
+use crate::v1;
+use pstor::{ApiVersion, ObjectKey, StorableObject, StorableObjectType};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Helper to convert from Vec<F> into Vec<T>.
+pub trait IntoVec<T>: Sized {
+    /// Performs the conversion.
+    fn into_vec(self) -> Vec<T>;
+}
+
+/// Frontend node definition.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct FrontendNode {
+    /// Frontend Node identification.
+    pub id: FrontendNodeId,
+    /// Endpoint of the csi-node instance (gRPC).
+    pub spec: FrontendNodeSpec,
+    /// Node labels.
+    pub state: Option<FrontendNodeState>,
+}
+
+impl FrontendNode {
+    pub fn new(spec: FrontendNodeSpec, state: Option<FrontendNodeState>) -> Self {
+        Self {
+            id: spec.id.clone(),
+            spec,
+            state,
+        }
+    }
+}
+
+/// Frontend node spec.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct FrontendNodeSpec {
+    /// Frontend Node identification.
+    pub id: FrontendNodeId,
+    /// Endpoint of the frontend instance.
+    pub endpoint: std::net::SocketAddr,
+    /// Node labels.
+    pub labels: FrontendNodeLabels,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct FrontendNodeState {}
+
+impl FrontendNodeSpec {
+    pub fn new(
+        id: FrontendNodeId,
+        endpoint: std::net::SocketAddr,
+        labels: FrontendNodeLabels,
+    ) -> Self {
+        Self {
+            id,
+            endpoint,
+            labels,
+        }
+    }
+}
+
+/// Multiple Frontend nodes.
+#[derive(Default, Debug, Clone)]
+pub struct FrontendNodes {
+    /// Vector of entries
+    pub entries: Vec<FrontendNode>,
+    /// The token to use in subsequent requests.
+    pub next_token: Option<u64>,
+}
+
+impl IntoVec<FrontendNodeSpec> for Vec<FrontendNodeSpec> {
+    fn into_vec(self) -> Vec<FrontendNodeSpec> {
+        self
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash)]
+pub struct FrontendNodeId(String);
+
+/// Frontend node labels
+pub type FrontendNodeLabels = HashMap<String, String>;
+
+/// Key used by the store to uniquely identify a VolumeSnapshot.
+pub struct FrontendNodeKey(FrontendNodeId);
+
+impl std::fmt::Display for FrontendNodeKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(::core::format_args!("{}", self.0))
+    }
+}
+impl From<&FrontendNodeId> for FrontendNodeKey {
+    fn from(id: &FrontendNodeId) -> Self {
+        Self(id.clone())
+    }
+}
+
+impl ObjectKey for FrontendNodeKey {
+    type Kind = StorableObjectType;
+
+    fn version(&self) -> ApiVersion {
+        ApiVersion::V0
+    }
+
+    fn key_type(&self) -> StorableObjectType {
+        StorableObjectType::FrontendNodeSpec
+    }
+
+    fn key_uuid(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl StorableObject for FrontendNodeSpec {
+    type Key = FrontendNodeKey;
+
+    fn key(&self) -> Self::Key {
+        FrontendNodeKey(self.id.clone())
+    }
+}
+
+impl std::fmt::Display for FrontendNodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(::core::format_args!("{}", self.0))
+    }
+}
+impl FrontendNodeId {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+impl From<&str> for FrontendNodeId {
+    fn from(id: &str) -> Self {
+        FrontendNodeId::from(id)
+    }
+}
+impl From<String> for FrontendNodeId {
+    fn from(id: String) -> Self {
+        FrontendNodeId::from(id.as_str())
+    }
+}
+impl From<&FrontendNodeId> for FrontendNodeId {
+    fn from(id: &FrontendNodeId) -> FrontendNodeId {
+        id.clone()
+    }
+}
+impl From<FrontendNodeId> for Option<String> {
+    fn from(id: FrontendNodeId) -> Option<String> {
+        Some(id.to_string())
+    }
+}
+impl From<FrontendNodeId> for String {
+    fn from(id: FrontendNodeId) -> String {
+        id.to_string()
+    }
+}
+impl From<&FrontendNodeId> for String {
+    fn from(id: &FrontendNodeId) -> String {
+        id.to_string()
+    }
+}
+impl Default for FrontendNodeId {
+    fn default() -> Self {
+        FrontendNodeId(uuid::Uuid::default().to_string())
+    }
+}
+impl FrontendNodeId {
+    pub fn from<T: Into<String>>(id: T) -> Self {
+        FrontendNodeId(id.into())
+    }
+    pub fn new() -> Self {
+        FrontendNodeId(uuid::Uuid::new_v4().to_string())
+    }
+}
+impl std::ops::Deref for FrontendNodeId {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct RegisterFrontendNode {
+    /// Frontend Node identification.
+    pub id: FrontendNodeId,
+    /// Endpoint of the csi-node instance (gRPC).
+    pub endpoint: std::net::SocketAddr,
+}
+
+impl RegisterFrontendNode {
+    pub fn new(id: FrontendNodeId, endpoint: std::net::SocketAddr) -> Self {
+        Self { id, endpoint }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct DeregisterFrontendNode {
+    /// Frontend Node identification.
+    pub id: FrontendNodeId,
+}
+
+impl DeregisterFrontendNode {
+    pub fn new(id: FrontendNodeId) -> Self {
+        Self { id }
+    }
+}
+
+impl From<DeregisterFrontendNode> for FrontendNodeKey {
+    fn from(value: DeregisterFrontendNode) -> Self {
+        Self(value.id)
+    }
+}
+
+impl From<FrontendNodeSpec> for v1::frontend_node::FrontendNodeSpec {
+    fn from(frontend_node_spec: FrontendNodeSpec) -> Self {
+        v1::frontend_node::FrontendNodeSpec {
+            id: frontend_node_spec.id.to_string(),
+            grpc_endpoint: frontend_node_spec.endpoint.to_string(),
+            labels: None,
+        }
+    }
+}
+
+impl From<FrontendNodeState> for v1::frontend_node::FrontendNodeState {
+    fn from(_frontend_node_state: FrontendNodeState) -> Self {
+        v1::frontend_node::FrontendNodeState {}
+    }
+}
+
+impl From<FrontendNode> for v1::frontend_node::FrontendNode {
+    fn from(frontend_node: FrontendNode) -> Self {
+        v1::frontend_node::FrontendNode {
+            id: frontend_node.id.to_string(),
+            spec: Some(frontend_node.spec.into()),
+            state: frontend_node.state.map(|state| state.into()),
+        }
+    }
+}
+
+impl From<FrontendNodes> for v1::frontend_node::FrontendNodes {
+    fn from(frontend_nodes: FrontendNodes) -> Self {
+        v1::frontend_node::FrontendNodes {
+            entries: frontend_nodes
+                .entries
+                .iter()
+                .map(|frontend_node| frontend_node.clone().into())
+                .collect(),
+            next_token: frontend_nodes.next_token,
+        }
+    }
+}

--- a/control-plane/pstor-proxy/src/types/misc.rs
+++ b/control-plane/pstor-proxy/src/types/misc.rs
@@ -1,0 +1,119 @@
+use crate::{
+    types::frontend_node::FrontendNodeId,
+    v1,
+    v1::common::{ReplyError, ReplyErrorKind, ResourceKind},
+};
+use serde::{Deserialize, Serialize};
+
+/// Filter for getting resources.
+#[derive(Serialize, Deserialize, Debug, Clone, strum_macros::Display)]
+pub enum Filter {
+    /// All objects.
+    None,
+    /// Filter by Frontend Node id.
+    FrontendNode(FrontendNodeId),
+}
+
+impl TryFrom<v1::frontend_node::get_frontend_nodes_request::Filter> for Filter {
+    type Error = ReplyError;
+    fn try_from(
+        filter: v1::frontend_node::get_frontend_nodes_request::Filter,
+    ) -> Result<Self, Self::Error> {
+        Ok(match filter {
+            v1::frontend_node::get_frontend_nodes_request::Filter::FrontendNode(
+                frontend_node_filter,
+            ) => Filter::FrontendNode(
+                FrontendNodeId::try_from(frontend_node_filter.frontend_node_id).map_err(
+                    |error| ReplyError {
+                        kind: ReplyErrorKind::InvalidArgument as i32,
+                        resource: ResourceKind::FrontendNodeKind as i32,
+                        source: "frontend_node.id".to_string(),
+                        extra: error.to_string(),
+                    },
+                )?,
+            ),
+        })
+    }
+}
+
+/// Paginated results.
+pub struct PaginatedResult<T> {
+    // Results
+    result: Vec<T>,
+    // Indicates whether or not this is the last paginated result.
+    last_result: bool,
+}
+
+impl<T> PaginatedResult<T> {
+    /// Create a new `PaginatedResult` instance.
+    pub fn new(result: Vec<T>, last_result: bool) -> Self {
+        Self {
+            result,
+            last_result,
+        }
+    }
+
+    /// Returns the result vector.
+    pub fn result(self) -> Vec<T> {
+        self.result
+    }
+
+    /// Return whether or not this is the last result.
+    pub fn last(&self) -> bool {
+        self.last_result
+    }
+
+    /// Length of the results vector.
+    pub fn len(&self) -> usize {
+        self.result.len()
+    }
+
+    /// Returns whether or not there are any results.
+    pub fn is_empty(&self) -> bool {
+        self.result.is_empty()
+    }
+}
+
+/// The type of max entries.
+pub type MaxEntries = u64;
+
+/// The type of the starting token.
+pub type StartingToken = u64;
+
+/// Pagination structure to allow multiple requests to retrieve a large number of entries.
+#[derive(Clone, Debug)]
+pub struct Pagination {
+    // Maximum number of entries to return per request.
+    max_entries: MaxEntries,
+    // The starting entry for each request.
+    starting_token: StartingToken,
+}
+
+impl Pagination {
+    /// Create a new `Pagination` instance.
+    pub fn new(max_entries: MaxEntries, starting_token: StartingToken) -> Self {
+        Self {
+            max_entries,
+            starting_token,
+        }
+    }
+
+    /// Get the max number of entries.
+    pub fn max_entries(&self) -> MaxEntries {
+        self.max_entries
+    }
+
+    /// Get the starting token
+    pub fn starting_token(&self) -> StartingToken {
+        self.starting_token
+    }
+}
+
+impl From<crate::v1::common::Pagination> for Pagination {
+    fn from(p: crate::v1::common::Pagination) -> Self {
+        Self {
+            max_entries: p.max_entries,
+            starting_token: p.starting_token,
+        }
+    }
+}

--- a/control-plane/pstor-proxy/src/types/mod.rs
+++ b/control-plane/pstor-proxy/src/types/mod.rs
@@ -1,0 +1,4 @@
+/// Frontend node types and trait impls.
+pub mod frontend_node;
+/// Common types and trait impls.
+pub mod misc;

--- a/utils/pstor/src/common.rs
+++ b/utils/pstor/src/common.rs
@@ -27,6 +27,7 @@ pub enum StorableObjectType {
     StoreLeaseLock,
     StoreLeaseOwner,
     SwitchOver,
+    FrontendNodeSpec,
 }
 
 /// Control plane api versions.


### PR DESCRIPTION
- Adds the new pstor-proxy binary.
- Adds the in memory cache for frontend registration.
- Adds the frontend registration grpc server and service.
- Adds the frontend grpc server and service.