### PR TITLE
CI stability fixes

### DIFF
--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -107,6 +107,7 @@ impl ComponentAction for IoEngine {
                 options.latest_io_api_version(),
                 &name,
                 socket,
+                40,
                 tokio::time::sleep,
             )
             .await?;

--- a/openapi/build.rs
+++ b/openapi/build.rs
@@ -15,9 +15,9 @@ fn main() {
 
     println!("cargo:rerun-if-changed=../nix/pkgs/openapi-generator");
     println!("cargo:rerun-if-changed=../control-plane/rest/openapi-specs");
-    println!("cargo:rerun-if-changed=version.txt");
     // seems the internal timestamp is taken before build.rs runs, so we can't set this
     // directive against files created during the build of build.rs??
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed
     // println!("cargo:rerun-if-changed=.");
+    // println!("cargo:rerun-if-changed=version.txt");
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -546,10 +546,10 @@ pub mod io_engine {
             version: IoEngineApiVersion,
             name: &str,
             endpoint: SocketAddr,
+            mut attempts: i32,
             sleep: S,
         ) -> Result<Self, String> {
             let endpoint_str = format!("http://{endpoint}");
-            let mut attempts = 20;
             let channel = loop {
                 match tonic::transport::Endpoint::new(endpoint_str.clone())
                     .map_err(|e| e.to_string())?

--- a/scripts/rust/generate-openapi-bindings.sh
+++ b/scripts/rust/generate-openapi-bindings.sh
@@ -7,6 +7,18 @@ die()
   exit "${_return}"
 }
 
+write_version()
+{
+  write_version="yes"
+  if [ -f "$VERSION_FILE" ] && [ "$(which openapi-generator-cli)" = "$(cat "$VERSION_FILE")" ]; then
+    write_version=
+  fi
+
+  if [ -n "$write_version" ]; then
+    which openapi-generator-cli > "$VERSION_FILE"
+  fi
+}
+
 set -e
 
 SCRIPTDIR=$(dirname "$0")
@@ -116,6 +128,8 @@ if [ -f "$RUST_FMT" ]; then
   ( cd "$tmpd"; rm Cargo.lock || true; rm "$(basename "$RUST_FMT")" )
 fi
 
+write_version
+
 if [[ "$skip_if_md5_same" = "yes" ]]; then
   source_md5sum=$(cd "$tmpd"; find . -type f -exec md5sum {} \; | md5sum)
   target_md5sum=$(cd "$TARGET"; find . -type f \( ! -name "version.txt" ! -name "build.rs" \) -exec md5sum {} \; | md5sum)
@@ -128,17 +142,6 @@ fi
 
 mv "$tmpd"/* "$TARGET"/
 rm -rf "$tmpd"
-
-write_version="yes"
-if [[ "$skip_if_md5_same" = "yes" ]]; then
-  if [ -f "$VERSION_FILE" ] && [ "$(which openapi-generator-cli)" = "$(cat "$VERSION_FILE")" ]; then
-    write_version=
-  fi
-fi
-
-if [ -n "$write_version" ]; then
-  which openapi-generator-cli > "$VERSION_FILE"
-fi
 
 # If the openapi bindings were modified then fail the check
 if [[ "$skip_git_diff" = "no" ]]; then

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -151,7 +151,8 @@ class Deployer(object):
     @staticmethod
     def start_with_opts(options: StartOptions):
         deployer_path = os.environ["ROOT_DIR"] + "/target/debug/deployer"
-        subprocess.run([deployer_path, "start"] + options.args())
+        # todo: get logs out to specific location
+        subprocess.run([deployer_path, "start"] + options.args(), check=True)
 
     # Stop containers
     @staticmethod

--- a/tests/bdd/features/rebuild/test_log_based_rebuild.py
+++ b/tests/bdd/features/rebuild/test_log_based_rebuild.py
@@ -55,10 +55,10 @@ def init():
         node_agent=True,
         cluster_agent=True,
         csi_node=True,
-        wait="10s",
         reconcile_period="300ms",
         faulted_child_wait_period=f"{FAULTED_CHILD_WAIT_SECS}s",
         cache_period="200ms",
+        io_engine_coreisol=True,
     )
     yield
     Deployer.stop()

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -259,6 +259,7 @@ impl Cluster {
                 format!("{}:10124", container.1 .1)
                     .parse::<SocketAddr>()
                     .unwrap(),
+                20,
                 tokio::time::sleep,
             )
             .await?),


### PR DESCRIPTION
    test(python/bdd): incorrect usage of retry decorator and full rebuild
    
    Retry decorator cannot be used on the fixture directly.
    Also check if a full rebuild happened using rebuild history in case child is
    reused for new nexus.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build(openapi): don't depend on version.txt
    
    Not quite sure why the version.txt was added since we know that we should not
    be adding output files as an input to the build.rs of a crate.
    This is causing extra rebuilds during CI!
    I suspect it may have been added to handle git clean of the openapi dir!
    I think the correct way to handle that is to simply move the output of the
    build.rs to the target folder where it should have lived :-)
    Let's remove this and then pay attention to missing rebuilds..
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(deployer): increase timeout for io-engine connect
    
    On GCP testing sometimes we fail to connect to the io-engine within a second.
    Doubling this for now should be sufficient.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(python/bdd): enable core isolation for log rebuild
    
    Speeds up the io-engine bootstrap.
    Also to consider, should we just enable isolation by default on the tests?
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(python/bdd): check error code of deployer start
    
    In case the deployer fails to start, let's error out early as it seems
    sometimes the tests still pass but when the tests fails it can lead into
    debugging the wrong path...
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
