### PR TITLE
Build and CI fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ dependencies = [
  "once_cell",
  "rand",
  "regex",
- "ring",
+ "ring 0.16.20",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -764,7 +764,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1336,7 +1336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1694,7 +1694,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1944,7 +1944,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1976,7 +1976,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2043,7 +2043,7 @@ checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.4",
  "pem",
- "ring",
+ "ring 0.16.20",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -2386,7 +2386,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2749,7 +2749,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -3233,10 +3233,25 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3288,17 +3303,17 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.8",
  "rustls-webpki",
  "sct",
 ]
@@ -3326,12 +3341,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3352,7 +3367,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3397,8 +3412,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -3735,7 +3750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3743,6 +3758,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -3896,7 +3917,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4031,7 +4052,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.3",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4450,6 +4471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4630,8 +4657,8 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4684,7 +4711,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -4693,7 +4720,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -4702,13 +4738,29 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -4718,10 +4770,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4730,10 +4794,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4742,10 +4824,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4754,13 +4848,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -17,7 +17,7 @@ path = "./src/lib.rs"
 
 [dependencies]
 # Actix Server, telemetry
-rustls = "0.21.7"
+rustls = "0.21.12"
 rustls-pemfile = "1.0.3"
 actix-web = { version = "4.4.0", features = ["rustls-0_21"] }
 actix-service = "2.0.2"

--- a/nix/pkgs/openapi-generator/default.nix
+++ b/nix/pkgs/openapi-generator/default.nix
@@ -28,7 +28,7 @@ let
       "find $out/.m2 -type f -regex '.+\\(\\.lastUpdated\\|resolver-status\\.properties\\|_remote\\.repositories\\)' -delete";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = if stdenv.hostPlatform.isDarwin then "sha256-rj4JkUDMp+4K/WaLZJUIbiEPH+VOVaT8LYlVOMk2xNs" else "sha256-Z3jyn5WQpIXJz+8irsfxZ8LeQc2D+FZbAIZo7ME9OAw=";
+    outputHash = if stdenv.hostPlatform.isDarwin then "sha256-8fk0lC3zBFgcGeBSASEDk0Zgz1xXLhJw6CSWszeSGf4=" else "sha256-mk6opj5FzELc/NambThC0K2ADJG2aRV4f8F2ZteMvMc=";
   };
 in
 stdenv.mkDerivation rec {

--- a/nix/pkgs/openapi-generator/default.nix
+++ b/nix/pkgs/openapi-generator/default.nix
@@ -28,7 +28,7 @@ let
       "find $out/.m2 -type f -regex '.+\\(\\.lastUpdated\\|resolver-status\\.properties\\|_remote\\.repositories\\)' -delete";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = if stdenv.hostPlatform.isDarwin then "sha256-8fk0lC3zBFgcGeBSASEDk0Zgz1xXLhJw6CSWszeSGf4=" else "sha256-mk6opj5FzELc/NambThC0K2ADJG2aRV4f8F2ZteMvMc=";
+    outputHash = if stdenv.hostPlatform.isDarwin then "sha256-rj4JkUDMp+4K/WaLZJUIbiEPH+VOVaT8LYlVOMk2xNs" else "sha256-Z3jyn5WQpIXJz+8irsfxZ8LeQc2D+FZbAIZo7ME9OAw=";
   };
 in
 stdenv.mkDerivation rec {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "c5037590290c6c7dae2e42e7da1e247e54ed2d49",
-        "sha256": "1ql5ziwfrpmc8cxhgflmdy2z06z4dsdfzjwb2vv9bag6a2chrvq8",
+        "rev": "d9a33d69a9c421d64c8d925428864e93be895dcc",
+        "sha256": "1lhz5haibfnbxwir61mhymxfqfgs2q1nb4rk88va8bpv6j2zlpbv",
         "type": "tarball",
-        "url": "https://github.com/nix-community/naersk/archive/c5037590290c6c7dae2e42e7da1e247e54ed2d49.tar.gz",
+        "url": "https://github.com/nix-community/naersk/archive/d9a33d69a9c421d64c8d925428864e93be895dcc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,22 +17,22 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5",
-        "sha256": "1qbyprn08917cszfm5syppi4r5p467qii4fzb2v1s0lrqqn0das4",
+        "rev": "914aba08a26cb10538b84d00d6cfb01c9776d80c",
+        "sha256": "0gx316gc7prjay5b0cr13x4zc2pdbiwxkfkpjvrlb2rml80lm4pm",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/914aba08a26cb10538b84d00d6cfb01c9776d80c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-23.11",
+        "branch": "release-22.11",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adac2842e7b44a6dfe2c589e5dab2d532f4e8315",
-        "sha256": "121dlkg8imh6my3ib6rg5bv2cx82k1jp0wk5a4skx5m0mxly4vqy",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "sha256": "1xi53rlslcprybsvrmipm69ypd3g3hr7wkxvzc73ag8296yclyll",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/adac2842e7b44a6dfe2c589e5dab2d532f4e8315.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-22_05": {
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2a42c742ab04b61d9b2f1edf392842cf9f27ebfd",
-        "sha256": "1wpkca75ysb2ssycc0dshd1m76q8iqhzrrbr6xmfmkkcj1p333nk",
+        "rev": "c0df7f2a856b5ff27a3ce314f6d7aacf5fda546f",
+        "sha256": "0hm2yznc083bys92h6zrx5lsar5nqphx1h27p7pxz4x7hmilxpsy",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/2a42c742ab04b61d9b2f1edf392842cf9f27ebfd.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/c0df7f2a856b5ff27a3ce314f6d7aacf5fda546f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "d9a33d69a9c421d64c8d925428864e93be895dcc",
-        "sha256": "1lhz5haibfnbxwir61mhymxfqfgs2q1nb4rk88va8bpv6j2zlpbv",
+        "rev": "c5037590290c6c7dae2e42e7da1e247e54ed2d49",
+        "sha256": "1ql5ziwfrpmc8cxhgflmdy2z06z4dsdfzjwb2vv9bag6a2chrvq8",
         "type": "tarball",
-        "url": "https://github.com/nix-community/naersk/archive/d9a33d69a9c421d64c8d925428864e93be895dcc.tar.gz",
+        "url": "https://github.com/nix-community/naersk/archive/c5037590290c6c7dae2e42e7da1e247e54ed2d49.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,22 +17,22 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "914aba08a26cb10538b84d00d6cfb01c9776d80c",
-        "sha256": "0gx316gc7prjay5b0cr13x4zc2pdbiwxkfkpjvrlb2rml80lm4pm",
+        "rev": "6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5",
+        "sha256": "1qbyprn08917cszfm5syppi4r5p467qii4fzb2v1s0lrqqn0das4",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/914aba08a26cb10538b84d00d6cfb01c9776d80c.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-22.11",
+        "branch": "release-23.11",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "sha256": "1xi53rlslcprybsvrmipm69ypd3g3hr7wkxvzc73ag8296yclyll",
+        "rev": "adac2842e7b44a6dfe2c589e5dab2d532f4e8315",
+        "sha256": "121dlkg8imh6my3ib6rg5bv2cx82k1jp0wk5a4skx5m0mxly4vqy",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/adac2842e7b44a6dfe2c589e5dab2d532f4e8315.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-22_05": {
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c0df7f2a856b5ff27a3ce314f6d7aacf5fda546f",
-        "sha256": "0hm2yznc083bys92h6zrx5lsar5nqphx1h27p7pxz4x7hmilxpsy",
+        "rev": "2a42c742ab04b61d9b2f1edf392842cf9f27ebfd",
+        "sha256": "1wpkca75ysb2ssycc0dshd1m76q8iqhzrrbr6xmfmkkcj1p333nk",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/c0df7f2a856b5ff27a3ce314f6d7aacf5fda546f.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/2a42c742ab04b61d9b2f1edf392842cf9f27ebfd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -50,7 +50,7 @@ http-body = { version = "0.4.5", optional = true }
 futures = { version = "0.3.28", optional = true }
 pin-project = { version = "1.1.3", optional = true }
 # SSL
-rustls = { version = "0.21.7", optional = true, features = [ "dangerous_configuration" ] }
+rustls = { version = "0.21.12", optional = true, features = [ "dangerous_configuration" ] }
 rustls-pemfile = "1.0.3"
 webpki = { version = "0.22.2", optional = true }
 hyper-rustls = { version = "0.24.1", optional = true }

--- a/tests/bdd/common/command.py
+++ b/tests/bdd/common/command.py
@@ -48,7 +48,6 @@ async def run_cmd_async_at(host, cmd):
             output_message += f"\nstderr:\n{result.stderr}"
 
         if result.exit_status != 0:
-
             output_message += f"\nReturned error code: {result.exit_status}"
 
             if result.stderr != "":

--- a/tests/bdd/common/fio.py
+++ b/tests/bdd/common/fio.py
@@ -5,6 +5,8 @@ from urllib.parse import parse_qs, ParseResult
 import os
 import subprocess
 
+fio_bin = shutil.which("fio")
+
 
 class Fio(object):
     def __init__(
@@ -71,7 +73,7 @@ class Fio(object):
         filename = ":".join(map(str, devs))
 
         command = (
-            f"sudo fio --ioengine=linuxaio --filename={filename} "
+            f"sudo {fio_bin} --ioengine=linuxaio --filename={filename} "
             f"--numjobs=1 --thread=1 {args} "
         )
 

--- a/tests/bdd/common/nvme.py
+++ b/tests/bdd/common/nvme.py
@@ -1,3 +1,4 @@
+from shutil import which
 from urllib.parse import urlparse, parse_qs, ParseResult
 from retrying import retry
 from common.command import run_cmd_async_at
@@ -5,6 +6,8 @@ from common.command import run_cmd_async_at
 import subprocess
 import time
 import json
+
+nvme_bin = which("nvme")
 
 
 async def nvme_remote_connect(remote, uri):
@@ -15,7 +18,7 @@ async def nvme_remote_connect(remote, uri):
     nqn = u.path[1:]
     hostnqn = nvme_hostnqn_arg(u)
 
-    command = f"sudo nvme connect -t tcp -s {port} -a {host} -n {nqn} {hostnqn}"
+    command = f"sudo {nvme_bin} connect -t tcp -s {port} -a {host} -n {nqn} {hostnqn}"
 
     await run_cmd_async_at(remote, command)
     return wait_nvme_find_device(uri)
@@ -26,7 +29,7 @@ async def nvme_remote_disconnect(remote, uri):
     u = urlparse(uri)
     nqn = u.path[1:]
 
-    command = "sudo nvme disconnect -n {0}".format(nqn)
+    command = f"sudo {nvme_bin} disconnect -n {nqn}"
     await run_cmd_async_at(remote, command)
 
 
@@ -37,7 +40,7 @@ async def nvme_remote_discover(remote, uri):
     host = u.hostname
     hostnqn = nvme_hostnqn_arg(u)
 
-    command = f"sudo nvme discover -t tcp -s {port} -a {host} {hostnqn}"
+    command = f"sudo {nvme_bin} discover -t tcp -s {port} -a {host} {hostnqn}"
     output = await run_cmd_async_at(remote, command).stdout
     if not u.path[1:] in str(output.stdout):
         raise ValueError("uri {} is not discovered".format(u.path[1:]))
@@ -46,7 +49,7 @@ async def nvme_remote_discover(remote, uri):
 def nvme_hostnqn_arg(uri: ParseResult):
     uri_query = parse_qs(uri.query)
     if uri_query.keys().__contains__("hostnqn"):
-        return "-q {}".format(uri_query["hostnqn"][0])
+        return " -q {}".format(uri_query["hostnqn"][0])
     else:
         return ""
 
@@ -58,7 +61,7 @@ def nvme_connect(uri):
     nqn = u.path[1:]
     hostnqn = nvme_hostnqn_arg(u)
 
-    command = f"sudo nvme connect -t tcp -s {port} -a {host} -n {nqn} {hostnqn}"
+    command = f"sudo {nvme_bin} connect -t tcp -s {port} -a {host} -n {nqn}{hostnqn}"
     print(command)
     subprocess.run(command, check=True, shell=True, capture_output=False)
 
@@ -67,7 +70,7 @@ def nvme_connect(uri):
 
 def nvme_id_ctrl(device):
     """Identify controller."""
-    command = "sudo nvme id-ctrl {0} -o json".format(device)
+    command = f"sudo {nvme_bin} id-ctrl {device} -o json"
     id_ctrl = json.loads(
         subprocess.run(
             command, shell=True, check=True, text=True, capture_output=True
@@ -79,7 +82,7 @@ def nvme_id_ctrl(device):
 
 def nvme_resv_report(device):
     """Reservation report."""
-    command = "sudo nvme resv-report {0} -c 1 -o json".format(device)
+    command = f"sudo {nvme_bin} resv-report {device} -c 1 -o json"
     resv_report = json.loads(
         subprocess.run(
             command, shell=True, check=True, text=True, capture_output=True
@@ -96,7 +99,7 @@ def nvme_discover(uri):
     host = u.hostname
     hostnqn = nvme_hostnqn_arg(u)
 
-    command = f"sudo nvme discover -t tcp -s {port} -a {host} {hostnqn}"
+    command = f"sudo {nvme_bin} discover -t tcp -s {port} -a {host} {hostnqn}"
     output = subprocess.run(
         command, check=True, shell=True, capture_output=True, encoding="utf-8"
     )
@@ -108,7 +111,7 @@ def nvme_find_device(uri):
     u = urlparse(uri)
     nqn = u.path[1:]
 
-    command = "sudo nvme list -v -o json"
+    command = f"sudo {nvme_bin} list -v -o json"
     discover = json.loads(
         subprocess.run(
             command, shell=True, check=True, text=True, capture_output=True
@@ -135,7 +138,7 @@ def nvme_find_device_path(uri):
     u = urlparse(uri)
     nqn = u.path[1:]
 
-    command = "sudo nvme list -v -o json"
+    command = f"sudo {nvme_bin} list -v -o json"
     discover = json.loads(
         subprocess.run(
             command, shell=True, check=True, text=True, capture_output=True
@@ -167,25 +170,25 @@ def nvme_disconnect(uri):
     u = urlparse(uri)
     nqn = u.path[1:]
 
-    command = "sudo nvme disconnect -n {0}".format(nqn)
+    command = f"sudo {nvme_bin} disconnect -n {nqn}"
     subprocess.run(command, check=True, shell=True, capture_output=True)
 
 
 def nvme_disconnect_all():
     """Disconnect from all connected nvme subsystems"""
-    command = "sudo nvme disconnect-all"
+    command = f"sudo {nvme_bin} disconnect-all"
     subprocess.run(command, check=True, shell=True, capture_output=True)
 
 
 def nvme_disconnect_controller(name):
     """Disconnect the given NVMe controller on this host."""
-    command = "sudo nvme disconnect -d {0}".format(name)
+    command = f"sudo {nvme_bin} disconnect -d {name}"
     subprocess.run(command, check=True, shell=True, capture_output=True)
 
 
 def nvme_list_subsystems(device):
     """Retrieve information for NVMe subsystems"""
-    command = "sudo nvme list-subsys {} -o json".format(device)
+    command = f"sudo {nvme_bin} list-subsys {device} -o json"
     subsystems = json.loads(
         subprocess.run(
             command, check=True, shell=True, capture_output=True, encoding="utf-8"
@@ -199,7 +202,7 @@ NS_PROPS = ["nguid", "eui64"]
 
 def identify_namespace(device):
     """Get properties of a namespace on this host"""
-    command = "sudo nvme id-ns {}".format(device)
+    command = f"sudo {nvme_bin} id-ns {device}"
     output = subprocess.run(
         command, check=True, shell=True, capture_output=True, encoding="utf-8"
     )
@@ -216,7 +219,7 @@ def nvme_set_reconnect_delay(uri, delay=10):
     u = urlparse(uri)
     nqn = u.path[1:]
 
-    command = "sudo nvme list -v -o json"
+    command = f"sudo {nvme_bin} list -v -o json"
     discover = json.loads(
         subprocess.run(
             command, shell=True, check=True, text=True, capture_output=True

--- a/tests/bdd/common/nvme.py
+++ b/tests/bdd/common/nvme.py
@@ -63,7 +63,16 @@ def nvme_connect(uri):
 
     command = f"sudo {nvme_bin} connect -t tcp -s {port} -a {host} -n {nqn}{hostnqn}"
     print(command)
-    subprocess.run(command, check=True, shell=True, capture_output=False)
+    try:
+        subprocess.run(
+            command, check=True, shell=True, capture_output=True, encoding="utf-8"
+        )
+    except subprocess.CalledProcessError as e:
+        # todo: handle this better!
+        if e.stderr == "already connected\n":
+            pass
+        else:
+            raise e
 
     return wait_nvme_find_device(uri)
 

--- a/tests/bdd/features/csi/controller/test_controller.py
+++ b/tests/bdd/features/csi/controller/test_controller.py
@@ -743,10 +743,9 @@ def check_nvmf_target(uri):
     host = u.hostname
     nqn = u.path[1:]
     hostnqn = parse_qs(u.query)["hostnqn"][0]
+    hostid = "b7097711-a6d7-425f-a76a-9cfcf83f31ba"
 
-    command = (
-        f"sudo {nvme_bin} discover -t tcp -s {port} -a {host} -q {hostnqn} -o json"
-    )
+    command = f"sudo {nvme_bin} discover -t tcp -s {port} -a {host} -I {hostid} -q {hostnqn} -o json"
     status = subprocess.run(
         command, shell=True, check=True, text=True, capture_output=True
     )

--- a/tests/bdd/features/csi/controller/test_controller.py
+++ b/tests/bdd/features/csi/controller/test_controller.py
@@ -19,6 +19,7 @@ import json
 from common.apiclient import ApiClient
 from common.csi import CsiHandle
 from common.deployer import Deployer
+from common.nvme import nvme_bin
 from common.operations import Cluster
 from openapi.model.create_pool_body import CreatePoolBody
 from openapi.exceptions import NotFoundException
@@ -743,7 +744,9 @@ def check_nvmf_target(uri):
     nqn = u.path[1:]
     hostnqn = parse_qs(u.query)["hostnqn"][0]
 
-    command = f"sudo nvme discover -t tcp -s {port} -a {host} -q {hostnqn} -o json"
+    command = (
+        f"sudo {nvme_bin} discover -t tcp -s {port} -a {host} -q {hostnqn} -o json"
+    )
     status = subprocess.run(
         command, shell=True, check=True, text=True, capture_output=True
     )

--- a/tests/bdd/features/ha/test_robustness.py
+++ b/tests/bdd/features/ha/test_robustness.py
@@ -73,10 +73,11 @@ def init_scenario(init, disks):
             node, name, CreatePoolBody([disks[disk_index]])
         )
     yield
-    Docker.restart_container("agent-ha-node")
-    ETCD_CLIENT.del_switchover(VOLUME_UUID)
-    Docker.restart_container("agent-ha-cluster")
-    Cluster.cleanup()
+    if Cluster.fixture_cleanup():
+        Docker.restart_container("agent-ha-node")
+        ETCD_CLIENT.del_switchover(VOLUME_UUID)
+        Docker.restart_container("agent-ha-cluster")
+        Cluster.cleanup()
 
 
 @scenario("robustness.feature", "reconnecting the new target times out")

--- a/tests/bdd/features/volume/get/test_feature.py
+++ b/tests/bdd/features/volume/get/test_feature.py
@@ -41,6 +41,7 @@ NODE_NAME = "io-engine-1"
 PAGINATED_MAX_ENTRIES_KEY = "max_entries"
 PAGINATED_STARTING_TOKEN = "starting_token"
 
+
 # This fixture will be automatically used by all tests.
 # It starts the deployer which launches all the necessary containers.
 # A pool is created for convenience such that it is available for use by the tests.

--- a/tests/bdd/features/volume/resize/test_resize_offline.py
+++ b/tests/bdd/features/volume/resize/test_resize_offline.py
@@ -52,6 +52,7 @@ VOLUME_SIZE = 52428800  # 50MiB
 VOLUME_NEW_SIZE = 83886080  # 80MiB
 VOLUME_SHRINK_SIZE = 41943040  # 40MiB
 
+
 # utility helper functions - BEGIN
 def cordon_node(node_name, label):
     ApiClient.nodes_api().put_node_cordon(node_name, label)
@@ -202,6 +203,7 @@ def disks(tmp_files):
 
 
 # Fixtures - END
+
 
 # This fixture will be automatically used by all tests.
 # It starts the deployer which launches all the necessary containers.

--- a/tests/bdd/features/volume/resize/test_resize_online.py
+++ b/tests/bdd/features/volume/resize/test_resize_online.py
@@ -58,6 +58,7 @@ VOLUME_SIZE = 104857600  # 100MiB
 VOLUME_NEW_SIZE = 209715200  # 200MiB
 VOLUME_SHRINK_SIZE = 52428800  # 50MiB
 
+
 # fixtures - BEGIN
 @pytest.fixture(scope="module")
 def tmp_files():
@@ -136,6 +137,7 @@ def test_volume_factory():
 
 
 # fixtures - END
+
 
 # utility helper functions - BEGIN
 def cordon_node(node_name, label):

--- a/tests/bdd/features/volume_group/create/test_create.py
+++ b/tests/bdd/features/volume_group/create/test_create.py
@@ -220,6 +220,7 @@ def check_pool_replicas_different_volumes():
 
 # HELPER METHODS
 
+
 # Creates the pools based on given nodes and counts.
 def create_node_pools(node_pool_map: Dict[str, int]):
     pool_index = 1

--- a/tests/bdd/features/volume_group/publish/test_publish.py
+++ b/tests/bdd/features/volume_group/publish/test_publish.py
@@ -191,6 +191,7 @@ def the_target_should_land_on_node_b():
 
 # HELPER METHODS
 
+
 # Creates the pools based on given nodes and counts.
 def create_node_pools(node_pool_map: Dict[str, int]):
     pool_index = 1

--- a/tests/bdd/features/volume_group/set_replica/test_set_replica.py
+++ b/tests/bdd/features/volume_group/set_replica/test_set_replica.py
@@ -230,6 +230,7 @@ def the_scale_down_operation_should_fail():
 
 # HELPER METHODS
 
+
 # Creates the pools based on given nodes and counts.
 def create_node_pools(node_pool_map: Dict[str, int]):
     pool_index = 1


### PR DESCRIPTION
    build: pin nixpkgs until we verify e2fs version requirement
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: upgrade rustls crate
    
    This is to address a dependabot alert.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(bdd): always specify hostid
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(python/ha): handle already connected error
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: upgrade nvmeadm crate and nixpkgs
    
    Allows us to specify a hostid and a hostnqn prefix.
    Upgrades nixpkgs to get the latest nvme cli tool.
    Updates a few tests to use correct binary.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>