### PR TITLE
Cherry-pick PR792

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -324,10 +324,10 @@ impl AgentToIoEngine for transport::DestroyPool {
 impl AgentToIoEngine for transport::CreateNexus {
     type IoEngineMessage = v0::CreateNexusV2Request;
     fn to_rpc(&self) -> Self::IoEngineMessage {
-        let nexus_config = self
-            .config
-            .clone()
-            .unwrap_or_else(|| NexusNvmfConfig::default().with_no_resv());
+        let nexus_config = match self.config.as_ref() {
+            Some(config) if config != &NexusNvmfConfig::default().with_no_resv() => config.clone(),
+            _ => NexusNvmfConfig::default().with_no_resv_v0(),
+        };
         Self::IoEngineMessage {
             name: self.name(),
             uuid: self.uuid.clone().into(),

--- a/control-plane/agents/src/bin/core/controller/scheduling/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/pool.rs
@@ -186,6 +186,10 @@ pub(crate) fn replica_rebuildable(
 /// Calculates the number of bytes required to rebuild this replica up to the given minimum.
 /// # Warning: valid only if the current blocks are exactly the same as the healthy replicas.
 pub(crate) fn rebuild_space_required(min_allocated_bytes: u64, replica: &Replica) -> u64 {
+    if !replica.thin {
+        return 0;
+    }
+
     let repl_allocated_bytes = replica
         .space
         .as_ref()
@@ -194,7 +198,7 @@ pub(crate) fn rebuild_space_required(min_allocated_bytes: u64, replica: &Replica
 
     // we've already allocated some bytes, so take those into account
     // did you read the warning above?
-    let bytes_needed = min_allocated_bytes - repl_allocated_bytes;
+    let bytes_needed = min_allocated_bytes - repl_allocated_bytes.min(min_allocated_bytes);
 
     // We need sufficient free space for at least the current allocation of other replicas, but
     // just this capacity may not be enough as applications may carry on issuing new writes.

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -231,8 +231,13 @@ impl Service {
         let node = nodes.write().await.get_mut(&node_state.id).cloned();
         let send_event = match node {
             None => {
-                let mut node =
-                    NodeWrapper::new(&node_state, self.deadline, self.comms_timeouts.clone());
+                let ha_disabled = self.registry.ha_disabled();
+                let mut node = NodeWrapper::new(
+                    &node_state,
+                    self.deadline,
+                    self.comms_timeouts.clone(),
+                    ha_disabled,
+                );
 
                 // On startup api version is not known, thus probe all apiversions
                 let result = match startup {

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -98,6 +98,8 @@ pub(crate) struct NodeWrapper {
     states: ResourceStatesLocked,
     /// The number of rebuilds in progress on the node.
     num_rebuilds: Arc<RwLock<NumRebuilds>>,
+    /// If HA is disabled, don't use reservations when creating nexuses.
+    disable_ha: bool,
 }
 
 impl NodeWrapper {
@@ -106,6 +108,7 @@ impl NodeWrapper {
         node: &NodeState,
         deadline: std::time::Duration,
         comms_timeouts: NodeCommsTimeout,
+        disable_ha: bool,
     ) -> Self {
         tracing::debug!("Creating new node {:?}", node);
         Self {
@@ -116,6 +119,7 @@ impl NodeWrapper {
             comms_timeouts,
             states: ResourceStatesLocked::new(),
             num_rebuilds: Arc::new(RwLock::new(0)),
+            disable_ha,
         }
     }
 
@@ -134,6 +138,7 @@ impl NodeWrapper {
             ),
             states: ResourceStatesLocked::new(),
             num_rebuilds: Arc::new(RwLock::new(0)),
+            disable_ha: false,
         }
     }
 
@@ -601,6 +606,7 @@ impl NodeWrapper {
         tracing::info!(
             node.id = %self.id(),
             node.endpoint = self.endpoint_str(),
+            api.versions = ?self.node_state.api_versions,
             startup,
             "Preloading node"
         );
@@ -1432,7 +1438,16 @@ impl NexusApi<()> for Arc<tokio::sync::RwLock<NodeWrapper>> {
             });
         }
         let dataplane = self.grpc_client_locked(request.id()).await?;
-        match dataplane.create_nexus(request).await {
+        let disable_resv = self.read().await.disable_ha;
+        let result = if disable_resv {
+            let mut request = request.clone();
+            request.config = None;
+            dataplane.create_nexus(&request).await
+        } else {
+            dataplane.create_nexus(request).await
+        };
+
+        match result {
             Ok(nexus) => {
                 self.update_nexus_state(Either::Insert(nexus.clone())).await;
                 Ok(nexus)

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -503,6 +503,13 @@ impl NexusNvmfConfig {
         self.reservation_type = NvmeReservation::Reserved;
         self
     }
+    /// On v0 reservations are mostly disabled, simply set key to 1 to avoid failure.
+    pub fn with_no_resv_v0(mut self) -> Self {
+        self.reservation_key = 1;
+        self.preempt_policy = NexusNvmePreemption::ArgKey(None);
+        self.reservation_type = NvmeReservation::Reserved;
+        self
+    }
 }
 
 impl Default for NexusNvmfConfig {


### PR DESCRIPTION
If a replica is thick then no rebuild space is required.. Ensure we don't overflow if allocated_bytes are larger than minimum required bytes (although this probably won't happen now that we short-circuit thick replicas..)