### PR TITLE
test: adjust grpc timeout

### DIFF
--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -293,7 +293,7 @@ async fn snapshot_timeout() {
             .with_min_req_timeout(None)
     }
     let req_timeout = Duration::from_millis(800);
-    let grpc_timeout = Duration::from_millis(250);
+    let grpc_timeout = Duration::from_millis(500);
 
     let cluster = ClusterBuilder::builder()
         .with_rest(true)

--- a/scripts/rust/linter.sh
+++ b/scripts/rust/linter.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 cargo fmt -- --version
-cargo fmt --all
+cargo fmt --all -- --config imports_granularity=Crate
 
 cargo clippy -- --version
 cargo clippy --all --all-targets $1 -- -D warnings


### PR DESCRIPTION
On very slow backend, it was seen that this timeout may not be enough.