### PR TITLE
fix(volume): don't allow unpublish from non-frontend node

### DIFF
--- a/control-plane/agents/src/bin/core/tests/event/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/event/mod.rs
@@ -130,7 +130,10 @@ async fn events() {
     let vol_client = cluster.grpc_client().volume();
 
     vol_client
-        .unpublish(&UnpublishVolume::new(&volid, false), None)
+        .unpublish(
+            &UnpublishVolume::new(&volid, false, vec![cluster.csi_node(0).into()]),
+            None,
+        )
         .await
         .unwrap();
 

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -887,7 +887,11 @@ async fn disown_unused_replicas() {
 
     cluster.composer().pause(&node).await.unwrap();
     volumes_api
-        .del_volume_target(&volume.spec.uuid, Some(false))
+        .del_volume_target(
+            &volume.spec.uuid,
+            Some(false),
+            Some(cluster.csi_node(0).as_str()),
+        )
         .await
         .expect_err("io-engine is down");
     cluster.composer().kill(&node).await.unwrap();

--- a/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
@@ -326,7 +326,11 @@ async fn unused_reconcile(cluster: &Cluster) {
     cluster.composer().kill(&nexus_node.id).await.unwrap();
     // 2. now we force unpublish the volume
     volumes_api
-        .del_volume_target(&volume.spec.uuid, Some(true))
+        .del_volume_target(
+            &volume.spec.uuid,
+            Some(true),
+            Some(cluster.csi_node(0).as_str()),
+        )
         .await
         .unwrap();
     // 3. publish on the previously unused node

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -142,7 +142,10 @@ async fn nexus_persistence_test_iteration(
     let nexus_uuid = nexus.uuid.clone();
 
     volume_client
-        .unpublish(&UnpublishVolume::new(&volume_state.uuid, false), None)
+        .unpublish(
+            &UnpublishVolume::new(&volume_state.uuid, false, vec![]),
+            None,
+        )
         .await
         .unwrap();
 
@@ -379,7 +382,10 @@ async fn publishing_test(cluster: &Cluster) {
         .expect_err("The Volume cannot be published again because it's already published");
 
     volume_client
-        .unpublish(&UnpublishVolume::new(&volume_state.uuid, false), None)
+        .unpublish(
+            &UnpublishVolume::new(&volume_state.uuid, false, vec![]),
+            None,
+        )
         .await
         .unwrap();
 
@@ -447,7 +453,10 @@ async fn publishing_test(cluster: &Cluster) {
         .expect_err("The volume is already published");
 
     volume_client
-        .unpublish(&UnpublishVolume::new(&volume_state.uuid, false), None)
+        .unpublish(
+            &UnpublishVolume::new(&volume_state.uuid, false, vec![]),
+            None,
+        )
         .await
         .unwrap();
 
@@ -491,12 +500,18 @@ async fn publishing_test(cluster: &Cluster) {
     cluster.composer().kill(target_node.as_str()).await.unwrap();
 
     volume_client
-        .unpublish(&UnpublishVolume::new(&volume_state.uuid, false), None)
+        .unpublish(
+            &UnpublishVolume::new(&volume_state.uuid, false, vec![]),
+            None,
+        )
         .await
         .expect_err("The node is not online...");
 
     volume_client
-        .unpublish(&UnpublishVolume::new(&volume_state.uuid, true), None)
+        .unpublish(
+            &UnpublishVolume::new(&volume_state.uuid, true, vec![]),
+            None,
+        )
         .await
         .expect("With force comes great responsibility...");
 
@@ -747,7 +762,10 @@ async fn replica_count_test(cluster: &Cluster) {
 
     let volume_state = volume.state();
     volume_client
-        .unpublish(&UnpublishVolume::new(&volume_state.uuid, false), None)
+        .unpublish(
+            &UnpublishVolume::new(&volume_state.uuid, false, vec![]),
+            None,
+        )
         .await
         .unwrap();
 
@@ -927,7 +945,7 @@ async fn publish_unpublish(cluster: &Cluster) {
     // Unpublish the volume2
     let _ = volume_client
         .unpublish(
-            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_2).unwrap(), false),
+            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_2).unwrap(), false, vec![]),
             None,
         )
         .await
@@ -936,7 +954,7 @@ async fn publish_unpublish(cluster: &Cluster) {
     // Unpublish the volume1
     let _ = volume_client
         .unpublish(
-            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_1).unwrap(), false),
+            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_1).unwrap(), false, vec![]),
             None,
         )
         .await
@@ -983,14 +1001,14 @@ async fn target_distribution(cluster: &Cluster) {
     // Cleanup
     let _ = volume_client
         .unpublish(
-            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_1).unwrap(), false),
+            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_1).unwrap(), false, vec![]),
             None,
         )
         .await
         .expect("The volume should be unpublished");
     let _ = volume_client
         .unpublish(
-            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_2).unwrap(), false),
+            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_2).unwrap(), false, vec![]),
             None,
         )
         .await
@@ -1063,7 +1081,7 @@ async fn offline_node(cluster: &Cluster) {
     // Unpublish volume2
     let _ = volume_client
         .unpublish(
-            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_2).unwrap(), false),
+            &UnpublishVolume::new(&VolumeId::try_from(VOLUME_2).unwrap(), false, vec![]),
             None,
         )
         .await

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -83,6 +83,7 @@ impl From<clients::tower::Error<RestJsonError>> for ApiClientError {
                         StatusCode::PRECONDITION_FAILED => Self::PreconditionFailed(detailed),
                         StatusCode::BAD_REQUEST => Self::InvalidArgument(detailed),
                         StatusCode::NOT_ACCEPTABLE => Self::NotAcceptable(detailed),
+                        StatusCode::UNAUTHORIZED => Self::NotAcceptable(detailed),
                         status => Self::GenericOperation(status, detailed),
                     }
                 }
@@ -365,11 +366,12 @@ impl RestApiClient {
         &self,
         volume_id: &uuid::Uuid,
         force: bool,
+        frontend_host: Option<&str>,
     ) -> Result<(), ApiClientError> {
         Self::delete_idempotent(
             self.rest_client
                 .volumes_api()
-                .del_volume_target(volume_id, Some(force))
+                .del_volume_target(volume_id, Some(force), frontend_host)
                 .await,
             true,
         )?;

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -323,6 +323,8 @@ message UnpublishVolumeRequest {
   // the nexus. Note: this option should be used only when we know the node will not become
   // accessible again and it is safe to do so.
   bool force = 2;
+  // frontend host requesting for volume unpublish.
+  repeated string frontend_nodes = 3;
 }
 
 // Share Volume request

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -1618,6 +1618,8 @@ pub trait UnpublishVolumeInfo: Send + Sync + std::fmt::Debug {
     fn uuid(&self) -> VolumeId;
     /// Force unpublish
     fn force(&self) -> bool;
+    /// Frontend node requesting unpublish.
+    fn frontend_nodes(&self) -> Vec<String>;
 }
 
 impl UnpublishVolumeInfo for UnpublishVolume {
@@ -1627,6 +1629,10 @@ impl UnpublishVolumeInfo for UnpublishVolume {
 
     fn force(&self) -> bool {
         self.force()
+    }
+
+    fn frontend_nodes(&self) -> Vec<String> {
+        self.frontend_nodes.clone()
     }
 }
 
@@ -1644,6 +1650,10 @@ impl UnpublishVolumeInfo for ValidatedUnpublishVolumeRequest {
     fn force(&self) -> bool {
         self.inner.force
     }
+
+    fn frontend_nodes(&self) -> Vec<String> {
+        self.inner.frontend_nodes.clone()
+    }
 }
 
 impl ValidateRequestTypes for UnpublishVolumeRequest {
@@ -1658,7 +1668,7 @@ impl ValidateRequestTypes for UnpublishVolumeRequest {
 
 impl From<&dyn UnpublishVolumeInfo> for UnpublishVolume {
     fn from(data: &dyn UnpublishVolumeInfo) -> Self {
-        UnpublishVolume::new(&data.uuid(), data.force())
+        UnpublishVolume::new(&data.uuid(), data.force(), data.frontend_nodes())
     }
 }
 
@@ -1667,6 +1677,7 @@ impl From<&dyn UnpublishVolumeInfo> for UnpublishVolumeRequest {
         Self {
             uuid: Some(data.uuid().to_string()),
             force: data.force(),
+            frontend_nodes: data.frontend_nodes().iter().map(|n| n.into()).collect(),
         }
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1710,6 +1710,13 @@ paths:
           schema:
             type: boolean
             default: false
+        - in: query
+          name: frontend_host
+          description: |-
+            Frontend host requesting the volume unpublish.
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: OK

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -58,11 +58,15 @@ impl apis::actix_server::Volumes for RestApi {
 
     async fn del_volume_target(
         Path(volume_id): Path<Uuid>,
-        Query(force): Query<Option<bool>>,
+        Query((force, frontend_host)): Query<(Option<bool>, Option<String>)>,
     ) -> Result<models::Volume, RestError<RestJsonError>> {
         let volume = client()
             .unpublish(
-                &UnpublishVolume::new(&volume_id.into(), force.unwrap_or(false)),
+                &UnpublishVolume::new(
+                    &volume_id.into(),
+                    force.unwrap_or(false),
+                    frontend_host.into_iter().collect(),
+                ),
                 None,
             )
             .await?;

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -648,13 +648,16 @@ pub struct UnpublishVolume {
     /// the nexus. Note: this option should be used only when we know the node will not become
     /// accessible again and it is safe to do so.
     force: bool,
+    /// The frontend node that was connected to volume and is unpublishing now.
+    pub frontend_nodes: Vec<String>,
 }
 impl UnpublishVolume {
     /// Create a new `UnpublishVolume` for the given uuid.
-    pub fn new(uuid: &VolumeId, force: bool) -> Self {
+    pub fn new(uuid: &VolumeId, force: bool, frontend_nodes: Vec<String>) -> Self {
         Self {
             uuid: uuid.clone(),
             force,
+            frontend_nodes,
         }
     }
     /// It's a force `Self`.

--- a/tests/bdd/features/csi/controller/controller.feature
+++ b/tests/bdd/features/csi/controller/controller.feature
@@ -113,3 +113,9 @@ Scenario: list existing volumes with pagination max entries set to 0
     When a ListVolumesRequest is sent to CSI controller with max_entries set to 0
     Then all volumes should be returned
     And the next token should be empty
+
+Scenario: unpublish volume from non-frontend node
+    Given a 2 replica volume published on a node
+    When the ControllerUnpublishVolume request arrives from a non-frontend node
+    Then nvmf target which exposes the volume should not be destroyed
+    And volume should remain as published

--- a/tests/bdd/features/csi/controller/test_controller.py
+++ b/tests/bdd/features/csi/controller/test_controller.py
@@ -158,6 +158,11 @@ def test_unpublish_volume(setup):
     """unpublish volume"""
 
 
+@scenario("controller.feature", "unpublish volume from non-frontend node")
+def test_unpublish_volume_from_nonfrontend_node(setup):
+    """unpublish volume from non-frontend node."""
+
+
 @scenario("controller.feature", "unpublish volume idempotency")
 def test_unpublish_volume_idempotency(setup):
     """unpublish volume idempotency"""
@@ -200,6 +205,17 @@ def two_nodes_with_one_pool_each():
 @given("2 existing volumes", target_fixture="two_volumes")
 def two_existing_volumes(_create_2_volumes_1_replica):
     return _create_2_volumes_1_replica
+
+
+@given("a 2 replica volume published on a node")
+def populate_published_2_replica_volume(_create_2_replica_nvmf_volume):
+    do_publish_volume(VOLUME4_UUID, NODE1)
+    # Make sure volume is published.
+    volume = ApiClient.volumes_api().get_volume(VOLUME4_UUID)
+    assert (
+        str(volume.spec.target.protocol) == "nvmf"
+    ), "Protocol mismatches for published volume"
+    return volume
 
 
 @given("a non-existing volume")
@@ -575,6 +591,12 @@ def get_controller_capabilities(csi_instance):
     )
 
 
+@when("the ControllerUnpublishVolume request arrives from a non-frontend node")
+def unpublish_from_non_frontend_node():
+    """the ControllerUnpublishVolume request arrives from a non-frontend node."""
+    do_unpublish_volume(VOLUME4_UUID, NODE2)
+
+
 @then("CSI controller should report all its capabilities")
 def check_get_controller_capabilities(get_caps_request):
     all_capabilities = [
@@ -934,6 +956,16 @@ def check_identical_volume_creation(create_the_same_volume):
     )
 
 
+@then("nvmf target which exposes the volume should not be destroyed")
+def volume_target_should_not_be_destroyed():
+    """nvmf target which exposes the volume should not be destroyed."""
+    vol = ApiClient.volumes_api().get_volume(VOLUME4_UUID)
+    assert str(vol.spec.target.protocol) == "nvmf", "Volume protocol mismatches"
+    assert vol.state.target["device_uri"].startswith(
+        ("nvmf://", "nvmf+tcp://", "nvmf+rdma+tcp://")
+    ), "Volume share URI mismatches"
+
+
 @then("only a single volume should be returned")
 def only_a_single_volume_should_be_returned(paginated_volumes_list):
     """only a single volume should be returned."""
@@ -997,6 +1029,12 @@ def check_unpublish_not_existing_volume(unpublish_not_existing_volume):
     assert (
         response == unpublish_not_existing_volume
     ), "Volume unpuplishing succeeded with unexpected response"
+
+
+@then("volume should remain as published")
+def volume_remains_published():
+    """volume should remain as published."""
+    pass
 
 
 @then("volume should report itself as published")

--- a/tests/io-engine/tests/rebuild.rs
+++ b/tests/io-engine/tests/rebuild.rs
@@ -974,7 +974,11 @@ async fn destroy_rebuilding_nexus() {
         assert!(child.uri.starts_with("nvmf"), "uri: {}", child.uri);
 
         volumes_api
-            .del_volume_target(&volume_1.state.uuid, None)
+            .del_volume_target(
+                &volume_1.state.uuid,
+                None,
+                Some(cluster.csi_node(0).as_str()),
+            )
             .await
             .unwrap();
 

--- a/utils/pstor-usage/src/volumes.rs
+++ b/utils/pstor-usage/src/volumes.rs
@@ -98,7 +98,7 @@ impl ResourceUpdates for Vec<models::Volume> {
 
             client
                 .volumes_api()
-                .del_volume_target(&volume.spec.uuid, Some(true))
+                .del_volume_target(&volume.spec.uuid, Some(true), Some(node_id.as_str()))
                 .await?;
         }
         Ok(())


### PR DESCRIPTION
In case application and volume target have already moved to a different node and there is a lagging ControllerUnpublish request that comes later, then this unpublish call can delete the newly created target, which is undesirable and leads to volume staging failures.