### PR TITLE
test(bdd): disconnect all controllers

### DIFF
--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 import common
 from common.docker import Docker
+from common.nvme import nvme_disconnect_allours_wait
 
 
 @dataclass
@@ -159,11 +160,13 @@ class Deployer(object):
 
     # Stop containers
     @staticmethod
-    def stop():
+    def stop(disconnect_nvme=False):
         print(f"DeployerStop: {datetime.now()}")
         clean = os.getenv("CLEAN")
         if clean is not None and clean.lower() in ("no", "false", "f", "0"):
             return
+        if disconnect_nvme:
+            nvme_disconnect_allours_wait()
         deployer_path = os.environ["ROOT_DIR"] + "/target/debug/deployer"
         subprocess.run([deployer_path, "stop"])
 

--- a/tests/bdd/features/ha/core-agent/test_target_switchover.py
+++ b/tests/bdd/features/ha/core-agent/test_target_switchover.py
@@ -71,7 +71,7 @@ def init():
         fio_spdk=True,
     )
     yield
-    Deployer.stop()
+    Deployer.stop(True)
 
 
 @scenario(

--- a/tests/bdd/features/ha/node-agent/test_path_replacement.py
+++ b/tests/bdd/features/ha/node-agent/test_path_replacement.py
@@ -38,7 +38,7 @@ NEXUS_NQN = f"{nvme_nqn_prefix}:{VOLUME_UUID}"
 # Interval to wait before HA Node agent classifies broken path as failed
 PATH_DETECTION_TIME = 2
 # FIO should be active long enough to outlive the detection interval.
-FIO_RUNTIME = PATH_DETECTION_TIME * 2
+FIO_RUNTIME = PATH_DETECTION_TIME * 4
 
 
 @scenario(
@@ -131,7 +131,7 @@ def background():
         ),
     )
     yield volume
-    Deployer.stop()
+    Deployer.stop(True)
 
 
 @pytest.fixture

--- a/tests/bdd/features/ha/test_robustness.py
+++ b/tests/bdd/features/ha/test_robustness.py
@@ -14,6 +14,7 @@ import subprocess
 
 from retrying import retry
 
+import common.nvme
 from common.deployer import Deployer
 from common.apiclient import ApiClient
 from common.docker import Docker
@@ -60,7 +61,7 @@ def init():
         agents_env="DETECTION_PERIOD=100ms,SUBSYS_REFRESH_PERIOD=100ms",
     )
     yield
-    Deployer.stop()
+    Deployer.stop(True)
 
 
 @pytest.fixture(autouse=True)
@@ -111,6 +112,8 @@ def a_connected_nvme_initiator(connect_to_first_path):
 @given("a deployer cluster")
 def a_deployer_cluster(init):
     """a deployer cluster."""
+    yield
+    common.nvme.nvme_disconnect_allours_wait()
 
 
 @given("a reconnect_delay set to 15s")


### PR DESCRIPTION
For the ha tests ensure all controllers are disconnected. Not entirely sure if this will fix existing flaky tests but seems that since node agent does not wait for bad controllers to get fully deleted, this may affect subsequent tests.