### PR TITLE
feat(topology/plugin): add show-labels in get/list node/nodes 

### DIFF
--- a/control-plane/plugin/src/lib.rs
+++ b/control-plane/plugin/src/lib.rs
@@ -10,8 +10,8 @@ use utils::tracing_telemetry::{FmtLayer, FmtStyle};
 
 use crate::{
     operations::{
-        Cordoning, Drain, Get, GetBlockDevices, GetSnapshots, List, ListExt, Operations,
-        PluginResult, RebuildHistory, ReplicaTopology, Scale,
+        Cordoning, Drain, Get, GetBlockDevices, GetSnapshots, GetWithArgs, List, ListExt,
+        ListWithArgs, Operations, PluginResult, RebuildHistory, ReplicaTopology, Scale,
     },
     resources::{
         blockdevice, cordon, drain, node, pool, snapshot, volume, CordonResources, DrainResources,
@@ -148,8 +148,10 @@ impl ExecuteOperation for GetResources {
             }
             GetResources::Pools => pool::Pools::list(&cli_args.output).await,
             GetResources::Pool { id } => pool::Pool::get(id, &cli_args.output).await,
-            GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
-            GetResources::Node(args) => node::Node::get(&args.node_id(), &cli_args.output).await,
+            GetResources::Nodes(args) => node::Nodes::list(args, &cli_args.output).await,
+            GetResources::Node(args) => {
+                node::Node::get(&args.node_id(), args, &cli_args.output).await
+            }
             GetResources::BlockDevices(bdargs) => {
                 blockdevice::BlockDevice::get_blockdevices(
                     &bdargs.node_id(),

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -74,12 +74,29 @@ pub trait ListExt {
     async fn list(output: &utils::OutputFormat, context: &Self::Context) -> PluginResult;
 }
 
+/// ListWithArgs trait.
+/// To be implemented by resources which support the 'list' operation with arguments.
+#[async_trait(?Send)]
+pub trait ListWithArgs {
+    type Args;
+    async fn list(args: &Self::Args, output: &utils::OutputFormat) -> PluginResult;
+}
+
 /// Get trait.
 /// To be implemented by resources which support the 'get' operation.
 #[async_trait(?Send)]
 pub trait Get {
     type ID;
     async fn get(id: &Self::ID, output: &utils::OutputFormat) -> PluginResult;
+}
+
+/// GetWithArgs trait.
+/// To be implemented by resources which support the 'get' operation with arguments.
+#[async_trait(?Send)]
+pub trait GetWithArgs {
+    type ID;
+    type Args;
+    async fn get(id: &Self::ID, args: &Self::Args, output: &utils::OutputFormat) -> PluginResult;
 }
 
 /// Scale trait.

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -1,6 +1,6 @@
 use crate::resources::{
     blockdevice::BlockDeviceArgs,
-    node::{DrainNodeArgs, GetNodeArgs},
+    node::{DrainNodeArgs, GetNodeArgs, GetNodesArgs},
     snapshot::VolumeSnapshotArgs,
     volume::VolumesArgs,
 };
@@ -49,7 +49,7 @@ pub enum GetResources {
     /// Get pool with the given ID.
     Pool { id: PoolId },
     /// Get all nodes.
-    Nodes,
+    Nodes(GetNodesArgs),
     /// Get node with the given ID.
     Node(GetNodeArgs),
     /// Get BlockDevices present on the Node. Lists usable devices by default.


### PR DESCRIPTION
**Get node without labels**
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get node node-0-154304
 ID             GRPC ENDPOINT        STATUS
 node-0-154304  95.216.216.11:10124  Online
 ```
**Get node with labels**

```
ashish@vm:~/code/rust/mayastor-extensions(develop)$ ./target/debug/kubectl-mayastor get node node-0-153279 --show-labels
 ID             GRPC ENDPOINT        STATUS  LABELS
 node-0-153279  135.181.89.44:10124  Online  C=D, A=B
 ```


**List nodes with labels**
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get nodes
 ID             GRPC ENDPOINT        STATUS
 node-0-154304  95.216.216.11:10124  Online
 node-1-154304  37.27.6.24:10124     Online
 node-2-154304  37.27.41.173:10124   Online
 ```
**List nodes with labels**
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get nodes --show-labels
 ID             GRPC ENDPOINT        STATUS  LABELS
 node-1-154304  37.27.6.24:10124     Online  P=Q
 node-0-154304  95.216.216.11:10124  Online  C=D, A=B
 node-2-154304  37.27.41.173:10124   Online
```