### PR TITLE
feat(topology): add pool filter on node_id and labels

### DIFF
--- a/control-plane/plugin/src/lib.rs
+++ b/control-plane/plugin/src/lib.rs
@@ -147,7 +147,7 @@ impl ExecuteOperation for GetResources {
             GetResources::VolumeReplicaTopology { id } => {
                 volume::Volume::topology(id, &cli_args.output).await
             }
-            GetResources::Pools => pool::Pools::list(&cli_args.output).await,
+            GetResources::Pools(args) => pool::Pools::list(args, &cli_args.output).await,
             GetResources::Pool { id } => pool::Pool::get(id, &cli_args.output).await,
             GetResources::Nodes(args) => node::Nodes::list(args, &cli_args.output).await,
             GetResources::Node(args) => {

--- a/control-plane/plugin/src/resources/error.rs
+++ b/control-plane/plugin/src/resources/error.rs
@@ -91,4 +91,11 @@ pub enum Error {
     ListSnapshotsError {
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,
     },
+    /// Error when get pool request fails.
+    #[snafu(display(
+        "Error while parsing labels `{labels}`. \
+        The supported formats for labels is: \
+        key1=value1,key2=value2"
+    ))]
+    LabelNodeFilter { labels: String },
 }

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -1,6 +1,7 @@
 use crate::resources::{
     blockdevice::BlockDeviceArgs,
     node::{DrainNodeArgs, GetNodeArgs, GetNodesArgs},
+    pool::GetPoolsArgs,
     snapshot::VolumeSnapshotArgs,
     volume::VolumesArgs,
 };
@@ -48,7 +49,7 @@ pub enum GetResources {
     /// Get volume snapshot topology based on input args.
     VolumeSnapshotTopology(VolumeSnapshotArgs),
     /// Get all pools.
-    Pools,
+    Pools(GetPoolsArgs),
     /// Get pool with the given ID.
     Pool { id: PoolId },
     /// Get all nodes.


### PR DESCRIPTION
This will be used for the command
1. `kubectl mayastor get pools --labels A=B,C=D`
2. `kubectl mayastor get pools --labels A=B,C=D --node <node_id>`
3. `kubectl mayastor get pools --node <node_id>`

