### PR TITLE
fix(serde): fix serialization error for get/list nodes

### DIFF
--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -118,7 +118,14 @@ impl ListWithArgs for Nodes {
             Ok(nodes) => {
                 let node_display =
                     NodeDisplayLabels::new_nodes(nodes.clone().into_body(), args.show_labels());
-                print_table(output, node_display);
+                match output {
+                    OutputFormat::Yaml | OutputFormat::Json => {
+                        print_table(output, node_display.inner);
+                    }
+                    OutputFormat::None => {
+                        print_table(output, node_display);
+                    }
+                }
             }
             Err(e) => {
                 return Err(Error::ListNodesError { source: e });
@@ -216,7 +223,14 @@ impl GetWithArgs for Node {
             Ok(node) => {
                 let node_display =
                     NodeDisplayLabels::new(node.clone().into_body(), args.show_labels());
-                print_table(output, node_display);
+                match output {
+                    OutputFormat::Yaml | OutputFormat::Json => {
+                        print_table(output, node_display.inner);
+                    }
+                    OutputFormat::None => {
+                        print_table(output, node_display);
+                    }
+                }
             }
             Err(e) => {
                 return Err(Error::GetNodeError {


### PR DESCRIPTION
The below error was seen while getting the nodes in json format 
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get node node-1-155678 -o json
thread 'main' panicked at dependencies/control-plane/control-plane/plugin/./src/resources/utils.rs:185:49:
called `Result::unwrap()` on an `Err` value: Error("can only flatten structs and maps (got a sequence)", line: 0, column: 0)
```

This  PR fixes it.

