### PR TITLE
fix(agents/ha/node): complete reconnect when path is deleting

### DIFF
--- a/control-plane/agents/src/bin/core/nexus/operations.rs
+++ b/control-plane/agents/src/bin/core/nexus/operations.rs
@@ -315,6 +315,10 @@ impl ResourceShutdownOperations for OperationGuardArc<NexusSpec> {
         registry: &Registry,
         request: &Self::Shutdown,
     ) -> Result<(), SvcError> {
+        if self.as_ref().is_shutdown() {
+            return Ok(());
+        }
+
         let node_id = self.as_ref().node.clone();
         let node = match registry.node_wrapper(&node_id).await {
             Err(error) if !request.lazy() => Err(error),


### PR DESCRIPTION
During the reconnect of a new path, the old path might take some time to disconnect.
Rather than wait for this (and timeout, which leads to retries) simply complete call as soon as path is deleting.