### PR TITLE
Don't destroy replicas part of shutdown nexuses

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -1,5 +1,6 @@
 pub(super) mod capacity;
 mod garbage_collector;
+mod re_shutdown;
 
 use crate::{
     controller::{
@@ -59,7 +60,10 @@ impl NexusReconciler {
     pub(crate) fn from(period: PollPeriods) -> Self {
         NexusReconciler {
             counter: PollTimer::from(period),
-            poll_targets: vec![Box::new(GarbageCollector::new())],
+            poll_targets: vec![
+                Box::new(GarbageCollector::new()),
+                Box::new(re_shutdown::ReShutdown::new()),
+            ],
         }
     }
     /// Return new `Self` with the default period

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/re_shutdown.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/re_shutdown.rs
@@ -1,0 +1,50 @@
+use crate::controller::{
+    reconciler::PollTriggerEvent,
+    resources::operations_helper::OperationSequenceGuard,
+    task_poller::{PollContext, PollEvent, PollResult, PollerState, TaskPoller},
+};
+
+/// ReShutdown nexuses if node comes back online with the Nexus intact.
+#[derive(Debug)]
+pub(super) struct ReShutdown {}
+impl ReShutdown {
+    /// Return a new `Self`.
+    pub(super) fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for ReShutdown {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        // Fetch all nexuses that are not properly shutdown
+        for nexus in context.registry().specs().failed_shutdown_nexuses().await {
+            let Some(volume_id) = &nexus.immutable_ref().owner else {
+                continue;
+            };
+            let Ok(_volume) = context.specs().volume(volume_id).await else {
+                continue;
+            };
+
+            let Ok(mut nexus) = nexus.operation_guard() else {
+                continue;
+            };
+
+            nexus.re_shutdown_nexus(context.registry()).await;
+        }
+        PollResult::Ok(PollerState::Idle)
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        false
+    }
+
+    async fn poll_event(&mut self, context: &PollContext) -> bool {
+        matches!(
+            context.event(),
+            PollEvent::Triggered(PollTriggerEvent::Start)
+                | PollEvent::Triggered(PollTriggerEvent::NodeStateChangeOnline)
+                | PollEvent::Triggered(PollTriggerEvent::NodeDrain)
+        )
+    }
+}

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -647,6 +647,19 @@ impl ResourceSpecsLocked {
             .collect()
     }
 
+    /// Get a list of resourced NexusSpecs's which have failed to shut down.
+    pub(crate) async fn failed_shutdown_nexuses(&self) -> Vec<ResourceMutex<NexusSpec>> {
+        self.read()
+            .nexuses
+            .values()
+            .filter(|nexus| {
+                let nexus_spec = nexus.lock();
+                nexus_spec.is_shutdown() && nexus_spec.status_info().shutdown_failed()
+            })
+            .cloned()
+            .collect()
+    }
+
     /// Get the resourced volume nexus target for the given volume.
     pub(crate) fn volume_target_nexus_rsc(
         &self,

--- a/control-plane/stor-port/src/types/v0/store/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus.rs
@@ -448,15 +448,26 @@ impl From<&NexusSpec> for DestroyNexus {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct NexusStatusInfo {
     shutdown_failed: bool,
+    #[serde(skip)]
+    reshutdown: bool,
 }
 
 impl NexusStatusInfo {
     /// Create a new nexus status info.
     pub fn new(shutdown_failed: bool) -> NexusStatusInfo {
-        Self { shutdown_failed }
+        Self {
+            shutdown_failed,
+            reshutdown: false,
+        }
     }
     /// Check the nexus had a failed shutdown or not.
     pub fn shutdown_failed(&self) -> bool {
         self.shutdown_failed
+    }
+    pub fn set_reshutdown(&mut self) {
+        self.reshutdown = true;
+    }
+    pub fn reshutdown(&self) -> bool {
+        self.reshutdown
     }
 }


### PR DESCRIPTION
    feat: re-shutdown nexus when node is online
    
    When nexus shutdown fails, if the node comes back online let's
    attempt the shutdown again.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix: don't disown replica from unshutdown nexus
    
    In case nexus shutdown failed we used to disown the replica from
    both the volume and the nexus.
    This can be a problem if the nexus is still running as the io-engine
    does not handle it gracefully, leading into pool lock issues.
    Instead, simply disown the replica from the volume and not the nexus.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
