### PR TITLE
feat(topology): add show labels in pools

### DIFF
--- a/control-plane/plugin/src/lib.rs
+++ b/control-plane/plugin/src/lib.rs
@@ -148,7 +148,9 @@ impl ExecuteOperation for GetResources {
                 volume::Volume::topology(id, &cli_args.output).await
             }
             GetResources::Pools(args) => pool::Pools::list(args, &cli_args.output).await,
-            GetResources::Pool { id } => pool::Pool::get(id, &cli_args.output).await,
+            GetResources::Pool(args) => {
+                pool::Pool::get(&args.pool_id(), args, &cli_args.output).await
+            }
             GetResources::Nodes(args) => node::Nodes::list(args, &cli_args.output).await,
             GetResources::Node(args) => {
                 node::Node::get(&args.node_id(), args, &cli_args.output).await

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -1,7 +1,7 @@
 use crate::resources::{
     blockdevice::BlockDeviceArgs,
     node::{DrainNodeArgs, GetNodeArgs, GetNodesArgs},
-    pool::GetPoolsArgs,
+    pool::{GetPoolArgs, GetPoolsArgs},
     snapshot::VolumeSnapshotArgs,
     volume::VolumesArgs,
 };
@@ -51,7 +51,7 @@ pub enum GetResources {
     /// Get all pools.
     Pools(GetPoolsArgs),
     /// Get pool with the given ID.
-    Pool { id: PoolId },
+    Pool(GetPoolArgs),
     /// Get all nodes.
     Nodes(GetNodesArgs),
     /// Get node with the given ID.


### PR DESCRIPTION
Get pool 
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pool pool-on-node-1 -n openebs --show-labels
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-1  aio:///dev/sdb?uuid=b324aa79-c8b3-4859-a6e8-1a51fbc5d944  true     node-1-237668  Online  10GiB     0 B        10GiB      0 B        topology-key=topology-value
```
List pools 
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pools  -n openebs --show-labels
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-2  aio:///dev/sdb?uuid=8045fe61-ae51-429b-9c73-4f8f60c42d44  true     node-2-237668  Online  10GiB     0 B        10GiB      0 B
 pool-on-node-0  aio:///dev/sdb?uuid=4b12de79-fa6c-4bfd-9ed0-4f5f57cfeb4c  true     node-0-237668  Online  10GiB     0 B        10GiB      0 B        zone=us-east-1
 pool-on-node-1  aio:///dev/sdb?uuid=b324aa79-c8b3-4859-a6e8-1a51fbc5d944  true     node-1-237668  Online  10GiB     0 B        10GiB      0 B        topology-key=topology-value
 ```
List Pools with node filter
```
[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pools  -n openebs --show-labels --node  node-2-237668
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-2  aio:///dev/sdb?uuid=8045fe61-ae51-429b-9c73-4f8f60c42d44  true     node-2-237668  Online  10GiB     0 B        10GiB      0 B

[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pools  -n openebs --show-labels --node  node-1-237668
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-1  aio:///dev/sdb?uuid=b324aa79-c8b3-4859-a6e8-1a51fbc5d944  true     node-1-237668  Online  10GiB     0 B        10GiB      0 B        topology-key=topology-value

[nix-shell:~/code/rust/mayastor-extensions]$ ./target/debug/kubectl-mayastor get pools  -n openebs --show-labels --node  node-0-237668
 ID              DISKS                                                     MANAGED  NODE           STATUS  CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  LABELS
 pool-on-node-0  aio:///dev/sdb?uuid=4b12de79-fa6c-4bfd-9ed0-4f5f57cfeb4c  true     node-0-237668  Online  10GiB     0 B        10GiB      0 B        zone=us-east-1
```
