### PR TITLE
Cherry Pick 862

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -1,5 +1,6 @@
 pub(super) mod capacity;
 mod garbage_collector;
+mod re_shutdown;
 
 use crate::{
     controller::{
@@ -59,7 +60,10 @@ impl NexusReconciler {
     pub(crate) fn from(period: PollPeriods) -> Self {
         NexusReconciler {
             counter: PollTimer::from(period),
-            poll_targets: vec![Box::new(GarbageCollector::new())],
+            poll_targets: vec![
+                Box::new(GarbageCollector::new()),
+                Box::new(re_shutdown::ReShutdown::new()),
+            ],
         }
     }
     /// Return new `Self` with the default period

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/re_shutdown.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/re_shutdown.rs
@@ -1,0 +1,50 @@
+use crate::controller::{
+    reconciler::PollTriggerEvent,
+    resources::operations_helper::OperationSequenceGuard,
+    task_poller::{PollContext, PollEvent, PollResult, PollerState, TaskPoller},
+};
+
+/// ReShutdown nexuses if node comes back online with the Nexus intact.
+#[derive(Debug)]
+pub(super) struct ReShutdown {}
+impl ReShutdown {
+    /// Return a new `Self`.
+    pub(super) fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for ReShutdown {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        // Fetch all nexuses that are not properly shutdown
+        for nexus in context.registry().specs().failed_shutdown_nexuses().await {
+            let Some(volume_id) = &nexus.immutable_ref().owner else {
+                continue;
+            };
+            let Ok(_volume) = context.specs().volume(volume_id).await else {
+                continue;
+            };
+
+            let Ok(mut nexus) = nexus.operation_guard() else {
+                continue;
+            };
+
+            nexus.re_shutdown_nexus(context.registry()).await;
+        }
+        PollResult::Ok(PollerState::Idle)
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        false
+    }
+
+    async fn poll_event(&mut self, context: &PollContext) -> bool {
+        matches!(
+            context.event(),
+            PollEvent::Triggered(PollTriggerEvent::Start)
+                | PollEvent::Triggered(PollTriggerEvent::NodeStateChangeOnline)
+                | PollEvent::Triggered(PollTriggerEvent::NodeDrain)
+        )
+    }
+}

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -13,8 +13,9 @@ use stor_port::{
         openapi::{apis::specs_api::tower::client::direct::Specs, models, models::SpecStatus},
         store::nexus::NexusSpec,
         transport::{
-            CreateVolume, DestroyShutdownTargets, DestroyVolume, Filter, GetSpecs, Nexus,
-            PublishVolume, RepublishVolume, VolumeShareProtocol,
+            CreateReplica, CreateVolume, DestroyReplica, DestroyShutdownTargets, DestroyVolume,
+            Filter, GetSpecs, Nexus, NodeStatus, PublishVolume, ReplicaId, RepublishVolume,
+            VolumeShareProtocol,
         },
     },
 };
@@ -537,4 +538,155 @@ async fn node_exhaustion() {
 
     assert_eq!(error.kind, ReplyErrorKind::ResourceExhausted);
     assert_eq!(error.resource, ResourceKind::Node);
+}
+
+#[tokio::test]
+async fn shutdown_failed_replica_owner() {
+    let grpc_timeout = Duration::from_millis(512);
+
+    const POOL_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_agents(vec!["core"])
+        .with_io_engines(2)
+        .with_tmpfs_pool(POOL_SIZE_BYTES)
+        .with_cache_period("100ms")
+        .with_reconcile_period(Duration::from_millis(100), Duration::from_millis(100))
+        .with_node_deadline("2s")
+        .with_options(|o| {
+            o.with_io_engine_env("MAYASTOR_HB_INTERVAL_SEC", "1")
+                .with_isolated_io_engine(true)
+        })
+        .with_req_timeouts_min(true, grpc_timeout, grpc_timeout)
+        .build()
+        .await
+        .unwrap();
+
+    let vol_cli = cluster.grpc_client().volume();
+
+    let volume = vol_cli
+        .create(
+            &CreateVolume {
+                uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
+                size: 5242880,
+                replicas: 2,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let volume = vol_cli
+        .publish(
+            &PublishVolume {
+                uuid: volume.uuid().clone(),
+                share: None,
+                target_node: Some(cluster.node(0)),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![cluster.node(1).to_string()],
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    cluster
+        .composer()
+        .pause(cluster.node(0).as_str())
+        .await
+        .unwrap();
+
+    cluster
+        .wait_node_status(cluster.node(0), NodeStatus::Unknown)
+        .await
+        .unwrap();
+
+    vol_cli
+        .republish(
+            &RepublishVolume {
+                uuid: volume.uuid().clone(),
+                target_node: Some(cluster.node(1)),
+                share: VolumeShareProtocol::Nvmf,
+                reuse_existing: true,
+                frontend_node: cluster.node(1),
+                reuse_existing_fallback: false,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    cluster
+        .composer()
+        .thaw(cluster.node(0).as_str())
+        .await
+        .unwrap();
+
+    cluster
+        .wait_node_status(cluster.node(0), NodeStatus::Online)
+        .await
+        .unwrap();
+
+    assert!(!wait_till_pool_locked(&cluster).await);
+
+    let nexus_cli = cluster.grpc_client().nexus();
+    let nexuses = nexus_cli
+        .get(Filter::Node(cluster.node(0)), None)
+        .await
+        .unwrap();
+    assert_eq!(nexuses.into_inner().len(), 1);
+
+    let request = DestroyShutdownTargets::new(volume.uuid().clone(), None);
+    vol_cli
+        .destroy_shutdown_target(&request, None)
+        .await
+        .unwrap();
+
+    let nexuses = nexus_cli
+        .get(Filter::Node(cluster.node(0)), None)
+        .await
+        .unwrap();
+    assert!(nexuses.into_inner().is_empty());
+}
+
+async fn poll_pool_locked(cluster: &Cluster, is_locked: &mut bool) {
+    if *is_locked {
+        return;
+    }
+
+    let replica_cli = cluster.grpc_client().replica();
+    let req = CreateReplica {
+        node: cluster.node(0),
+        uuid: ReplicaId::new(),
+        pool_id: cluster.pool(0, 0),
+        size: 4 * 1024 * 1024,
+        thin: true,
+        ..Default::default()
+    };
+
+    let Ok(replica) = replica_cli.create(&req, None).await else {
+        *is_locked = true;
+        return;
+    };
+
+    let req = DestroyReplica::from(replica);
+    *is_locked = replica_cli.destroy(&req, None).await.is_err();
+}
+
+async fn wait_till_pool_locked(cluster: &Cluster) -> bool {
+    let timeout = Duration::from_secs(2);
+    let start = std::time::Instant::now();
+    let mut is_locked = false;
+    loop {
+        poll_pool_locked(cluster, &mut is_locked).await;
+        if is_locked {
+            return true;
+        }
+
+        if std::time::Instant::now() > (start + timeout) {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
 }

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -647,6 +647,19 @@ impl ResourceSpecsLocked {
             .collect()
     }
 
+    /// Get a list of resourced NexusSpecs's which have failed to shut down.
+    pub(crate) async fn failed_shutdown_nexuses(&self) -> Vec<ResourceMutex<NexusSpec>> {
+        self.read()
+            .nexuses
+            .values()
+            .filter(|nexus| {
+                let nexus_spec = nexus.lock();
+                nexus_spec.is_shutdown() && nexus_spec.status_info().shutdown_failed()
+            })
+            .cloned()
+            .collect()
+    }
+
     /// Get the resourced volume nexus target for the given volume.
     pub(crate) fn volume_target_nexus_rsc(
         &self,

--- a/control-plane/stor-port/src/types/v0/store/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus.rs
@@ -448,15 +448,26 @@ impl From<&NexusSpec> for DestroyNexus {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct NexusStatusInfo {
     shutdown_failed: bool,
+    #[serde(skip)]
+    reshutdown: bool,
 }
 
 impl NexusStatusInfo {
     /// Create a new nexus status info.
     pub fn new(shutdown_failed: bool) -> NexusStatusInfo {
-        Self { shutdown_failed }
+        Self {
+            shutdown_failed,
+            reshutdown: false,
+        }
     }
     /// Check the nexus had a failed shutdown or not.
     pub fn shutdown_failed(&self) -> bool {
         self.shutdown_failed
+    }
+    pub fn set_reshutdown(&mut self) {
+        self.reshutdown = true;
+    }
+    pub fn reshutdown(&self) -> bool {
+        self.reshutdown
     }
 }


### PR DESCRIPTION
    feat: re-shutdown nexus when node is online
    
    When nexus shutdown fails, if the node comes back online let's
    attempt the shutdown again.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix: don't disown replica from unshutdown nexus
    
    In case nexus shutdown failed we used to disown the replica from
    both the volume and the nexus.
    This can be a problem if the nexus is still running as the io-engine
    does not handle it gracefully, leading into pool lock issues.
    Instead, simply disown the replica from the volume and not the nexus.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
