### PR TITLE
fix(csi-driver): support getting device size from devpath

### DIFF
--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -492,12 +492,14 @@ impl node_server::Node for Node {
         let required_bytes = request
             .capacity_range
             .as_ref()
-            .ok_or(failure!(
-                Code::InvalidArgument,
-                "Cannot expand volume '{}': invalid request {:?}: missing CapacityRange",
-                request.volume_id,
-                request
-            ))?
+            .ok_or_else(|| {
+                failure!(
+                    Code::InvalidArgument,
+                    "Cannot expand volume '{}': invalid request {:?}: missing CapacityRange",
+                    request.volume_id,
+                    request
+                )
+            })?
             .required_bytes;
 
         let _guard = VolumeOpGuard::new(vol_uuid)?;
@@ -512,11 +514,13 @@ impl node_server::Node for Node {
                     error
                 )
             })?
-            .ok_or(failure!(
-                Code::InvalidArgument,
-                "failed to find a device for volume {}",
-                vol_uuid
-            ))?
+            .ok_or_else(|| {
+                failure!(
+                    Code::InvalidArgument,
+                    "failed to find a device for volume {}",
+                    vol_uuid
+                )
+            })?
             .devname();
 
         // Get device size.

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -1,6 +1,6 @@
 use crate::{
     block_vol::{publish_block_volume, unpublish_block_volume},
-    dev::{get_size_from_dev_name, Device},
+    dev::{sysfs_dev_size, Device},
     filesystem_ops::FileSystem,
     filesystem_vol::{publish_fs_volume, stage_fs_volume, unpublish_fs_volume, unstage_fs_volume},
     mount::find_mount,
@@ -502,7 +502,7 @@ impl node_server::Node for Node {
 
         let _guard = VolumeOpGuard::new(vol_uuid)?;
 
-        let dev_name = Device::lookup(&vol_uuid)
+        let dev_path = Device::lookup(&vol_uuid)
             .await
             .map_err(|error| {
                 failure!(
@@ -522,11 +522,11 @@ impl node_server::Node for Node {
         // Get device size.
         // The underlying block device should already have been expanded to the
         // required size as a part of the ControllerExpandVolume call.
-        let device_capacity = get_size_from_dev_name(dev_name.as_str()).map_err(|error| {
+        let device_capacity = sysfs_dev_size(dev_path.as_str()).map_err(|error| {
             failure!(
                 Code::Internal,
                 "failed to find the device size of device {}: {}",
-                dev_name,
+                dev_path,
                 error
             )
         })? as i64;

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -536,13 +536,14 @@ impl node_server::Node for Node {
         })? as i64;
 
         // The NVMf volume target capacity is often less than the requested capacity. This
-        // difference should be no more than 5 MiB in size. We should trim the required capacity
-        // down by 5 MiB so that the capacity of the device is verified to be greater than or
+        // difference should be no more than 10MiB in size. We should trim the required capacity
+        // down by 10MiB so that the capacity of the device is verified to be greater than or
         // equal to this corrected capacity. This is required because we are not comparing the
         // required capacity against the REST API Volume resource.
-        const MAX_NEXUS_CAPACITY_DIFFERENCE: i64 = 5 * 1024 * 1024;
+        // 10MiB includes addition leeway on top of the 5MiB required.
+        const MAX_NEXUS_CAPACITY_DIFFERENCE: i64 = 10 * 1024 * 1024;
         // Ensure device_capacity is greater than or equal to required_bytes.
-        if device_capacity < (required_bytes - MAX_NEXUS_CAPACITY_DIFFERENCE) {
+        if (device_capacity + MAX_NEXUS_CAPACITY_DIFFERENCE) < required_bytes {
             return Err(failure!(
                 Code::FailedPrecondition,
                 "block device capacity is lower than the required"


### PR DESCRIPTION
Changes:
- the Device::lookup() API doesn't return a dev-name, but instead returns a dev-path. Changed the size function to accept either.
- the `failure!` macro prints errors event if they are never encountered, when used with the `ok_or()` combinator. Using the `ok_or_else()` combinator instead.
- Adjusting the expected capacity of the nexus during NodeExpandVolume call to be at most 10MiB less than the requested capacity.