### PR TITLE
fix(reconciler/volume): disown replica from disowned volumes nexus

### DIFF
--- a/control-plane/stor-port/src/types/v0/store/replica.rs
+++ b/control-plane/stor-port/src/types/v0/store/replica.rs
@@ -8,8 +8,9 @@ use crate::{
             AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
         },
         transport::{
-            self, CreateReplica, HostNqn, PoolId, PoolUuid, Protocol, ReplicaId, ReplicaKind,
-            ReplicaName, ReplicaOwners, ReplicaShareProtocol, SnapshotCloneSpecParams, VolumeId,
+            self, CreateReplica, HostNqn, NexusId, PoolId, PoolUuid, Protocol, ReplicaId,
+            ReplicaKind, ReplicaName, ReplicaOwners, ReplicaShareProtocol, SnapshotCloneSpecParams,
+            VolumeId,
         },
     },
     IntoOption,
@@ -108,6 +109,13 @@ impl ReplicaSpec {
     /// Check if this replica is owned by the volume.
     pub fn owned_by(&self, id: &VolumeId) -> bool {
         self.owners.owned_by(id)
+    }
+    /// Check if this replica is owned by any of the nexus in volume spec.
+    pub fn owned_by_nexus(&self, nexus_id: &[&NexusId]) -> bool {
+        self.owners
+            .nexuses()
+            .iter()
+            .any(|owner| nexus_id.contains(&owner))
     }
 }
 


### PR DESCRIPTION
While we disown a replica from volume we used to validate if the replica is owned by any nexus. In some cases involving Outage on volume target node we observed that the new nexus do get created after the volumeattachments are deleted from the node. However, we werent able to disown the Unknown replica from volume since it was still owned by old target.

Now we check if replica is owned by the current target of the volume rather then if it is owned by any target.