### PR TITLE
chore: fix pytest version to 7.4.4

### DIFF
--- a/tests/bdd/requirements.txt
+++ b/tests/bdd/requirements.txt
@@ -6,3 +6,4 @@ docker==5.0.3
 asyncssh==2.14.1
 etcd3==0.12.0
 requests==2.31.0
+pytest==7.4.4


### PR DESCRIPTION
#### Why we need the PR?
The latest version of pytest has deprecated `fixturemanager` which is causing failures in pytests. This pins the version to `7.4.4`.