### PR TITLE
XFS compat with older kernels when formatting

### DIFF
--- a/control-plane/csi-driver/src/bin/node/filesystem_ops.rs
+++ b/control-plane/csi-driver/src/bin/node/filesystem_ops.rs
@@ -112,8 +112,8 @@ pub(crate) trait FileSystemOps: Send + Sync {
 #[async_trait]
 impl FileSystemOps for Ext4Fs {
     async fn create(&self, device: &str) -> Result<(), Error> {
-        let binary = format!("mkfs.{}", "ext4");
-        let output = Command::new(&binary)
+        let binary = "mkfs.ext4";
+        let output = Command::new(binary)
             .arg(device)
             .output()
             .await
@@ -209,8 +209,16 @@ impl FileSystemOps for Ext4Fs {
 #[async_trait]
 impl FileSystemOps for XFs {
     async fn create(&self, device: &str) -> Result<(), Error> {
-        let binary = format!("mkfs.{}", "xfs");
-        let output = Command::new(&binary)
+        let binary = "mkfs.xfs";
+        let args = match std::env::var("MKFS_XFS_ARGS") {
+            Ok(args) => args
+                .split_whitespace()
+                .map(str::to_string)
+                .collect::<Vec<_>>(),
+            _ => vec![],
+        };
+        let output = Command::new(binary)
+            .args(args)
             .arg(device)
             .output()
             .await
@@ -297,8 +305,8 @@ impl FileSystemOps for XFs {
 #[async_trait]
 impl FileSystemOps for BtrFs {
     async fn create(&self, device: &str) -> Result<(), Error> {
-        let binary = format!("mkfs.{}", "btrfs");
-        let output = Command::new(&binary)
+        let binary = "mkfs.btrfs";
+        let output = Command::new(binary)
             .arg(device)
             .output()
             .await
@@ -393,7 +401,7 @@ impl FileSystemOps for BtrFs {
 }
 
 // Acknowledge the output from Command.
-fn ack_command_output(output: Output, binary: String) -> Result<(), Error> {
+fn ack_command_output(output: Output, binary: &str) -> Result<(), Error> {
     trace!(
         "Output from {} command: {}, status code: {:?}",
         binary,

--- a/terraform/cluster/mod/k8s/repo.sh
+++ b/terraform/cluster/mod/k8s/repo.sh
@@ -43,9 +43,10 @@ elif [ "$RUNTIME" = "containerd" ]; then
   sudo add-apt-repository --yes "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 fi
 
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+KUBE_APT_V=$(echo "${kube_version}" | awk -F. '{ sub(/-.*/, ""); print "v" $1 "." $2 }')
+curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBE_APT_V/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
-deb https://apt.kubernetes.io/ kubernetes-xenial main
+deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBE_APT_V/deb/ /
 EOF
 
 sudo apt-get update

--- a/terraform/cluster/mod/k8s/repo.sh
+++ b/terraform/cluster/mod/k8s/repo.sh
@@ -43,6 +43,7 @@ elif [ "$RUNTIME" = "containerd" ]; then
   sudo add-apt-repository --yes "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 fi
 
+sudo mkdir -p /etc/apt/keyrings/
 KUBE_APT_V=$(echo "${kube_version}" | awk -F. '{ sub(/-.*/, ""); print "v" $1 "." $2 }')
 curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBE_APT_V/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list

--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -103,7 +103,7 @@ variable "master_vcpu" {
 variable "kubernetes_version" {
   type        = string
   description = "Version of all kubernetes components"
-  default     = "1.26.0-00"
+  default     = "1.26.14-1.1"
 }
 
 variable "kubeconfig_output" {


### PR DESCRIPTION
    feat(csi/xfs): allow extra mkfs.xfs args
    
    Allows supporting older kernel versions when formatting the volumes,
    example: "-m bigtime=0,inobtcount=0"
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>