### PR TITLE
fix(volume/resize): more appropriate error mapping

### DIFF
--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -907,7 +907,7 @@ impl From<SvcError> for ReplyError {
                 extra,
             },
             SvcError::ResizeReplError { .. } => ReplyError {
-                kind: ReplyErrorKind::FailedPrecondition,
+                kind: ReplyErrorKind::ResourceExhausted,
                 resource: ResourceKind::Replica,
                 source,
                 extra,


### PR DESCRIPTION
Quoting from gRPC documentation:
"There is a fair bit of overlap between FAILED_PRECONDITION and OUT_OF_RANGE. We recommend using OUT_OF_RANGE (the more specific error) when it applies so that callers who are iterating through a space can easily look for an OUT_OF_RANGE error to detect when they are done."

The Mayastor CSI driver maps ResourceExhausted to OutOfRange for VolumeExpansion.