### PR TITLE
build: update mayastor-dependencies submodule

### DIFF
--- a/nix/lib/sourcer.nix
+++ b/nix/lib/sourcer.nix
@@ -3,12 +3,15 @@ let
   whitelistSource = src: allowedPrefixes:
     builtins.path {
       filter = (path: type:
-        lib.any
+        (lib.any
           (allowedPrefix:
             (lib.hasPrefix (toString (src + "/${allowedPrefix}")) path) ||
             (type == "directory" && lib.hasPrefix path (toString (src + "/${allowedPrefix}")))
           )
-          allowedPrefixes);
+          allowedPrefixes)
+        # there's no reason for this to be part of the build
+        && path != (toString (src + "/utils/dependencies/scripts/release.sh"))
+      );
       path = src;
       name = "controller";
     };


### PR DESCRIPTION
    build: don't let the release.sh cause rebuilds
    
    Don't copy the release.sh to the build source, since it's not required.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    build: update mayastor-dependencies submodule
    
    This fixes an issue where the images were not being pushed due to
    a bug on the registry image presence for CI.
    
    Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
