### PR TITLE
Replace deprecated Jaeger components with OpenTel 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,15 +208,15 @@ dependencies = [
 
 [[package]]
 name = "actix-web-opentelemetry"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbeb48a7523926c2e555044ace1c3715956be38b8d34fc27484c8a1d9642de6"
+checksum = "d6e0327e7b731c61b77fb54b278477aa3ebd09752bde38d169863167636e2d48"
 dependencies = [
  "actix-http",
  "actix-web",
  "futures-util",
+ "opentelemetry",
  "opentelemetry-semantic-conventions",
- "opentelemetry_api",
  "serde",
 ]
 
@@ -271,7 +271,7 @@ dependencies = [
  "stor-port",
  "tokio",
  "tokio-udev",
- "tonic",
+ "tonic 0.10.2",
  "tower",
  "tracing",
  "url",
@@ -967,7 +967,7 @@ dependencies = [
  "sys-mount",
  "sysfs",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
  "tower",
  "tracing",
@@ -1085,7 +1085,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -1107,10 +1107,13 @@ dependencies = [
  "openapi",
  "opentelemetry",
  "opentelemetry-jaeger",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "rpc",
  "stor-port",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tower",
  "tracing",
  "tracing-opentelemetry",
@@ -1349,7 +1352,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
  "tower",
  "tower-service",
@@ -1382,7 +1385,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
  "tracing",
  "uuid",
@@ -1628,7 +1631,7 @@ dependencies = [
  "serde_json",
  "stor-port",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
  "tower",
  "tracing",
@@ -2624,59 +2627,12 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-http"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "opentelemetry_api",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876958ba9084f390f913fcf04ddf7bbbb822898867bb0a51cc28f2b9e5c1b515"
-dependencies = [
- "async-trait",
  "futures-core",
- "futures-util",
- "opentelemetry",
- "opentelemetry-semantic-conventions",
- "thrift",
- "tokio",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
+ "futures-sink",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -2685,22 +2641,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.20.0"
+name = "opentelemetry-http"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb7f5ef13427696ae8382c6f3bb7dcdadb5994223d6b983c7c50a46df7d19277"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "thrift",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic 0.11.0",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic 0.11.0",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
- "ordered-float 3.9.1",
+ "opentelemetry",
+ "ordered-float 4.2.0",
  "percent-encoding",
  "rand",
- "regex",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2717,9 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.9.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -2989,7 +3010,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
  "url",
  "utils",
@@ -3270,7 +3291,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
 ]
 
@@ -3806,7 +3827,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
  "url",
  "utils",
@@ -4199,6 +4220,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.4",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4306,21 +4354,22 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -4329,6 +4378,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -4343,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4517,7 +4567,9 @@ dependencies = [
  "git-version-macro",
  "heck",
  "opentelemetry",
- "opentelemetry-jaeger",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "strum",
  "strum_macros",
  "tracing",
@@ -4650,6 +4702,16 @@ name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -53,7 +53,7 @@ futures-util = { version = "0.3.28" }
 crossbeam-queue = "0.3.8"
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ] }
-opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
+opentelemetry = { version = "0.22.0" }
 tracing = "0.1.37"
 nix = { version = "0.27.1", default-features = false }
 prost-types = "0.12.1"

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/nexus.rs
@@ -86,7 +86,7 @@ impl crate::controller::io_engine::NexusListApi for super::RpcClient {
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::NexusApi<()> for super::RpcClient {
-    #[tracing::instrument(name = "rpc::v1::nexus::create", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "rpc::v1::nexus::create", level = "info", skip(self), err)]
     async fn create_nexus(&self, request: &CreateNexus) -> Result<Nexus, SvcError> {
         let response =
             self.nexus()
@@ -99,7 +99,7 @@ impl crate::controller::io_engine::NexusApi<()> for super::RpcClient {
         Self::nexus_opt(response.into_inner().nexus, &request.node, "create_nexus")
     }
 
-    #[tracing::instrument(name = "rpc::v1::nexus::destroy", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "rpc::v1::nexus::destroy", level = "info", skip(self), err)]
     async fn destroy_nexus(&self, request: &DestroyNexus) -> Result<(), SvcError> {
         let result = self.nexus().destroy_nexus(request.to_rpc()).await;
         match result {
@@ -118,7 +118,7 @@ impl crate::controller::io_engine::NexusApi<()> for super::RpcClient {
         }
     }
 
-    #[tracing::instrument(name = "rpc::v1::nexus::resize", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "rpc::v1::nexus::resize", level = "info", skip(self), err)]
     async fn resize_nexus(&self, request: &ResizeNexus) -> Result<Nexus, SvcError> {
         let result = self
             .nexus()
@@ -238,7 +238,7 @@ impl crate::controller::io_engine::NexusShareApi<Nexus, Nexus> for super::RpcCli
 impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::RpcClient {
     #[tracing::instrument(
         name = "rpc::v1::nexus::add_child",
-        level = "debug",
+        level = "info",
         skip(self),
         fields(rpc.io_engine = true),
         err
@@ -282,7 +282,7 @@ impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::Rp
 
     #[tracing::instrument(
         name = "rpc::v1::nexus::remove_child",
-        level = "debug",
+        level = "info",
         skip(self),
         fields(rpc.io_engine = true),
         err
@@ -320,7 +320,7 @@ impl crate::controller::io_engine::NexusChildApi<Nexus, Nexus, ()> for super::Rp
         }
     }
 
-    #[tracing::instrument(name = "rpc::v1::nexus::fault_child", level = "debug", skip(self), fields(rpc.io_engine = true), err)]
+    #[tracing::instrument(name = "rpc::v1::nexus::fault_child", level = "info", skip(self), fields(rpc.io_engine = true), err)]
     async fn fault_child(&self, request: &FaultNexusChild) -> Result<(), SvcError> {
         let _ = self
             .nexus()
@@ -379,7 +379,7 @@ impl super::RpcClient {
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::NexusSnapshotApi for super::RpcClient {
-    #[tracing::instrument(name = "rpc::v1::nexus::snapshot", level = "debug", skip(self))]
+    #[tracing::instrument(name = "rpc::v1::nexus::snapshot", level = "info", skip(self))]
     async fn create_nexus_snapshot(
         &self,
         request: &CreateNexusSnapshot,

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/replica.rs
@@ -88,7 +88,7 @@ impl crate::controller::io_engine::ReplicaListApi for super::RpcClient {
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::ReplicaApi for super::RpcClient {
-    #[tracing::instrument(name = "rpc::v1::replica::create", level = "debug", skip(self))]
+    #[tracing::instrument(name = "rpc::v1::replica::create", level = "info", skip(self))]
     async fn create_replica(&self, request: &CreateReplica) -> Result<Replica, SvcError> {
         let rpc_replica = self
             .replica()
@@ -102,7 +102,7 @@ impl crate::controller::io_engine::ReplicaApi for super::RpcClient {
         Ok(replica)
     }
 
-    #[tracing::instrument(name = "rpc::v1::replica::destroy", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "rpc::v1::replica::destroy", level = "info", skip(self), err)]
     async fn destroy_replica(&self, request: &DestroyReplica) -> Result<(), SvcError> {
         let _ = self
             .replica()
@@ -115,7 +115,7 @@ impl crate::controller::io_engine::ReplicaApi for super::RpcClient {
         Ok(())
     }
 
-    #[tracing::instrument(name = "rpc::v1::replica::resize", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "rpc::v1::replica::resize", level = "info", skip(self), err)]
     async fn resize_replica(&self, request: &ResizeReplica) -> Result<Replica, SvcError> {
         let rpc_replica = self
             .replica()
@@ -177,7 +177,7 @@ impl crate::controller::io_engine::ReplicaApi for super::RpcClient {
 
 #[async_trait::async_trait]
 impl crate::controller::io_engine::ReplicaSnapshotApi for super::RpcClient {
-    #[tracing::instrument(name = "rpc::v1::replica::snapshot", level = "debug", skip(self))]
+    #[tracing::instrument(name = "rpc::v1::replica::snapshot", level = "info", skip(self))]
     async fn create_repl_snapshot(
         &self,
         request: &CreateReplicaSnapshot,
@@ -193,6 +193,11 @@ impl crate::controller::io_engine::ReplicaSnapshotApi for super::RpcClient {
         response.into_inner().try_to_agent()
     }
 
+    #[tracing::instrument(
+        name = "rpc::v1::replica::destroy_repl_snapshot",
+        level = "info",
+        skip(self)
+    )]
     async fn destroy_repl_snapshot(
         &self,
         request: &DestroyReplicaSnapshot,
@@ -230,6 +235,7 @@ impl crate::controller::io_engine::ReplicaSnapshotApi for super::RpcClient {
         ret.snapshots.iter().map(|s| s.try_to_agent()).collect()
     }
 
+    #[tracing::instrument(name = "rpc::v1::replica::snapshot::clone", level = "info", skip(self))]
     async fn create_snapshot_clone(
         &self,
         request: &IoEngCreateSnapshotClone,

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -25,10 +25,10 @@ humantime = "2.1.0"
 utils = { path = "../../utils/utils-lib" }
 rpc = { path = "../../rpc"}
 uuid = { version = "1.4.1", features = ["v4"] }
-tracing-opentelemetry = "0.21.0"
-opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
-opentelemetry-http = { version = "0.9.0" }
-opentelemetry-semantic-conventions = "0.12.0"
+tracing-opentelemetry = "0.23.0"
+opentelemetry = { version = "0.22.0" }
+opentelemetry-http = { version = "0.11.1" }
+opentelemetry-semantic-conventions = "0.14.0"
 tracing = "0.1.37"
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 serde_json = "1.0.107"

--- a/control-plane/grpc/src/operations/pool/client.rs
+++ b/control-plane/grpc/src/operations/pool/client.rs
@@ -38,7 +38,7 @@ impl PoolClient {
 /// This converts the client side data into a RPC request.
 #[tonic::async_trait]
 impl PoolOperations for PoolClient {
-    #[tracing::instrument(name = "PoolClient::create", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "PoolClient::create", level = "info", skip(self), err)]
     async fn create(
         &self,
         request: &dyn CreatePoolInfo,
@@ -55,7 +55,7 @@ impl PoolOperations for PoolClient {
         }
     }
 
-    #[tracing::instrument(name = "PoolClient::destroy", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "PoolClient::destroy", level = "info", skip(self), err)]
     async fn destroy(
         &self,
         request: &dyn DestroyPoolInfo,

--- a/control-plane/grpc/src/operations/volume/client.rs
+++ b/control-plane/grpc/src/operations/volume/client.rs
@@ -56,7 +56,7 @@ impl Deref for VolumeClient {
 /// This converts the client side data into a RPC request.
 #[tonic::async_trait]
 impl VolumeOperations for VolumeClient {
-    #[tracing::instrument(name = "VolumeClient::create", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "VolumeClient::create", level = "info", skip(self), err)]
     async fn create(
         &self,
         request: &dyn CreateVolumeInfo,
@@ -106,7 +106,7 @@ impl VolumeOperations for VolumeClient {
         }
     }
 
-    #[tracing::instrument(name = "VolumeClient::destroy", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "VolumeClient::destroy", level = "info", skip(self), err)]
     async fn destroy(
         &self,
         request: &dyn DestroyVolumeInfo,
@@ -120,6 +120,7 @@ impl VolumeOperations for VolumeClient {
         }
     }
 
+    #[tracing::instrument(name = "VolumeClient::resize", level = "info", skip(self), err)]
     async fn resize(
         &self,
         request: &dyn ResizeVolumeInfo,
@@ -167,7 +168,7 @@ impl VolumeOperations for VolumeClient {
         }
     }
 
-    #[tracing::instrument(name = "VolumeClient::publish", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "VolumeClient::publish", level = "info", skip(self), err)]
     async fn publish(
         &self,
         request: &dyn PublishVolumeInfo,
@@ -184,7 +185,7 @@ impl VolumeOperations for VolumeClient {
         }
     }
 
-    #[tracing::instrument(name = "VolumeClient::republish", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "VolumeClient::republish", level = "info", skip(self), err)]
     async fn republish(
         &self,
         request: &dyn RepublishVolumeInfo,
@@ -218,7 +219,7 @@ impl VolumeOperations for VolumeClient {
         }
     }
 
-    #[tracing::instrument(name = "VolumeClient::set_replica", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "VolumeClient::set_replica", level = "info", skip(self), err)]
     async fn set_replica(
         &self,
         request: &dyn SetVolumeReplicaInfo,
@@ -234,7 +235,7 @@ impl VolumeOperations for VolumeClient {
             None => Err(ReplyError::invalid_response(ResourceKind::Volume)),
         }
     }
-    #[tracing::instrument(name = "VolumeClient::set_property", level = "debug", skip(self), err)]
+    #[tracing::instrument(name = "VolumeClient::set_property", level = "info", skip(self), err)]
     async fn set_property(
         &self,
         req: &dyn SetVolumePropertyInfo,
@@ -258,6 +259,11 @@ impl VolumeOperations for VolumeClient {
         }
     }
 
+    #[tracing::instrument(
+        name = "VolumeClient::destroy_shutdown_target",
+        level = "info",
+        skip(self)
+    )]
     async fn destroy_shutdown_target(
         &self,
         request: &dyn DestroyShutdownTargetsInfo,
@@ -275,7 +281,7 @@ impl VolumeOperations for VolumeClient {
         }
     }
 
-    #[tracing::instrument(name = "VolumeClient::create_snapshot", level = "debug", skip(self))]
+    #[tracing::instrument(name = "VolumeClient::create_snapshot", level = "info", skip(self))]
     async fn create_snapshot(
         &self,
         request: &dyn CreateVolumeSnapshotInfo,
@@ -292,7 +298,7 @@ impl VolumeOperations for VolumeClient {
         }
     }
 
-    #[tracing::instrument(name = "VolumeClient::delete_snapshot", level = "debug", skip(self))]
+    #[tracing::instrument(name = "VolumeClient::destroy_snapshot", level = "info", skip(self))]
     async fn destroy_snapshot(
         &self,
         request: &dyn DestroyVolumeSnapshotInfo,
@@ -360,7 +366,7 @@ impl VolumeOperations for VolumeClient {
 
     #[tracing::instrument(
         name = "VolumeClient::create_snapshot_volume",
-        level = "debug",
+        level = "info",
         skip(self),
         err
     )]

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -21,8 +21,8 @@ rustls = "0.21.12"
 rustls-pemfile = "1.0.3"
 actix-web = { version = "4.4.0", features = ["rustls-0_21"] }
 actix-service = "2.0.2"
-opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
-actix-web-opentelemetry = "0.15.0"
+opentelemetry = { version = "0.22.0" }
+actix-web-opentelemetry = "0.17.0"
 tracing = "0.1.37"
 once_cell = "1.18.0"
 async-trait = "0.1.73"

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -133,6 +133,7 @@ impl CreateReplicaSnapshot {
 }
 
 /// The request type to delete a replica's snapshot.
+#[derive(Debug)]
 pub struct DestroyReplicaSnapshot {
     /// Id of the snapshot to be deleted.
     pub snap_id: SnapshotId,

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -32,6 +32,6 @@ humantime = "2.1.0"
 reqwest = { version = "0.11.22", features = ["multipart"] }
 futures = "0.3.28"
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 events-api = { path = "../utils/dependencies/apis/events" }

--- a/deployer/misc/otel_agent_config.yaml
+++ b/deployer/misc/otel_agent_config.yaml
@@ -1,0 +1,20 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  batch:
+
+exporters:
+  otlp:
+    #endpoint: xxxx:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp]

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -58,7 +58,7 @@ impl ComponentAction for CoreAgent {
             binary = binary.with_args(vec!["--faulted-child-wait-period", &twait.to_string()]);
         }
         if cfg.container_exists("jaeger") {
-            let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());
+            let jaeger_config = format!("jaeger.{}", cfg.get_name());
             binary = binary.with_args(vec!["--jaeger", &jaeger_config]);
         }
         if options.eventing {

--- a/deployer/src/infra/agents/ha/cluster.rs
+++ b/deployer/src/infra/agents/ha/cluster.rs
@@ -29,7 +29,7 @@ impl ComponentAction for HaClusterAgent {
         spec = spec.with_args(vec!["--store", &etcd]);
 
         if cfg.container_exists("jaeger") {
-            let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());
+            let jaeger_config = format!("jaeger.{}", cfg.get_name());
             spec = spec.with_args(vec!["--jaeger", &jaeger_config])
         };
 

--- a/deployer/src/infra/agents/ha/node.rs
+++ b/deployer/src/infra/agents/ha/node.rs
@@ -33,7 +33,7 @@ impl ComponentAction for HaNodeAgent {
             }
         }
         if cfg.container_exists("jaeger") {
-            let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());
+            let jaeger_config = format!("jaeger.{}", cfg.get_name());
             spec = spec.with_args(vec!["--jaeger", &jaeger_config])
         };
         if options.eventing {

--- a/deployer/src/infra/csi-driver/controller.rs
+++ b/deployer/src/infra/csi-driver/controller.rs
@@ -33,7 +33,7 @@ impl ComponentAction for CsiController {
                 .with_args(vec!["--csi-socket", CSI_SOCKET]);
 
             if cfg.container_exists("jaeger") {
-                let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());
+                let jaeger_config = format!("jaeger.{}", cfg.get_name());
                 binary = binary.with_args(vec!["--jaeger", &jaeger_config])
             };
 

--- a/deployer/src/infra/rest.rs
+++ b/deployer/src/infra/rest.rs
@@ -45,7 +45,7 @@ impl ComponentAction for Rest {
             }
 
             if cfg.container_exists("jaeger") {
-                let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());
+                let jaeger_config = format!("jaeger.{}:4317", cfg.get_name());
                 binary = binary.with_args(vec!["--jaeger", &jaeger_config])
             };
 

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -348,6 +348,21 @@ impl KeyValues {
             None
         }
     }
+    /// Convert to otel resource attributes.
+    pub(crate) fn into_otel_attrs(self) -> Option<String> {
+        if !self.inner.is_empty() {
+            let mut arg_start = "processors:\n  resource:\n    attributes:\n".to_string();
+            self.inner.into_iter().for_each(|(k, v)| {
+                let _ = write!(
+                    arg_start,
+                    "      - key: {k}\n        value: {v}\n        action: insert\n"
+                );
+            });
+            Some(arg_start)
+        } else {
+            None
+        }
+    }
 }
 
 impl StartOptions {

--- a/k8s/forward/Cargo.toml
+++ b/k8s/forward/Cargo.toml
@@ -19,4 +19,4 @@ serde_json = "1.0.107"
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ] }
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -8,11 +8,6 @@ edition = "2018"
 name = "openapi"
 path = "src/lib.rs"
 
-[[example]]
-name = "tower-client"
-path = "./examples/clients/tower/main.rs"
-required-features = [ "tower-client", "tower-trace" ]
-
 [features]
 default = [ "tower-client-rls", "tower-trace" ]
 actix-server = [ "actix" ]
@@ -38,7 +33,7 @@ serde_urlencoded = "0.7"
 
 # actix dependencies
 actix-web = { version = "4.4.0", features = ["rustls-0_21"], optional = true }
-actix-web-opentelemetry = { version = "0.15.0", optional = true }
+actix-web-opentelemetry = { version = "0.17.0", optional = true }
 awc = { version = "3.2.0", optional = true }
 
 # tower and hyper dependencies
@@ -57,9 +52,9 @@ hyper-rustls = { version = "0.24.1", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 tokio-native-tls = { version = "0.3.1", optional = true }
 # tracing and telemetry
-opentelemetry-jaeger = { version = "0.19.0", features = ["rt-tokio-current-thread"], optional = true  }
-tracing-opentelemetry = { version = "0.21.0", optional = true }
-opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"], optional = true }
-opentelemetry-http = { version = "0.9.0", optional = true }
+opentelemetry-jaeger = { version = "0.21.0", features = ["rt-tokio-current-thread"], optional = true  }
+tracing-opentelemetry = { version = "0.23.0", optional = true }
+opentelemetry = { version = "0.22.0", optional = true }
+opentelemetry-http = { version = "0.11.1", optional = true }
 tracing = { version = "0.1.37", optional = true }
-tracing-subscriber = { version = "0.3.17", optional = true }
+tracing-subscriber = { version = "0.3.18", optional = true }

--- a/scripts/rust/generate-openapi-bindings.sh
+++ b/scripts/rust/generate-openapi-bindings.sh
@@ -112,7 +112,7 @@ tmpd=$(mktemp -d /tmp/openapi-gen-XXXXXXX)
 
 # Generate a new openapi crate
 openapi-generator-cli generate -i "$SPEC" -g rust-mayastor -o "$tmpd"
-( cd "$tmpd"; rm -rf api; rm -rf .* 2>/dev/null || true )
+( cd "$tmpd"; rm -rf api; rm -rf examples; rm -rf .* 2>/dev/null || true )
 
 if [[ $default_toml = "no" ]]; then
   cp "$CARGO_TOML" "$tmpd"

--- a/tests/bdd/features/rebuild/test_log_based_rebuild.py
+++ b/tests/bdd/features/rebuild/test_log_based_rebuild.py
@@ -309,7 +309,7 @@ def the_volume_target_becomes_unreachable_along_with_its_local_child():
     verify_nexus_switchover()
 
 
-@retry(wait_fixed=200, stop_max_attempt_number=20)
+@retry(wait_fixed=200, stop_max_attempt_number=80)
 def verify_full_rebuilds():
     """a full rebuild starts for both of the unhealthy children"""
     children = []

--- a/utils/deployer-cluster/Cargo.toml
+++ b/utils/deployer-cluster/Cargo.toml
@@ -25,7 +25,11 @@ tonic = "0.10.2"
 tower = { version = "0.4.13", features = [ "timeout", "util" ] }
 # Tracing
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
-opentelemetry-jaeger = { version = "0.19.0", features = ["rt-tokio-current-thread"] }
-tracing-opentelemetry = "0.21.0"
-opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
+tracing-opentelemetry = "0.23.0"
+# Open Telemetry
+opentelemetry = { version = "0.22.0" }
+opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio-current-thread"] }
+opentelemetry-otlp = { version = "0.15.0" }
+opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry-jaeger = "0.21.0"

--- a/utils/utils-lib/Cargo.toml
+++ b/utils/utils-lib/Cargo.toml
@@ -4,16 +4,22 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
-tracing-opentelemetry = "0.21.0"
-opentelemetry = { version = "0.20.0", features = ["rt-tokio-current-thread"] }
-opentelemetry-jaeger = { version = "0.19.0", features = ["rt-tokio-current-thread"] }
-version-info = { path = "../dependencies/version-info", default-features = false }
-git-version-macro = { path = "../dependencies/git-version-macro" }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
+tracing-opentelemetry = "0.23.0"
 tracing = "0.1.37"
+
+opentelemetry = { version = "0.22.0" }
+
+opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio-current-thread"] }
+opentelemetry-otlp = { version = "0.15.0" }
+opentelemetry-semantic-conventions = "0.14.0"
+
 url = "2.4.1"
-event-publisher = { path = "../dependencies/event-publisher" }
-tracing-filter = { path = "../dependencies/tracing-filter" }
 strum = "0.25.0"
 strum_macros = "0.25.2"
 heck = "0.4.1"
+
+version-info = { path = "../dependencies/version-info", default-features = false }
+git-version-macro = { path = "../dependencies/git-version-macro" }
+event-publisher = { path = "../dependencies/event-publisher" }
+tracing-filter = { path = "../dependencies/tracing-filter" }


### PR DESCRIPTION
    fix(tracing): reduce tracing instrument spans to info
    
    New batch exporter used by opentel crate handles larger data better so we
    can be a bit more relaxed.
    This allows us to have good jaeger tracing and logs even with info.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: upgrade tracing and otel crates
    
    Upgrades all tracing and open telemetry crates.
    Replaces deprecated jaeger tracing create with generic opentel crate.
    Replaces deprecated jaeger jaeger with opentel collector.
    Removed openapi examples as they are not valid for our deps anymore.
    todo: upgrade openapi generator
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>