### PR TITLE
feat(callhome): add bustype and rotational properties to block device

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -74,6 +74,7 @@ impl IoEngineToAgent for v0::BlockDevice {
                 .as_ref()
                 .map(|filesystem| filesystem.to_agent()),
             available: self.available,
+            ..Default::default()
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -78,6 +78,8 @@ impl IoEngineToAgent for v1::host::BlockDevice {
                 .as_ref()
                 .map(|filesystem| filesystem.to_agent()),
             available: self.available,
+            connection_type: self.connection_type.clone(),
+            is_rotational: self.is_rotational,
         }
     }
 }

--- a/control-plane/grpc/proto/v1/blockdevice/blockdevice.proto
+++ b/control-plane/grpc/proto/v1/blockdevice/blockdevice.proto
@@ -28,6 +28,10 @@ message BlockDevice {
   // identifies if device is available for use (ie. is not "currently" in
   // use)
   bool available = 11;
+  // the type of bus through which the device is connected to the system
+  string connection_type = 12;
+  // indicates whether the device is rotational or non-rotational
+  optional bool is_rotational = 13;
 }
 
 message Partition {

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -358,6 +358,8 @@ impl From<BlockDevice> for blockdevice::BlockDevice {
                 mountpoint: bd.mountpoint,
             }),
             available: bd.available,
+            connection_type: bd.connection_type,
+            is_rotational: bd.is_rotational,
         }
     }
 }
@@ -389,6 +391,8 @@ impl TryFrom<blockdevice::BlockDevice> for BlockDevice {
                 mountpoint: filesystem.mountpoint,
             }),
             available: bd.available,
+            connection_type: bd.connection_type,
+            is_rotational: bd.is_rotational,
         })
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2210,6 +2210,9 @@ components:
             identifies if device is available for use (ie. is not "currently" in
              use)
           type: boolean
+        connection_type:
+          description: the type of bus through which the device is connected to the system
+          type: string
         devlinks:
           description: list of udev generated symlinks by which device may be identified
           type: array
@@ -2258,6 +2261,9 @@ components:
             - label
             - mountpoint
             - uuid
+        is_rotational:
+          description: indicates whether the device is rotational or non-rotational
+          type: boolean
         model:
           description: device model - useful for identifying devices
           type: string
@@ -2298,6 +2304,7 @@ components:
           minimum: 0
       required:
         - available
+        - connection_type
         - devlinks
         - devmajor
         - devminor

--- a/control-plane/stor-port/src/types/v0/transport/blockdevice.rs
+++ b/control-plane/stor-port/src/types/v0/transport/blockdevice.rs
@@ -78,12 +78,17 @@ pub struct BlockDevice {
     /// identifies if device is available for use (ie. is not "currently" in
     /// use)
     pub available: bool,
+    /// the type of bus through which the device is connected to the system
+    pub connection_type: String,
+    /// indicates whether the device is rotational or non-rotational
+    pub is_rotational: Option<bool>,
 }
 
 impl From<BlockDevice> for models::BlockDevice {
     fn from(src: BlockDevice) -> Self {
         models::BlockDevice::new_all(
             src.available,
+            src.connection_type,
             src.devlinks,
             src.devmajor as i32,
             src.devminor as i32,
@@ -91,6 +96,7 @@ impl From<BlockDevice> for models::BlockDevice {
             src.devpath,
             src.devtype,
             src.filesystem.into_opt(),
+            src.is_rotational,
             src.model,
             src.partition.into_opt(),
             src.size,


### PR DESCRIPTION
Added bus type("connection_type") and rotational ("is_rotational") properties to block device to be able to generate storage media metrics.

connection_type: the type of bus through which the device is connected to the system
is_rotational: indicates whether the device is rotational or non-rotational