### PR TITLE
fix(legacy prefix detection): calculate range end for legacy prefix instead of empty

### DIFF
--- a/utils/pstor/src/products/v1.rs
+++ b/utils/pstor/src/products/v1.rs
@@ -23,6 +23,6 @@ pub fn key_prefix_obj<K: AsRef<str>>(key_type: K) -> String {
 
 /// Fetches the product v1 key prefix and returns true if entry is present.
 pub async fn detect_product_v1_prefix<S: Store>(store: &mut S) -> Result<bool, crate::Error> {
-    let prefix = store.get_values_paged(&key_prefix(), 3, "").await?;
+    let prefix = store.get_values_paged_all(&key_prefix(), 3).await?;
     Ok(!prefix.is_empty())
 }


### PR DESCRIPTION
#### What is the issue?

For legacy prefix detection we used the paginated call with range end as `""`, which was incorrect as `""` range end fetches all the values, irrespective of the key prefix. Now we calculate the range end with legacy prefix thus we get only the specific KVs.