### PR TITLE
Revert affinity code and add core isolation in deployer start.

### DIFF
--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -112,7 +112,6 @@ fn test_deserialization_v1_to_v2() {
                             );
                             labels
                         },
-                        affinity: Vec::new(),
                     })),
                 }),
                 sequencer: Default::default(),

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -1067,8 +1067,6 @@ fn context_into_topology(context: &CreateParams) -> CreateVolumeTopology {
     let mut pool_inclusive_label_topology: HashMap<String, String> = HashMap::new();
     let mut node_inclusive_label_topology: HashMap<String, String> = HashMap::new();
     let mut node_exclusive_label_topology: HashMap<String, String> = HashMap::new();
-    let mut pool_affinity_label_topology: Vec<String> = Vec::<String>::new();
-    let mut node_affinity_label_topology: Vec<String> = Vec::<String>::new();
     pool_inclusive_label_topology.insert(dsp_created_by_key(), String::from(DSP_OPERATOR));
     pool_inclusive_label_topology.extend(
         context
@@ -1081,13 +1079,6 @@ fn context_into_topology(context: &CreateParams) -> CreateVolumeTopology {
         context
             .publish_params()
             .pool_has_topology_key()
-            .clone()
-            .unwrap_or_default(),
-    );
-    pool_affinity_label_topology.extend(
-        context
-            .publish_params()
-            .pool_affinity_topology_key()
             .clone()
             .unwrap_or_default(),
     );
@@ -1112,23 +1103,14 @@ fn context_into_topology(context: &CreateParams) -> CreateVolumeTopology {
             .clone()
             .unwrap_or_default(),
     );
-    node_affinity_label_topology.extend(
-        context
-            .publish_params()
-            .node_affinity_topology_key()
-            .clone()
-            .unwrap_or_default(),
-    );
     CreateVolumeTopology::new(
         Some(models::NodeTopology::labelled(LabelledTopology {
             exclusion: node_exclusive_label_topology,
             inclusion: node_inclusive_label_topology,
-            affinitykey: node_affinity_label_topology,
         })),
         Some(PoolTopology::labelled(LabelledTopology {
             exclusion: Default::default(),
             inclusion: pool_inclusive_label_topology,
-            affinitykey: pool_affinity_label_topology,
         })),
     )
 }

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -157,13 +157,6 @@ message LabelledTopology {
   common.StringMapValue exclusion = 1;
   // inclusive labels
   common.StringMapValue inclusion = 2;
-  // affinity labels
-  optional AffinityLabels affinity_labels = 3;
-}
-
-message AffinityLabels{
-  // affinity labels
-  repeated string affinity = 1;
 }
 
 message ExplicitNodeTopology {

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -642,10 +642,6 @@ impl From<volume::LabelledTopology> for LabelledTopology {
                 Some(labels) => labels.value,
                 None => HashMap::new(),
             },
-            affinity: match labelled_topology_grpc_type.affinity_labels {
-                Some(labels) => labels.affinity,
-                None => Vec::new(),
-            },
         }
     }
 }
@@ -658,9 +654,6 @@ impl From<LabelledTopology> for volume::LabelledTopology {
             }),
             inclusion: Some(crate::common::StringMapValue {
                 value: topo.inclusion,
-            }),
-            affinity_labels: Some(volume::AffinityLabels {
-                affinity: topo.affinity,
             }),
         }
     }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2481,8 +2481,6 @@ components:
           - ''
         inclusion:
           - ''
-        affinitykey:
-          - ''
       description: labelled topology
       type: object
       properties:
@@ -2512,22 +2510,9 @@ components:
           type: object
           additionalProperties:
             type: string
-        affinitykey:
-          example: ''
-          description: |-
-            This feature includes resources with identical $label keys. For example,
-             if the affinity key is set to "Zone":
-             Initially, a resource that matches the label is selected, example "Zone: A".
-             Subsequently, all other resources must match the given label "Zone: A",
-             effectively adding this requirement as an inclusion label.
-          type: array
-          items:
-            example: 'Zone'
-            type: string
       required:
         - exclusion
         - inclusion
-        - affinitykey
     Topology:
       description: node and pool topology for volumes
       type: object

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -255,9 +255,6 @@ pub struct LabelledTopology {
     /// Inclusive labels.
     #[serde(default)]
     pub inclusion: HashMap<String, String>,
-    /// Affinity labels.
-    #[serde(default)]
-    pub affinity: Vec<String>,
 }
 
 impl From<models::LabelledTopology> for LabelledTopology {
@@ -265,13 +262,12 @@ impl From<models::LabelledTopology> for LabelledTopology {
         Self {
             exclusion: src.exclusion,
             inclusion: src.inclusion,
-            affinity: src.affinitykey,
         }
     }
 }
 impl From<LabelledTopology> for models::LabelledTopology {
     fn from(src: LabelledTopology) -> Self {
-        Self::new(src.exclusion, src.inclusion, src.affinity)
+        Self::new(src.exclusion, src.inclusion)
     }
 }
 

--- a/tests/bdd/features/volume/nexus/test_feature.py
+++ b/tests/bdd/features/volume/nexus/test_feature.py
@@ -45,7 +45,6 @@ def a_published_selfhealing_volume():
                 labelled=LabelledTopology(
                     exclusion={},
                     inclusion={"node": IO_ENGINE_2},
-                    affinitykey=[],
                 )
             )
         ),

--- a/tests/bdd/features/volume/topology/test_feature.py
+++ b/tests/bdd/features/volume/topology/test_feature.py
@@ -167,7 +167,6 @@ def a_request_for_a_volume_with_topology_different_from_pools(create_request):
                 labelled=LabelledTopology(
                     exclusion={},
                     inclusion={"fake-label-key": "fake-label-value"},
-                    affinitykey=[],
                 )
             )
         ),
@@ -188,7 +187,6 @@ def a_request_for_a_volume_with_topology_same_as_pool_labels(create_request):
                 labelled=LabelledTopology(
                     exclusion={},
                     inclusion=disk_pool_label,
-                    affinitykey=[],
                 )
             )
         ),
@@ -250,7 +248,6 @@ def an_existing_published_volume_with_a_topology_matching_pool_labels():
                     labelled=LabelledTopology(
                         exclusion={},
                         inclusion=disk_pool_label,
-                        affinitykey=[],
                     )
                 )
             ),
@@ -278,7 +275,6 @@ def an_existing_published_volume_with_a_topology_not_matching_pool_labels():
                     labelled=LabelledTopology(
                         exclusion={},
                         inclusion={"pool1-specific-key": "pool1-specific-value"},
-                        affinitykey=[],
                     )
                 )
             ),
@@ -485,7 +481,6 @@ def volume_creation_should_succeed_with_a_returned_volume_object_with_topology(
                 labelled=LabelledTopology(
                     exclusion={},
                     inclusion=disk_pool_label,
-                    affinitykey=[],
                 )
             )
         ),

--- a/tests/bdd/features/volume/topology/test_node_topology.py
+++ b/tests/bdd/features/volume/topology/test_node_topology.py
@@ -12,7 +12,6 @@ from common.deployer import Deployer
 from common.apiclient import ApiClient
 from common.docker import Docker
 from common.nvme import nvme_connect, nvme_disconnect
-from time import sleep
 from common.fio import Fio
 from common.operations import Cluster
 
@@ -275,8 +274,7 @@ NODE_LABELS = [
 
 @pytest.fixture(scope="module")
 def init():
-    Deployer.start(NUM_IO_ENGINES)
-    time.sleep(10)
+    Deployer.start(NUM_IO_ENGINES, io_engine_coreisol=True)
     # Create the nodes with labels.
     for label, node_name in NODE_LABELS:
         [key, value] = label.split("=")
@@ -568,7 +566,6 @@ def create_volume_body(
                 inclusion={
                     **inclusion_labels,
                 },
-                affinitykey=[],
             )
         )
     )

--- a/tests/bdd/features/volume/topology/test_pool_topology.py
+++ b/tests/bdd/features/volume/topology/test_pool_topology.py
@@ -12,7 +12,6 @@ from common.deployer import Deployer
 from common.apiclient import ApiClient
 from common.docker import Docker
 from common.nvme import nvme_connect, nvme_disconnect
-from time import sleep
 from common.fio import Fio
 from common.operations import Cluster
 
@@ -186,9 +185,7 @@ POOL_CONFIGURATIONS = [
 
 @pytest.fixture(scope="module")
 def init():
-    Deployer.start(NUM_IO_ENGINES)
-
-    time.sleep(10)
+    Deployer.start(NUM_IO_ENGINES, io_engine_coreisol=True)
     # Create the pools.
     for config in POOL_CONFIGURATIONS:
         ApiClient.pools_api().put_node_pool(
@@ -380,7 +377,6 @@ def create_volume_body(replica, volume_pool_topology_inclusion_label):
                     key.strip(): value.strip(),
                     DISKPOOL_LABEL_KEY: DISKPOOL_LABEL_VAL,
                 },
-                affinitykey=[],
             )
         )
     )


### PR DESCRIPTION
affinity topology code needs to be removed as a part of 4.1 , this PR caters that