### PR TITLE
refactor(csi-node): avoid two lookups for device during fs expansion

### DIFF
--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -598,7 +598,7 @@ impl node_server::Node for Node {
         filesystem_handle
             .fs_ops()
             .map_err(|err| failure!(Code::InvalidArgument, "{}", err))?
-            .expand(&args.volume_path)
+            .expand(&args.volume_path, Some(dev_path))
             .await
             .map_err(|err| failure!(Code::Internal, "{}", err))?;
 


### PR DESCRIPTION
During NodeExpanVolume, we look up the underlyting device for the Published/Staged Filesystem early on. We look up the device during the ext4 resize case also. This change passes the device path (/dev/device-name style path) to the expand API, and avoids the second lookup.