### PR TITLE
feat: connect over tcp if initiator isn't rdma capable

### DIFF
--- a/control-plane/agents/src/bin/ha/node/server.rs
+++ b/control-plane/agents/src/bin/ha/node/server.rs
@@ -135,7 +135,7 @@ async fn disconnect_controller(
             // changed, for example due to interface name modified in io-engine args.
             let same_controller = is_same_controller(&new_path_uri, &subsystem)?;
             if same_controller {
-                tracing::info!(path, "Not disconnecting same NVMe controller");
+                tracing::info!(path, "Not disconnecting same NVMe controller. old subsys {subsystem:?}, new path {new_path_uri:?}");
                 Ok(None)
             } else {
                 tracing::info!(path, "Disconnecting NVMe controller");
@@ -476,6 +476,16 @@ struct ParsedUri {
     nqn: String,
 }
 
+impl std::fmt::Debug for ParsedUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParsedUri")
+            .field("host", &self.host())
+            .field("port", &self.port())
+            .field("transport", &self.transport())
+            .field("nqn", &self.nqn())
+            .finish()
+    }
+}
 impl ParsedUri {
     fn new(uri: Uri) -> Result<ParsedUri, SvcError> {
         let host = uri.host().ok_or(SvcError::InvalidArguments {})?.to_string();

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -10,6 +10,7 @@ use csi_driver::{
     filesystem::FileSystem as Fs,
     limiter::VolumeOpGuard,
 };
+use once_cell::sync::OnceCell;
 use rpc::{
     csi,
     csi::{
@@ -76,6 +77,12 @@ impl Node {
 
 const ATTACH_TIMEOUT_INTERVAL: Duration = Duration::from_millis(100);
 const ATTACH_RETRIES: u32 = 100;
+// A type and static variable used to check and set node's rdma capability during startup.
+// This is used to decide if initiator can indeed connect over rdma.
+// First index bool tells if we need to fallback to tcp connect in case initiator node is
+// not rdma capable. Second index bool is the actual capability indicator.
+type CheckAndFallbackNvmeConnect = (bool, bool);
+pub(crate) static RDMA_CONNECT_CHECK: OnceCell<CheckAndFallbackNvmeConnect> = OnceCell::new();
 
 // Determine if given access mode in conjunction with ro mount flag makes
 // sense or not. If access mode is not supported or the combination does

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -12,6 +12,7 @@
 , gitVersions
 , openapi-generator
 , which
+, rdma-core
 , systemdMinimal
 , utillinux
 , sourcer
@@ -71,7 +72,7 @@ let
 
     inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE;
     nativeBuildInputs = [ clang pkg-config openapi-generator which git llvmPackages.bintools ];
-    buildInputs = [ llvmPackages.libclang protobuf openssl.dev systemdMinimal.dev utillinux.dev ];
+    buildInputs = [ llvmPackages.libclang protobuf openssl.dev systemdMinimal.dev utillinux.dev rdma-core ];
     doCheck = false;
   };
   release_build = { "release" = true; "debug" = false; };

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -2,7 +2,7 @@
 # avoid dependency on docker tool chain. Though the maturity of OCI
 # builder in nixpkgs is questionable which is why we postpone this step.
 
-{ pkgs, xfsprogs_5_16, busybox, dockerTools, lib, e2fsprogs, btrfs-progs, utillinux, fetchurl, control-plane, tini, sourcer, img_tag ? "", img_org ? "", img_prefix }:
+{ pkgs, xfsprogs_5_16, rdma-core, busybox, dockerTools, lib, e2fsprogs, btrfs-progs, utillinux, fetchurl, control-plane, tini, sourcer, img_tag ? "", img_org ? "", img_prefix }:
 let
   repo-org = if img_org != "" then img_org else "${builtins.readFile (pkgs.runCommand "repo_org" {
     buildInputs = with pkgs; [ git ];
@@ -104,7 +104,7 @@ let
       inherit buildType;
       name = "node";
       config = {
-        Env = [ "PATH=${lib.makeBinPath [ "/" xfsprogs e2fsprogs_1_46_2 btrfs-progs utillinux ]}" ];
+        Env = [ "PATH=${lib.makeBinPath [ "/" xfsprogs rdma-core e2fsprogs_1_46_2 btrfs-progs utillinux ]}" ];
       };
     };
   };

--- a/shell.nix
+++ b/shell.nix
@@ -39,6 +39,7 @@ mkShell {
     pre-commit
     python3
     utillinux
+    rdma-core
     which
   ] ++ pkgs.lib.optional (!norust) rust
   ++ pkgs.lib.optionals (system != "aarch64-darwin") [


### PR DESCRIPTION
- Added a cli option to control whether fallback is required or not. default kept `false`. We can make this default true once tested thoroughly. have some setup limitations currently.
- todo: adding a check(if required) to see if nvme_rdma module is available or not.