### PR TITLE
build: harden build by pre-fetching dependencies

### DIFF
--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -74,6 +74,9 @@ let
     doCheck = false;
   };
   release_build = { "release" = true; "debug" = false; };
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = ../../../Cargo.lock;
+  };
 in
 let
   build_with_naersk = { buildType, cargoBuildFlags }:
@@ -104,7 +107,7 @@ let
   builder = if incremental then build_with_naersk else build_with_default;
 in
 {
-  inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE version src;
+  inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE version src cargoDeps;
 
   build = { buildType, cargoBuildFlags ? [ ] }:
     if allInOne then


### PR DESCRIPTION
Attempt to vendor the cargo deps for up to 25 times Supports linking the resulting derivation into a global location through env var CARGO_VENDOR_DIR, example:
> CARGO_VENDOR_DIR=/tmp ./scripts/release.sh --image ""
/nix/store/2x03mh7l1q0jx4xfsd3nw4h4ks0pxxya-cargo-vendor-dir Cargo vendored dependencies pre-fetched into /tmp/$BRANCH/mayastor-controller after 1 attempt(s)

This can allow us to create a place holder in the jenkins nodes to keep the last dependencies for each main branch of each repo.