### PR TITLE
Cherry Pick 914: use topology when decreasing replicas

### DIFF
--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -168,6 +168,21 @@ impl ChildSorters {
         match Self::sort_by_health(a, b) {
             Ordering::Equal => match Self::sort_by_child(a, b) {
                 Ordering::Equal => {
+                    // remove mismatched topology replicas first
+                    if let (Some(a), Some(b)) = (a.valid_node_topology(), b.valid_node_topology()) {
+                        match a.cmp(b) {
+                            Ordering::Equal => {}
+                            // todo: what if the pool and node topology are at odds with each other?
+                            _else => return _else,
+                        }
+                    }
+                    if let (Some(a), Some(b)) = (a.valid_pool_topology(), b.valid_pool_topology()) {
+                        match a.cmp(b) {
+                            Ordering::Equal => {}
+                            _else => return _else,
+                        }
+                    }
+
                     let childa_is_local = !a.spec().share.shared();
                     let childb_is_local = !b.spec().share.shared();
                     if childa_is_local == childb_is_local {

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -176,6 +176,8 @@ pub(crate) struct ReplicaItem {
     /// a Affinity Group and the already created volumes have replicas
     /// on this pool.
     ag_replicas_on_pool: Option<u64>,
+    valid_pool_topology: Option<bool>,
+    valid_node_topology: Option<bool>,
 }
 
 impl ReplicaItem {
@@ -197,7 +199,31 @@ impl ReplicaItem {
             child_spec,
             child_info,
             ag_replicas_on_pool,
+            valid_pool_topology: None,
+            valid_node_topology: None,
         }
+    }
+    /// Set the validity of the replica's node topology.
+    /// If set to false, this means the replica is not in sync with the volume topology and
+    /// therefore should be replaced by another replica which is in sync.
+    pub(crate) fn with_node_topology(mut self, valid_node_topology: Option<bool>) -> ReplicaItem {
+        self.valid_node_topology = valid_node_topology;
+        self
+    }
+    /// Set the validity of the replica's pool topology.
+    /// If set to false, this means the replica is not in sync with the volume topology and
+    /// therefore should be replaced by another replica which is in sync.
+    pub(crate) fn with_pool_topology(mut self, valid_pool_topology: Option<bool>) -> ReplicaItem {
+        self.valid_pool_topology = valid_pool_topology;
+        self
+    }
+    /// Get a reference to the node topology validity flag.
+    pub(crate) fn valid_node_topology(&self) -> &Option<bool> {
+        &self.valid_node_topology
+    }
+    /// Get a reference to the pool topology validity flag.
+    pub(crate) fn valid_pool_topology(&self) -> &Option<bool> {
+        &self.valid_pool_topology
     }
     /// Get a reference to the replica spec.
     pub(crate) fn spec(&self) -> &ReplicaSpec {


### PR DESCRIPTION
When removing volume replicas, take the topology into account and prefer to remove replicas which don't line up with the volume topology. This can happen when a volume's topology has been modified.