### PR TITLE
feat(app node): add rest api endpoints and integrate control-plane grpc

### DIFF
--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2033,6 +2033,108 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: []
+  /app-nodes:
+    get:
+      tags:
+        - AppNodes
+      operationId: get_app_nodes
+      parameters:
+        - in: query
+          name: max_entries
+          description: The maximum number of results to return.
+          schema:
+            type: integer
+            default: 0
+          required: true
+        - in: query
+          name: starting_token
+          description: The offset to start pagination from.
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppNodes'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+          '5XX':
+            $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
+  '/app-nodes/{app_node_id}':
+    put:
+      tags:
+        - AppNodes
+      operationId: register_app_node
+      parameters:
+        - in: path
+          name: app_node_id
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppNodeId'
+      requestBody:
+        description: Contents of the app node to be registered.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterAppNode'
+        required: true
+      responses:
+        '204':
+          description: OK
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: []
+    delete:
+      tags:
+        - AppNodes
+      operationId: deregister_app_node
+      parameters:
+        - name: app_node_id
+          in: path
+          description: ID of the app node to be deregistered.
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppNodeId'
+      responses:
+        '204':
+          description: OK
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: []
+    get:
+      tags:
+        - AppNodes
+      operationId: get_app_node
+      parameters:
+        - name: app_node_id
+          in: path
+          description: Id of the app node.
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppNodeId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppNode'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+          '5XX':
+            $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: []
 components:
   securitySchemes:
     JWT:
@@ -2055,6 +2157,10 @@ components:
     NodeId:
       description: storage node identifier
       example: io-engine-1
+      type: string
+    AppNodeId:
+      description: App node identifier.
+      example: csi-node-1
       type: string
     PoolId:
       description: storage pool identifier
@@ -3902,6 +4008,99 @@ components:
       required:
         - cordonlabels
         - drainlabels
+    RegisterAppNode:
+      example:
+        endpoint: '10.1.0.5:50055'
+        labels:
+          openebs.io/csi-node.nvme-ana: true,
+          openebs.io/zone: us-east-1a
+      type: object
+      properties:
+        endpoint:
+          description: |-
+            gRPC server endpoint of the app node.
+          type: string
+          format: url
+        labels:
+          description: |-
+              Labels to be set on the app node.
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - id
+        - endpoint
+    AppNode:
+      description: |-
+        Represents an application node, which connects to the target node via a share protocol (eg: nvmf).
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/AppNodeId'
+        spec:
+          $ref: '#/components/schemas/AppNodeSpec'
+        state:
+          $ref: '#/components/schemas/AppNodeState'
+      required:
+        - id
+        - spec
+    AppNodeSpec:
+      description: |-
+        App node attributes.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/AppNodeId'
+        endpoint:
+          description: |-
+            gRPC server endpoint of the app node.
+          type: string
+          format: url
+        labels:
+          description: |-
+              Labels to be set on the app node.
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - id
+        - endpoint
+    AppNodeState:
+      description: |-
+        Deemed state of the app node.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/AppNodeId'
+        endpoint:
+          description: |-
+            gRPC server endpoint of the app node.
+          type: string
+          format: url
+        status:
+          description: |-
+            Deemed Status of the app node.
+          type: string
+          enum:
+            - Online
+            - Offline
+      required:
+        - id
+        - endpoint
+        - status
+    AppNodes:
+      description: |-
+        Array of app nodes plus the next token for subsequent get requests when using pagination.
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppNode'
+        next_token:
+          type: integer
+      required:
+        - entries
   responses:
     ClientError:
       description: Client side error

--- a/control-plane/rest/service/src/v0/app_node.rs
+++ b/control-plane/rest/service/src/v0/app_node.rs
@@ -1,0 +1,84 @@
+use super::*;
+use grpc::operations::{
+    app_node::traits::AppNodeOperations, MaxEntries, Pagination, StartingToken,
+};
+use rest_client::versions::v0::models::{AppNode, AppNodes, RegisterAppNode};
+use std::net::AddrParseError;
+use stor_port::types::v0::transport::DeregisterAppNode;
+
+fn client() -> impl AppNodeOperations {
+    core_grpc().app_node()
+}
+
+#[async_trait::async_trait]
+impl apis::actix_server::AppNodes for RestApi {
+    async fn deregister_app_node(
+        Path(app_node_id): Path<String>,
+    ) -> Result<(), RestError<RestJsonError>> {
+        client()
+            .deregister_app_node(
+                &DeregisterAppNode {
+                    id: app_node_id.into(),
+                },
+                None,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn get_app_node(
+        Path(app_node_id): Path<String>,
+    ) -> Result<AppNode, RestError<RestJsonError>> {
+        let app_node = client()
+            .get(Filter::AppNode(app_node_id.into()), None)
+            .await?;
+        Ok(app_node.into())
+    }
+
+    async fn get_app_nodes(
+        Query((max_entries, starting_token)): Query<(isize, Option<isize>)>,
+    ) -> Result<AppNodes, RestError<RestJsonError>> {
+        let starting_token = starting_token.unwrap_or_default();
+
+        // If max entries is 0, pagination is disabled. All app nodes will be returned in a
+        // single call.
+        let pagination = if max_entries > 0 {
+            Some(Pagination::new(
+                max_entries as MaxEntries,
+                starting_token as StartingToken,
+            ))
+        } else {
+            None
+        };
+        let app_nodes = client().list(pagination, None).await?;
+        Ok(models::AppNodes {
+            entries: app_nodes.entries.into_iter().map(|e| e.into()).collect(),
+            next_token: app_nodes.next_token.map(|t| t as isize),
+        })
+    }
+
+    async fn register_app_node(
+        Path(app_node_id): Path<String>,
+        Body(register_app_node): Body<RegisterAppNode>,
+    ) -> Result<(), RestError<RestJsonError>> {
+        client()
+            .register_app_node(
+                &stor_port::types::v0::transport::RegisterAppNode {
+                    id: app_node_id.into(),
+                    endpoint: register_app_node.endpoint.parse().map_err(
+                        |error: AddrParseError| {
+                            ReplyError::invalid_argument(
+                                ResourceKind::AppNode,
+                                "app_node.endpoint",
+                                error.to_string(),
+                            )
+                        },
+                    )?,
+                    labels: register_app_node.labels,
+                },
+                None,
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/control-plane/rest/service/src/v0/mod.rs
+++ b/control-plane/rest/service/src/v0/mod.rs
@@ -2,6 +2,7 @@
 //! Version 0 of the URI's
 //! Ex: /v0/nodes
 
+pub mod app_node;
 pub mod block_devices;
 pub mod children;
 pub mod jsongrpc;

--- a/control-plane/stor-port/src/types/v0/store/app_node.rs
+++ b/control-plane/stor-port/src/types/v0/store/app_node.rs
@@ -1,4 +1,5 @@
 use crate::types::v0::transport::AppNodeId;
+use openapi::models;
 use pstor::{ApiVersion, ObjectKey, StorableObject, StorableObjectType};
 use serde::{Deserialize, Serialize};
 
@@ -60,5 +61,11 @@ impl AppNodeSpec {
             endpoint,
             labels,
         }
+    }
+}
+
+impl From<AppNodeSpec> for models::AppNodeSpec {
+    fn from(src: AppNodeSpec) -> Self {
+        Self::new_all(src.id, src.endpoint.to_string(), src.labels)
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/app_node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/app_node.rs
@@ -5,6 +5,7 @@ use crate::{
         transport::Filter,
     },
 };
+use openapi::models;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
@@ -123,5 +124,25 @@ impl GetAppNode {
     /// Get the inner `Filter`.
     pub fn filter(&self) -> &Filter {
         &self.filter
+    }
+}
+
+impl From<AppNodeStatus> for models::app_node_state::Status {
+    fn from(value: AppNodeStatus) -> Self {
+        match value {
+            AppNodeStatus::Online => Self::Online,
+            AppNodeStatus::Offline => Self::Offline,
+        }
+    }
+}
+impl From<AppNodeState> for models::AppNodeState {
+    fn from(src: AppNodeState) -> Self {
+        Self::new_all(src.id, src.endpoint.to_string(), src.status)
+    }
+}
+
+impl From<AppNode> for models::AppNode {
+    fn from(src: AppNode) -> Self {
+        Self::new_all(src.id, src.spec, src.state.map(|state| state.into()))
     }
 }


### PR DESCRIPTION
App Node: Represents a CSI node or a node where io app/initiator would be situated.

Goals:
- App node resource is needed to issue commands to the node for operations like fsfreeze, unfreeze.
- App nodes will now register itself to the control-plane via the rest API.
- These app nodes would be used to issue fsfreeze, unfreeze as a part of snapshot creation to ensure filesystem consistency.

Changes in this PR:
- This adds the rest api endpoints for registration and operations for app nodes