### PR TITLE
feat(csi-driver): add pre-publish hook to cleanup stale entries

### DIFF
--- a/control-plane/csi-driver/proto/node-service.proto
+++ b/control-plane/csi-driver/proto/node-service.proto
@@ -20,6 +20,8 @@ service NodePlugin {
   rpc UnfreezeFS (UnfreezeFSRequest) returns (UnfreezeFSReply) {}
   // Find the volume identified by the volume ID, and return volume information.
   rpc FindVolume (FindVolumeRequest) returns (FindVolumeReply) {}
+  // Force unstage the volume.
+  rpc ForceUnstageVolume (ForceUnstageVolumeRequest) returns (ForceUnstageVolumeReply) {}
 }
 
 enum VolumeType {
@@ -53,4 +55,12 @@ message FindVolumeRequest {
 message FindVolumeReply {
   optional VolumeType volume_type = 1;
   string device_path = 2; // the device path for the volume
+}
+
+// The request message containing ID of the volume to be force unstaged.
+message ForceUnstageVolumeRequest {
+  string volume_id = 1;
+}
+// Message for response on volume force unstage.
+message ForceUnstageVolumeReply {
 }

--- a/control-plane/csi-driver/src/bin/controller/config.rs
+++ b/control-plane/csi-driver/src/bin/controller/config.rs
@@ -15,6 +15,8 @@ pub(crate) struct CsiControllerConfig {
     node_selector: HashMap<String, String>,
     /// Max Outstanding Create Volume Requests.
     create_volume_limit: usize,
+    /// Force unstage volume.
+    force_unstage_volume: bool,
 }
 
 impl CsiControllerConfig {
@@ -43,11 +45,19 @@ impl CsiControllerConfig {
                 .map(|s| s.map(|s| s.as_str())),
         )?;
 
+        let force_unstage_volume = args.get_flag("force-unstage-volume");
+        if !force_unstage_volume {
+            tracing::warn!(
+                "Force unstage volume is disabled, can trigger potential data corruption!"
+            );
+        }
+
         CONFIG.get_or_init(|| Self {
             rest_endpoint: rest_endpoint.into(),
             io_timeout: io_timeout.into(),
             node_selector,
             create_volume_limit,
+            force_unstage_volume,
         });
         Ok(())
     }
@@ -77,5 +87,9 @@ impl CsiControllerConfig {
     /// Get the node selector label segment.
     pub(crate) fn node_selector_segment(&self) -> HashMap<String, String> {
         self.node_selector.clone()
+    }
+    /// Force unstage volume.
+    pub(crate) fn force_unstage_volume(&self) -> bool {
+        self.force_unstage_volume
     }
 }

--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -111,12 +111,19 @@ async fn main() -> anyhow::Result<()> {
                 .help("Formatting style to be used while logging")
         )
         .arg(
-        Arg::new("ansi-colors")
-            .long("ansi-colors")
-            .default_value("true")
-            .value_parser(clap::value_parser!(bool))
-            .help("Enable ansi color for logs")
-    )
+            Arg::new("ansi-colors")
+                .long("ansi-colors")
+                .default_value("true")
+                .value_parser(clap::value_parser!(bool))
+                .help("Enable ansi color for logs")
+        )
+        .arg(
+            Arg::new("force-unstage-volume")
+                .long("force-unstage-volume")
+                .default_value("true")
+                .value_parser(clap::value_parser!(bool))
+                .help("Enable force unstage volume feature")
+        )
         .get_matches();
 
     utils::print_package_info!();

--- a/control-plane/csi-driver/src/bin/node/findmnt.rs
+++ b/control-plane/csi-driver/src/bin/node/findmnt.rs
@@ -4,6 +4,7 @@ use csi_driver::filesystem::FileSystem as Fs;
 use serde_json::Value;
 use std::{collections::HashMap, process::Command, str::FromStr, string::String, vec::Vec};
 use tracing::{error, warn};
+use utils::csi_plugin_name;
 
 // Keys of interest we expect to find in the JSON output generated
 // by findmnt.
@@ -13,9 +14,18 @@ const FSTYPE_KEY: &str = "fstype";
 
 #[derive(Debug)]
 pub(crate) struct DeviceMount {
-    #[allow(dead_code)]
     mount_path: String,
     fstype: FileSystem,
+}
+
+impl std::fmt::Display for DeviceMount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MountPath: {}, FileSystem: {}",
+            self.mount_path, self.fstype
+        )
+    }
 }
 
 impl DeviceMount {
@@ -26,6 +36,10 @@ impl DeviceMount {
     /// File system type
     pub(crate) fn fstype(&self) -> FileSystem {
         self.fstype.clone()
+    }
+    /// Get the mount path.
+    pub(crate) fn mount_path(&self) -> String {
+        self.mount_path.clone()
     }
 }
 
@@ -206,6 +220,135 @@ pub(crate) fn get_mountpaths(device_path: &str) -> Result<Vec<DeviceMount>, Devi
                     }
                 } else {
                     warn!("missing target field {:?}", entry);
+                }
+            }
+            Ok(mountpaths)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+const DRIVER_NAME: &str = "driverName";
+const VOLUME_HANDLE: &str = "volumeHandle";
+const METADATA_FILE: &str = "vol_data.json";
+const DEVICE_PATTERN: &str = "nvme";
+
+/// This filter is to be used specifically search for mountpoints in context of k8s
+///
+/// # Fields
+/// * `driver` - Name of the csi driver which provisioned the volume.
+/// * `volume_id` - Name of the volume which is being searched for.
+/// * `file_name` - Name of the file where kubelet stores the metadata.
+/// * `device_pattern` - Pattern to search for a specific type of device, ex nvme.
+#[derive(Debug)]
+struct FilterCsiMounts<'a> {
+    driver: &'a str,
+    volume_id: &'a str,
+    file_name: &'a str,
+    device_pattern: &'a str,
+}
+
+/// Finds CSI mount points using `findmnt` and filters based on the given criteria.
+fn find_csi_mount(filter: FilterCsiMounts) -> Result<Vec<HashMap<String, String>>, DeviceError> {
+    let output = Command::new(FIND_MNT).args(FIND_MNT_ARGS).output()?;
+
+    if !output.status.success() {
+        return Err(DeviceError::new(String::from_utf8(output.stderr)?.as_str()));
+    }
+
+    let json_str = String::from_utf8(output.stdout)?;
+    let json: Value = serde_json::from_str(&json_str)?;
+
+    let mut results: Vec<HashMap<String, String>> = Vec::new();
+    filter_csi_findmnt(&json, &filter, &mut results);
+
+    Ok(results)
+}
+
+/// Filters JSON output from `findmnt` for matching CSI mount points as per the filter.
+fn filter_csi_findmnt(
+    json_val: &Value,
+    filter: &FilterCsiMounts,
+    results: &mut Vec<HashMap<String, String>>,
+) {
+    match json_val {
+        Value::Array(json_array) => {
+            for jsonvalue in json_array {
+                filter_csi_findmnt(jsonvalue, filter, results);
+            }
+        }
+        Value::Object(json_map) => {
+            if let Some(source_value) = json_map.get(SOURCE_KEY) {
+                let source_str = key_adjusted_value(SOURCE_KEY, source_value);
+                if source_str.contains(filter.device_pattern) {
+                    if let Some(target_value) = json_map.get(TARGET_KEY) {
+                        let target_str = target_value.as_str().unwrap_or_default();
+
+                        if let Some(parent_path) = std::path::Path::new(target_str).parent() {
+                            let vol_data_path = parent_path.join(filter.file_name);
+                            let vol_data_path_str = vol_data_path.to_string_lossy();
+
+                            if let Ok(vol_data) = read_vol_data_json(&vol_data_path_str) {
+                                if vol_data.get(DRIVER_NAME)
+                                    == Some(&Value::String(filter.driver.to_string()))
+                                    && vol_data.get(VOLUME_HANDLE)
+                                        == Some(&Value::String(filter.volume_id.to_string()))
+                                {
+                                    results.push(jsonmap_to_hashmap(json_map));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            for (_, jsonvalue) in json_map {
+                if jsonvalue.is_array() || jsonvalue.is_object() {
+                    filter_csi_findmnt(jsonvalue, filter, results);
+                }
+            }
+        }
+        _ => (),
+    };
+}
+
+/// Reads and parses a file into a JSON object.
+fn read_vol_data_json(path: &str) -> Result<serde_json::Map<String, Value>, DeviceError> {
+    let file = std::fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+    let json: serde_json::Map<String, Value> = serde_json::from_reader(reader)?;
+    Ok(json)
+}
+
+/// Retrieves mount paths for a given CSI volume ID by parsing the metadata file.
+pub(crate) async fn get_csi_mountpaths(volume_id: &str) -> Result<Vec<DeviceMount>, DeviceError> {
+    let filter = FilterCsiMounts {
+        driver: &csi_plugin_name(),
+        volume_id,
+        file_name: METADATA_FILE,
+        device_pattern: DEVICE_PATTERN,
+    };
+    match find_csi_mount(filter) {
+        Ok(results) => {
+            let mut mountpaths: Vec<DeviceMount> = Vec::new();
+            for entry in results {
+                if let Some(mountpath) = entry.get(TARGET_KEY) {
+                    if let Some(fstype) = entry.get(FSTYPE_KEY) {
+                        mountpaths.push(DeviceMount::new(
+                            mountpath.to_string(),
+                            Fs::from_str(fstype)
+                                .unwrap_or(Fs::Unsupported(fstype.to_string()))
+                                .into(),
+                        ))
+                    } else {
+                        warn!(volume.id=%volume_id, "Missing fstype for {mountpath}");
+                        mountpaths.push(DeviceMount::new(
+                            mountpath.to_string(),
+                            Fs::Unsupported("".to_string()).into(),
+                        ))
+                    }
+                } else {
+                    warn!(volume.id=%volume_id, ?entry, "Missing target field");
                 }
             }
             Ok(mountpaths)

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -164,7 +164,7 @@ fn get_access_type(volume_capability: &Option<VolumeCapability>) -> Result<&Acce
 
 /// Detach the nexus device from the system, either at volume unstage,
 /// or after failed filesystem mount at volume stage.
-async fn detach(uuid: &Uuid, errheader: String) -> Result<(), Status> {
+pub(crate) async fn detach(uuid: &Uuid, errheader: String) -> Result<(), Status> {
     if let Some(device) = Device::lookup(uuid).await.map_err(|error| {
         failure!(
             Code::Internal,

--- a/control-plane/csi-driver/src/bin/node/nodeplugin_grpc.rs
+++ b/control-plane/csi-driver/src/bin/node/nodeplugin_grpc.rs
@@ -3,26 +3,39 @@
 //! node as a IoEngine CSI node plugin, but it is not possible to do so within
 //! the CSI framework. This service must be deployed on all nodes the
 //! IoEngine CSI node plugin is deployed.
+
 use crate::{
+    dev::Device,
+    findmnt,
     fsfreeze::{fsfreeze, FsFreezeOpt},
+    mount::lazy_unmount_mountpaths,
     nodeplugin_svc,
     nodeplugin_svc::{find_mount, lookup_device},
+    runtime,
     shutdown_event::Shutdown,
 };
-use csi_driver::node::internal::{
-    node_plugin_server::{NodePlugin, NodePluginServer},
-    FindVolumeReply, FindVolumeRequest, FreezeFsReply, FreezeFsRequest, UnfreezeFsReply,
-    UnfreezeFsRequest, VolumeType,
+use csi_driver::{
+    limiter::VolumeOpGuard,
+    node::internal::{
+        node_plugin_server::{NodePlugin, NodePluginServer},
+        FindVolumeReply, FindVolumeRequest, ForceUnstageVolumeReply, ForceUnstageVolumeRequest,
+        FreezeFsReply, FreezeFsRequest, UnfreezeFsReply, UnfreezeFsRequest, VolumeType,
+    },
 };
 use nodeplugin_svc::TypeOfMount;
+use nvmeadm::{error::NvmeError, nvmf_subsystem::Subsystem};
+use utils::nvme_target_nqn_prefix;
+
 use tonic::{transport::Server, Request, Response, Status};
 use tracing::{debug, error, info};
+use uuid::Uuid;
 
 #[derive(Debug, Default)]
 pub(crate) struct NodePluginSvc {}
 
 #[tonic::async_trait]
 impl NodePlugin for NodePluginSvc {
+    #[tracing::instrument(err, skip_all)]
     async fn freeze_fs(
         &self,
         request: Request<FreezeFsRequest>,
@@ -32,6 +45,7 @@ impl NodePlugin for NodePluginSvc {
         Ok(Response::new(FreezeFsReply {}))
     }
 
+    #[tracing::instrument(err, skip_all)]
     async fn unfreeze_fs(
         &self,
         request: Request<UnfreezeFsRequest>,
@@ -53,6 +67,71 @@ impl NodePlugin for NodePluginSvc {
             volume_type: mount.map(Into::<VolumeType>::into).map(Into::into),
             device_path: device.devname(),
         }))
+    }
+
+    #[tracing::instrument(err, fields(volume.uuid = request.get_ref().volume_id), skip(self, request))]
+    async fn force_unstage_volume(
+        &self,
+        request: Request<ForceUnstageVolumeRequest>,
+    ) -> Result<Response<ForceUnstageVolumeReply>, Status> {
+        let volume_id = request.into_inner().volume_id;
+
+        let _guard = VolumeOpGuard::new_str(&volume_id)?;
+
+        debug!("Starting cleanup for volume: {volume_id}");
+
+        let nqn = format!("{}:{volume_id}", nvme_target_nqn_prefix());
+        match Subsystem::try_from_nqn(&nqn) {
+            Ok(subsystem_paths) => {
+                for subsystem_path in subsystem_paths {
+                    info!("Processing subsystem: {subsystem_path:?}");
+                    if !subsystem_path.state.contains("deleting") {
+                        runtime::spawn_blocking(move || {
+                            subsystem_path
+                                .disconnect()
+                                .map_err(|error| Status::aborted(error.to_string()))
+                        })
+                        .await
+                        .map_err(|error| Status::aborted(error.to_string()))??;
+                    }
+                }
+                Err(Status::internal(format!(
+                    "Cleanup initiated for all stale entries of: {volume_id}. Returning error for validation on retry."
+                )))
+            }
+            Err(NvmeError::NqnNotFound { .. }) => {
+                let uuid = Uuid::parse_str(&volume_id).map_err(|error| {
+                    Status::invalid_argument(format!("Invalid volume UUID: {volume_id}, {error}"))
+                })?;
+
+                if let Ok(Some(device)) = Device::lookup(&uuid).await {
+                    let mountpaths = findmnt::get_mountpaths(&device.devname())?;
+                    debug!(
+                        "Device: {} found, with mount paths: {}, issuing unmount",
+                        device.devname(),
+                        mountpaths
+                            .iter()
+                            .map(|devmount| devmount.to_string())
+                            .collect::<Vec<String>>()
+                            .join(", ")
+                    );
+                    lazy_unmount_mountpaths(&mountpaths).await?;
+                } else {
+                    let mountpaths = findmnt::get_csi_mountpaths(&volume_id).await?;
+                    debug!(
+                        "Device was not found, detected mount paths: {}, issuing unmount",
+                        mountpaths
+                            .iter()
+                            .map(|devmount| devmount.to_string())
+                            .collect::<Vec<String>>()
+                            .join(", ")
+                    );
+                    lazy_unmount_mountpaths(&mountpaths).await?;
+                }
+                Ok(Response::new(ForceUnstageVolumeReply {}))
+            }
+            Err(error) => Err(Status::aborted(error.to_string())),
+        }
     }
 }
 

--- a/control-plane/csi-driver/src/bin/node/shutdown_event.rs
+++ b/control-plane/csi-driver/src/bin/node/shutdown_event.rs
@@ -13,8 +13,8 @@ mod tests {
     use csi_driver::node::internal::{
         node_plugin_client::NodePluginClient,
         node_plugin_server::{NodePlugin, NodePluginServer},
-        FindVolumeReply, FindVolumeRequest, FreezeFsReply, FreezeFsRequest, UnfreezeFsReply,
-        UnfreezeFsRequest, VolumeType,
+        FindVolumeReply, FindVolumeRequest, ForceUnstageVolumeReply, ForceUnstageVolumeRequest,
+        FreezeFsReply, FreezeFsRequest, UnfreezeFsReply, UnfreezeFsRequest, VolumeType,
     };
     use std::{
         str::FromStr,
@@ -72,6 +72,13 @@ mod tests {
                 volume_type: Some(VolumeType::Rawblock as i32),
                 device_path: "".to_string(),
             }))
+        }
+
+        async fn force_unstage_volume(
+            &self,
+            _request: Request<ForceUnstageVolumeRequest>,
+        ) -> Result<Response<ForceUnstageVolumeReply>, Status> {
+            unimplemented!()
         }
     }
 

--- a/deployer/src/infra/csi-driver/controller.rs
+++ b/deployer/src/infra/csi-driver/controller.rs
@@ -30,7 +30,9 @@ impl ComponentAction for CsiController {
                 .with_args(vec!["--rest-endpoint", "http://rest:8081"])
                 // Make sure that CSI socket is always under shared directory
                 // regardless of what its default value is.
-                .with_args(vec!["--csi-socket", CSI_SOCKET]);
+                .with_args(vec!["--csi-socket", CSI_SOCKET])
+                // Disable force unstage volume. TODO: remove the flag and fix test.
+                .with_args(vec!["--force-unstage-volume", "false"]);
 
             if cfg.container_exists("jaeger") {
                 let jaeger_config = format!("jaeger.{}", cfg.get_name());


### PR DESCRIPTION
Scenario:
If an node undergoes a network partition and the application pods on it are moved by out-of-service taint then it can happen that the stale mount paths and the nvme controllers get left around, because CSI NodeUnstage was never called.
Once the node comes back and joins the cluster and the application pod comes back to the same node, it can happen that the stale nvme path gets live again causing the existing buffer data to be flushed potentially causing data corruption.

Changes:
This adds a pre-publish hook that can intercept the ControllerPublish and issue cleanup on the node if stale entries are detected.