### PR TITLE
check cluster capacity limit during volume resize, and also allow volume resize via rest plugin

### DIFF
--- a/control-plane/agents/src/bin/core/tests/volume/resize.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/resize.rs
@@ -5,11 +5,14 @@ use grpc::operations::{
 };
 use std::time::Duration;
 use stor_port::{
-    transport_api::ReplyErrorKind,
+    transport_api::{ReplyError, ReplyErrorKind},
     types::v0::transport::{
-        CreateVolume, DestroyVolume, Filter, PublishVolume, ResizeVolume, VolumeShareProtocol,
+        CreateVolume, DestroyVolume, Filter, PublishVolume, ResizeVolume, Volume, VolumeId,
+        VolumeShareProtocol,
     },
 };
+
+use uuid::Uuid;
 
 const SIZE: u64 = 50 * 1024 * 1024; // 50MiB
 const EXPANDED_SIZE: u64 = 2 * SIZE; // 100MiB
@@ -233,6 +236,28 @@ async fn resize_on_no_capacity_pool() {
     let vol_obj = &v_arr.entries[0];
     // Size shouldn't have changed.
     assert!(vol_obj.spec().size == volume.spec().size);
+
+    // try a resize again, this time setting cluster capacity limit.
+    let _ = vol_cli
+        .resize(
+            &ResizeVolume {
+                uuid: volume.uuid().clone(),
+                requested_size: EXPANDED_SIZE,
+                cluster_capacity_limit: Some(EXPANDED_SIZE + CAPACITY_LIMIT_DIFF),
+            },
+            None,
+        )
+        .await
+        .expect_err("Expected error due to insufficient pool capacity");
+
+    let v_arr = vol_cli
+        .get(Filter::Volume(volume.spec().uuid), false, None, None)
+        .await
+        .unwrap();
+    let vol_obj = &v_arr.entries[0];
+    // Size shouldn't have changed.
+    assert!(vol_obj.spec().size == volume.spec().size);
+
     // TODO: Add reclaim monitor validations for replicas that got resized as part
     // of this failed volume resize.
 }
@@ -264,6 +289,79 @@ async fn resize_with_cluster_capacity_limit() {
 
     // resize within the capacity limit
     grpc_resize_volume_with_limit(&vol_cli, Some(EXPANDED_SIZE + CAPACITY_LIMIT_DIFF), None).await;
+    // resize a new volume, but reduce the limit set previously. The limit balance
+    // calculations are expected to work based on reduced limit value now.
+    grpc_resize_volume_with_limit(
+        &vol_cli,
+        Some(EXPANDED_SIZE + CAPACITY_LIMIT_DIFF / 2),
+        None,
+    )
+    .await;
+}
+
+// Take 600MiB pool. Create five volumes of 50MiB each, totalling a usage of 250MiB.
+// Set cluster capacity limit to 400MiB and expand all five volumes to 100MiB.
+// Since remaining limit is 150MiB, three volumes should successfully expand and
+// two must fail to expand.
+#[tokio::test]
+async fn resize_with_cluster_capacity_limit_concurrent() {
+    let cluster = ClusterBuilder::builder()
+        .with_rest(false)
+        .with_agents(vec!["core"])
+        .with_io_engines(2)
+        .with_pool(0, "malloc:///p1?size_mb=600")
+        .with_cache_period("1s")
+        .with_reconcile_period(Duration::from_secs(1), Duration::from_secs(1))
+        .with_options(|o| o.with_isolated_io_engine(true))
+        .build()
+        .await
+        .unwrap();
+
+    let num_volumes = 5;
+    let mut success = 0;
+    let mut failure = 0;
+    let vol_cli = cluster.grpc_client().volume();
+    let volume_ids = create_volumes(&vol_cli, 5).await;
+    let mut results = Vec::with_capacity(num_volumes);
+
+    // Create a channel to collect results from the concurrent tasks
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Result<Volume, ReplyError>>(num_volumes);
+    // For each task
+    let refc_vol_cli = std::sync::Arc::new(vol_cli);
+
+    for volume_id in volume_ids {
+        let refp_vol_cli = std::sync::Arc::clone(&refc_vol_cli);
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let hdl = refp_vol_cli
+                .resize(
+                    &ResizeVolume {
+                        uuid: volume_id.try_into().unwrap(),
+                        requested_size: EXPANDED_SIZE,
+                        cluster_capacity_limit: Some(4 * EXPANDED_SIZE),
+                    },
+                    None,
+                )
+                .await;
+
+            // Send the result to the channel
+            tx.send(hdl).await.unwrap();
+        });
+    }
+    // Collect results from the channel
+    for _ in 0 .. num_volumes {
+        results.push(rx.recv().await.unwrap());
+    }
+
+    results.iter().for_each(|r| {
+        if r.is_ok() {
+            success += 1;
+        } else {
+            failure += 1;
+        }
+    });
+    assert_eq!(success, 3);
+    assert_eq!(failure, 2);
 }
 
 async fn grpc_resize_volume_with_limit(
@@ -271,10 +369,12 @@ async fn grpc_resize_volume_with_limit(
     capacity: Option<u64>,
     expected_error: Option<ReplyErrorKind>,
 ) {
+    let vol_uuid = Uuid::new_v4();
+
     let volume = volume_client
         .create(
             &CreateVolume {
-                uuid: "de3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
+                uuid: vol_uuid.try_into().unwrap(),
                 size: SIZE,
                 replicas: 2,
                 thin: false,
@@ -325,4 +425,29 @@ async fn grpc_resize_volume_with_limit(
                 .unwrap();
         }
     }
+}
+
+// Creates count number of volumes, and return the uuid of volume to be resized.
+async fn create_volumes(volume_client: &dyn VolumeOperations, count: u64) -> Vec<Uuid> {
+    let mut volumes = Vec::with_capacity(count as usize);
+    for _ in 0 .. count {
+        let vol_uuid = Uuid::new_v4();
+        let volume = volume_client
+            .create(
+                &CreateVolume {
+                    uuid: vol_uuid.try_into().unwrap(),
+                    size: SIZE,
+                    replicas: 1,
+                    thin: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        volumes.push(volume.uuid().try_into().unwrap())
+    }
+
+    volumes
 }

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -1127,7 +1127,7 @@ impl From<&dyn DestroyVolumeInfo> for DestroyVolumeRequest {
 pub struct ValidatedResizeVolumeRequest {
     uuid: VolumeId,
     requested_size: u64,
-    capacity_limit: Option<u64>,
+    cluster_capacity_limit: Option<u64>,
 }
 /// Trait to be implemented for ResizeVolume operation.
 pub trait ResizeVolumeInfo: Send + Sync + std::fmt::Debug {
@@ -1136,7 +1136,7 @@ pub trait ResizeVolumeInfo: Send + Sync + std::fmt::Debug {
     /// Requested new size of the volume, in bytes
     fn req_size(&self) -> u64;
     /// Total capacity limit for all volumes, in bytes
-    fn capacity_limit(&self) -> Option<u64>;
+    fn cluster_capacity_limit(&self) -> Option<u64>;
 }
 
 impl ResizeVolumeInfo for ResizeVolume {
@@ -1148,8 +1148,8 @@ impl ResizeVolumeInfo for ResizeVolume {
         self.requested_size
     }
 
-    fn capacity_limit(&self) -> Option<u64> {
-        self.capacity_limit
+    fn cluster_capacity_limit(&self) -> Option<u64> {
+        self.cluster_capacity_limit
     }
 }
 
@@ -1159,7 +1159,7 @@ impl ValidateRequestTypes for ResizeVolumeRequest {
         Ok(ValidatedResizeVolumeRequest {
             uuid: VolumeId::try_from(StringValue(Some(self.uuid)))?,
             requested_size: self.requested_size,
-            capacity_limit: self.capacity_limit,
+            cluster_capacity_limit: self.capacity_limit,
         })
     }
 }
@@ -1169,7 +1169,7 @@ impl From<&dyn ResizeVolumeInfo> for ResizeVolume {
         Self {
             uuid: data.uuid(),
             requested_size: data.req_size(),
-            capacity_limit: data.capacity_limit(),
+            cluster_capacity_limit: data.cluster_capacity_limit(),
         }
     }
 }
@@ -1179,7 +1179,7 @@ impl From<&dyn ResizeVolumeInfo> for ResizeVolumeRequest {
         Self {
             uuid: data.uuid().to_string(),
             requested_size: data.req_size(),
-            capacity_limit: data.capacity_limit(),
+            capacity_limit: data.cluster_capacity_limit(),
         }
     }
 }
@@ -1193,8 +1193,8 @@ impl ResizeVolumeInfo for ValidatedResizeVolumeRequest {
         self.requested_size
     }
 
-    fn capacity_limit(&self) -> Option<u64> {
-        self.capacity_limit
+    fn cluster_capacity_limit(&self) -> Option<u64> {
+        self.cluster_capacity_limit
     }
 }
 

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -85,6 +85,11 @@ pub trait Get {
 pub trait Scale {
     type ID;
     async fn scale(id: &Self::ID, replica_count: u8, output: &utils::OutputFormat) -> PluginResult;
+    async fn resize(
+        id: &Self::ID,
+        requested_size: u64,
+        output: &utils::OutputFormat,
+    ) -> PluginResult;
 }
 
 /// Replica topology trait.

--- a/control-plane/plugin/src/resources/error.rs
+++ b/control-plane/plugin/src/resources/error.rs
@@ -74,6 +74,12 @@ pub enum Error {
         id: String,
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,
     },
+    /// Error when resize volume request fails.
+    #[snafu(display("Failed to resize volume {id}. Error {source}"))]
+    ResizeVolumeError {
+        id: String,
+        source: openapi::tower::client::Error<openapi::models::RestJsonError>,
+    },
     /// Error when set volume property request fails.
     #[snafu(display("Failed to set volume {id} property, Error {source}"))]
     ScaleVolumePropertyError {

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -205,7 +205,7 @@ impl apis::actix_server::Volumes for RestApi {
                 &ResizeVolume {
                     uuid: volume_id.into(),
                     requested_size: resize_volume_body.size as u64,
-                    capacity_limit: None,
+                    cluster_capacity_limit: None,
                 },
                 None,
             )

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -477,15 +477,15 @@ pub struct ResizeVolume {
     /// The requested new size of the volume in bytes.
     pub requested_size: u64,
     /// Total capacity limit of all volumes' provisioning.
-    pub capacity_limit: Option<u64>,
+    pub cluster_capacity_limit: Option<u64>,
 }
 impl ResizeVolume {
     /// Create a new `ResizeVolume` request.
-    pub fn new(uuid: VolumeId, requested_size: u64, capacity_limit: Option<u64>) -> Self {
+    pub fn new(uuid: VolumeId, requested_size: u64, cluster_capacity_limit: Option<u64>) -> Self {
         Self {
             uuid,
             requested_size,
-            capacity_limit,
+            cluster_capacity_limit,
         }
     }
 }


### PR DESCRIPTION
- Enforce cluster capacity limit checks during volume resize.
- Allow volume resize operation via REST plugin.