### PR TITLE
feat(app node): register csi nodes to control plane

### DIFF
--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -1,5 +1,4 @@
 use crate::CsiControllerConfig;
-use std::collections::HashMap;
 use stor_port::types::v0::openapi::{
     clients,
     clients::tower::StatusCode,
@@ -12,6 +11,7 @@ use stor_port::types::v0::openapi::{
 
 use anyhow::{anyhow, Result};
 use once_cell::sync::OnceCell;
+use std::collections::HashMap;
 use tracing::{debug, info, instrument};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -93,18 +93,18 @@ impl From<clients::tower::Error<RestJsonError>> for ApiClientError {
     }
 }
 
-static REST_CLIENT: OnceCell<IoEngineApiClient> = OnceCell::new();
+static REST_CLIENT: OnceCell<RestApiClient> = OnceCell::new();
 
 /// Single instance API client for accessing REST API gateway.
 /// Encapsulates communication with REST API by exposing a set of
 /// high-level API functions, which perform (de)serialization
 /// of API request/response objects.
 #[derive(Debug)]
-pub struct IoEngineApiClient {
+pub struct RestApiClient {
     rest_client: clients::tower::ApiClient,
 }
 
-impl IoEngineApiClient {
+impl RestApiClient {
     /// Initialize API client instance. Must be called prior to
     /// obtaining the client instance.
     pub(crate) fn initialize() -> Result<()> {
@@ -143,7 +143,7 @@ impl IoEngineApiClient {
 
     /// Obtain client instance. Panics if called before the client
     /// has been initialized.
-    pub(crate) fn get_client() -> &'static IoEngineApiClient {
+    pub(crate) fn get_client() -> &'static RestApiClient {
         REST_CLIENT.get().expect("Rest client is not initialized")
     }
 }
@@ -154,7 +154,7 @@ pub(crate) enum ListToken {
     Number(isize),
 }
 
-impl IoEngineApiClient {
+impl RestApiClient {
     /// List all nodes available in IoEngine cluster.
     pub(crate) async fn list_nodes(&self) -> Result<Vec<Node>, ApiClientError> {
         let response = self.rest_client.nodes_api().get_nodes(None).await?;

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -1,7 +1,6 @@
 use crate::{
-    client::ListToken, ApiClientError, CreateVolumeTopology, CsiControllerConfig, IoEngineApiClient,
+    client::ListToken, ApiClientError, CreateVolumeTopology, CsiControllerConfig, RestApiClient,
 };
-
 use csi_driver::context::{CreateParams, PublishParams};
 use rpc::csi::{volume_content_source::Type, Topology as CsiTopology, *};
 use stor_port::types::v0::openapi::{
@@ -289,7 +288,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         let mut volume_context = args.parameters.clone();
 
         // First check if the volume already exists.
-        match IoEngineApiClient::get_client()
+        match RestApiClient::get_client()
             .get_volume_for_create(&parsed_vol_uuid)
             .await
         {
@@ -319,7 +318,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
                 let volume = match volume_content_source {
                     Some(snapshot_uuid) => {
-                        IoEngineApiClient::get_client()
+                        RestApiClient::get_client()
                             .create_snapshot_volume(
                                 &parsed_vol_uuid,
                                 &snapshot_uuid,
@@ -333,7 +332,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                             .await?
                     }
                     None => {
-                        IoEngineApiClient::get_client()
+                        RestApiClient::get_client()
                             .create_volume(
                                 &parsed_vol_uuid,
                                 replica_count,
@@ -391,7 +390,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             Status::invalid_argument(format!("Malformed volume UUID: {}", args.volume_id))
         })?;
         let _guard = csi_driver::limiter::VolumeOpGuard::new(volume_uuid)?;
-        IoEngineApiClient::get_client()
+        RestApiClient::get_client()
             .delete_volume(&volume_uuid)
             .await
             .map_err(|e| {
@@ -440,9 +439,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         }
 
         // Check if the volume is already published.
-        let volume = IoEngineApiClient::get_client()
-            .get_volume(&volume_id)
-            .await?;
+        let volume = RestApiClient::get_client().get_volume(&volume_id).await?;
 
         let params = PublishParams::try_from(&args.volume_context)?;
 
@@ -482,52 +479,52 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                         return Err(Status::internal(m));
                     }
                 },
-            _ => {
+                _ => {
 
-                // Check for node being cordoned.
-                fn cordon_check(spec: Option<&NodeSpec>) -> bool {
-                    if let Some(spec) = spec {
-                        return spec.cordondrainstate.is_some()
+                    // Check for node being cordoned.
+                    fn cordon_check(spec: Option<&NodeSpec>) -> bool {
+                        if let Some(spec) = spec {
+                            return spec.cordondrainstate.is_some()
+                        }
+                        false
                     }
-                    false
-                }
 
-                // if the csi-node happens to be a data-plane node, use that for nexus creation, otherwise
-                // let the control-plane select the target node.
-                let target_node = match IoEngineApiClient::get_client().get_node(&node_id).await {
-                    Err(ApiClientError::ResourceNotExists(_)) => Ok(None),
-                    Err(error) => Err(error),
-                    // When nodes are not online for any reason (eg: io-engine no longer runs) on said node,
-                    // then let the control-plane decide where to place the target. Node should not be cordoned.
-                    Ok(node) if node.state.as_ref().map(|n| n.status).unwrap_or(NodeStatus::Unknown) != NodeStatus::Online || cordon_check(node.spec.as_ref()) => {
-                        Ok(None)
-                    },
-                    // For 1-replica volumes, don't pre-select the target node. This will allow the
-                    // control-plane to pin the target to the replica node.
-                    Ok(_) if volume.spec.num_replicas == 1 => Ok(None),
-                    Ok(_) => Ok(Some(node_id.as_str())),
-                }?;
+                    // if the csi-node happens to be a data-plane node, use that for nexus creation, otherwise
+                    // let the control-plane select the target node.
+                    let target_node = match RestApiClient::get_client().get_node(&node_id).await {
+                        Err(ApiClientError::ResourceNotExists(_)) => Ok(None),
+                        Err(error) => Err(error),
+                        // When nodes are not online for any reason (eg: io-engine no longer runs) on said node,
+                        // then let the control-plane decide where to place the target. Node should not be cordoned.
+                        Ok(node) if node.state.as_ref().map(|n| n.status).unwrap_or(NodeStatus::Unknown) != NodeStatus::Online || cordon_check(node.spec.as_ref()) => {
+                            Ok(None)
+                        },
+                        // For 1-replica volumes, don't pre-select the target node. This will allow the
+                        // control-plane to pin the target to the replica node.
+                        Ok(_) if volume.spec.num_replicas == 1 => Ok(None),
+                        Ok(_) => Ok(Some(node_id.as_str())),
+                    }?;
 
-                // Volume is not published.
-                let v = IoEngineApiClient::get_client()
-                    .publish_volume(&volume_id, target_node, protocol, args.node_id.clone(), &publish_context)
-                    .await?;
+                    // Volume is not published.
+                    let v = RestApiClient::get_client()
+                        .publish_volume(&volume_id, target_node, protocol, args.node_id.clone(), &publish_context)
+                        .await?;
 
-                if let Some((node, uri)) = get_volume_share_location(&v) {
-                    debug!(
+                    if let Some((node, uri)) = get_volume_share_location(&v) {
+                        debug!(
                         "Volume {} successfully published on node {} via {}",
                         volume_id, node, uri
                     );
-                    uri
-                } else {
-                    let m = format!(
-                        "Volume {volume_id} has been successfully published but URI is not available"
-                    );
-                    error!("{}", m);
-                    return Err(Status::internal(m));
+                        uri
+                    } else {
+                        let m = format!(
+                            "Volume {volume_id} has been successfully published but URI is not available"
+                        );
+                        error!("{}", m);
+                        return Err(Status::internal(m));
+                    }
                 }
-            }
-        };
+            };
 
         publish_context.insert("uri".to_string(), uri);
 
@@ -553,10 +550,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         })?;
         let _guard = csi_driver::limiter::VolumeOpGuard::new(volume_uuid)?;
         // Check if target volume exists.
-        let volume = match IoEngineApiClient::get_client()
-            .get_volume(&volume_uuid)
-            .await
-        {
+        let volume = match RestApiClient::get_client().get_volume(&volume_uuid).await {
             Ok(volume) => volume,
             Err(ApiClientError::ResourceNotExists { .. }) => {
                 debug!("Volume {} does not exist, not unpublishing", args.volume_id);
@@ -575,7 +569,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         }
 
         // Do forced volume upublish as Kubernetes already detached the volume.
-        IoEngineApiClient::get_client()
+        RestApiClient::get_client()
             .unpublish_volume(&volume_uuid, true)
             .await
             .map_err(|e| {
@@ -602,7 +596,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             Status::invalid_argument(format!("Malformed volume UUID: {}", args.volume_id))
         })?;
         let _guard = csi_driver::limiter::VolumeOpGuard::new(volume_uuid)?;
-        let _volume = IoEngineApiClient::get_client()
+        let _volume = RestApiClient::get_client()
             .get_volume(&volume_uuid)
             .await
             .map_err(|_e| Status::unimplemented("Not implemented"))?;
@@ -656,7 +650,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
         let vt_mapper = VolumeTopologyMapper::init().await?;
 
-        let volumes = IoEngineApiClient::get_client()
+        let volumes = RestApiClient::get_client()
             .list_volumes(max_entries, ListToken::String(args.starting_token))
             .await
             .map_err(|e| Status::internal(format!("Failed to list volumes, error = {e:?}")))?;
@@ -708,7 +702,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
         let pools: Vec<Pool> = if let Some(node) = node {
             debug!("Calculating pool capacity for node {}", node);
-            IoEngineApiClient::get_client()
+            RestApiClient::get_client()
                 .get_node_pools(node)
                 .await
                 .map_err(|e| {
@@ -718,7 +712,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                 })?
         } else {
             debug!("Calculating overall pool capacity");
-            IoEngineApiClient::get_client()
+            RestApiClient::get_client()
                 .list_pools()
                 .await
                 .map_err(|e| {
@@ -805,7 +799,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             Status::invalid_argument(format!("Malformed snapshot ID: {}", request.name))
         })?;
 
-        let snapshot = IoEngineApiClient::get_client()
+        let snapshot = RestApiClient::get_client()
             .create_volume_snapshot(&volume_uuid, &snap_uuid)
             .await
             .map_err(|error| match error {
@@ -831,7 +825,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             Status::invalid_argument(format!("Malformed snapshot UUID: {}", args.snapshot_id))
         })?;
 
-        IoEngineApiClient::get_client()
+        RestApiClient::get_client()
             .delete_volume_snapshot(&snapshot_uuid)
             .await
             .map_err(|e| {
@@ -865,7 +859,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             return Err(Status::invalid_argument("max_entries can't be negative"));
         }
 
-        let snapshots = IoEngineApiClient::get_client()
+        let snapshots = RestApiClient::get_client()
             .list_volume_snapshots(vol_uuid, snap_uuid, max_entries, request.starting_token)
             .await?;
 

--- a/control-plane/csi-driver/src/bin/controller/identity.rs
+++ b/control-plane/csi-driver/src/bin/controller/identity.rs
@@ -1,6 +1,7 @@
-use crate::{ApiClientError, IoEngineApiClient};
+use crate::{ApiClientError, RestApiClient};
 use csi_driver::CSI_PLUGIN_NAME;
 use rpc::csi::*;
+
 use std::collections::HashMap;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, instrument};
@@ -65,7 +66,7 @@ impl rpc::csi::identity_server::Identity for CsiIdentitySvc {
         // communicates to the Container Orchestrator that the plugin is not yet initialised but
         // should not be restarted. See the CSI spec:
         // https://github.com/container-storage-interface/spec/blob/5b0d4540158a260cb3347ef1c87ede8600afb9bf/csi.proto#L252-L256
-        let ready = match IoEngineApiClient::get_client().list_nodes().await {
+        let ready = match RestApiClient::get_client().list_nodes().await {
             Ok(_) => true,
             Err(ApiClientError::ServerCommunication { .. }) => {
                 error!("Failed to access REST API gateway, CSI Controller plugin is not ready",);

--- a/control-plane/csi-driver/src/bin/controller/pvwatcher.rs
+++ b/control-plane/csi-driver/src/bin/controller/pvwatcher.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info};
 pub(crate) struct PvGarbageCollector {
     pub(crate) pv_handle: Api<PersistentVolume>,
     orphan_period: Option<humantime::Duration>,
-    rest_client: &'static crate::IoEngineApiClient,
+    rest_client: &'static crate::RestApiClient,
 }
 
 /// Methods implemented by PV Garbage Collector
@@ -24,7 +24,7 @@ impl PvGarbageCollector {
         Ok(Self {
             pv_handle: Api::<PersistentVolume>::all(client),
             orphan_period,
-            rest_client: crate::IoEngineApiClient::get_client(),
+            rest_client: crate::RestApiClient::get_client(),
         })
     }
     /// Starts watching PV events.

--- a/control-plane/csi-driver/src/bin/controller/server.rs
+++ b/control-plane/csi-driver/src/bin/controller/server.rs
@@ -1,11 +1,7 @@
-use futures::TryFutureExt;
-use tokio::{
-    io::{AsyncRead, AsyncWrite, ReadBuf},
-    net::UnixListener,
-};
-use tonic::transport::{server::Connected, Server};
-use tracing::{debug, error, info};
+use crate::{controller::CsiControllerSvc, identity::CsiIdentitySvc};
+use rpc::csi::{controller_server::ControllerServer, identity_server::IdentityServer};
 
+use futures::TryFutureExt;
 use std::{
     fs,
     io::ErrorKind,
@@ -14,10 +10,12 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-
-use rpc::csi::{controller_server::ControllerServer, identity_server::IdentityServer};
-
-use crate::{controller::CsiControllerSvc, identity::CsiIdentitySvc};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::UnixListener,
+};
+use tonic::transport::{server::Connected, Server};
+use tracing::{debug, error, info};
 
 #[derive(Debug)]
 struct UnixStream(tokio::net::UnixStream);

--- a/control-plane/csi-driver/src/bin/node/client.rs
+++ b/control-plane/csi-driver/src/bin/node/client.rs
@@ -102,7 +102,13 @@ pub(crate) struct AppNodesClientWrapper {
 
 impl AppNodesClientWrapper {
     /// Initialize AppNodes API client instance.
-    pub(crate) fn initialize(endpoint: &String) -> anyhow::Result<AppNodesClientWrapper> {
+    pub(crate) fn initialize(
+        endpoint: Option<&String>,
+    ) -> anyhow::Result<Option<AppNodesClientWrapper>> {
+        let Some(endpoint) = endpoint else {
+            return Ok(None);
+        };
+
         let url = clients::tower::Url::parse(endpoint)
             .map_err(|error| anyhow!("Invalid API endpoint URL {}: {:?}", endpoint, error))?;
 
@@ -121,9 +127,9 @@ impl AppNodesClientWrapper {
             endpoint, DEFAULT_TIMEOUT_FOR_REST_REQUESTS,
         );
 
-        Ok(Self {
+        Ok(Some(Self {
             client: AppNodesClient::new(Arc::new(tower)),
-        })
+        }))
     }
 
     /// Register an app node.

--- a/control-plane/csi-driver/src/bin/node/client.rs
+++ b/control-plane/csi-driver/src/bin/node/client.rs
@@ -1,0 +1,155 @@
+use stor_port::types::v0::openapi::{
+    apis::app_nodes_api::tower::client::AppNodesClient,
+    clients,
+    clients::tower::StatusCode,
+    models::{RegisterAppNode, RestJsonError},
+};
+
+use anyhow::{anyhow, Result};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use stor_port::types::v0::openapi::apis::app_nodes_api::tower::client::direct::AppNodes;
+use tonic::Status;
+use tracing::info;
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ApiClientError {
+    // Error while communicating with the server.
+    ServerCommunication(String),
+    // Requested resource already exists. This error has a dedicated variant
+    // in order to handle resource idempotency properly.
+    ResourceAlreadyExists(String),
+    // No resource instance exists.
+    ResourceNotExists(String),
+    NotImplemented(String),
+    RequestTimeout(String),
+    Aborted(String),
+    Conflict(String),
+    ResourceExhausted(String),
+    // Generic operation errors.
+    GenericOperation(StatusCode, String),
+    // Problems with parsing response body.
+    InvalidResponse(String),
+    /// URL is malformed.
+    MalformedUrl(String),
+    /// Invalid argument.
+    InvalidArgument(String),
+    /// Unavailable.
+    Unavailable(String),
+    /// Precondition Failed.
+    PreconditionFailed(String),
+}
+
+impl From<ApiClientError> for Status {
+    fn from(error: ApiClientError) -> Self {
+        match error {
+            ApiClientError::ResourceNotExists(reason) => Status::not_found(reason),
+            ApiClientError::NotImplemented(reason) => Status::unimplemented(reason),
+            ApiClientError::RequestTimeout(reason) => Status::deadline_exceeded(reason),
+            ApiClientError::Conflict(reason) => Status::aborted(reason),
+            ApiClientError::Aborted(reason) => Status::aborted(reason),
+            ApiClientError::Unavailable(reason) => Status::unavailable(reason),
+            ApiClientError::InvalidArgument(reason) => Status::invalid_argument(reason),
+            ApiClientError::PreconditionFailed(reason) => Status::failed_precondition(reason),
+            ApiClientError::ResourceExhausted(reason) => Status::resource_exhausted(reason),
+            error => Status::internal(format!("Operation failed: {error:?}")),
+        }
+    }
+}
+
+impl From<clients::tower::Error<RestJsonError>> for ApiClientError {
+    fn from(error: clients::tower::Error<RestJsonError>) -> Self {
+        match error {
+            clients::tower::Error::Request(request) => {
+                Self::ServerCommunication(request.to_string())
+            }
+            clients::tower::Error::Response(response) => match response {
+                clients::tower::ResponseError::Expected(_) => {
+                    // TODO: Revisit status codes checks after improving REST API HTTP codes
+                    // (CAS-1124).
+                    let detailed = response.to_string();
+                    match response.status() {
+                        StatusCode::NOT_FOUND => Self::ResourceNotExists(detailed),
+                        StatusCode::UNPROCESSABLE_ENTITY => Self::ResourceAlreadyExists(detailed),
+                        StatusCode::NOT_IMPLEMENTED => Self::NotImplemented(detailed),
+                        StatusCode::REQUEST_TIMEOUT => Self::RequestTimeout(detailed),
+                        StatusCode::CONFLICT => Self::Conflict(detailed),
+                        StatusCode::INSUFFICIENT_STORAGE => Self::ResourceExhausted(detailed),
+                        StatusCode::SERVICE_UNAVAILABLE => Self::Unavailable(detailed),
+                        StatusCode::PRECONDITION_FAILED => Self::PreconditionFailed(detailed),
+                        StatusCode::BAD_REQUEST => Self::InvalidArgument(detailed),
+                        status => Self::GenericOperation(status, detailed),
+                    }
+                }
+                clients::tower::ResponseError::PayloadError { .. } => {
+                    Self::InvalidResponse(response.to_string())
+                }
+                clients::tower::ResponseError::Unexpected(_) => {
+                    Self::InvalidResponse(response.to_string())
+                }
+            },
+        }
+    }
+}
+
+/// Default rest api timeout for requests.
+const DEFAULT_TIMEOUT_FOR_REST_REQUESTS: Duration = Duration::from_secs(5);
+
+/// Wrapper for AppNodes REST API client.
+pub(crate) struct AppNodesClientWrapper {
+    client: AppNodesClient,
+}
+
+impl AppNodesClientWrapper {
+    /// Initialize AppNodes API client instance.
+    pub(crate) fn initialize(endpoint: &String) -> anyhow::Result<AppNodesClientWrapper> {
+        let url = clients::tower::Url::parse(endpoint)
+            .map_err(|error| anyhow!("Invalid API endpoint URL {}: {:?}", endpoint, error))?;
+
+        let tower = clients::tower::Configuration::builder()
+            .with_timeout(DEFAULT_TIMEOUT_FOR_REST_REQUESTS)
+            .build_url(url)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "Failed to create openapi configuration, Error: '{:?}'",
+                    error
+                )
+            })?;
+
+        info!(
+            "API client is initialized with endpoint {}, request timeout = {:?}",
+            endpoint, DEFAULT_TIMEOUT_FOR_REST_REQUESTS,
+        );
+
+        Ok(Self {
+            client: AppNodesClient::new(Arc::new(tower)),
+        })
+    }
+
+    /// Register an app node.
+    pub(crate) async fn register_app_node(
+        &self,
+        app_node_id: &str,
+        endpoint: &str,
+        labels: &Option<HashMap<String, String>>,
+    ) -> Result<(), ApiClientError> {
+        self.client
+            .register_app_node(
+                app_node_id,
+                RegisterAppNode::new_all(endpoint, labels.clone()),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Deregister an app node.
+    pub(crate) async fn deregister_app_node(
+        &self,
+        app_node_id: &str,
+    ) -> Result<(), ApiClientError> {
+        self.client.deregister_app_node(app_node_id).await?;
+
+        Ok(())
+    }
+}

--- a/control-plane/csi-driver/src/bin/node/k8s.rs
+++ b/control-plane/csi-driver/src/bin/node/k8s.rs
@@ -1,0 +1,33 @@
+use k8s_openapi::api::core::v1::Node as K8sNode;
+use kube::{
+    api::{Patch, PatchParams},
+    Api,
+};
+use serde_json::Value;
+use tracing::trace;
+
+/// Patch a k8s node with the given patch.
+pub(crate) async fn patch_k8s_node(
+    client: &kube::client::Client,
+    node_name: &str,
+    node_patch: &Value,
+) -> anyhow::Result<()> {
+    let nodes: Api<K8sNode> = Api::all(client.clone());
+    match nodes
+        .patch(
+            node_name,
+            &PatchParams::apply("node_label_patch").force(),
+            &Patch::Apply(node_patch),
+        )
+        .await
+    {
+        Ok(_) => trace!("Patched node: {} with patch: {}", node_name, node_patch),
+        Err(error) => anyhow::bail!(
+            "Failed to patch node: {} with patch: {}. {}",
+            node_name,
+            node_patch,
+            error
+        ),
+    }
+    Ok(())
+}

--- a/control-plane/csi-driver/src/bin/node/main.rs
+++ b/control-plane/csi-driver/src/bin/node/main.rs
@@ -4,6 +4,7 @@ use std::process::ExitCode;
 /// todo: cleanup this module cfg repetition..
 #[cfg(target_os = "linux")]
 mod block_vol;
+mod client;
 /// Configuration Parameters.
 #[cfg(target_os = "linux")]
 pub(crate) mod config;
@@ -22,6 +23,7 @@ mod format;
 pub(crate) mod fsfreeze;
 #[cfg(target_os = "linux")]
 mod identity;
+pub(crate) mod k8s;
 #[cfg(target_os = "linux")]
 mod main_;
 #[cfg(target_os = "linux")]
@@ -36,6 +38,7 @@ mod nodeplugin_grpc;
 mod nodeplugin_nvme;
 #[cfg(target_os = "linux")]
 mod nodeplugin_svc;
+mod registration;
 /// Shutdown event which lets the plugin know it needs to stop processing new events and
 /// complete any existing ones before shutting down.
 #[cfg(target_os = "linux")]

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -133,7 +133,8 @@ pub(super) async fn main() -> anyhow::Result<()> {
                 .long("grpc-endpoint")
                 .value_name("ENDPOINT")
                 .help("ip address where this instance runs, and optionally the gRPC port")
-                .required(true)
+                .default_value("0.0.0.0")
+                .required(false)
         )
         .arg(
             Arg::new("v")

--- a/control-plane/csi-driver/src/bin/node/registration.rs
+++ b/control-plane/csi-driver/src/bin/node/registration.rs
@@ -1,0 +1,37 @@
+use crate::client::AppNodesClientWrapper;
+use snafu::Snafu;
+use std::{collections::HashMap, time::Duration};
+use tokio::task::JoinError;
+use tracing::error;
+
+#[derive(Debug, Snafu)]
+pub(crate) enum RegistrationError {
+    TokioTaskWait { source: JoinError },
+}
+
+/// Default registration interval.
+const REGISTRATION_INTERVAL_ON_SUCCESS: Duration = Duration::from_secs(60 * 5);
+/// Default registration interval on error.
+const REGISTRATION_INTERVAL_ON_ERROR: Duration = Duration::from_secs(30);
+
+pub(crate) async fn run_registration_loop(
+    id: String,
+    endpoint: String,
+    labels: Option<HashMap<String, String>>,
+    client: &AppNodesClientWrapper,
+) {
+    let mut logged_error = false;
+    loop {
+        let interval_duration = match client.register_app_node(&id, &endpoint, &labels).await {
+            Ok(_) => REGISTRATION_INTERVAL_ON_SUCCESS,
+            Err(e) => {
+                if !logged_error {
+                    error!("Failed to register app node: {:?}", e);
+                    logged_error = true;
+                }
+                REGISTRATION_INTERVAL_ON_ERROR
+            }
+        };
+        tokio::time::sleep(interval_duration).await;
+    }
+}

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -307,6 +307,9 @@ pub struct StartOptions {
 
     #[clap(long, default_value = "false")]
     pub eventing: bool,
+
+    #[clap(long, default_value = "false")]
+    pub enable_app_node_registration: bool,
 }
 
 /// List of KeyValues

--- a/nix/pkgs/openapi-generator/source.json
+++ b/nix/pkgs/openapi-generator/source.json
@@ -1,6 +1,6 @@
 {
   "owner": "openebs",
   "repo": "openapi-generator",
-  "rev": "4ccb259371ebe642a20ceeedb940589476e52aac",
-  "hash": "sha256-htKo1G+pvrkgZgpA62UIX+KvLkN1RTjdRO3uR8cQMhQ="
+  "rev": "46e786139a6dbe48869bbe4f5a87d4d31d5bcc04",
+  "hash": "sha256:08s7z09i9q1hgx74yxs5rq7cb40gkd8qhl6w5i39gcm880jwlhc5"
 }


### PR DESCRIPTION
 App Node: Represents a CSI node or a node where io app/initiator would be situated.
 
 Changes in this PR:
    - This adds the registration logic for csi-node to control-plane via rest api.
    - This csi-node info would be used to issue FIFREEZE and FITHAW via csi-controller.
    - Moves the rest api client to the common csi-driver library to be used by both csi-controller and csi-node.