### PR TITLE
fix(csi/node): patch ana label with merge

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
+      - run: echo "CI_REPORT_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
       - uses: DeterminateSystems/nix-installer-action@v14
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Pre-populate nix-shell
@@ -35,26 +36,26 @@ jobs:
         run: |
           nix-shell --run "deployer start --image-pull-policy always -w 60s && deployer stop"
           nix-shell --run "./scripts/python/test.sh"
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: failed-docker-logs
-          path: docker-logs.txt
       - name: Cleanup
         if: always()
         run: |
+          nix-shell --run "./scripts/ci-report.sh"
           nix-shell --run "./scripts/python/test-residue-cleanup.sh"
-          cat /proc/meminfo | grep -i huge
-      - name: Surface failing tests
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ci-report-bdd
+          path: ./ci-report/ci-report.tar.gz
+      - name: Pytest BDD Report
         if: always()
         uses: pmeier/pytest-results-action@main
         with:
-          path: report.xml
+          path: ci-report/bdd-report.xml
           summary: true
           display-options: a
           fail-on-empty: true
           title: Test results
-# debugging
+      # debugging
       # - name: Setup tmate session
       #   if: ${{ failure() }}
       #   timeout-minutes: 240

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
+      - run: echo "CI_REPORT_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
       - uses: DeterminateSystems/nix-installer-action@v14
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Pre-populate nix-shell
@@ -38,13 +39,20 @@ jobs:
       - name: Run Tests
         run: |
           # pre-pull the required container images
-          deployer start --image-pull-policy always -w 60s && deployer stop
+          nix-shell --run "deployer start --image-pull-policy always -w 60s && deployer stop"
           # includes both unit and integration tests
           nix-shell --run "./scripts/rust/test.sh"
       - name: Cleanup
         if: always()
-        run: nix-shell --run "./scripts/rust/deployer-cleanup.sh"
-# debugging
+        run: |
+          nix-shell --run "./scripts/ci-report.sh"
+          nix-shell --run "./scripts/rust/deployer-cleanup.sh"
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ci-report-int
+          path: ./ci-report/ci-report.tar.gz
+      # debugging
       # - name: Setup tmate session
       #   if: ${{ failure() }}
       #   timeout-minutes: 120

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __pycache__
 /report.xml
 /docker-logs.txt
 /.tmp
+/ci-report/

--- a/control-plane/csi-driver/src/bin/node/k8s.rs
+++ b/control-plane/csi-driver/src/bin/node/k8s.rs
@@ -16,8 +16,8 @@ pub(crate) async fn patch_k8s_node(
     match nodes
         .patch(
             node_name,
-            &PatchParams::apply("node_label_patch").force(),
-            &Patch::Apply(node_patch),
+            &PatchParams::default(),
+            &Patch::Merge(node_patch),
         )
         .await
     {

--- a/scripts/ci-report.sh
+++ b/scripts/ci-report.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(dirname "$0")"
+export ROOT_DIR="$SCRIPT_DIR/.."
+SUDO=$(which sudo)
+CI_REPORT_START_DATE=${CI_REPORT_START_DATE:--3h}
+
+set -eu
+
+mkdir -p "$ROOT_DIR/ci-report"
+cd "$ROOT_DIR/ci-report"
+
+journalctl --since="$CI_REPORT_START_DATE" -o short-precise > journalctl.txt
+journalctl -k -b0 -o short-precise > dmesg.txt
+lsblk -tfa > lsblk.txt
+$SUDO nvme list -v > nvme.txt
+$SUDO nvme list-subsys -v >> nvme.txt
+cat /proc/meminfo > meminfo.txt
+
+find . -type f \( -name "*.txt" -o -name "*.xml" \) -print0 | xargs -0 tar -czvf ci-report.tar.gz

--- a/scripts/python/test.sh
+++ b/scripts/python/test.sh
@@ -15,8 +15,9 @@ set -e
 
 SCRIPT_DIR="$(dirname "$0")"
 export ROOT_DIR="$SCRIPT_DIR/../.."
-REPORT="$ROOT_DIR/report.xml"
-export FAILED_DOCKER_LOGS="$ROOT_DIR/docker-logs.txt"
+CI_REPORT="$ROOT_DIR/ci-report"
+REPORT="$CI_REPORT/bdd-report.xml"
+export FAILED_DOCKER_LOGS="$CI_REPORT/docker-logs.txt"
 
 cleanup() {
   "$SCRIPT_DIR"/test-residue-cleanup.sh || true
@@ -50,6 +51,8 @@ cleanup >/dev/null
 if ! [[ "${DISABLE[*]}" =~ "${CLEAN:-yes}" ]]; then
   trap cleanup_handler INT QUIT TERM HUP EXIT
 fi
+
+mkdir -p "$CI_REPORT"
 
 # Extra arguments will be provided directly to pytest, otherwise the bdd folder will be tested with default arguments
 if [ $# -eq 0 ]; then

--- a/scripts/rust/deployer-cleanup.sh
+++ b/scripts/rust/deployer-cleanup.sh
@@ -8,8 +8,7 @@ cleanup_ws_tmp() {
   # This contains tmp for container artifacts, example: pool disk images
   tmp_dir="$(realpath "$ROOT_DIR/.tmp")"
 
-  devices=$(losetup -l -J | jq -r --arg tmp_dir=$tmp_dir '.loopdevices[]|select(."back-file" | startswith($tmp_dir))')
-  for device in $(echo $devices | jq -r '.loopdevices[].name'); do
+  for device in $(losetup -l -J | jq -r --arg tmp_dir $tmp_dir '.loopdevices[]|select(."back-file" | startswith($tmp_dir)) | .name'); do
     echo "Found stale loop device: $device"
 
     $SUDO $(which vgremove) -y --select="pv_name=$device" || :

--- a/utils/deployer-cluster/src/lvm.rs
+++ b/utils/deployer-cluster/src/lvm.rs
@@ -2,6 +2,38 @@
 
 use crate::TmpDiskFile;
 
+/// Possible device states are SUSPENDED, ACTIVE, and READ-ONLY.
+/// The dmsetup suspend command sets a device state to SUSPENDED.
+/// When a device is suspended, all I/O operations to that device stop.
+/// The dmsetup resume command restores a device state to ACTIVE.
+#[derive(Eq, PartialEq)]
+pub enum DMState {
+    Suspended,
+    Active,
+    ReadOnly,
+}
+impl TryFrom<&str> for DMState {
+    type Error = anyhow::Error;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value.to_uppercase().as_str() {
+            "SUSPENDED" => Ok(Self::Suspended),
+            "ACTIVE" => Ok(Self::Active),
+            "READ-ONLY" => Ok(Self::ReadOnly),
+            state => Err(anyhow::anyhow!("Unknown state: {state}")),
+        }
+    }
+}
+impl std::fmt::Display for DMState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = match self {
+            DMState::Suspended => "Suspended",
+            DMState::Active => "Active",
+            DMState::ReadOnly => "Read-Only",
+        };
+        write!(f, "{state}")
+    }
+}
+
 /// An LVM Logical Volume.
 pub struct Lvol {
     name: String,
@@ -13,14 +45,59 @@ impl Lvol {
         &self.path
     }
     /// Suspends the device for IO.
+    /// # Warning
+    /// The device is only suspended once the open count reaches 0.
+    /// This means the device might not be suspended after the suspend call completes.
+    /// More over, seems the device is also not blocked for new open calls!
+    /// You should consider using [Self::suspend_await].
     pub fn suspend(&self) -> anyhow::Result<()> {
         let _ = VolGroup::command(&["dmsetup", "suspend", self.path.as_str()])?;
         Ok(())
+    }
+    /// Suspends the device for IO and awaits for it to be suspended.
+    pub async fn suspend_await(&self) -> anyhow::Result<()> {
+        self.suspend()?;
+        self.await_state(DMState::Suspended, std::time::Duration::from_secs(10))
+            .await?;
+        Ok(())
+    }
+    /// Waits until the device reaches the given state for up to the given timeout.
+    pub async fn await_state(
+        &self,
+        wanted_state: DMState,
+        timeout: std::time::Duration,
+    ) -> anyhow::Result<()> {
+        let start = std::time::Instant::now();
+        let mut state = self.dm_state()?;
+        loop {
+            if state == wanted_state {
+                return Ok(());
+            }
+            if start.elapsed() > timeout {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            state = self.dm_state()?;
+        }
+        Err(anyhow::anyhow!(
+            "Failed to reach {wanted_state}, current: {state}"
+        ))
     }
     /// Resumes the device for IO.
     pub fn resume(&self) -> anyhow::Result<()> {
         let _ = VolGroup::command(&["dmsetup", "resume", self.path.as_str()])?;
         Ok(())
+    }
+    /// Get the dmsetup info.
+    pub fn dm_info(&self) -> anyhow::Result<String> {
+        let output = VolGroup::command(&["dmsetup", "info", self.path.as_str()])?;
+        Ok(output)
+    }
+    fn dm_state(&self) -> anyhow::Result<DMState> {
+        let output =
+            VolGroup::command(&["dmsetup", "info", "-C", "-osuspended", self.path.as_str()])?;
+        let state = output.lines().skip(1).collect::<String>();
+        DMState::try_from(state.as_str())
     }
 }
 impl Drop for Lvol {
@@ -42,10 +119,18 @@ impl VolGroup {
     pub fn new(name: &str, size: u64) -> Result<Self, anyhow::Error> {
         let backing_file = TmpDiskFile::new(name, size);
 
-        let dev_loop = Self::command(&["losetup", "--show", "-f", backing_file.path()])?;
+        let dev_loop = Self::command(&[
+            "losetup",
+            "--show",
+            "--direct-io=on",
+            "-f",
+            backing_file.path(),
+        ])?;
         let dev_loop = dev_loop.trim_end().to_string();
         let _ = Self::command(&["pvcreate", dev_loop.as_str()])?;
-        let _ = Self::command(&["vgcreate", name, dev_loop.as_str()])?;
+        // We disable auto activation here, otherwise when the systemd activation service runs
+        // it may activate all the Lvols, which is not always wanted.
+        let _ = Self::command(&["vgcreate", "--setautoactivation=n", name, dev_loop.as_str()])?;
 
         Ok(Self {
             backing_file,
@@ -68,14 +153,13 @@ impl VolGroup {
     /// Run a command with sudo, and the given args.
     /// The output string is returned.
     fn command(args: &[&str]) -> Result<String, anyhow::Error> {
-        let cmd = args.first().unwrap();
-        let output = std::process::Command::new(env!("SUDO"))
-            .arg("-E")
-            .args(args)
-            .output()?;
+        let mut binding = std::process::Command::new(env!("SUDO"));
+        let cmd = binding.arg("-E").args(args);
+        let output = cmd.output()?;
         if !output.status.success() {
             return Err(anyhow::anyhow!(
-                "{cmd} Exit Code: {}\nstdout: {}, stderr: {}",
+                "{:?} Exit Code: {}\nstdout: {}, stderr: {}",
+                cmd.get_args(),
                 output.status,
                 String::from_utf8(output.stdout).unwrap_or_default(),
                 String::from_utf8(output.stderr).unwrap_or_default()
@@ -94,7 +178,22 @@ impl Drop for VolGroup {
             self.backing_file.path()
         );
 
-        let _ = Self::command(&["vgremove", "-y", self.name.as_str()]);
-        let _ = Self::command(&["losetup", "-d", self.dev_loop.as_str()]);
+        let now = std::time::Instant::now();
+        while now.elapsed() < std::time::Duration::from_secs(2) {
+            let remove = Self::command(&["vgremove", "-f", "-y", self.name.as_str()]);
+            println!("{remove:?}");
+            if remove.is_ok() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(150));
+        }
+        println!(
+            "{:?}",
+            Self::command(&["pvremove", "-f", "-y", self.dev_loop.as_str()])
+        );
+        println!(
+            "{:?}",
+            Self::command(&["losetup", "-d", self.dev_loop.as_str()])
+        );
     }
 }


### PR DESCRIPTION
    ci(gha): upload test report
    
    Add test script which generates a report tar with useful
    information such as journalctl logs and nvme devices
    Upload this tar on github actions
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test(dmsetup): ensure lvm device suspended
    
    The slow_pool tests fails on CI because of 2 separate reasons:
    1. we need to wait until device is susppended
    2. we need to disable auto activation of the VG which actives the LVs
    
    Adds a busy-wait until the device is suspended.
    Also setup losetup with direct io on always.
    Adds a bit more logging in case things go awry.
    Disables VG auto activation.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    test: cleanup loop devices properly
    
    The = sign is not part of the jq arg, so remove it.
    Also simplify the whole thing in a single jq command.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(csi/node): patch ana label with merge
    
    Previously a server-side apply was being used which seems to have issues on some k8s
    clusters with dual ip stack.
    Here we're patching a label so a merge patch should suffice.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
