### PR TITLE
refactor: use pagination to load values from pstor

### DIFF
--- a/control-plane/agents/src/bin/core/controller/resources/migration.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/migration.rs
@@ -16,10 +16,13 @@ pub const MSP_OPERATOR: &str = "msp-operator";
 pub(crate) async fn migrate_product_v1_to_v2<S: Store>(
     store: &mut S,
     spec_type: StorableObjectType,
+    etcd_max_page_size: i64,
 ) -> Result<(), StoreError> {
     info!("Migrating {spec_type:?} from v1 to v2 key space");
     let prefix = &product_v1_key_prefix_obj(spec_type);
-    let store_entries = store.get_values_prefix(prefix).await?;
+    let store_entries = store
+        .get_values_paged_all(prefix, etcd_max_page_size)
+        .await?;
     for (k, v) in store_entries {
         let id = k
             .split('/')

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -18,7 +18,7 @@ pub(crate) mod watch;
 use clap::Parser;
 use controller::registry::NumRebuilds;
 use std::{net::SocketAddr, num::ParseIntError};
-use utils::{version_info_str, DEFAULT_GRPC_SERVER_ADDR};
+use utils::{version_info_str, DEFAULT_GRPC_SERVER_ADDR, ETCD_MAX_PAGE_LIMIT};
 
 use stor_port::HostAccessControl;
 use utils::tracing_telemetry::{trace::TracerProvider, KeyValue};
@@ -108,6 +108,10 @@ pub(crate) struct CliArgs {
     /// This is useful when the frontend nodes do not support the NVMe ANA feature.
     #[clap(long, env = "HA_DISABLED")]
     pub(crate) disable_ha: bool,
+
+    /// Etcd Pagination Limit.
+    #[clap(long, default_value = ETCD_MAX_PAGE_LIMIT)]
+    pub(crate) etcd_page_limit: u32,
 }
 impl CliArgs {
     fn args() -> Self {
@@ -178,6 +182,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         },
         cli_args.thin_args,
         cli_args.disable_ha,
+        cli_args.etcd_page_limit as i64,
     )
     .await?;
 

--- a/control-plane/agents/src/bin/core/tests/controller/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/controller/mod.rs
@@ -1,12 +1,16 @@
 use deployer_cluster::{etcd_client::Client, *};
 use stor_port::{
-    pstor::{etcd::Etcd, StoreObj},
+    pstor::{etcd::Etcd, key_prefix_obj, ApiVersion, StorableObjectType, StoreKv, StoreObj},
     types::v0::{
         openapi::models,
         store::registry::{ControlPlaneService, StoreLeaseOwner, StoreLeaseOwnerKey},
         transport,
     },
 };
+
+use serde_json::Value;
+use std::str::FromStr;
+use uuid::Uuid;
 
 /// Test that the content of the registry is correctly loaded from the persistent store on start up.
 #[tokio::test]
@@ -211,4 +215,90 @@ async fn core_agent_lease_lock() {
     let core = cluster.composer().inspect("core").await.unwrap();
     tracing::info!("core: {:?}", core.state);
     assert_eq!(Some(false), core.state.unwrap().running);
+}
+
+const OLD_VOLUME_PREFIX: &str = "/namespace/default/control-plane/VolumeSpec";
+
+#[tokio::test]
+async fn etcd_pagination() {
+    let lease_ttl = std::time::Duration::from_secs(2);
+    let cluster = ClusterBuilder::builder()
+        .with_io_engines(0)
+        .with_rest(false)
+        .with_jaeger(false)
+        .with_store_lease_ttl(lease_ttl)
+        .build()
+        .await
+        .unwrap();
+
+    let mut etcd = Etcd::new("0.0.0.0:2379").await.unwrap();
+
+    let node_prefix = key_prefix_obj(StorableObjectType::NodeSpec, ApiVersion::V0);
+    let volume_prefix = key_prefix_obj(StorableObjectType::VolumeSpec, ApiVersion::V0);
+
+    // Persist some nodes in etcd.
+    for i in 1 .. 11 {
+        let key = format!("{}/node{}", node_prefix, i);
+        let json_str = format!(
+            r#"{{"id":"mayastor-node{}","endpoint":"136.144.51.107:10124","labels":{{}}}}"#,
+            i
+        );
+        let value = Value::from_str(&json_str).unwrap();
+        etcd.put_kv(&key, &value).await.unwrap();
+    }
+
+    // Persist some volumes in new keyspace in etcd.
+    for _i in 1 .. 4 {
+        let uuid = Uuid::new_v4();
+        let key = format!("{}/{}", volume_prefix, uuid);
+        let json_str = r#"{"uuid":"456122b1-7e19-4148-a890-579ca785a119","size":2147483648,"labels":{"local":"true"},"num_replicas":3,"status":{"Created":"Online"},"target":{"node":"mayastor-node4","nexus":"d6ccbb97-d13e-4ffb-91a0-c7607bb01f8f","protocol":"nvmf"},"policy":{"self_heal":true},"topology":{"node":{"Explicit":{"allowed_nodes":["mayastor-node2","mayastor-master","mayastor-node3","mayastor-node1","mayastor-node4"],"preferred_nodes":["mayastor-node2","mayastor-node3","mayastor-node4","mayastor-master","mayastor-node1"]}},"pool":{"Labelled":{"exclusion":{},"inclusion":{"openebs.io/created-by":"msp-operator"}}}},"last_nexus_id":"d6ccbb97-d13e-4ffb-91a0-c7607bb01f8f","operation":null}"#;
+        let value = Value::from_str(json_str).unwrap();
+        etcd.put_kv(&key, &value).await.unwrap();
+    }
+
+    // Persist some volumes in old key space in etcd.
+    for _i in 1 .. 6 {
+        let uuid = Uuid::new_v4();
+        let key = format!("{}/{}", OLD_VOLUME_PREFIX, uuid);
+        let json_str = r#"{"uuid":"456122b1-7e19-4148-a890-579ca785a119","size":2147483648,"labels":{"local":"true"},"num_replicas":3,"status":{"Created":"Online"},"target":{"node":"mayastor-node4","nexus":"d6ccbb97-d13e-4ffb-91a0-c7607bb01f8f","protocol":"nvmf"},"policy":{"self_heal":true},"topology":{"node":{"Explicit":{"allowed_nodes":["mayastor-node2","mayastor-master","mayastor-node3","mayastor-node1","mayastor-node4"],"preferred_nodes":["mayastor-node2","mayastor-node3","mayastor-node4","mayastor-master","mayastor-node1"]}},"pool":{"Labelled":{"exclusion":{},"inclusion":{"openebs.io/created-by":"msp-operator"}}}},"last_nexus_id":"d6ccbb97-d13e-4ffb-91a0-c7607bb01f8f","operation":null}"#;
+        let value = Value::from_str(json_str).unwrap();
+        etcd.put_kv(&key, &value).await.unwrap();
+    }
+
+    // Persist some nexus info in old key space in etcd.
+    for _i in 1 .. 6 {
+        let uuid = Uuid::new_v4();
+        let key = format!("{}", uuid);
+        let json_str = r#"{"children":[{"healthy":true,"uuid":"82779efa-a0c7-4652-a37b-83eefd894714"},{"healthy":true,"uuid":"2d98fa96-ac12-40be-acdc-e3559c0b1530"},{"healthy":true,"uuid":"620ff519-419a-48d6-97a8-c1ba3260d87e"}],"clean_shutdown":false}"#;
+        let value = Value::from_str(json_str).unwrap();
+        etcd.put_kv(&key, &value).await.unwrap();
+    }
+
+    // There Should be exactly 10 Nodes.
+    let node_kvs = etcd.get_values_paged_all(&node_prefix, 3).await.unwrap();
+    assert_eq!(node_kvs.len(), 10);
+
+    // There Should be exactly 5 New Volumes.
+    let volume_kvs = etcd.get_values_paged_all(&volume_prefix, 3).await.unwrap();
+    assert_eq!(volume_kvs.len(), 3);
+
+    // There Should be exactly 5 Old Volumes.
+    let volume_kvs = etcd
+        .get_values_paged_all(OLD_VOLUME_PREFIX, 3)
+        .await
+        .unwrap();
+    assert_eq!(volume_kvs.len(), 5);
+
+    cluster.restart_core().await;
+    cluster
+        .volume_service_liveness(None)
+        .await
+        .expect("Should have restarted by now");
+
+    // There Should be exactly 10 New Volumes, after the migration.
+    let volume_kvs_all = etcd.get_values_paged_all(&volume_prefix, 3).await.unwrap();
+    assert_eq!(volume_kvs_all.len(), 8);
+
+    let all = etcd.get_values_paged_all("", 3).await.unwrap();
+    assert_eq!(all.len(), 26);
 }

--- a/utils/pstor/src/api.rs
+++ b/utils/pstor/src/api.rs
@@ -33,6 +33,14 @@ pub trait StoreKv: Sync + Send + Clone {
         &mut self,
         key_prefix: &str,
         limit: i64,
+        range_end: &str,
+    ) -> Result<Vec<(String, Value)>, Error>;
+    /// Returns a vector of tuples. Each tuple represents a key-value pair. It paginates through all
+    /// the values for the prefix with limit.
+    async fn get_values_paged_all(
+        &mut self,
+        key_prefix: &str,
+        limit: i64,
     ) -> Result<Vec<(String, Value)>, Error>;
     /// Deletes all key values from a given prefix.
     async fn delete_values_prefix(&mut self, key_prefix: &str) -> Result<(), Error>;

--- a/utils/pstor/src/error.rs
+++ b/utils/pstor/src/error.rs
@@ -86,4 +86,6 @@ pub enum Error {
         source: Box<Error>,
         description: String,
     },
+    #[snafu(display("Failed to parse range end for start key: '{}'", start_key))]
+    RangeEnd { start_key: String },
 }

--- a/utils/pstor/src/products/v1.rs
+++ b/utils/pstor/src/products/v1.rs
@@ -23,6 +23,6 @@ pub fn key_prefix_obj<K: AsRef<str>>(key_type: K) -> String {
 
 /// Fetches the product v1 key prefix and returns true if entry is present.
 pub async fn detect_product_v1_prefix<S: Store>(store: &mut S) -> Result<bool, crate::Error> {
-    let prefix = store.get_values_prefix(&key_prefix()).await?;
+    let prefix = store.get_values_paged(&key_prefix(), 3, "").await?;
     Ok(!prefix.is_empty())
 }

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -131,3 +131,6 @@ pub const SNAPSHOT_MAX_TRANSACTION_LIMIT: usize = 5;
 
 /// Label for the csi-node nvme ana multi-path.
 pub const CSI_NODE_NVME_ANA: &str = "openebs.io/csi-node.nvme-ana";
+
+/// Max limit for etcd pagination.
+pub const ETCD_MAX_PAGE_LIMIT: &str = "500";


### PR DESCRIPTION
### Changes in the PR.

- Changes the spec population from etcd from non paged call to a paged call.
- Also incorporates the pagination to legacy migration flows.