### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/develop-to-release.yml
+++ b/.github/workflows/develop-to-release.yml
@@ -27,7 +27,7 @@ jobs:
             automated-pr
           draft: false
           signoff: true
-          token: ${{ secrets.OPENEBS_CI }}
+          token: ${{ secrets.ORG_CI_GITHUB }}
       - name: Approve Pull Request by CI Bot
         if: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
@@ -39,10 +39,10 @@ jobs:
         run: |
           gh pr review ${{ steps.cpr.outputs.pull-request-number }} --approve
         env:
-          GH_TOKEN: ${{ secrets.OPENEBS_CI_2 }}
+          GH_TOKEN: ${{ secrets.ORG_CI_GITHUB_2 }}
       - name: Bors Merge Pull Request
         if: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           gh pr comment ${{ steps.cpr.outputs.pull-request-number }} --body "bors merge"
         env:
-          GH_TOKEN: ${{ secrets.OPENEBS_CI }}
+          GH_TOKEN: ${{ secrets.ORG_CI_GITHUB }}

--- a/.github/workflows/develop-to-release.yml
+++ b/.github/workflows/develop-to-release.yml
@@ -7,11 +7,12 @@ jobs:
   prepareReleaseBranch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check if the submodules are correct
         run: |
           branch="${{ github.ref_name }}"
           ./scripts/git/set-submodule-branches.sh --branch "$branch"
+          ./scripts/nix/git-submodule-init.sh
           ./scripts/rust/branch_ancestor.sh
       - name: Create Pull Request
         id: cpr

--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -10,7 +10,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install CommitLint and Dependencies


### PR DESCRIPTION
    ci(gha): update secret names
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci(gha): init the submodules during workflow
    
    A previous change now made a script called by the submodule workflow call
    the submodules...
    Perhaps we should modify this as doesn't seem quite right but for now let's
    simply init the gitmodules.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>