### PR TITLE
fix(agent/core): rebuild space required

### DIFF
--- a/control-plane/agents/src/bin/core/controller/scheduling/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/pool.rs
@@ -186,6 +186,10 @@ pub(crate) fn replica_rebuildable(
 /// Calculates the number of bytes required to rebuild this replica up to the given minimum.
 /// # Warning: valid only if the current blocks are exactly the same as the healthy replicas.
 pub(crate) fn rebuild_space_required(min_allocated_bytes: u64, replica: &Replica) -> u64 {
+    if !replica.thin {
+        return 0;
+    }
+
     let repl_allocated_bytes = replica
         .space
         .as_ref()
@@ -194,7 +198,7 @@ pub(crate) fn rebuild_space_required(min_allocated_bytes: u64, replica: &Replica
 
     // we've already allocated some bytes, so take those into account
     // did you read the warning above?
-    let bytes_needed = min_allocated_bytes - repl_allocated_bytes;
+    let bytes_needed = min_allocated_bytes - repl_allocated_bytes.min(min_allocated_bytes);
 
     // We need sufficient free space for at least the current allocation of other replicas, but
     // just this capacity may not be enough as applications may carry on issuing new writes.


### PR DESCRIPTION
If a replica is thick then no rebuild space is required.. Ensure we don't overflow if allocated_bytes are larger than minimum required bytes (although this probably won't happen now that we short-circuit thick replicas..)