### PR TITLE
fix(ha-node): use transport info from nvme connect response

### DIFF
--- a/control-plane/csi-driver/src/bin/node/dev/iscsi.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/iscsi.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::{dev::util::extract_uuid, match_dev::match_iscsi_device};
 
-use super::{Attach, Detach, DeviceError, DeviceName};
+use super::{Attach, AttachParameters, Detach, DeviceError, DeviceName};
 
 mod iscsiadm;
 use iscsiadm::IscsiAdmin;
@@ -169,6 +169,10 @@ impl Attach for IscsiAttach {
 
     async fn fixup(&self) -> Result<(), DeviceError> {
         Ok(())
+    }
+
+    fn attach_parameters(&self) -> AttachParameters {
+        AttachParameters::Iscsi
     }
 }
 

--- a/control-plane/csi-driver/src/bin/node/dev/nbd.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/nbd.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, convert::TryFrom};
 
 use url::Url;
 
-use super::{Attach, DeviceError, DeviceName};
+use super::{Attach, AttachParameters, DeviceError, DeviceName};
 
 pub(super) struct Nbd {
     path: String,
@@ -50,5 +50,9 @@ impl Attach for Nbd {
 
     async fn fixup(&self) -> Result<(), DeviceError> {
         Ok(())
+    }
+
+    fn attach_parameters(&self) -> AttachParameters {
+        AttachParameters::Nbd
     }
 }

--- a/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
@@ -26,7 +26,7 @@ use crate::{
     runtime,
 };
 
-use super::{Attach, Detach, DeviceError, DeviceName};
+use super::{Attach, AttachParameters, Detach, DeviceError, DeviceName};
 
 lazy_static::lazy_static! {
     static ref DEVICE_REGEX: Regex = Regex::new(r"nvme(\d{1,5})n(\d{1,5})").unwrap();
@@ -284,6 +284,14 @@ impl Attach for NvmfAttach {
             Ok(_) => Ok(()),
             Err(error) => Err(error),
         }
+    }
+
+    fn attach_parameters(&self) -> AttachParameters {
+        AttachParameters::Nvmf(super::NvmfAttachParameters {
+            _host: self.host.clone(),
+            _port: self.port,
+            transport: self.transport,
+        })
     }
 }
 

--- a/control-plane/grpc/proto/v1/ha/csi_node_nvme.proto
+++ b/control-plane/grpc/proto/v1/ha/csi_node_nvme.proto
@@ -10,8 +10,16 @@ message NvmeConnectRequest {
   common.MapWrapper publish_context = 2;
 }
 
-message NvmeConnectResponse {
+// chosen enum variant values to match these values as TrType in nvmeadm.
+enum TrType {
+  Invalid = 0;
+  Rdma = 1;
+  Fc = 2;
+  Tcp = 3;
+}
 
+message NvmeConnectResponse {
+  optional TrType transport_used = 1;
 }
 
 service NvmeOperations {


### PR DESCRIPTION
With tcpFallback option enabled, the csi-node can make a decision to connect an rdma capable target over tcp if the initiator is not rdma capable. However, after the NvmeConnectResponse is received at ha-node, the ha-node doesn't know that fallback could've happened. The ha-node blindly goes ahead validating the new path presence by matching using rdma transport parsed from target uri, which it doesn't find because new path got connected over tcp. This cascades a SubsystemNotFound error up to ha-cluster agent that reinitiates republish and keeps looping in same problem.
This fix passes the actual transport used for connect info from csi-node to ha-node in NvmeConnectResponse, letting ha-node validate using accurate transport.