### PR TITLE
Delete Orphaned Volumes on a timer

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/node/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/node/nexus.rs
@@ -140,7 +140,7 @@ async fn find_shutdown_volumes(
         // else the drain operation is timed out
 
         // todo: this should be handled better..
-        if platform::current_plaform_type() == platform::PlatformType::Deployer {
+        if platform::current_platform_type() == platform::PlatformType::Deployer {
             for vi in node_spec.node_draining_volumes().await {
                 let mut volume = context.specs().volume(&vi).await?;
                 let request = DestroyShutdownTargets::new(vi, None);

--- a/control-plane/agents/src/bin/ha/node/path_provider.rs
+++ b/control-plane/agents/src/bin/ha/node/path_provider.rs
@@ -1,5 +1,5 @@
 use nvmeadm::nvmf_subsystem::{NvmeSubsystems, Subsystem};
-use stor_port::platform::{current_plaform_type, PlatformType};
+use stor_port::platform::{current_platform_type, PlatformType};
 use utils::NVME_TARGET_NQN_PREFIX;
 
 #[cfg(target_os = "linux")]
@@ -121,7 +121,7 @@ impl CachedNvmePathProvider {
     }
     #[cfg(target_os = "linux")]
     fn udev_supported() -> bool {
-        match current_plaform_type() {
+        match current_platform_type() {
             PlatformType::K8s => true,
             PlatformType::None => true,
             PlatformType::Deployer => false,

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -1,4 +1,6 @@
-use crate::{ApiClientError, CreateVolumeTopology, CsiControllerConfig, IoEngineApiClient};
+use crate::{
+    client::ListToken, ApiClientError, CreateVolumeTopology, CsiControllerConfig, IoEngineApiClient,
+};
 
 use csi_driver::context::{CreateParams, PublishParams};
 use rpc::csi::{volume_content_source::Type, Topology as CsiTopology, *};
@@ -652,7 +654,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         let vt_mapper = VolumeTopologyMapper::init().await?;
 
         let volumes = IoEngineApiClient::get_client()
-            .list_volumes(max_entries, args.starting_token)
+            .list_volumes(max_entries, ListToken::String(args.starting_token))
             .await
             .map_err(|e| Status::internal(format!("Failed to list volumes, error = {e:?}")))?;
 

--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -19,7 +19,7 @@ const REST_TIMEOUT: &str = "30s";
 fn initialize_controller(args: &ArgMatches) -> anyhow::Result<()> {
     CsiControllerConfig::initialize(args)?;
     IoEngineApiClient::initialize()
-        .map_err(|e| anyhow::anyhow!("Failed to initialize API client, error = {}", e))?;
+        .map_err(|error| anyhow::anyhow!("Failed to initialize API client, error = {error}"))?;
     Ok(())
 }
 
@@ -32,9 +32,8 @@ async fn ping_rest_api() {
         Ok(nodes) => {
             let names: Vec<String> = nodes.into_iter().map(|n| n.id).collect();
             info!(
-                "REST API endpoints available, {} IoEngine node(s) reported: {:?}",
-                names.len(),
-                names,
+                "REST API endpoint available, {len} IoEngine node(s) reported: {names:?}",
+                len = names.len(),
             );
         }
     }
@@ -136,7 +135,7 @@ async fn main() -> anyhow::Result<()> {
     ping_rest_api().await;
 
     // Starts PV Garbage Collector if platform type is k8s
-    if stor_port::platform::current_plaform_type() == stor_port::platform::PlatformType::K8s {
+    if stor_port::platform::current_platform_type() == stor_port::platform::PlatformType::K8s {
         let gc_instance = pvwatcher::PvGarbageCollector::new(orphan_period).await?;
         tokio::spawn(async move { gc_instance.run_watcher().await });
     }

--- a/control-plane/csi-driver/src/bin/controller/server.rs
+++ b/control-plane/csi-driver/src/bin/controller/server.rs
@@ -1,4 +1,3 @@
-use crate::IoEngineApiClient;
 use futures::TryFutureExt;
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
@@ -35,9 +34,10 @@ impl Connected for UnixStream {
 }
 
 #[derive(Clone, Debug)]
-pub struct UdsConnectInfo {
-    pub peer_addr: Option<Arc<tokio::net::unix::SocketAddr>>,
-    pub peer_cred: Option<tokio::net::unix::UCred>,
+#[allow(unused)]
+struct UdsConnectInfo {
+    peer_addr: Option<Arc<tokio::net::unix::SocketAddr>>,
+    peer_cred: Option<tokio::net::unix::UCred>,
 }
 
 impl AsyncRead for UnixStream {
@@ -68,33 +68,16 @@ impl AsyncWrite for UnixStream {
     }
 }
 
-pub struct CsiServer {}
-
-#[tracing::instrument]
-async fn ping_rest_api() {
-    info!("Checking REST API endpoint accessibility ...");
-
-    match IoEngineApiClient::get_client().list_nodes().await {
-        Err(e) => error!(?e, "REST API endpoint is not accessible"),
-        Ok(nodes) => {
-            let names: Vec<String> = nodes.into_iter().map(|n| n.id).collect();
-            info!(
-                "REST API endpoints available, {} IoEngine node(s) reported: {:?}",
-                names.len(),
-                names,
-            );
-        }
-    }
-}
-
+pub(super) struct CsiServer {}
 impl CsiServer {
-    pub async fn run(csi_socket: String) -> anyhow::Result<()> {
+    /// Runs the CSI Server identity and controller services.
+    pub async fn run(csi_socket: &str) -> anyhow::Result<()> {
         // It seems we're not ensuring only 1 csi server is running at a time because here
         // we don't bind to a port for example but to a unix socket.
         // todo: Can we do something about this?
 
         // Remove existing CSI socket from previous runs.
-        match fs::remove_file(&csi_socket) {
+        match fs::remove_file(csi_socket) {
             Ok(_) => info!("Removed stale CSI socket {}", csi_socket),
             Err(err) => {
                 if err.kind() != ErrorKind::NotFound {
@@ -108,12 +91,12 @@ impl CsiServer {
         debug!("CSI RPC server is listening on {}", csi_socket);
 
         let incoming = {
-            let uds = UnixListener::bind(&csi_socket)?;
+            let uds = UnixListener::bind(csi_socket)?;
 
             // Change permissions on CSI socket to allow non-privileged clients to access it
             // to simplify testing.
             if let Err(e) = fs::set_permissions(
-                &csi_socket,
+                csi_socket,
                 std::os::unix::fs::PermissionsExt::from_mode(0o777),
             ) {
                 error!("Failed to change permissions for CSI socket: {:?}", e);
@@ -128,9 +111,6 @@ impl CsiServer {
                 }
             }
         };
-
-        // Try to detect REST API endpoint to debug the accessibility status.
-        ping_rest_api().await;
 
         let cfg = crate::CsiControllerConfig::get_config();
 

--- a/control-plane/csi-driver/src/bin/controller/server.rs
+++ b/control-plane/csi-driver/src/bin/controller/server.rs
@@ -33,6 +33,7 @@ impl Connected for UnixStream {
     }
 }
 
+// Not sure why we need the inner fields, probably worth checking if we can remove them.
 #[derive(Clone, Debug)]
 #[allow(unused)]
 struct UdsConnectInfo {

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -236,7 +236,7 @@ pub(super) async fn main() -> anyhow::Result<()> {
         anyhow::bail!("Failed to detect nvme_tcp kernel module. Run `modprobe nvme_tcp` to load the kernel module. {}", error);
     }
 
-    if platform::current_plaform_type() == platform::PlatformType::K8s {
+    if platform::current_platform_type() == platform::PlatformType::K8s {
         check_ana_and_label_node(matches.get_one::<String>("node-name").expect("required")).await?;
     }
 

--- a/utils/platform/src/lib.rs
+++ b/utils/platform/src/lib.rs
@@ -33,7 +33,7 @@ pub enum PlatformType {
 }
 
 /// Get the current `PlatformType`.
-pub fn current_plaform_type() -> PlatformType {
+pub fn current_platform_type() -> PlatformType {
     if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
         PlatformType::K8s
     } else {
@@ -51,7 +51,7 @@ static PLATFORM: OnceCell<Box<dyn PlatformInfo>> = OnceCell::const_new();
 pub async fn init_cluster_info() -> Result<&'static dyn PlatformInfo, PlatformError> {
     PLATFORM
         .get_or_try_init(|| async move {
-            Ok(match current_plaform_type() {
+            Ok(match current_platform_type() {
                 PlatformType::K8s => Box::new(k8s::K8s::new().await?) as Box<dyn PlatformInfo>,
                 PlatformType::Deployer => {
                     Box::new(deployer::Deployer::new()) as Box<dyn PlatformInfo>


### PR DESCRIPTION
    fix(csi-controller/gc): list volumes with pagination
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    chore: correct typo in the plaftform code
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor(csi-controller/gc): reduce excessive unwrap and nesting
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(csi-controller/orphaned-vols): gc orphaned volumes on a timer
    
    Due to a k8s bug, when pv deletion is attempted before pvc deletion, we may not
    receive the delete request, and thus leaking volumes, which cannot be deleted
    through any user facing api.
    
    Existing code to clean up orphaned volumes was being made use for the case when
    certain pv events might be missed.
    Therefore current WA is to delete the csi-controller pod.
    This change makes use of this existing logic but runs it on a given time period
    which is by default 5 minutes, which  allows us to automatically WA the bug.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>