### PR TITLE
Repo chores

### DIFF
--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -21,5 +21,14 @@ jobs:
           if [ ! ${{ github.ref }} = "refs/heads/staging" ]; then
             first_commit=${{ github.event.pull_request.base.sha }}
             last_commit=${{ github.event.pull_request.head.sha }}
+            # Ensure code-review commits don't get merged
+            sed "s/code-review-rule': \[0/code-review-rule': [2/g" -i commitlint.config.js
             npx commitlint --from $first_commit --to $last_commit -V
+
+            git log --pretty=format:%s $first_commit..$last_commit > ./subjects
+            duplicates="$(cat ./subjects | sort | uniq -D)"
+            if [ "$duplicates" != "" ]; then
+              echo -e "Duplicate commits found:\n$duplicates" >&2
+              exit 1
+            fi
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,11 +2574,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.56"
+version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2606,9 +2606,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.91"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
 dependencies = [
  "cc",
  "libc",
@@ -4421,9 +4421,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "untrusted"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,10 +2,24 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'example']],
+    'code-review-rule': [0, 'always'],
   },
   defaultIgnores: false,
   ignores: [
       (message) => message.startsWith('chore(bors): merge pull request #'),
       (message) => message.startsWith('Merge #')
-  ]
+  ],
+  plugins: [
+    {
+      rules: {
+        'code-review-rule': ({subject}) => {
+          const REVIEW_COMMENTS = `Please don't merge code-review commits, instead squash them in the parent commit`;
+          if (subject.includes('code-review')) return [ false, REVIEW_COMMENTS ];
+          if (subject.includes('review comments')) return [ false, REVIEW_COMMENTS ];
+          if (subject.includes('address comments')) return [ false, REVIEW_COMMENTS ];
+          return [ true ];
+        },
+      },
+    },
+  ],
 }

--- a/tests/bdd/requirements.txt
+++ b/tests/bdd/requirements.txt
@@ -3,6 +3,6 @@ python-dateutil==2.8.2
 retrying==1.3.4
 urllib3==1.26.18
 docker==5.0.3
-asyncssh==2.14.1
+asyncssh==2.14.2
 etcd3==0.12.0
 requests==2.31.0


### PR DESCRIPTION
    build: upgrade openssl and unsafe-yaml crates
    
    This addresses new dependabot security alerts.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci: try to further sanitize commits before merging
    
    Checks for a few common words and outputs the error if found.
    These commits bring no value when browsing the history and should
    be squashed onto the parent commit.
    todo: We should also block duplicate commits, though unsure how
    to do this atm.
    
    Checks for duplicate commit subjects.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test: upgrade asyncssh to address dependabot alert
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
