### PR TITLE
CI fixes and disable partial rebuild with cli arg

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
@@ -97,7 +97,7 @@ async fn hot_spare_nexus_reconcile(
     squash_results(results)
 }
 
-#[tracing::instrument(skip(context, nexus), fields(nexus.uuid = %nexus.uuid(), nexus.node = %nexus.as_ref().node, volume.uuid = tracing::field::Empty, request.reconcile = true))]
+#[tracing::instrument(skip(context, volume, nexus), fields(volume = ?volume.as_ref(), nexus.uuid = %nexus.uuid(), nexus.node = %nexus.as_ref().node, volume.uuid = tracing::field::Empty, request.reconcile = true))]
 async fn generic_nexus_reconciler(
     volume: &mut OperationGuardArc<VolumeSpec>,
     nexus: &mut OperationGuardArc<NexusSpec>,

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -86,6 +86,8 @@ pub(crate) struct RegistryInner<S: Store> {
     /// The duration for which the reconciler waits for the replica to
     /// to be healthy again before attempting to online the faulted child.
     faulted_child_wait_period: Option<std::time::Duration>,
+    /// Disable partial rebuild for volume targets.
+    disable_partial_rebuild: bool,
     reconciler: ReconcilerControl,
     config: parking_lot::RwLock<CoreRegistryConfig>,
     /// system-wide maximum number of concurrent rebuilds allowed.
@@ -118,6 +120,7 @@ impl Registry {
         reconcile_period: std::time::Duration,
         reconcile_idle_period: std::time::Duration,
         faulted_child_wait_period: Option<std::time::Duration>,
+        disable_partial_rebuild: bool,
         max_rebuilds: Option<NumRebuilds>,
         create_volume_limit: usize,
         host_acl: Vec<HostAccessControl>,
@@ -159,6 +162,7 @@ impl Registry {
                 reconcile_period,
                 reconcile_idle_period,
                 faulted_child_wait_period,
+                disable_partial_rebuild,
                 reconciler: ReconcilerControl::new(),
                 config: parking_lot::RwLock::new(
                     Self::get_config(&mut store, legacy_prefix_present)
@@ -201,9 +205,14 @@ impl Registry {
         Ok(registry)
     }
 
-    /// Check if the HA feature is enabled.
+    /// Check if the HA feature is disabled.
     pub(crate) fn ha_disabled(&self) -> bool {
         self.ha_disabled
+    }
+
+    /// Check if the partial rebuilds are disabled.
+    pub(crate) fn partial_rebuild_disabled(&self) -> bool {
+        self.disable_partial_rebuild
     }
 
     /// Formats the store endpoint with a default port if one isn't supplied.

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -47,6 +47,10 @@ pub(crate) struct CliArgs {
     #[clap(long)]
     pub(crate) faulted_child_wait_period: Option<humantime::Duration>,
 
+    /// Disable partial rebuild for volume targets.
+    #[clap(long, env = "DISABLE_PARTIAL_REBUILD")]
+    pub(crate) disable_partial_rebuild: bool,
+
     /// Deadline for the io-engine instance keep alive registration.
     #[clap(long, short, default_value = "10s")]
     pub(crate) deadline: humantime::Duration,
@@ -185,6 +189,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.reconcile_period.into(),
         cli_args.reconcile_idle_period.into(),
         cli_args.faulted_child_wait_period.map(|t| t.into()),
+        cli_args.disable_partial_rebuild,
         cli_args.max_rebuilds,
         cli_args.create_volume_limit,
         if cli_args.hosts_acl.contains(&HostAccessControl::None) {

--- a/control-plane/agents/src/bin/core/tests/rebuild/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/rebuild/mod.rs
@@ -44,14 +44,14 @@ async fn build_cluster(num_ioe: u32, pool_size: u64) -> Cluster {
 // gets and validates rebuild history response from rest api.
 #[tokio::test]
 async fn rebuild_history_for_full_rebuild() {
-    let cluster = build_cluster(4, 52428800).await;
+    let cluster = build_cluster(3, 52428800).await;
 
     let vol_target = cluster.node(0).to_string();
     let api_client = cluster.rest_v00();
     let volume_api = api_client.volumes_api();
     let nexus_client = cluster.grpc_client().nexus();
 
-    let body = CreateVolumeBody::new(VolumePolicy::new(true), 3, 10485760u64, false);
+    let body = CreateVolumeBody::new(VolumePolicy::new(true), 2, 10485760u64, false);
     let volid = VolumeId::new();
     let volume = volume_api.put_volume(&volid, body).await.unwrap();
     let volume = volume_api
@@ -92,7 +92,7 @@ async fn rebuild_history_for_full_rebuild() {
     let volume_state = volume.state.clone();
     assert_eq!(volume_state.status, VolumeStatus::Online);
     let nexus = volume_state.target.unwrap();
-    assert_eq!(nexus.children.len(), 3);
+    assert_eq!(nexus.children.len(), 2);
     nexus
         .children
         .iter()
@@ -173,16 +173,15 @@ async fn rebuild_history_for_full_rebuild() {
 // validates that rebuild type is Partial rebuild,
 // validates that previously faulted child is not removed from nexus,
 // gets and validates rebuild history response from rest api.
-
 #[tokio::test]
 async fn rebuild_history_for_partial_rebuild() {
-    let cluster = build_cluster(4, 52428800).await;
+    let cluster = build_cluster(3, 52428800).await;
 
     let vol_target = cluster.node(0).to_string();
     let api_client = cluster.rest_v00();
     let volume_api = api_client.volumes_api();
     let nexus_client = cluster.grpc_client().nexus();
-    let body = CreateVolumeBody::new(VolumePolicy::new(true), 3, 10485760u64, false);
+    let body = CreateVolumeBody::new(VolumePolicy::new(true), 2, 10485760u64, false);
     let volid = VolumeId::new();
     let volume = volume_api.put_volume(&volid, body).await.unwrap();
     let volume = volume_api
@@ -220,7 +219,7 @@ async fn rebuild_history_for_partial_rebuild() {
         history.records.len(),
         "Number of rebuild record should be 0"
     );
-    assert_eq!(nexus.children.len(), 3);
+    assert_eq!(nexus.children.len(), 2);
     nexus
         .children
         .iter()

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -332,8 +332,7 @@ async fn snapshot_timeout() {
     cluster.composer().pause("core").await.unwrap();
     cluster.composer().thaw(&cluster.node(1)).await.unwrap();
     tokio::time::sleep(req_timeout - grpc_timeout).await;
-    cluster.composer().restart("core").await.unwrap();
-    cluster.volume_service_liveness(None).await.unwrap();
+    cluster.restart_core_with_liveness(None).await.unwrap();
 
     let snapshots = vol_cli
         .get_snapshots(Filter::Snapshot(snapshot_id.clone()), false, None, None)
@@ -355,7 +354,7 @@ async fn snapshot_timeout() {
         .create_snapshot(&CreateVolumeSnapshot::new(volume.uuid(), snapshot_id), None)
         .await
         .unwrap();
-    tracing::info!("Replica Snapshot: {replica_snapshot:?}");
+    tracing::info!("Volume Snapshot: {snapshot:?}");
 
     assert_eq!(snapshot.meta().txn_id().as_str(), "2");
     assert_eq!(snapshot.meta().transactions().len(), 2);
@@ -402,6 +401,7 @@ async fn snapshot_timeout() {
         .await
         .unwrap();
     let snapshot = &snapshots.entries[0];
+    tracing::info!("Snapshot: {snapshot:?}");
 
     assert_eq!(snapshot.meta().txn_id().as_str(), "1");
     assert!(snapshot.meta().transactions().is_empty());

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -445,6 +445,13 @@ impl StartOptions {
         self
     }
     #[must_use]
+    pub fn with_agents_env(mut self, key: &str, val: &str) -> Self {
+        let mut env = self.agents_env.unwrap_or_default();
+        env.push(KeyValue::new(key.to_string(), val.to_string()));
+        self.agents_env = Some(env);
+        self
+    }
+    #[must_use]
     pub fn with_isolated_io_engine(mut self, isolate: bool) -> Self {
         self.io_engine_isolate = isolate;
         self

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -646,6 +646,17 @@ impl ClusterBuilder {
         self.opts = set(self.opts);
         self
     }
+    /// Update the start options, if enabled.
+    #[must_use]
+    pub fn with_options_en<F>(mut self, enabled: bool, set: F) -> Self
+    where
+        F: Fn(StartOptions) -> StartOptions,
+    {
+        if enabled {
+            self.opts = set(self.opts);
+        }
+        self
+    }
     /// Enable/Disable the default tokio tracing setup.
     #[must_use]
     pub fn with_default_tracing(self) -> Self {


### PR DESCRIPTION

    feat(rebuild): add cli arg to disable partial rebuild
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(rebuild): use only 3 io engines to reduce hugepages
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(snapshot): fix race condition
    
    Kill the agent-core and restart it after only. Otherwise during stop the
    core is still running for a little which the test code does not account for.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
