### PR TITLE
Allow custom logging for the bdd tests

### DIFF
--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -332,6 +332,13 @@ pub struct StartOptions {
 
     #[clap(long, default_value = "false")]
     pub enable_app_node_registration: bool,
+
+    /// Add custom RUST_LOG env to all containers.
+    #[clap(long)]
+    rust_log: Option<String>,
+    /// Add custom RUST_LOG_SILENCE env to all containers.
+    #[clap(long)]
+    rust_log_silence: Option<String>,
 }
 
 /// List of KeyValues
@@ -626,6 +633,8 @@ impl StartOptions {
             .with_base_image(self.base_image.clone())
             .with_prune_reuse(!self.reuse_cluster, self.reuse_cluster, self.reuse_cluster)
             .autorun(false)
+            .with_rust_log(self.rust_log.clone())
+            .with_rust_log_silence(self.rust_log_silence.clone())
             .load_existing_containers()
             .await
             .configure(components.clone())?

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -36,6 +36,8 @@ class StartOptions:
     io_engine_devices: [str] = ()
     request_timeout: str = ""
     no_min_timeouts: bool = False
+    rust_log: str = None
+    rust_log_silence: str = None
 
     def args(self):
         args = [
@@ -83,6 +85,19 @@ class StartOptions:
             args.append(f"--request-timeout={self.request_timeout}")
         if self.no_min_timeouts:
             args.append(f"--no-min-timeouts")
+        if self.rust_log is not None:
+            args.append(f"--rust-log={self.rust_log}")
+        else:
+            rust_log = os.getenv("RUST_LOG")
+            if rust_log is not None:
+                args.append(f"--rust-log={rust_log}")
+
+        if self.rust_log_silence is not None:
+            args.append(f"--rust-log-silence={self.rust_log_silence}")
+        else:
+            rust_log_silence = os.getenv("RUST_LOG_SILENCE")
+            if rust_log_silence is not None:
+                args.append(f"--rust-log-silence={rust_log_silence}")
 
         agent_arg = "--agents=Core"
         if self.ha_node_agent:
@@ -122,6 +137,8 @@ class Deployer(object):
         io_engine_devices=[],
         request_timeout="",
         no_min_timeouts=False,
+        rust_log: str = None,
+        rust_log_silence: str = None,
     ):
         options = StartOptions(
             io_engines,
@@ -146,6 +163,8 @@ class Deployer(object):
             io_engine_devices=io_engine_devices,
             request_timeout=request_timeout,
             no_min_timeouts=no_min_timeouts,
+            rust_log=rust_log,
+            rust_log_silence=rust_log_silence,
         )
         pytest.deployer_options = options
         Deployer.start_with_opts(options)


### PR DESCRIPTION
    test(bdd): use new rust-log args
    
    Now you can setup RUST_LOG which will be forwarded to the containers.
    todo: we might not want to see this in deployer itself, so perhaps
    we can also add some knob to ensure it's only used for the containers.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test: run cleanup only once
    
    Ensure the cleanup trap is disabled when exiting.
    Also add more robust checks for FAST and CLEAN modes.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test: allow modifying rust-log for deployer containers
    
    This will aid debugging as allows us to increase verbosity of all
    or a subset of the rust modules.
    todo: we may want to do this with more fine grained control.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
