### PR TITLE
build(utils/version): add correct git HEAD paths

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -15,8 +15,9 @@ module.exports = {
         'code-review-rule': ({subject}) => {
           const REVIEW_COMMENTS = `Please don't merge code-review commits, instead squash them in the parent commit`;
           if (subject.includes('code-review')) return [ false, REVIEW_COMMENTS ];
-          if (subject.includes('review comments')) return [ false, REVIEW_COMMENTS ];
-          if (subject.includes('address comments')) return [ false, REVIEW_COMMENTS ];
+          if (subject.includes('review comment')) return [ false, REVIEW_COMMENTS ];
+          if (subject.includes('address comment')) return [ false, REVIEW_COMMENTS ];
+          if (subject.includes('addressed comment')) return [ false, REVIEW_COMMENTS ];
           return [ true ];
         },
       },

--- a/scripts/git/branch_ancestor.sh
+++ b/scripts/git/branch_ancestor.sh
@@ -180,6 +180,9 @@ function findBranchesSharingFirstCommonCommit() {
     local BASE_BRANCH
     if [[ -z "${1+x}" || "$1" == '.' ]]; then
         BASE_BRANCH="$CURRENT_BRANCH"
+        if [ "$CURRENT_BRANCH" = "" ]; then
+          return
+        fi
     else
         BASE_BRANCH="$1"
     fi

--- a/utils/utils-lib/build.rs
+++ b/utils/utils-lib/build.rs
@@ -13,9 +13,16 @@ fn main() -> BuildResult {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let git_path = std::path::Path::new("../../.git");
-    if git_path.exists() {
-        println!("cargo:rerun-if-changed=../../.git/HEAD");
+    fn add_git_head(root: &str) {
+        let git_path = std::path::Path::new(root).join(".git/HEAD");
+        if git_path.exists() {
+            println!("cargo:rerun-if-changed={}", git_path.display());
+        }
+    }
+
+    add_git_head("../..");
+    if let Ok(ext) = std::env::var("EXTENSIONS_SRC") {
+        add_git_head(&ext);
     }
 
     Ok(())


### PR DESCRIPTION
When this is used a dependency for extensions the build.rs for utils-lib ends up adding an invalid git path to the cargo re-runs. This actually causes continuous rebuilding on the extensions repo. Fixes this by ensure the path exists and by checking specifically for the extensions env var.
The latter one is, to put it bluntly, a hack, but atm I don't know else to do it in a quick way.