### PR TITLE
fix(getNode): return single element in get node

### DIFF
--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -220,18 +220,17 @@ impl GetWithArgs for Node {
     type Args = GetNodeArgs;
     async fn get(id: &Self::ID, args: &Self::Args, output: &utils::OutputFormat) -> PluginResult {
         match RestClient::client().nodes_api().get_node(id).await {
-            Ok(node) => {
-                let node_display =
-                    NodeDisplayLabels::new(node.clone().into_body(), args.show_labels());
-                match output {
-                    OutputFormat::Yaml | OutputFormat::Json => {
-                        print_table(output, node_display.inner);
-                    }
-                    OutputFormat::None => {
-                        print_table(output, node_display);
-                    }
+            Ok(node) => match output {
+                OutputFormat::Yaml | OutputFormat::Json => {
+                    print_table(output, node.clone().into_body());
                 }
-            }
+                OutputFormat::None => {
+                    print_table(
+                        output,
+                        NodeDisplayLabels::new(node.into_body(), args.show_labels()),
+                    );
+                }
+            },
             Err(e) => {
                 return Err(Error::GetNodeError {
                     id: id.to_string(),


### PR DESCRIPTION
There was a regression issue in which `kubectl-mayastor get node node-1-155665 -ojson` was returning an array
```
[
  {
    "id": "node-1-155665",
    "spec": {
      "grpcEndpoint": "135.181.42.41:10124",
      "id": "node-1-155665",
      "node_nqn": "nqn.2019-05.io.openebs:node-name:node-1-155665"
    },
    "state": {
      "grpcEndpoint": "135.181.42.41:10124",
      "id": "node-1-155665",
      "status": "Online",
      "node_nqn": "nqn.2019-05.io.openebs:node-name:node-1-155665"
    }
  }
]
```


Earlier in 2.5 release it was returning a single element as below:
```
{
  "id": "node-1-155665",
  "spec": {
    "grpcEndpoint": "135.181.42.41:10124",
    "id": "node-1-155665",
    "node_nqn": "nqn.2019-05.io.openebs:node-name:node-1-155665"
  },
  "state": {
    "grpcEndpoint": "135.181.42.41:10124",
    "id": "node-1-155665",
    "status": "Online",
    "node_nqn": "nqn.2019-05.io.openebs:node-name:node-1-155665"
  }
}
```

This PR fixes that 