### PR TITLE
test(upgrade-rebuild): add upgrade test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,9 @@ name = "io-engine-tests"
 version = "1.0.0"
 dependencies = [
  "deployer-cluster",
+ "glob",
  "grpc",
+ "nvmeadm",
  "openapi",
  "rpc",
  "stor-port",

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
@@ -97,7 +97,7 @@ async fn hot_spare_nexus_reconcile(
     squash_results(results)
 }
 
-#[tracing::instrument(skip(context, nexus), fields(nexus.uuid = %nexus.uuid(), nexus.node = %nexus.as_ref().node, volume.uuid = tracing::field::Empty, request.reconcile = true))]
+#[tracing::instrument(skip(context, volume, nexus), fields(volume = ?volume.as_ref(), nexus.uuid = %nexus.uuid(), nexus.node = %nexus.as_ref().node, volume.uuid = tracing::field::Empty, request.reconcile = true))]
 async fn generic_nexus_reconciler(
     volume: &mut OperationGuardArc<VolumeSpec>,
     nexus: &mut OperationGuardArc<NexusSpec>,

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -86,6 +86,8 @@ pub(crate) struct RegistryInner<S: Store> {
     /// The duration for which the reconciler waits for the replica to
     /// to be healthy again before attempting to online the faulted child.
     faulted_child_wait_period: Option<std::time::Duration>,
+    /// Disable partial rebuild for volume targets.
+    disable_partial_rebuild: bool,
     reconciler: ReconcilerControl,
     config: parking_lot::RwLock<CoreRegistryConfig>,
     /// system-wide maximum number of concurrent rebuilds allowed.
@@ -118,6 +120,7 @@ impl Registry {
         reconcile_period: std::time::Duration,
         reconcile_idle_period: std::time::Duration,
         faulted_child_wait_period: Option<std::time::Duration>,
+        disable_partial_rebuild: bool,
         max_rebuilds: Option<NumRebuilds>,
         create_volume_limit: usize,
         host_acl: Vec<HostAccessControl>,
@@ -159,6 +162,7 @@ impl Registry {
                 reconcile_period,
                 reconcile_idle_period,
                 faulted_child_wait_period,
+                disable_partial_rebuild,
                 reconciler: ReconcilerControl::new(),
                 config: parking_lot::RwLock::new(
                     Self::get_config(&mut store, legacy_prefix_present)
@@ -201,9 +205,14 @@ impl Registry {
         Ok(registry)
     }
 
-    /// Check if the HA feature is enabled.
+    /// Check if the HA feature is disabled.
     pub(crate) fn ha_disabled(&self) -> bool {
         self.ha_disabled
+    }
+
+    /// Check if the partial rebuilds are disabled.
+    pub(crate) fn partial_rebuild_disabled(&self) -> bool {
+        self.disable_partial_rebuild
     }
 
     /// Formats the store endpoint with a default port if one isn't supplied.

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -47,6 +47,10 @@ pub(crate) struct CliArgs {
     #[clap(long)]
     pub(crate) faulted_child_wait_period: Option<humantime::Duration>,
 
+    /// Disable partial rebuild for volume targets.
+    #[clap(long, env = "DISABLE_PARTIAL_REBUILD")]
+    pub(crate) disable_partial_rebuild: bool,
+
     /// Deadline for the io-engine instance keep alive registration.
     #[clap(long, short, default_value = "10s")]
     pub(crate) deadline: humantime::Duration,
@@ -185,6 +189,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.reconcile_period.into(),
         cli_args.reconcile_idle_period.into(),
         cli_args.faulted_child_wait_period.map(|t| t.into()),
+        cli_args.disable_partial_rebuild,
         cli_args.max_rebuilds,
         cli_args.create_volume_limit,
         if cli_args.hosts_acl.contains(&HostAccessControl::None) {

--- a/control-plane/agents/src/bin/core/tests/rebuild/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/rebuild/mod.rs
@@ -44,14 +44,14 @@ async fn build_cluster(num_ioe: u32, pool_size: u64) -> Cluster {
 // gets and validates rebuild history response from rest api.
 #[tokio::test]
 async fn rebuild_history_for_full_rebuild() {
-    let cluster = build_cluster(4, 52428800).await;
+    let cluster = build_cluster(3, 52428800).await;
 
     let vol_target = cluster.node(0).to_string();
     let api_client = cluster.rest_v00();
     let volume_api = api_client.volumes_api();
     let nexus_client = cluster.grpc_client().nexus();
 
-    let body = CreateVolumeBody::new(VolumePolicy::new(true), 3, 10485760u64, false);
+    let body = CreateVolumeBody::new(VolumePolicy::new(true), 2, 10485760u64, false);
     let volid = VolumeId::new();
     let volume = volume_api.put_volume(&volid, body).await.unwrap();
     let volume = volume_api
@@ -92,7 +92,7 @@ async fn rebuild_history_for_full_rebuild() {
     let volume_state = volume.state.clone();
     assert_eq!(volume_state.status, VolumeStatus::Online);
     let nexus = volume_state.target.unwrap();
-    assert_eq!(nexus.children.len(), 3);
+    assert_eq!(nexus.children.len(), 2);
     nexus
         .children
         .iter()
@@ -173,16 +173,15 @@ async fn rebuild_history_for_full_rebuild() {
 // validates that rebuild type is Partial rebuild,
 // validates that previously faulted child is not removed from nexus,
 // gets and validates rebuild history response from rest api.
-
 #[tokio::test]
 async fn rebuild_history_for_partial_rebuild() {
-    let cluster = build_cluster(4, 52428800).await;
+    let cluster = build_cluster(3, 52428800).await;
 
     let vol_target = cluster.node(0).to_string();
     let api_client = cluster.rest_v00();
     let volume_api = api_client.volumes_api();
     let nexus_client = cluster.grpc_client().nexus();
-    let body = CreateVolumeBody::new(VolumePolicy::new(true), 3, 10485760u64, false);
+    let body = CreateVolumeBody::new(VolumePolicy::new(true), 2, 10485760u64, false);
     let volid = VolumeId::new();
     let volume = volume_api.put_volume(&volid, body).await.unwrap();
     let volume = volume_api
@@ -220,7 +219,7 @@ async fn rebuild_history_for_partial_rebuild() {
         history.records.len(),
         "Number of rebuild record should be 0"
     );
-    assert_eq!(nexus.children.len(), 3);
+    assert_eq!(nexus.children.len(), 2);
     nexus
         .children
         .iter()

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -332,8 +332,7 @@ async fn snapshot_timeout() {
     cluster.composer().pause("core").await.unwrap();
     cluster.composer().thaw(&cluster.node(1)).await.unwrap();
     tokio::time::sleep(req_timeout - grpc_timeout).await;
-    cluster.composer().restart("core").await.unwrap();
-    cluster.volume_service_liveness(None).await.unwrap();
+    cluster.restart_core_with_liveness(None).await.unwrap();
 
     let snapshots = vol_cli
         .get_snapshots(Filter::Snapshot(snapshot_id.clone()), false, None, None)
@@ -355,7 +354,7 @@ async fn snapshot_timeout() {
         .create_snapshot(&CreateVolumeSnapshot::new(volume.uuid(), snapshot_id), None)
         .await
         .unwrap();
-    tracing::info!("Replica Snapshot: {replica_snapshot:?}");
+    tracing::info!("Volume Snapshot: {snapshot:?}");
 
     assert_eq!(snapshot.meta().txn_id().as_str(), "2");
     assert_eq!(snapshot.meta().transactions().len(), 2);
@@ -402,6 +401,7 @@ async fn snapshot_timeout() {
         .await
         .unwrap();
     let snapshot = &snapshots.entries[0];
+    tracing::info!("Snapshot: {snapshot:?}");
 
     assert_eq!(snapshot.meta().txn_id().as_str(), "1");
     assert!(snapshot.meta().transactions().is_empty());

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -460,6 +460,16 @@ impl StartOptions {
         self
     }
     #[must_use]
+    pub fn with_io_engine_bin(mut self, binary: &str) -> Self {
+        self.io_engine_bin = Some(binary.to_string());
+        self
+    }
+    #[must_use]
+    pub fn with_io_engine_img(mut self, image: &str) -> Self {
+        self.io_engine_image = image.to_string();
+        self
+    }
+    #[must_use]
     pub fn with_io_engine_devices(mut self, devices: Vec<&str>) -> Self {
         self.io_engine_devices = devices.into_iter().map(Into::into).collect();
         self

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -445,6 +445,13 @@ impl StartOptions {
         self
     }
     #[must_use]
+    pub fn with_agents_env(mut self, key: &str, val: &str) -> Self {
+        let mut env = self.agents_env.unwrap_or_default();
+        env.push(KeyValue::new(key.to_string(), val.to_string()));
+        self.agents_env = Some(env);
+        self
+    }
+    #[must_use]
     pub fn with_isolated_io_engine(mut self, isolate: bool) -> Self {
         self.io_engine_isolate = isolate;
         self

--- a/tests/io-engine/Cargo.toml
+++ b/tests/io-engine/Cargo.toml
@@ -18,4 +18,6 @@ deployer-cluster = { path = "../../utils/deployer-cluster" }
 stor-port = { path = "../../control-plane/stor-port" }
 rpc = { path = "../../rpc" }
 grpc = { path = "../../control-plane/grpc" }
+nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
 tracing = "0.1.37"
+glob = "0.3.1"

--- a/tests/io-engine/tests/upgrade.rs
+++ b/tests/io-engine/tests/upgrade.rs
@@ -1,0 +1,346 @@
+use deployer_cluster::{Cluster, ClusterBuilder, FindVolumeRequest};
+use openapi::{
+    apis::volumes_api::tower::client::direct::Volumes, models, models::PublishVolumeBody,
+};
+
+use nvmeadm::parse_value;
+use std::{collections::HashMap, convert::TryInto, path::PathBuf, str::FromStr, time::Duration};
+use tokio::sync::oneshot::error::TryRecvError;
+
+#[tokio::test]
+#[ignore]
+async fn upgrade() {
+    let gb = 1024 * 1024 * 1024u64;
+    let pool_size = 10 * gb;
+    let volume_1_size = 8 * gb;
+    let replicas = 3;
+    let drain_nexus = true;
+
+    let cluster = ClusterBuilder::builder()
+        .with_io_engines(replicas)
+        .with_csi(false, true)
+        .with_tmpfs_pool(pool_size)
+        .with_cache_period("1s")
+        .with_reconcile_period(Duration::from_secs(2), Duration::from_secs(2))
+        .with_agents(vec!["Core", "HaNode", "HaCluster"])
+        .with_options(|o| o.with_isolated_io_engine(true).with_io_engine_cores(2))
+        .build()
+        .await
+        .unwrap();
+
+    let cli = cluster.rest_v00();
+    let volumes_api = cli.volumes_api();
+    let nodes_api = cli.nodes_api();
+
+    cluster
+        .composer()
+        .exec(&cluster.csi_container(0), vec!["nvme", "disconnect-all"])
+        .await
+        .unwrap();
+
+    let mut volume_1 = volumes_api
+        .put_volume(
+            &"ec4e66fd-3b33-4439-b504-d49aba53da26".try_into().unwrap(),
+            models::CreateVolumeBody::new(
+                models::VolumePolicy::new(true),
+                replicas as u8,
+                volume_1_size,
+                false,
+            ),
+        )
+        .await
+        .unwrap();
+    volume_1 = volumes_api
+        .put_volume_target(
+            &volume_1.spec.uuid,
+            PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                cluster.node(0).to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+            ),
+        )
+        .await
+        .unwrap();
+    tracing::info!(
+        "Volume replicas: {:?}",
+        volume_1.state.target.as_ref().unwrap().children
+    );
+    let (_, r) = tokio::sync::oneshot::channel::<()>();
+    let task = run_fio_vol(&cluster, volume_1.clone(), r).await;
+
+    let mut subsys = NvmeSubsystem::lookup(&volume_1.spec.uuid.to_string()).unwrap();
+    let mut path_number = subsys.paths.first().map(|p| p.instance).unwrap();
+
+    tracing::info!("First controller is {path_number}");
+    let mut drain_node = 99;
+    for _ in 0 .. 15 {
+        drain_node = (drain_node + 1) % replicas;
+        let drain_node = cluster.node(drain_node);
+        let target_node = volume_1.spec.target.clone().unwrap().node;
+
+        if !drain_nexus && target_node == drain_node.as_str() {
+            continue;
+        }
+
+        tracing::info!("Draining node {drain_node}");
+        nodes_api
+            .put_node_drain(&drain_node, "drain")
+            .await
+            .unwrap();
+
+        cluster.composer().restart(&drain_node).await.unwrap();
+
+        'outer: loop {
+            subsys.reload().unwrap();
+            if let Some((p, false)) = subsys.path_n() {
+                if target_node == drain_node.as_str() {
+                    if p.state == "live" && p.instance != path_number {
+                        path_number = p.instance;
+                        tracing::info!("New controller is {path_number}");
+                        break 'outer;
+                    }
+                } else if p.state == "live" {
+                    break 'outer;
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        tracing::info!("Removing cordon from node {target_node}");
+        nodes_api
+            .delete_node_cordon(&drain_node, "drain")
+            .await
+            .unwrap();
+
+        tracing::info!("Waiting volume Online...");
+        volume_1 = wait_till_volume_online(volume_1, volumes_api)
+            .await
+            .unwrap();
+        assert_eq!(
+            volume_1.state.target.as_ref().unwrap().children.len(),
+            replicas as usize
+        );
+
+        tracing::info!("Wait for 5 secs...");
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        if task.is_finished() {
+            tracing::error!("FINISHED");
+            break;
+        }
+    }
+    tracing::info!("Drain/Rebuild Loop Exit");
+
+    let code = task.await.unwrap();
+    cluster
+        .composer()
+        .exec(&cluster.csi_container(0), vec!["nvme", "disconnect-all"])
+        .await
+        .unwrap();
+
+    assert_eq!(code, Some(0), "Fio Failure");
+
+    volumes_api.del_volume(&volume_1.state.uuid).await.unwrap();
+}
+
+async fn run_fio_vol(
+    cluster: &Cluster,
+    volume: models::Volume,
+    stop: tokio::sync::oneshot::Receiver<()>,
+) -> tokio::task::JoinHandle<Option<i64>> {
+    run_fio_vol_verify(cluster, volume, stop, None, "300s").await
+}
+async fn run_fio_vol_verify(
+    cluster: &Cluster,
+    volume: models::Volume,
+    mut stop: tokio::sync::oneshot::Receiver<()>,
+    verify: Option<bool>,
+    time: &str,
+) -> tokio::task::JoinHandle<Option<i64>> {
+    let fio_builder = |device: &str| {
+        let filename = format!("--filename={device}");
+        let time = format!("--runtime={time}");
+        vec![
+            "fio",
+            "--direct=1",
+            "--ioengine=libaio",
+            "--bs=4k",
+            "--iodepth=16",
+            "--verify=crc32",
+            "--verify_fatal=1",
+            "--numjobs=1",
+            "--name=fio",
+            "--random_generator=tausworthe64",
+            "--loops=5",
+            filename.as_str(),
+        ]
+        .into_iter()
+        .chain(match verify {
+            Some(true) => {
+                vec![
+                    "--readwrite=read",
+                    "--verify_only",
+                    "--verify_dump=1",
+                    "--verify_state_load=1",
+                ]
+            }
+            Some(false) => {
+                vec![
+                    "--readwrite=write",
+                    "--verify_state_save=1",
+                    "--time_based",
+                    time.as_str(),
+                ]
+            }
+            None => {
+                vec!["--readwrite=randrw", "--verify_async=2", "--verify_dump=1"]
+            }
+        })
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+    };
+
+    let mut node = cluster.csi_node_client(0).await.unwrap();
+    node.node_stage_volume(&volume, HashMap::new())
+        .await
+        .unwrap();
+
+    let response = node
+        .internal()
+        .find_volume(FindVolumeRequest {
+            volume_id: volume.spec.uuid.to_string(),
+        })
+        .await
+        .unwrap();
+
+    let device_path = response.into_inner().device_path;
+    let device_path = device_path.trim_end();
+    let fio_cmd = fio_builder(device_path);
+    let fio_cmdline = fio_cmd
+        .iter()
+        .fold(String::new(), |acc, next| format!("{acc} {next}"));
+    let composer = cluster.composer_nt().clone();
+    let csi_node = cluster.csi_container(0);
+
+    tokio::spawn(async move {
+        let code = loop {
+            let (code, out) = composer.exec(&csi_node, fio_cmd.clone()).await.unwrap();
+            tracing::info!("{}: {}, code: {:?}", fio_cmdline, out, code);
+            if code != Some(0) {
+                return code;
+            }
+            assert_eq!(code, Some(0));
+
+            if stop.try_recv().is_ok() || matches!(stop.try_recv(), Err(TryRecvError::Closed)) {
+                break code;
+            }
+        };
+
+        if code == Some(0) {
+            node.node_unstage_volume(&volume).await.unwrap();
+        }
+        code
+    })
+}
+
+async fn wait_till_volume_online(
+    volume: models::Volume,
+    volume_client: &dyn Volumes,
+) -> Result<models::Volume, models::Volume> {
+    wait_till_volume_online_tmo(volume, volume_client, Duration::from_secs(60 * 10)).await
+}
+
+async fn wait_till_volume_online_tmo(
+    volume: models::Volume,
+    volume_client: &dyn Volumes,
+    timeout: Duration,
+) -> Result<models::Volume, models::Volume> {
+    let start = std::time::Instant::now();
+    loop {
+        let volume = volume_client.get_volume(&volume.spec.uuid).await.unwrap();
+
+        if volume.state.status == models::VolumeStatus::Online {
+            return Ok(volume);
+        }
+
+        if std::time::Instant::now() > (start + timeout) {
+            tracing::error!(?volume, "Timeout waiting for the volume become online");
+            return Err(volume);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+#[derive(Clone, Debug)]
+struct NvmeSubsystem {
+    /// The sysfs path.
+    sysfs_path: PathBuf,
+    /// NVMe Qualified Name (NQN).
+    #[allow(dead_code)]
+    nqn: String,
+    /// One or more NVMe paths (ANA).
+    paths: Vec<NvmePath>,
+}
+impl NvmeSubsystem {
+    fn lookup(uuid: &str) -> Result<Self, ()> {
+        let expected_nqn = format!("nqn.2019-05.io.openebs:{uuid}");
+        let paths = glob::glob("/sys/class/nvme-subsystem/nvme-subsys*").unwrap();
+        for path in paths {
+            let sysfs_path = path.unwrap();
+            let nqn = parse_value::<String>(&sysfs_path, "subsysnqn").unwrap();
+            if nqn != expected_nqn {
+                continue;
+            }
+            let mut subsys = Self {
+                sysfs_path,
+                nqn,
+                paths: vec![],
+            };
+            subsys.reload()?;
+            return Ok(subsys);
+        }
+        Err(())
+    }
+    fn path_n(&self) -> Option<(NvmePath, bool)> {
+        let path_number = self.paths.first().cloned();
+        path_number.map(|n| (n, self.paths.len() > 1))
+    }
+    fn reload(&mut self) -> Result<(), ()> {
+        self.paths.clear();
+        let sysfs = self.sysfs_path.display().to_string();
+        let pattern = format!("{sysfs}/nvme?");
+        let paths = glob::glob(&pattern).unwrap();
+        for path in paths {
+            let path = path.unwrap();
+            let name = path.strip_prefix(&sysfs).unwrap().display().to_string();
+            let instance = u32::from_str(name.trim_start_matches("nvme")).unwrap();
+            let nqn = parse_value::<String>(&path, "subsysnqn").unwrap();
+            let state = parse_value::<String>(&path, "state").unwrap();
+            let serial = parse_value::<String>(&path, "serial").unwrap();
+            let model = parse_value::<String>(&path, "model").unwrap();
+
+            if serial.is_empty() || model.is_empty() {
+                debug_assert!(false, "SERIAL MODEL");
+                continue;
+            }
+            self.paths.push(NvmePath {
+                nqn,
+                state,
+                instance,
+            })
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct NvmePath {
+    #[allow(dead_code)]
+    nqn: String,
+    state: String,
+    instance: u32,
+}

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -654,6 +654,17 @@ impl ClusterBuilder {
         self.opts = set(self.opts);
         self
     }
+    /// Update the start options, if enabled.
+    #[must_use]
+    pub fn with_options_en<F>(mut self, enabled: bool, set: F) -> Self
+    where
+        F: Fn(StartOptions) -> StartOptions,
+    {
+        if enabled {
+            self.opts = set(self.opts);
+        }
+        self
+    }
     /// Enable/Disable the default tokio tracing setup.
     #[must_use]
     pub fn with_default_tracing(self) -> Self {

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -8,7 +8,6 @@ use deployer_lib::{
 };
 use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
 
-use openapi::apis::Uuid;
 use stor_port::{transport_api::TimeoutOptions, types::v0::transport};
 
 use clap::Parser;
@@ -82,7 +81,11 @@ pub fn default_options() -> StartOptions {
         .with_env_tags(vec!["CARGO_PKG_NAME"])
 }
 
-struct ComposeTestNt {
+/// A wrapper over the composer utility meant to ensure termination in the
+/// correct order.
+/// todo: I suspect this is not working because composer itself is being created
+///  with cleaning enabled, so this won't actually work as expected!
+pub struct ComposeTestNt {
     logs_on_panic: bool,
     clean: bool,
     allow_clean_on_panic: bool,
@@ -156,7 +159,7 @@ impl Drop for ComposeTestNt {
 /// Cluster with the composer, the rest client and the jaeger pipeline
 #[allow(unused)]
 pub struct Cluster {
-    composer: ComposeTestNt,
+    composer: Arc<ComposeTestNt>,
     rest_client: rest_client::RestClient,
     grpc_client: Option<CoreClient>,
     trace_guard: Arc<tracing::subscriber::DefaultGuard>,
@@ -164,8 +167,13 @@ pub struct Cluster {
 }
 
 impl Cluster {
-    /// compose utility
+    /// A reference to the compose test utility.
     pub fn composer(&self) -> &ComposeTest {
+        &self.composer
+    }
+    /// A reference to our wrapper over the compose utility.
+    /// This can be safely sent across threads.
+    pub fn composer_nt(&self) -> &Arc<ComposeTestNt> {
         &self.composer
     }
 
@@ -455,7 +463,7 @@ impl Cluster {
         };
 
         let cluster = Cluster {
-            composer,
+            composer: Arc::new(composer),
             rest_client,
             grpc_client,
             trace_guard,
@@ -732,7 +740,11 @@ impl ClusterBuilder {
     /// Add a tmpfs img pool with `disk` to the indexed io-engine node with the specified `size`.
     #[must_use]
     pub fn with_tmpfs_pool_ix(mut self, node: u32, size: u64) -> Self {
-        let disk = TmpDiskFile::new(&Uuid::new_v4().to_string(), size);
+        // If we use a new file everytime it can also pollute the workspace when
+        // we don't clean up properly...
+        // Let's try to reuse the same disk for now and see how it goes..
+        let name = format!("index-{index}-node-{node}", index = self.pools.len());
+        let disk = TmpDiskFile::new(&name, size);
         if let Some(pools) = self.pools.get_mut(&node) {
             pools.push(PoolDisk::Tmp(disk));
         } else {


### PR DESCRIPTION
Add a test which exercises the upgrade/rebuild path by draining all nodes for a certain number of iterations.
This test is disabled by default and can be run manually if we need to re-run the same test again.