### PR TITLE
refactor(plugin): expand scope of ExecuteOperations trait

### DIFF
--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -54,7 +54,7 @@ impl CliArgs {
         )
         .context(RestClientSnafu)?;
         self.operation
-            .execute(&self.args)
+            .execute(CliArgs::args().args, Some(&CliArgs::args().args.output))
             .await
             .context(ResourcesSnafu)
     }

--- a/control-plane/plugin/src/resources/error.rs
+++ b/control-plane/plugin/src/resources/error.rs
@@ -102,6 +102,9 @@ pub enum Error {
         key1=value1,key2=value2"
     ))]
     LabelNodeFilter { labels: String },
+
+    #[snafu(display("Expected output to be a Some"))]
+    OutputFormatAbsent,
 }
 
 /// Errors related to label topology formats.


### PR DESCRIPTION
The Trait ExecuteOptions requires a specific type from the this repo to work. This poses as a limitation for repos which use this codebase as a git module. This change adheres to the patterns where a clap::Parser struct instance is passed to the function, while removing dependency on the exact type of clap::Parser. Also, adds an output argument to support the existing users of this trait who depend on the CliArgs.output member from the cli_args arg.