### PR TITLE
ci: specify opentel receiver endpoint

### DIFF
--- a/deployer/misc/otel_agent_config.yaml
+++ b/deployer/misc/otel_agent_config.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: jaeger:4317
 
 processors:
   batch:
@@ -15,6 +16,6 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlp]
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ otlp ]

--- a/k8s/operators/Cargo.toml
+++ b/k8s/operators/Cargo.toml
@@ -3,36 +3,38 @@ name = "k8s-operators"
 description = "K8S Operator"
 version = "1.0.0"
 edition = "2018"
-authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 
 [[bin]]
 name = "operator-diskpool"
 path = "src/pool/main.rs"
+required-features = ["bin"]
 
 [lib]
 name = "k8s_operators"
 path = "src/lib.rs"
 
-
 [features]
-default = [ "rls" ]
-rls = [ "openapi/tower-client-rls" ]
-tls = [ "openapi/tower-client-tls" ]
-
+default = ["rls", "bin"]
+bin = ["openapi", "utils", "anyhow", "chrono", "clap", "futures", "snafu", "tokio", "humantime", "tracing"]
+rls = ["openapi/tower-client-rls"]
+tls = ["openapi/tower-client-tls"]
 
 [dependencies]
-openapi = { path = "../../openapi", default-features = false, features = [ "tower-client", "tower-trace" ] }
-utils = { path = "../../utils/utils-lib" }
-anyhow = "1.0.75"
-chrono = "0.4.31"
-clap =  { version = "4.4.6", features = ["color", "env", "string"] }
-futures = "0.3.28"
+# CRD
 k8s-openapi = { version = "0.20.0", features = ["v1_22"] }
 kube = { version = "0.87.0", features = ["derive", "runtime"] }
-schemars = "0.8.15"
-serde = "1.0.188"
-serde_json = "1.0.107"
-snafu = "0.7.5"
-tokio = { version = "1.32.0", features = ["full"] }
-humantime = "2.1.0"
-tracing = "0.1.37"
+schemars = { version = "0.8.15" }
+serde = { version = "1.0.188" }
+serde_json = { version = "1.0.107" }
+
+# Binary
+openapi = { path = "../../openapi", default-features = false, features = ["tower-client", "tower-trace"], optional = true }
+utils = { path = "../../utils/utils-lib", optional = true }
+anyhow = { version = "1.0.75", optional = true }
+chrono = { version = "0.4.31", optional = true }
+clap = { version = "4.4.6", features = ["color", "env", "string"], optional = true }
+futures = { version = "0.3.28", optional = true }
+snafu = { version = "0.7.5", optional = true }
+tokio = { version = "1.32.0", features = ["full"], optional = true }
+humantime = { version = "2.1.0", optional = true }
+tracing = { version = "0.1.37", optional = true }

--- a/k8s/operators/src/pool/diskpool/crd/v1beta2.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta2.rs
@@ -1,8 +1,10 @@
 use kube::CustomResource;
-use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+#[cfg(feature = "openapi")]
+use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
 
 #[derive(
     CustomResource, Serialize, Deserialize, Default, Debug, Eq, PartialEq, Clone, JsonSchema,
@@ -29,11 +31,11 @@ printcolumn = r#"{ "name":"available", "type":"integer", "format": "int64", "min
 /// The pool spec which contains the parameters we use when creating the pool
 pub struct DiskPoolSpec {
     /// The node the pool is placed on
-    node: String,
+    pub node: String,
     /// The disk device the pool is located on
-    disks: Vec<String>,
+    pub disks: Vec<String>,
     /// The topology for data placement.
-    topology: Option<Topology>,
+    pub topology: Option<Topology>,
 }
 
 /// Placement pool topology used by volume operations.
@@ -104,11 +106,11 @@ pub struct DiskPoolStatus {
     /// Pool status from respective control plane object.
     pub pool_status: Option<PoolStatus>,
     /// Capacity as number of bytes.
-    capacity: u64,
+    pub capacity: u64,
     /// Used number of bytes.
-    used: u64,
+    pub used: u64,
     /// Available number of bytes.
-    available: u64,
+    pub available: u64,
 }
 
 impl Default for DiskPoolStatus {
@@ -133,7 +135,8 @@ impl DiskPoolStatus {
         }
     }
 
-    /// Set when operator is attempting delete on pool.
+    /// Set when operator is attempting to delete on pool.
+    #[cfg(feature = "openapi")]
     pub fn terminating(p: Pool) -> Self {
         let state = p.state.unwrap_or_default();
         let free = if state.capacity > state.used {
@@ -168,6 +171,7 @@ impl DiskPoolStatus {
     }
 }
 
+#[cfg(feature = "openapi")]
 impl From<RestPoolStatus> for PoolStatus {
     fn from(p: RestPoolStatus) -> Self {
         match p {
@@ -180,6 +184,7 @@ impl From<RestPoolStatus> for PoolStatus {
 }
 
 /// Returns DiskPoolStatus from Control plane pool object.
+#[cfg(feature = "openapi")]
 impl From<Pool> for DiskPoolStatus {
     fn from(p: Pool) -> Self {
         if let Some(state) = p.state {


### PR DESCRIPTION
When running on the CI we an opentel receiver to push the traces to an external collector.
With recent versions of the receiver, it now listens only on localhost which was prevent it from receiving the traces to begin with. Now we specify the domain name of the receiver.