### PR TITLE
fix: listen on the IPv6 unspecified address

### DIFF
--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -133,7 +133,7 @@ pub(super) async fn main() -> anyhow::Result<()> {
                 .long("grpc-endpoint")
                 .value_name("ENDPOINT")
                 .help("ip address where this instance runs, and optionally the gRPC port")
-                .default_value("0.0.0.0")
+                .default_value("[::]")
                 .required(false)
         )
         .arg(
@@ -440,7 +440,7 @@ fn validate_endpoints(
     // sent in registration request.
     if registration_enabled && grpc_endpoint_url.ip().is_unspecified() {
         return Err(anyhow::format_err!(
-            "gRPC endpoint: `0.0.0.0` is not allowed if registration is enabled"
+            "gRPC endpoint: `[::]`/`0.0.0.0` is not allowed if registration is enabled"
         ));
     }
     Ok(grpc_endpoint_url)

--- a/control-plane/csi-driver/src/bin/node/shutdown_event.rs
+++ b/control-plane/csi-driver/src/bin/node/shutdown_event.rs
@@ -90,7 +90,7 @@ mod tests {
         tokio::spawn(async move {
             if let Err(e) = Server::builder()
                 .add_service(NodePluginServer::new(NodePluginSvc::new(first_sender)))
-                .serve_with_shutdown("0.0.0.0:50011".parse().unwrap(), wait(shutdown_receiver))
+                .serve_with_shutdown("[::]:50011".parse().unwrap(), wait(shutdown_receiver))
                 .await
             {
                 panic!("gRPC server failed with error: {e}");
@@ -98,7 +98,7 @@ mod tests {
         });
         tokio::time::sleep(Duration::from_millis(250)).await;
         let channel =
-            tonic::transport::Endpoint::from(Uri::from_str("https://0.0.0.0:50011").unwrap())
+            tonic::transport::Endpoint::from(Uri::from_str("https://[::]:50011").unwrap())
                 .connect()
                 .await
                 .unwrap();

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -17,8 +17,8 @@ use utils::DEFAULT_GRPC_CLIENT_ADDR;
 #[structopt(name = utils::package_description!(), version = utils::version_info_str!())]
 pub(crate) struct CliArgs {
     /// The bind address for the REST interface (with HTTPS)
-    /// Default: 0.0.0.0:8080
-    #[clap(long, default_value = "0.0.0.0:8080")]
+    /// Default: [::]:8080
+    #[clap(long, default_value = "[::]:8080")]
     https: String,
     /// The bind address for the REST interface (with HTTP)
     #[clap(long)]

--- a/deployer/src/infra/agents/ha/cluster.rs
+++ b/deployer/src/infra/agents/ha/cluster.rs
@@ -12,7 +12,7 @@ impl ComponentAction for HaClusterAgent {
     fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
         let mut spec = ContainerSpec::from_binary(
             "agent-ha-cluster",
-            Binary::from_dbg("agent-ha-cluster").with_args(vec!["-g=0.0.0.0:11500"]),
+            Binary::from_dbg("agent-ha-cluster").with_args(vec!["-g=[::]:11500"]),
         )
         .with_portmap("11500", "11500");
 

--- a/deployer/src/infra/etcd.rs
+++ b/deployer/src/infra/etcd.rs
@@ -12,9 +12,9 @@ impl ComponentAction for Etcd {
                     "--data-dir",
                     "/tmp/etcd-data",
                     "--advertise-client-urls",
-                    "http://0.0.0.0:2379",
+                    "http://[::]:2379",
                     "--listen-client-urls",
-                    "http://0.0.0.0:2379",
+                    "http://[::]:2379",
                     // these ensure fast startup since it's not a cluster anyway
                     "--heartbeat-interval=1",
                     "--election-timeout=5",
@@ -38,7 +38,7 @@ impl ComponentAction for Etcd {
     }
     async fn wait_on(&self, options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
         if !options.no_etcd {
-            let _store = EtcdStore::new("0.0.0.0:2379")
+            let _store = EtcdStore::new("[::]:2379")
                 .await
                 .expect("Failed to connect to etcd.");
         }

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -393,7 +393,7 @@ impl Cluster {
 
     /// remove etcd store lock for `name` instance
     pub async fn remove_store_lock(&self, name: ControlPlaneService) {
-        let mut store = etcd_client::Client::connect(["0.0.0.0:2379"], None)
+        let mut store = etcd_client::Client::connect(["[::]:2379"], None)
             .await
             .expect("Failed to connect to etcd.");
         store

--- a/utils/pstor-usage/src/simulation.rs
+++ b/utils/pstor-usage/src/simulation.rs
@@ -165,7 +165,7 @@ impl Simulation {
         };
         let cleanup = cluster.is_none() || self.total_stats;
 
-        let etcd = Etcd::new(Url::parse("http://0.0.0.0:2379")?).await?;
+        let etcd = Etcd::new(Url::parse("http://[::]:2379")?).await?;
 
         // create some pools as backing for the volumes
         let four_mb = 4096 * 1024;

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -83,13 +83,13 @@ pub const LOKI_LABEL: &str = "app=loki";
 pub const LOKI_PORT: &str = "http-metrics";
 
 /// The default value to be assigned as GRPC server addr if not overridden.
-pub const DEFAULT_GRPC_SERVER_ADDR: &str = "0.0.0.0:50051";
+pub const DEFAULT_GRPC_SERVER_ADDR: &str = "[::]:50051";
 
 /// The default value to be assigned as GRPC client addr if not overridden.
 pub const DEFAULT_GRPC_CLIENT_ADDR: &str = "https://core:50051";
 
 /// The default value to be assigned as JSON GRPC server addr if not overridden.
-pub const DEFAULT_JSON_GRPC_SERVER_ADDR: &str = "0.0.0.0:50052";
+pub const DEFAULT_JSON_GRPC_SERVER_ADDR: &str = "[::]:50052";
 
 /// The default value to be assigned as JSON GRPC client addr if not overridden.
 pub const DEFAULT_JSON_GRPC_CLIENT_ADDR: &str = "https://jsongrpc:50052";
@@ -98,13 +98,13 @@ pub const DEFAULT_JSON_GRPC_CLIENT_ADDR: &str = "https://jsongrpc:50052";
 pub const DEFAULT_GRPC_CLIENT_CONCURRENCY: usize = 25;
 
 /// The default value to be assigned as cluster agent GRPC server addr if not overridden.
-pub const DEFAULT_CLUSTER_AGENT_SERVER_ADDR: &str = "0.0.0.0:11500";
+pub const DEFAULT_CLUSTER_AGENT_SERVER_ADDR: &str = "[::]:11500";
 
 /// The default value to be assigned as cluster agent GRPC client addr if not overridden.
 pub const DEFAULT_CLUSTER_AGENT_CLIENT_ADDR: &str = "https://agent-ha-cluster:11500";
 
 /// The default value to be assigned as node-agent GRPC server addr if not overridden.
-pub const DEFAULT_NODE_AGENT_SERVER_ADDR: &str = "0.0.0.0:11600";
+pub const DEFAULT_NODE_AGENT_SERVER_ADDR: &str = "[::]:11600";
 
 /// The default worker threads cap for the api-rest service.
 pub const DEFAULT_REST_MAX_WORKER_THREADS: &str = "8";


### PR DESCRIPTION
This is a step towards making mayastor work on dual-stack/ipv6-only clusters.