### PR TITLE
Fix python CI tests

### DIFF
--- a/control-plane/agents/src/bin/ha/node/server.rs
+++ b/control-plane/agents/src/bin/ha/node/server.rs
@@ -171,6 +171,11 @@ impl NodeAgentSvc {
 
         tracing::info!(new_path, "Connecting to NVMe target");
 
+        // Check to ensure Nqn is already connected
+        if Subsystem::try_from_nqn(&nqn).is_err() {
+            return Err(SvcError::ReplaceNqnNotFound { nqn });
+        }
+
         // Check if the NVMe subsystem already exists to not
         // delete it in case of unsuccessful path replacement.
         let preexisted_subsystem = Subsystem::get(

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -288,6 +288,8 @@ pub enum SvcError {
     InvalidApiVersion { api_version: Option<ApiVersion> },
     #[snafu(display("The subsystem with nqn: {} is not found, {}", nqn, details))]
     SubsystemNotFound { nqn: String, details: String },
+    #[snafu(display("Can't add new path to subsystem with nqn: {nqn} as it is not present"))]
+    ReplaceNqnNotFound { nqn: String },
     #[snafu(display(
         "The subsystem {} has unexpected Nqn ({}), expected ({})",
         path,
@@ -425,6 +427,7 @@ impl SvcError {
             Self::Unimplemented { .. } => tonic::Code::Unimplemented,
             Self::RestrictedReplicaCount { .. } => tonic::Code::FailedPrecondition,
             Self::ReplicaSetPropertyFailed { .. } => tonic::Code::DataLoss,
+            Self::ReplaceNqnNotFound { .. } => tonic::Code::FailedPrecondition,
             _ => tonic::Code::Internal,
         }
     }
@@ -875,6 +878,12 @@ impl From<SvcError> for ReplyError {
             SvcError::SubsystemNotFound { .. } => ReplyError {
                 kind: ReplyErrorKind::NotFound,
                 resource: ResourceKind::NvmeSubsystem,
+                source,
+                extra,
+            },
+            SvcError::ReplaceNqnNotFound { .. } => ReplyError {
+                kind: ReplyErrorKind::FailedPrecondition,
+                resource: ResourceKind::NvmePath,
                 source,
                 extra,
             },

--- a/tests/bdd/common/etcd.py
+++ b/tests/bdd/common/etcd.py
@@ -23,3 +23,7 @@ class Etcd(object):
     def del_switchover(self, volume_id):
         key = "{}/SwitchOver/{}".format(self.__ns_key(), volume_id)
         self.client.delete(key)
+
+    def del_all_switchover(self):
+        key_prefix = "{}/SwitchOver/".format(self.__ns_key())
+        self.client.delete_prefix(key_prefix)

--- a/tests/bdd/features/ha/test_robustness.py
+++ b/tests/bdd/features/ha/test_robustness.py
@@ -24,6 +24,7 @@ from common.nvme import (
     nvme_disconnect,
     nvme_list_subsystems,
     nvme_set_reconnect_delay,
+    nvme_find_subsystem_devices_all,
 )
 from common.operations import Cluster
 
@@ -75,9 +76,12 @@ def init_scenario(init, disks):
         )
     yield
     if Cluster.fixture_cleanup():
-        Docker.restart_container("agent-ha-node")
-        ETCD_CLIENT.del_switchover(VOLUME_UUID)
+        Docker.kill_container("agent-ha-cluster")
+        Docker.kill_container("agent-ha-node")
+        ETCD_CLIENT.del_all_switchover()
+        common.nvme.nvme_disconnect_allours_wait()
         Docker.restart_container("agent-ha-cluster")
+        Docker.restart_container("agent-ha-node")
         Cluster.cleanup()
 
 
@@ -113,7 +117,6 @@ def a_connected_nvme_initiator(connect_to_first_path):
 def a_deployer_cluster(init):
     """a deployer cluster."""
     yield
-    common.nvme.nvme_disconnect_allours_wait()
 
 
 @given("a reconnect_delay set to 15s")


### PR DESCRIPTION
    fix(ha/node): don't replace path if nqn is not found
    
    In case of a race condition, the volume may be removed but the ha
    logic is still running. In this case it may attempt to connect the
    new path.
    This is a short term fix, probably we need a better approach.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(bdd): nvme list devices fix
    
    Existing nvme list devices was buggy, it does not filter subsystems.
    Instead, build device list from scratch.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
