### PR TITLE
fix(topology): remove the internal labels while displaying

### DIFF
--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -323,7 +323,9 @@ impl Label for Pool {
             }
             OutputFormat::None => {
                 // In case the output format is not specified, show a success message.
-                let labels = pool.spec.unwrap().labels.unwrap_or_default();
+                let mut labels = pool.spec.unwrap().labels.unwrap_or_default();
+                let internal_label = external_utils::dsp_created_by_key();
+                labels.remove(&internal_label);
                 println!("Pool {id} labelled successfully. Current labels: {labels:?}");
             }
         }


### PR DESCRIPTION
This OPr removes the internal label while labeling a pool

The develop code was like 
```
$ ./target/debug/kubectl-mayastor label pool pool-on-node-one A=B -n openebs
Pool pool-on-node-one labelled successfully. Current labels: {"A": "B", "openebs.io/created-by": "operator-diskpool"}
```

After this PR 

```
$ ./target/debug/kubectl-mayastor label pool pool-on-node-one C=D -n openebs
Pool pool-on-node-one labelled successfully. Current labels: {"C": "D", "A": "B"}
```