### PR TITLE
refactor(ha): extend reuse_existing use cases

### DIFF
--- a/control-plane/agents/src/bin/ha/cluster/etcd.rs
+++ b/control-plane/agents/src/bin/ha/cluster/etcd.rs
@@ -96,8 +96,11 @@ impl EtcdStore {
 
         let entries = store_entries
             .into_iter()
-            .map(|(_, v)| v)
-            .map(serde_json::from_value)
+            .map(|(_, v)| {
+                let mut spec: SwitchOverSpec = serde_json::from_value(v)?;
+                spec.reuse_existing = true;
+                Ok(spec)
+            })
             .collect::<Result<Vec<SwitchOverSpec>, serde_json::Error>>()?;
 
         Ok(entries.iter().map(Into::into).collect())

--- a/control-plane/agents/src/bin/ha/cluster/switchover.rs
+++ b/control-plane/agents/src/bin/ha/cluster/switchover.rs
@@ -447,8 +447,8 @@ impl SwitchOverRequest {
                         return Err(anyhow!("Nvme path deadline exceeded"));
                     }
                 }
-                info!(volume.uuid=%self.volume_id, "Retrying Republish without older target reuse");
-                self.set_reuse_existing(false);
+                self.set_reuse_existing(!self.reuse_existing);
+                info!(volume.uuid=%self.volume_id, reuse_existing=self.reuse_existing, "Retrying Republish");
                 self.set_stage(Stage::RepublishVolume);
                 Err(anyhow!("Nvme path replacement failed with older target"))
             }


### PR DESCRIPTION
### Changes

1. Node Replace Path is racy, we should atleast retry again with reuse existing as true, if the path connect deadline exceeded.
2. We should try with reuse existing as true when the agent loads up incase of restart.