### PR TITLE
Cherry-Pick PR 898

### DIFF
--- a/control-plane/csi-driver/src/lib.rs
+++ b/control-plane/csi-driver/src/lib.rs
@@ -71,3 +71,5 @@ pub mod limiter;
 /// Contains tools to advertise the same set of capabilities across different
 /// CSI microservices.
 pub mod plugin_capabilities;
+/// Request Tracing.
+pub mod trace;

--- a/control-plane/csi-driver/src/trace.rs
+++ b/control-plane/csi-driver/src/trace.rs
@@ -1,0 +1,47 @@
+/// A csi request which can be traced.
+pub struct CsiRequest<'a> {
+    request: &'a str,
+    start: std::time::Instant,
+}
+
+impl<'a> CsiRequest<'a> {
+    /// Add new request and info trace it.
+    pub fn new_info(request: &'a str) -> Self {
+        tracing::info!("[ CSI ] {request} Request started");
+
+        Self::new(request)
+    }
+    /// Add new request and debug trace it.
+    pub fn new_dbg(request: &'a str) -> Self {
+        tracing::debug!("[ CSI ] {request} Request started");
+
+        Self::new(request)
+    }
+    /// Add new request and trace trace it.
+    pub fn new_trace(request: &'a str) -> Self {
+        tracing::trace!("[ CSI ] {request} Request started");
+
+        Self::new(request)
+    }
+
+    fn new(request: &'a str) -> Self {
+        Self {
+            request,
+            start: std::time::Instant::now(),
+        }
+    }
+
+    /// Get completion log message.
+    pub fn log_str(self) -> String {
+        format!(
+            "[ CSI ] {} Request completed successfully after {:?}",
+            self.request,
+            self.start.elapsed()
+        )
+    }
+
+    /// Log completion info.
+    pub fn info_ok(self) {
+        tracing::info!("{}", self.log_str())
+    }
+}

--- a/control-plane/csi-driver/src/trace.rs
+++ b/control-plane/csi-driver/src/trace.rs
@@ -44,4 +44,8 @@ impl<'a> CsiRequest<'a> {
     pub fn info_ok(self) {
         tracing::info!("{}", self.log_str())
     }
+    /// Log completion trace.
+    pub fn trace_ok(self) {
+        tracing::info!("{}", self.log_str())
+    }
 }

--- a/scripts/python/test-residue-cleanup.sh
+++ b/scripts/python/test-residue-cleanup.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(dirname "$0")"
+
+# Cleans up the deployer's leftovers
+"$SCRIPT_DIR"/../rust/deployer-cleanup.sh || true
+
 # Cleans up the iptables rules added by bdd tests
 
 set -euo pipefail

--- a/scripts/python/test.sh
+++ b/scripts/python/test.sh
@@ -19,7 +19,6 @@ export ROOT_DIR="$SCRIPT_DIR/../.."
 cleanup_handler() {
   ERROR=$?
   "$SCRIPT_DIR"/test-residue-cleanup.sh || true
-  "$SCRIPT_DIR"/../rust/deployer-cleanup.sh || true
   if [ $ERROR != 0 ]; then exit $ERROR; fi
 }
 


### PR DESCRIPTION
    fix(csi/node): increase info level logging
    
    This will trace most requests and their completions as info.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(csi/controller): increase info level logging
    
    This will trace most requests and their completions as info.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(bdd): clean up properly
    
    Ensure the python tests cleanup also cleans up the deployer cluster, in case
    the test run is forcefully aborted
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>