### PR TITLE
test(events): increase rebuild timeout

### DIFF
--- a/control-plane/agents/src/bin/core/tests/event/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/event/mod.rs
@@ -289,7 +289,7 @@ async fn rebuild_begin_event_test(sub: &mut BusSubscription<EventMessage>) {
 }
 
 async fn rebuild_end_event_test(sub: &mut BusSubscription<EventMessage>) {
-    let rebuid_end_event_message = timeout(Duration::from_millis(50), get_next_event(sub))
+    let rebuid_end_event_message = timeout(Duration::from_millis(500), get_next_event(sub))
         .await
         .unwrap()
         .unwrap();


### PR DESCRIPTION
Increase timeout for rebuild end event to fix the CI failure.