### PR TITLE
build: support multiple head tags

### DIFF
--- a/nix/lib/version.nix
+++ b/nix/lib/version.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
     vers=${tag}
     if [ -z "$vers" ]; then
-      vers=`${git}/bin/git tag --points-at HEAD`
+      vers=`${git}/bin/git describe --exact-match 2>/dev/null || echo -n`
     fi
     if [ -z "$vers" ]; then
       vers=`${git}/bin/git rev-parse --short=12 HEAD`

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,7 @@ dockerhub_tag_exists() {
 
 # Get the tag at the HEAD
 get_tag() {
-  vers=`git tag --points-at HEAD`
+  vers=$(git describe --exact-match 2>/dev/null || echo -n)
   echo -n $vers
 }
 get_hash() {


### PR DESCRIPTION
When we tag with no changes, we should pick the latest annotated tag.