### PR TITLE
Disallow NR rsnapshots and rebuilds without replica ancestry rebuild fix

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/host.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/host.rs
@@ -27,6 +27,9 @@ impl crate::controller::io_engine::HostApi for super::RpcClient {
             api_versions: Some(vec![ApiVersion::V0]),
             instance_uuid: None,
             node_nqn: None,
+            features: None,
+            bugfixes: None,
+            version: None,
         })
     }
 

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/host.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/host.rs
@@ -1,6 +1,6 @@
 use crate::controller::io_engine::translation::IoEngineToAgent;
 use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
-use grpc::operations::registration;
+use grpc::operations::{registration, registration::traits::RegisterInfo};
 use rpc::v1::host::ListBlockDevicesRequest;
 use stor_port::{
     transport_api::{v0::BlockDevices, ResourceKind},
@@ -43,6 +43,9 @@ impl crate::controller::io_engine::HostApi for super::RpcClient {
         };
 
         Ok(Register {
+            version: registration_info.io_version(),
+            features: registration_info.features(),
+            bugfixes: registration_info.bugfixes(),
             id: registration_info.id.into(),
             grpc_endpoint: std::net::SocketAddr::from_str(&registration_info.grpc_endpoint)
                 .map_err(|error| SvcError::NodeGrpcEndpoint {

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -250,6 +250,7 @@ mod tests {
             NodeStatus::Online,
             None,
             None,
+            None,
         );
         NodeWrapper::new_stub(&state)
     }

--- a/control-plane/agents/src/bin/core/node/registry.rs
+++ b/control-plane/agents/src/bin/core/node/registry.rs
@@ -1,6 +1,6 @@
 use crate::controller::{registry::Registry, wrapper::NodeWrapper};
 use agents::errors::SvcError;
-use stor_port::types::v0::transport::{NodeId, NodeState, Register};
+use stor_port::types::v0::transport::{NodeBugFix, NodeId, NodeState, Register};
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -67,5 +67,16 @@ impl Registry {
         if automatic {
             self.specs().register_node(self, request).await.ok();
         }
+    }
+
+    /// Verify if all nodes have the rebuild ancestry fix and error out otherwise.
+    pub async fn verify_rebuild_ancestry_fix(&self) -> Result<(), SvcError> {
+        if !self
+            .specs()
+            .nodes_have_fix(NodeBugFix::NexusRebuildReplicaAncestry)
+        {
+            return Err(SvcError::UpgradeRequiredToRebuild {});
+        }
+        Ok(())
     }
 }

--- a/control-plane/agents/src/bin/core/node/registry.rs
+++ b/control-plane/agents/src/bin/core/node/registry.rs
@@ -70,12 +70,14 @@ impl Registry {
     }
 
     /// Verify if all nodes have the rebuild ancestry fix and error out otherwise.
-    pub async fn verify_rebuild_ancestry_fix(&self) -> Result<(), SvcError> {
-        if !self
-            .specs()
-            .nodes_have_fix(NodeBugFix::NexusRebuildReplicaAncestry)
-        {
-            return Err(SvcError::UpgradeRequiredToRebuild {});
+    pub fn verify_nodes_fix<'a>(
+        &self,
+        nodes: impl Iterator<Item = &'a NodeId>,
+        fix: &NodeBugFix,
+    ) -> Result<(), SvcError> {
+        let specs = self.specs().read();
+        for node in nodes {
+            specs.node_has_fix(node, fix)?;
         }
         Ok(())
     }

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -188,6 +188,9 @@ impl Service {
                         api_versions: None,
                         instance_uuid: None,
                         node_nqn: node.node_nqn().clone(),
+                        features: None,
+                        bugfixes: None,
+                        version: None,
                     },
                     true,
                 )

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -103,7 +103,6 @@ impl ResourceSpecsLocked {
     }
 
     /// Check if all nodes have the fix.
-    #[allow(dead_code)]
     pub(crate) fn nodes_have_fix(&self, fix: NodeBugFix) -> bool {
         self.read().nodes.values().any(|n| n.lock().has_fix(&fix))
     }

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -185,6 +185,33 @@ impl NodeWrapper {
                         node_state.node_nqn
                     );
                 }
+
+                if self.node_state().features != node_state.features {
+                    tracing::warn!(
+                        node.id=%node_state.id,
+                        "Node features changed from {:?} to {:?}",
+                        self.node_state().features,
+                        node_state.features
+                    );
+                }
+
+                if self.node_state().bugfixes != node_state.bugfixes {
+                    tracing::warn!(
+                        node.id=%node_state.id,
+                        "Node bugfixes changed from {:?} to {:?}",
+                        self.node_state().bugfixes,
+                        node_state.bugfixes
+                    );
+                }
+
+                if self.node_state().version != node_state.version {
+                    tracing::warn!(
+                        node.id=%node_state.id,
+                        "Node version changed from {:?} to {:?}",
+                        self.node_state().version,
+                        node_state.version
+                    );
+                }
             }
             self.node_state = node_state;
             true

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -199,6 +199,9 @@ fn test_deserialization_v1_to_v2() {
                 Default::default(),
                 None,
                 None,
+                None,
+                None,
+                None
             )),
         },
         TestEntry {

--- a/control-plane/agents/src/bin/core/tests/node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/node/mod.rs
@@ -23,6 +23,9 @@ fn new_node(
             NodeLabels::new(),
             None,
             node_nqn.clone(),
+            None,
+            None,
+            None,
         )),
         Some(NodeState::new(id, endpoint, status, api_versions, node_nqn)),
     )

--- a/control-plane/agents/src/bin/core/tests/node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/node/mod.rs
@@ -13,6 +13,7 @@ fn new_node(
     status: NodeStatus,
     api_versions: Option<Vec<ApiVersion>>,
     node_nqn: Option<HostNqn>,
+    version: &Option<String>,
 ) -> Node {
     let endpoint = std::str::FromStr::from_str(&endpoint).unwrap();
     Node::new(
@@ -25,9 +26,16 @@ fn new_node(
             node_nqn.clone(),
             None,
             None,
-            None,
+            version.clone(),
         )),
-        Some(NodeState::new(id, endpoint, status, api_versions, node_nqn)),
+        Some(NodeState::new(
+            id,
+            endpoint,
+            status,
+            api_versions,
+            node_nqn,
+            version.clone(),
+        )),
     )
 }
 
@@ -54,6 +62,10 @@ async fn node() {
     let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
     assert_eq!(nodes.0.len(), 1);
+    let version = nodes
+        .0
+        .first()
+        .and_then(|n| n.state().and_then(|n| n.version.clone()));
     assert_eq!(
         nodes.0.first().unwrap(),
         &new_node(
@@ -61,7 +73,8 @@ async fn node() {
             grpc.clone(),
             NodeStatus::Online,
             None,
-            Some(HostNqn::from_nodename(&maya_name.to_string()))
+            Some(HostNqn::from_nodename(&maya_name.to_string())),
+            &version
         )
     );
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -76,7 +89,8 @@ async fn node() {
             grpc.clone(),
             NodeStatus::Online,
             None,
-            Some(HostNqn::from_nodename(&maya_name.to_string()))
+            Some(HostNqn::from_nodename(&maya_name.to_string())),
+            &version
         )
     );
 
@@ -92,7 +106,8 @@ async fn node() {
             grpc.clone(),
             NodeStatus::Offline,
             None,
-            Some(HostNqn::from_nodename(&maya_name.to_string()))
+            Some(HostNqn::from_nodename(&maya_name.to_string())),
+            &version
         )
     );
     cluster.composer().start(maya_name.as_str()).await.unwrap();
@@ -114,7 +129,8 @@ async fn node() {
             grpc.clone(),
             NodeStatus::Online,
             None,
-            Some(HostNqn::from_nodename(&maya_name.to_string()))
+            Some(HostNqn::from_nodename(&maya_name.to_string())),
+            &version
         )
     );
 

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -604,8 +604,6 @@ async fn snapshot_upgrade() {
             b.with_io_engines(2)
                 .with_idle_io_engines(2)
                 .with_io_engine_tag("v2.6.1")
-                // testing: remove me
-                .with_idle_io_engine_bin("~/git/mayastor/io-engine/target/debug/io-engine-fix")
         })
         .build()
         .await

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -12,8 +12,8 @@ use stor_port::{
         openapi::models,
         transport::{
             CreateReplica, CreateVolume, DestroyPool, DestroyReplica, DestroyVolume, Filter,
-            PublishVolume, ReplicaId, SetVolumeReplica, SnapshotId, Volume, VolumeShareProtocol,
-            VolumeStatus,
+            NodeStatus, PublishVolume, ReplicaId, SetVolumeReplica, SnapshotId, Volume,
+            VolumeShareProtocol, VolumeStatus,
         },
     },
 };
@@ -587,6 +587,133 @@ async fn unknown_snapshot_garbage_collector() {
         .await
         .expect("Should get replica snaps");
     assert_eq!(snaps.snapshots.len(), 3);
+}
+
+#[tokio::test]
+async fn snapshot_upgrade() {
+    let mb = 1024 * 1024;
+    let gc_period = Duration::from_millis(200);
+    let cluster = ClusterBuilder::builder()
+        .with_rest(false)
+        .with_agents(vec!["core"])
+        .with_tmpfs_pool_ix(0, 100 * mb)
+        .with_tmpfs_pool_ix(1, 100 * mb)
+        .with_cache_period("200ms")
+        .with_reconcile_period(gc_period, gc_period)
+        .with_options(|b| {
+            b.with_io_engines(2)
+                .with_idle_io_engines(1)
+                .with_io_engine_tag("v2.6.1")
+                // testing: remove me
+                .with_idle_io_engine_bin("~/git/mayastor/io-engine/target/debug/io-engine-fix")
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let vol_cli = cluster.grpc_client().volume();
+
+    let volume_1 = vol_cli
+        .create(
+            &CreateVolume {
+                uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
+                size: 16 * mb,
+                replicas: 1,
+                thin: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let volume_2 = vol_cli
+        .create(
+            &CreateVolume {
+                uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b8".try_into().unwrap(),
+                size: 16 * mb,
+                replicas: 2,
+                thin: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let volume_1 = vol_cli
+        .publish(
+            &PublishVolume {
+                uuid: volume_1.uuid().clone(),
+                share: Some(VolumeShareProtocol::Nvmf),
+                target_node: Some(cluster.node(0)),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _snapshot = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume_1.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .unwrap();
+    let error = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume_2.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .expect_err("Can't take nr snapshot");
+    assert_eq!(error.kind, ReplyErrorKind::FailedPrecondition);
+
+    let error = vol_cli
+        .set_replica(
+            &SetVolumeReplica {
+                uuid: volume_1.uuid().clone(),
+                replicas: 2,
+            },
+            None,
+        )
+        .await
+        .expect_err("No rebuild on older version!");
+    assert_eq!(error.kind, ReplyErrorKind::FailedPrecondition);
+
+    cluster.composer().stop(&cluster.node(0)).await.unwrap();
+    cluster
+        .wait_node_status(cluster.node(0), NodeStatus::Unknown)
+        .await
+        .unwrap();
+    cluster.composer().start(&cluster.node(2)).await.unwrap();
+    cluster
+        .wait_node_status(cluster.node(0), NodeStatus::Online)
+        .await
+        .unwrap();
+    cluster.wait_pool_online(cluster.pool(0, 0)).await.unwrap();
+
+    tokio::time::sleep(gc_period * 5).await;
+
+    let _volume = vol_cli
+        .set_replica(
+            &SetVolumeReplica {
+                uuid: volume_1.uuid().clone(),
+                replicas: 2,
+            },
+            None,
+        )
+        .await
+        .expect("After upgrade this should work!");
+
+    vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume_2.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .expect("Now we can take nr snapshot");
 }
 
 #[tokio::test]

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -655,7 +655,9 @@ impl ResourceReplicas for OperationGuardArc<VolumeSpec> {
             .and_then(|t| registry.specs().nexus_rsc(t.nexus()))
         {
             let mut guard = nexus_spec.operation_guard()?;
-            guard.attach_replica(registry, &new_replica).await?;
+            guard
+                .attach_replica(registry, &new_replica, self.has_snapshots())
+                .await?;
 
             if request.delete {
                 self.remove_child_replica(request.replica(), &mut guard, registry)

--- a/control-plane/agents/src/bin/core/volume/registry.rs
+++ b/control-plane/agents/src/bin/core/volume/registry.rs
@@ -21,8 +21,8 @@ use stor_port::{
             volume::VolumeSpec,
         },
         transport::{
-            uri_with_hostnqn, Nexus, NexusStatus, ReplicaSnapshot, ReplicaStatus, ReplicaTopology,
-            SnapshotId, Volume, VolumeId, VolumeState, VolumeStatus, VolumeUsage,
+            uri_with_hostnqn, Nexus, NexusStatus, NodeBugFix, ReplicaSnapshot, ReplicaStatus,
+            ReplicaTopology, SnapshotId, Volume, VolumeId, VolumeState, VolumeStatus, VolumeUsage,
         },
     },
     IntoOption,
@@ -357,5 +357,18 @@ impl Registry {
             snapshots.push(grpc_mod::VolumeSnapshot::new(&spec, state));
         }
         PaginatedResult::new(snapshots, last)
+    }
+
+    /// Verify if all replica nodes have the rebuild ancestry fix and error out otherwise.
+    pub fn volume_replica_nodes_fix(
+        &self,
+        volume: &VolumeSpec,
+        fix: &NodeBugFix,
+    ) -> Result<(), SvcError> {
+        let specs = self.specs().read();
+        let replicas = specs.volume_replicas_it(&volume.uuid);
+        let nodes = specs.replica_nodes(replicas);
+
+        self.verify_nodes_fix(nodes.iter(), fix)
     }
 }

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -58,6 +58,10 @@ impl ResourceSnapshotting for OperationGuardArc<VolumeSpec> {
     ) -> Result<Self::CreateOutput, SvcError> {
         let state = registry.volume_state(request.source_id()).await?;
 
+        if self.as_ref().num_replicas > 1 {
+            registry.verify_rebuild_ancestry_fix().await?;
+        }
+
         let operation = VolumeOperation::CreateSnapshot(request.uuid().clone());
         let spec_clone = self.start_update(registry, &state, operation).await?;
 

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -31,8 +31,8 @@ use stor_port::{
             volume::{VolumeOperation, VolumeSpec, VolumeTarget},
         },
         transport::{
-            CreateReplicaSnapshot, DestroyReplicaSnapshot, NodeId, SnapshotId, SnapshotParameters,
-            SnapshotTxId, VolumeId,
+            CreateReplicaSnapshot, DestroyReplicaSnapshot, NodeBugFix, NodeId, SnapshotId,
+            SnapshotParameters, SnapshotTxId, VolumeId,
         },
     },
 };
@@ -59,7 +59,8 @@ impl ResourceSnapshotting for OperationGuardArc<VolumeSpec> {
         let state = registry.volume_state(request.source_id()).await?;
 
         if self.as_ref().num_replicas > 1 {
-            registry.verify_rebuild_ancestry_fix().await?;
+            let replicas_nodes = state.replica_topology.values().flat_map(|v| v.node());
+            registry.verify_nodes_fix(replicas_nodes, &NodeBugFix::NexusRebuildReplicaAncestry)?;
         }
 
         let operation = VolumeOperation::CreateSnapshot(request.uuid().clone());

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -1060,6 +1060,8 @@ impl SpecOperationsHelper for VolumeSpec {
                             resource: ResourceKind::AffinityGroup,
                             count: *replica_count,
                         })
+                    } else if *replica_count > self.num_replicas && self.has_snapshots() {
+                        registry.verify_rebuild_ancestry_fix().await
                     } else {
                         Ok(())
                     }

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -41,8 +41,9 @@ use stor_port::{
             SpecStatus, SpecTransaction,
         },
         transport::{
-            CreateReplica, CreateVolume, NodeId, PoolId, Protocol, Replica, ReplicaId, ReplicaName,
-            ReplicaOwners, SnapshotId, VolumeId, VolumeShareProtocol, VolumeState, VolumeStatus,
+            CreateReplica, CreateVolume, NodeBugFix, NodeId, PoolId, Protocol, Replica, ReplicaId,
+            ReplicaName, ReplicaOwners, SnapshotId, VolumeId, VolumeShareProtocol, VolumeState,
+            VolumeStatus,
         },
     },
 };
@@ -442,6 +443,16 @@ impl ResourceSpecs {
             // Use complete resource map for pagination, without any filtering.
             PaginatedResult::new(self.volume_snapshots.paginate(offset, length), last_result)
         }
+    }
+
+    /// Get an iterator for all the replicas owned by the given volume.
+    pub(crate) fn volume_replicas_it<'a>(
+        &'a self,
+        id: &'a VolumeId,
+    ) -> impl Iterator<Item = &'a ResourceMutex<ReplicaSpec>> + Clone + std::fmt::Debug {
+        self.replicas
+            .values()
+            .filter(|r| r.lock().owners.owned_by(id))
     }
 }
 
@@ -1061,7 +1072,8 @@ impl SpecOperationsHelper for VolumeSpec {
                             count: *replica_count,
                         })
                     } else if *replica_count > self.num_replicas && self.has_snapshots() {
-                        registry.verify_rebuild_ancestry_fix().await
+                        let fix = NodeBugFix::NexusRebuildReplicaAncestry;
+                        registry.volume_replica_nodes_fix(self, &fix)
                     } else {
                         Ok(())
                     }

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -196,6 +196,8 @@ pub enum SvcError {
     Internal { details: String },
     #[snafu(display("Invalid Arguments"))]
     InvalidArguments {},
+    #[snafu(display("IoEngine upgrade is required to rebuild volume with snapshots"))]
+    UpgradeRequiredToRebuild {},
     #[snafu(display("Invalid {}, labels: {} ", resource_kind, labels))]
     InvalidLabel {
         labels: String,
@@ -550,6 +552,13 @@ impl From<SvcError> for ReplyError {
 
             SvcError::InvalidArguments { .. } => ReplyError {
                 kind: ReplyErrorKind::InvalidArgument,
+                resource: ResourceKind::Unknown,
+                source,
+                extra,
+            },
+
+            SvcError::UpgradeRequiredToRebuild { .. } => ReplyError {
+                kind: ReplyErrorKind::FailedPrecondition,
                 resource: ResourceKind::Unknown,
                 source,
                 extra,

--- a/control-plane/grpc/proto/v1/node/target_node.proto
+++ b/control-plane/grpc/proto/v1/node/target_node.proto
@@ -28,6 +28,8 @@ message NodeSpec {
   optional CordonDrainState cordon_drain_state = 4;
   // the host nqn
   optional string node_nqn = 5;
+  // the io-engine version
+  optional string version = 6;
 }
 
 message NodeState {
@@ -39,6 +41,8 @@ message NodeState {
   NodeStatus status = 3;
   // the host nqn
   optional string node_nqn = 4;
+  // the io-engine version
+  optional string version = 5;
 }
 
 // Multiple nodes
@@ -127,11 +131,11 @@ message DrainNodeReply {
 }
 
 message CordonDrainState {
-    oneof cordondrainstate {
-        CordonedState cordoned = 1;
-        DrainState draining = 2;
-        DrainState drained = 3;
-      }
+  oneof cordondrainstate {
+    CordonedState cordoned = 1;
+    DrainState draining = 2;
+    DrainState drained = 3;
+  }
 }
 
 message CordonedState {

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -96,7 +96,7 @@ impl TryFrom<node::Node> for Node {
                 spec.node_nqn.try_into_opt()?,
                 None,
                 None,
-                None,
+                spec.version,
             )),
             None => None,
         };
@@ -123,6 +123,7 @@ impl TryFrom<node::Node> for Node {
                     status,
                     None,
                     state.node_nqn.try_into_opt()?,
+                    state.version,
                 ))
             }
             None => None,
@@ -180,6 +181,7 @@ impl From<Node> for node::Node {
                 None => None,
             },
             node_nqn: types_v0_spec.node_nqn().as_ref().map(|nqn| nqn.to_string()),
+            version: types_v0_spec.version().clone(),
         });
         let grpc_node_state = match types_v0_node.state() {
             None => None,
@@ -190,6 +192,7 @@ impl From<Node> for node::Node {
                     endpoint: types_v0_state.grpc_endpoint.to_string(),
                     status: grpc_node_status as i32,
                     node_nqn: types_v0_state.node_nqn.as_ref().map(|nqn| nqn.to_string()),
+                    version: types_v0_state.version.clone(),
                 })
             }
         };

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -94,6 +94,9 @@ impl TryFrom<node::Node> for Node {
                     None => None,
                 },
                 spec.node_nqn.try_into_opt()?,
+                None,
+                None,
+                None,
             )),
             None => None,
         };

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -2,7 +2,9 @@ use crate::{
     operations::{Cordoning, Drain, GetWithArgs, Label, ListWithArgs, PluginResult},
     resources::{
         error::Error,
-        utils::{self, print_table, CreateRow, CreateRows, GetHeaderRow, OutputFormat},
+        utils::{
+            self, optional_cell, print_table, CreateRow, CreateRows, GetHeaderRow, OutputFormat,
+        },
         NodeId,
     },
     rest_wrapper::RestClient,
@@ -75,6 +77,7 @@ impl CreateRow for openapi::models::Node {
             grpc_endpoint: spec.grpc_endpoint,
             status: openapi::models::NodeStatus::Unknown,
             node_nqn: spec.node_nqn,
+            version: spec.version,
         });
         let statuses = match spec.cordondrainstate {
             None => format!("{:?}", state.status),
@@ -98,7 +101,12 @@ impl CreateRow for openapi::models::Node {
                 )
             }
         };
-        row![self.id, state.grpc_endpoint, statuses]
+        row![
+            self.id,
+            state.grpc_endpoint,
+            statuses,
+            optional_cell(state.version)
+        ]
     }
 }
 

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -45,7 +45,7 @@ lazy_static! {
         "AVAILABLE",
         "COMMITTED"
     ];
-    pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS"];
+    pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS", "VERSION"];
     pub static ref REPLICA_TOPOLOGIES_PREFIX: Row = row!["VOLUME-ID"];
     pub static ref REPLICA_TOPOLOGY_HEADERS: Row = row![
         "ID",

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2912,6 +2912,9 @@ components:
             - $ref: '#/components/schemas/CordonDrainState'
         node_nqn:
           $ref: '#/components/schemas/HostNqn'
+        version:
+          description: Version of the io-engine instance
+          type: string
       additionalProperties: false
       required:
         - grpcEndpoint
@@ -2933,6 +2936,9 @@ components:
           $ref: '#/components/schemas/NodeStatus'
         node_nqn:
           $ref: '#/components/schemas/HostNqn'
+        version:
+          description: Version of the io-engine instance
+          type: string
       required:
         - grpcEndpoint
         - id

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -98,6 +98,8 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
     let io_engine2 = cluster.node(1);
 
     let listed_node = client.nodes_api().get_node(io_engine1.as_str()).await;
+    let listed_node = listed_node.unwrap();
+    let version = listed_node.spec.as_ref().unwrap().version.clone();
     let mut node = models::Node {
         id: io_engine1.to_string(),
         spec: Some(models::NodeSpec {
@@ -109,6 +111,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
             labels: None,
             cordondrainstate: None,
             node_nqn: Some(HostNqn::from_nodename(&io_engine1.to_string()).to_string()),
+            version: version.clone(),
         }),
         state: Some(models::NodeState {
             id: io_engine1.to_string(),
@@ -118,9 +121,10 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
             ),
             status: models::NodeStatus::Online,
             node_nqn: Some(HostNqn::from_nodename(&io_engine1.to_string()).to_string()),
+            version,
         }),
     };
-    assert_eq!(listed_node.unwrap(), node);
+    assert_eq!(listed_node, node);
 
     let _ = client.pools_api().get_pools(None).await.unwrap();
     let pool = client

--- a/control-plane/stor-port/src/types/v0/store/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus.rs
@@ -166,6 +166,12 @@ impl NexusSpec {
             _ => None,
         })
     }
+    /// Get an iterator that references all the replica ids in the nexus.
+    pub fn replica_ids(&self) -> impl Iterator<Item = &ReplicaId> {
+        self.children
+            .iter()
+            .flat_map(|c| c.as_replica_ref().as_ref().map(|c| c.uuid()))
+    }
 }
 
 impl From<&NexusSpec> for CreateNexus {

--- a/control-plane/stor-port/src/types/v0/store/nexus_child.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus_child.rs
@@ -16,10 +16,17 @@ pub enum NexusChild {
 }
 
 impl NexusChild {
-    /// Return Self as ReplicaUri
+    /// Return Self as ReplicaUri.
     pub fn as_replica(&self) -> Option<ReplicaUri> {
         match &self {
             NexusChild::Replica(replica) => Some(replica.clone()),
+            NexusChild::Uri(_) => None,
+        }
+    }
+    /// Return Self as ReplicaUri
+    pub fn as_replica_ref(&self) -> Option<&ReplicaUri> {
+        match &self {
+            NexusChild::Replica(replica) => Some(replica),
             NexusChild::Uri(_) => None,
         }
     }

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -509,6 +509,7 @@ impl From<NodeSpec> for models::NodeSpec {
             labels,
             src.cordon_drain_state.into_opt(),
             src.node_nqn.into_opt(),
+            src.version,
         )
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -254,6 +254,10 @@ impl VolumeMetadata {
     pub fn num_snapshots(&self) -> usize {
         self.runtime.snapshots.len()
     }
+    /// Check if there's any snapshot.
+    pub fn has_snapshots(&self) -> bool {
+        self.runtime.has_snapshots()
+    }
 }
 
 /// Volume meta information.

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -193,6 +193,7 @@ impl NodeState {
         status: NodeStatus,
         api_versions: Option<Vec<ApiVersion>>,
         node_nqn: Option<HostNqn>,
+        version: Option<String>,
     ) -> Self {
         Self {
             id,
@@ -203,7 +204,7 @@ impl NodeState {
             node_nqn,
             features: None,
             bugfixes: None,
-            version: None,
+            version,
         }
     }
     /// Get the node identification.
@@ -256,6 +257,7 @@ impl From<NodeState> for models::NodeState {
             src.id,
             src.status,
             src.node_nqn.into_opt(),
+            src.version,
         )
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -869,15 +869,24 @@ pub struct AddNexusReplica {
     pub replica: ReplicaUri,
     /// Auto start rebuilding.
     pub auto_rebuild: bool,
+    /// Snapshots are present in the other replicas.
+    pub snapshots_present: bool,
 }
 impl AddNexusReplica {
     /// Return new `Self` from it's properties.
-    pub fn new(node: &NodeId, nexus: &NexusId, replica: &ReplicaUri, auto_rebuild: bool) -> Self {
+    pub fn new(
+        node: &NodeId,
+        nexus: &NexusId,
+        replica: &ReplicaUri,
+        auto_rebuild: bool,
+        snapshots_present: bool,
+    ) -> Self {
         Self {
             node: node.clone(),
             nexus: nexus.clone(),
             replica: replica.clone(),
             auto_rebuild,
+            snapshots_present,
         }
     }
 }

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -275,7 +275,7 @@ impl Cluster {
         }
         Err(())
     }
-    /// Wait till the node is in the given status.
+    /// Wait till the pool is online.
     pub async fn wait_pool_online(&self, pool_id: PoolId) -> Result<(), ()> {
         let timeout = Duration::from_secs(2);
         let start = std::time::Instant::now();

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -48,7 +48,7 @@ use stor_port::{
             definitions::ObjectKey,
             registry::{ControlPlaneService, StoreLeaseLockKey},
         },
-        transport::CreatePool,
+        transport::{CreatePool, Filter, NodeId, NodeStatus, PoolId, PoolStatus},
     },
 };
 use tokio::{net::UnixStream, time::sleep};
@@ -251,6 +251,52 @@ impl Cluster {
         Err(ReplyError::invalid_reply_error(
             "Max tries exceeded, node service not up".to_string(),
         ))
+    }
+
+    /// Wait till the node is in the given status.
+    pub async fn wait_node_status(&self, node_id: NodeId, status: NodeStatus) -> Result<(), ()> {
+        let timeout = Duration::from_secs(2);
+        let node_cli = self.grpc_client().node();
+        let start = std::time::Instant::now();
+        loop {
+            let node = node_cli
+                .get(Filter::Node(node_id.clone()), true, None)
+                .await
+                .expect("Cant get node object");
+            if let Some(node) = node.0.get(0) {
+                if node.state().map(|n| &n.status) == Some(&status) {
+                    return Ok(());
+                }
+            }
+            if std::time::Instant::now() > (start + timeout) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        Err(())
+    }
+    /// Wait till the node is in the given status.
+    pub async fn wait_pool_online(&self, pool_id: PoolId) -> Result<(), ()> {
+        let timeout = Duration::from_secs(2);
+        let start = std::time::Instant::now();
+        loop {
+            let filter = Filter::Pool(pool_id.clone());
+            if let Ok(pools) = self.grpc_client().pool().get(filter, None).await {
+                if pools
+                    .into_inner()
+                    .first()
+                    .and_then(|p| p.state().map(|s| s.status == PoolStatus::Online))
+                    == Some(true)
+                {
+                    return Ok(());
+                }
+            }
+            if std::time::Instant::now() > (start + timeout) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        Err(())
     }
 
     /// return grpc handle to the container

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -381,6 +381,16 @@ impl Cluster {
         self.volume_service_liveness(timeout_opts).await
     }
 
+    /// Replace the given old node with a new one from the idles.
+    pub async fn replace_node(&self, old: NodeId, new: NodeId) -> Result<(), ()> {
+        self.composer().stop(&old).await.unwrap();
+        self.wait_node_status(old, NodeStatus::Unknown)
+            .await
+            .unwrap();
+        self.composer().start(&new).await.unwrap();
+        Ok(())
+    }
+
     /// remove etcd store lock for `name` instance
     pub async fn remove_store_lock(&self, name: ControlPlaneService) {
         let mut store = etcd_client::Client::connect(["0.0.0.0:2379"], None)

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -30,10 +30,11 @@ pub fn fio_spdk_image() -> String {
 
 /// Io-Engine container image used for testing.
 pub fn io_engine_image() -> String {
-    format!(
-        "{TARGET_REGISTRY}/{PRODUCT_NAME}-io-engine:{}",
-        target_tag()
-    )
+    io_engine_image_tagged(target_tag())
+}
+/// Io-Engine container image used for testing, but with a custom tag.
+pub fn io_engine_image_tagged(tag: String) -> String {
+    format!("{TARGET_REGISTRY}/{PRODUCT_NAME}-io-engine:{tag}")
 }
 
 /// Environment variable that points to an io-engine binary.


### PR DESCRIPTION
    feat: expose io-engine version via rest

    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    refactor: verify rebuild validity using replica nodes only

    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix: don't add replica to nexus which can't rebuild properly
    
    Check if all nodes have the rebuild fix for the following operations:
    - increase replica count on volume
    - move replica
    - add replica to nexus
    - take snapshot on nr volume
    
    Checking all nodes might lead to some false positives and also some issues if some nodes
    have been removed from power but not from the pstor, but it's a very
    simple way of ensuring all nodes are fixed.
    A potential improvement may be to check if the replica nodes have the fix.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(deployer): add idle io-engines
    
    These are useful to sort of simulate upgrades.
    This is required because there's no easy way of updating a container image tag.
    A better alternative to add in the future would be to extend composer to add
    containers to existing cluster and extending cluster to allow for this via its
    components as well.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat: update deps and handle features and bugfixes info
    
    This is now parsed from the io-engine registration and can be used to determine
    if a certain function can be performed or not.
    Also persists these to the pstor.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>