### PR TITLE
Cherry pick csi-trace and csi-node uri fixes to develop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,14 +20,14 @@ repos:
     -   id: rust-lint
         name: Rust lint
         description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
-        entry: nix-shell --pure --run 'cargo-clippy --all --all-targets -- -D warnings'
+        entry: nix-shell --pure --run './scripts/rust/linter.sh clippy'
         pass_filenames: false
         types: [file, rust]
         language: system
     -   id: rust-style
         name: Rust style
         description: Run cargo fmt on files included in the commit. rustfmt should be installed before-hand.
-        entry: nix-shell --pure --run 'cargo-fmt --all -- --check'
+        entry: nix-shell --pure --run './scripts/rust/linter.sh fmt'
         exclude: openapi/
         pass_filenames: false
         types: [file, rust]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,8 +115,7 @@ pipeline {
       steps {
         sh 'printenv'
         sh 'nix-shell --run "./scripts/rust/generate-openapi-bindings.sh"'
-        sh 'nix-shell --run "cargo fmt --all -- --check"'
-        sh 'nix-shell --run "cargo clippy --all-targets -- -D warnings"'
+        sh 'nix-shell --run "./scripts/rust/linter.sh"'
         sh 'nix-shell --run "black --check tests/bdd"'
         sh 'nix-shell --run "./scripts/git/check-submodule-branches.sh"'
       }

--- a/control-plane/csi-driver/src/trace.rs
+++ b/control-plane/csi-driver/src/trace.rs
@@ -46,6 +46,6 @@ impl<'a> CsiRequest<'a> {
     }
     /// Log completion trace.
     pub fn trace_ok(self) {
-        tracing::info!("{}", self.log_str())
+        tracing::trace!("{}", self.log_str())
     }
 }

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -123,6 +123,10 @@ pub struct StartOptions {
     #[clap(long)]
     pub csi_node: bool,
 
+    /// Enable the rest client in the csi-node plugin.
+    #[clap(long, requires = "csi_node")]
+    pub csi_node_rest: bool,
+
     /// Use `N` csi-node instances
     #[clap(long, requires = "csi_node")]
     pub app_nodes: Option<u32>,

--- a/scripts/rust/linter.sh
+++ b/scripts/rust/linter.sh
@@ -1,7 +1,31 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+
+set -e
+
+FMT_ERROR=
+
+OP="${1:-}"
+
+case "$OP" in
+  "" | "fmt" | "clippy")
+    ;;
+  *)
+    echo "linter $OP not supported"
+    exit 2
+esac
 
 cargo fmt -- --version
-cargo fmt --all
-
 cargo clippy -- --version
-cargo clippy --all --all-targets $1 -- -D warnings
+
+if [ -z "$OP" ] || [  "$OP" = "fmt" ]; then
+  cargo fmt --all --check || FMT_ERROR=$?
+  if [ -n "$FMT_ERROR" ]; then
+    cargo fmt --all
+  fi
+fi
+
+if [ -z "$OP" ] || [  "$OP" = "clippy" ]; then
+  cargo clippy --all --all-targets -- -D warnings
+fi
+
+exit ${FMT_ERROR:-0}

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -16,6 +16,7 @@ class StartOptions:
     wait: str = "10s"
     csi_controller: bool = False
     csi_node: bool = False
+    csi_rest: bool = False
     reconcile_period: str = ""
     faulted_child_wait_period: str = ""
     cache_period: str = ""
@@ -48,6 +49,8 @@ class StartOptions:
             args.append("--csi-controller")
         if self.csi_node:
             args.append("--csi-node")
+        if self.csi_rest:
+            args.append("--csi-node-rest")
         if self.jaeger:
             args.append("--jaeger")
         if len(self.reconcile_period) > 0:
@@ -104,6 +107,7 @@ class Deployer(object):
         wait="10s",
         csi_controller=False,
         csi_node=False,
+        csi_rest=False,
         reconcile_period="",
         faulted_child_wait_period="",
         cache_period="",
@@ -128,6 +132,7 @@ class Deployer(object):
             wait,
             csi_controller=csi_controller,
             csi_node=csi_node,
+            csi_rest=csi_rest,
             reconcile_period=reconcile_period,
             faulted_child_wait_period=faulted_child_wait_period,
             cache_period=cache_period,

--- a/tests/bdd/features/csi/node/node.feature
+++ b/tests/bdd/features/csi/node/node.feature
@@ -29,6 +29,11 @@ Feature: CSI node plugin
     When staging a volume with a volume_capability with a mount with an unsupported fs_type
     Then the request should fail
 
+  Scenario: stage volume request with incorrect uri in the publish context
+    When staging a volume with an incorrect uri
+    But the rest client is enabled
+    Then the request should succeed
+
   Scenario: staging a single writer volume
     When staging an "ext4" volume as "MULTI_NODE_SINGLE_WRITER"
     Then the request should succeed

--- a/tests/bdd/features/csi/node/test_node.py
+++ b/tests/bdd/features/csi/node/test_node.py
@@ -107,7 +107,7 @@ def get_volume_capability(volume, read_only):
 
 @pytest.fixture(scope="module")
 def setup():
-    Deployer.start(1, csi_node=True)
+    Deployer.start(1, csi_node=True, csi_rest=True)
 
     # Create 2 pools.
     pool_labels = disk_pool_label
@@ -236,6 +236,13 @@ def test_restaging_a_volume():
 @scenario("node.feature", "stage volume request with unsupported fs_type")
 def test_stage_volume_request_with_unsupported_fs_type():
     """Stage volume request with unsupported fs_type."""
+
+
+@scenario(
+    "node.feature", "stage volume request with incorrect uri in the publish context"
+)
+def test_stage_volume_request_with_incorrect_uri_in_the_publish_context():
+    """stage volume request with incorrect uri in the publish context."""
 
 
 @scenario("node.feature", "stage volume request without specified access_mode")
@@ -625,6 +632,37 @@ def attempt_to_stage_volume_with_unsupported_fs_type(
     assert error.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
 
+@when("staging a volume with an incorrect uri")
+def _(
+    get_published_nexus, csi_instance, staging_target_path, io_timeout, staged_volumes
+):
+    nexus = get_published_nexus
+    volume = Volume(
+        nexus.uuid,
+        nexus.protocol,
+        nexus.uri,
+        "MULTI_NODE_SINGLE_WRITER",
+        staging_target_path,
+        "ext4",
+    )
+    csi_instance.node.NodeStageVolume(
+        pb.NodeStageVolumeRequest(
+            volume_id=nexus.uuid,
+            publish_context={"uri": "bad", "ioTimeout": io_timeout},
+            staging_target_path=staging_target_path,
+            volume_capability=pb.VolumeCapability(
+                access_mode=pb.VolumeCapability.AccessMode(
+                    mode=pb.VolumeCapability.AccessMode.Mode.MULTI_NODE_SINGLE_WRITER
+                ),
+                mount=pb.VolumeCapability.MountVolume(fs_type="ext4", mount_flags=[]),
+            ),
+            secrets={},
+            volume_context={},
+        )
+    )
+    staged_volumes[volume.uuid] = volume
+
+
 @when(parsers.parse('staging an "{fs_type}" volume as "{mode}"'))
 def stage_new_volume(
     get_published_nexus, stage_volume, staging_target_path, fs_type, mode
@@ -774,6 +812,12 @@ def _(generic_staged_volume):
     nvme_set_ctrl_loss_tmo(uri, 1)
     ApiClient.volumes_api().del_volume_target(generic_staged_volume.uuid)
     wait_nvme_gone_device(uri)
+
+
+@when("the rest client is enabled")
+def _():
+    """the rest client is enabled."""
+    pass
 
 
 @then("the volume should be stageable again")


### PR DESCRIPTION
    chore(bors): merge pull request #903

    903: fix(csi/stage): fetch uri via REST r=tiagolobocastro a=tiagolobocastro

    On a NodeStage call, it's possible that the publish_context URI is out of date. This can happen when the volume has been moved to another node, and the app pod is pinned to a node and the node restarts.
    See Mayastor Issue 1781 for more details.

    For this fix, we add a new option to enable rest client for the csi-node. Ideally we'd like to strictly adhere to CSI spec, and avoid doing any mayastor specific operations (effectively being a mostly generic nvme-connect csi-driver but the immutability of the publish_context makes this a bit difficult.

    Anyways, we add a new flag --enable-rest which is optional, thus still allowing us to run without this layer.
    This will be enabled by default on the helm chart.

    We also further check for the Nexus Online/Degraded state, which should help avoid a bunch of nvme connect errors in the kernel.

    With this, we can also improve a few things down the line, such as ensuring resize before publish, etc... but we should take these 1 at a time and not suddendly do everything via rest...

    Co-authored-by: Tiago Castro <tiagolobocastro@gmail.com>
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(csi-driver): trace was mistakenly added as info

    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>