### PR TITLE
Feature: Configuring rest components for TLS

### DIFF
--- a/control-plane/csi-driver/src/bin/controller/config.rs
+++ b/control-plane/csi-driver/src/bin/controller/config.rs
@@ -1,7 +1,11 @@
 use anyhow::Context;
 use clap::ArgMatches;
 use once_cell::sync::OnceCell;
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 static CONFIG: OnceCell<CsiControllerConfig> = OnceCell::new();
 
@@ -17,6 +21,8 @@ pub(crate) struct CsiControllerConfig {
     create_volume_limit: usize,
     /// Force unstage volume.
     force_unstage_volume: bool,
+    /// Path to the CA certificate file.
+    ca_certificate_path: Option<PathBuf>,
 }
 
 impl CsiControllerConfig {
@@ -50,7 +56,9 @@ impl CsiControllerConfig {
             tracing::warn!(
                 "Force unstage volume is disabled, can trigger potential data corruption!"
             );
-        }
+        };
+
+        let ca_certificate_path: Option<&PathBuf> = args.get_one::<PathBuf>("tls-client-ca-path");
 
         CONFIG.get_or_init(|| Self {
             rest_endpoint: rest_endpoint.into(),
@@ -58,6 +66,7 @@ impl CsiControllerConfig {
             node_selector,
             create_volume_limit,
             force_unstage_volume,
+            ca_certificate_path: ca_certificate_path.cloned(),
         });
         Ok(())
     }
@@ -91,5 +100,10 @@ impl CsiControllerConfig {
     /// Force unstage volume.
     pub(crate) fn force_unstage_volume(&self) -> bool {
         self.force_unstage_volume
+    }
+
+    /// Path to the CA certificate file.
+    pub(crate) fn ca_certificate_path(&self) -> Option<&Path> {
+        self.ca_certificate_path.as_deref()
     }
 }

--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -131,6 +131,11 @@ async fn main() -> anyhow::Result<()> {
                 .value_parser(clap::value_parser!(bool))
                 .help("Enable force unstage volume feature")
         )
+        .arg(
+            Arg::new("tls-client-ca-path")
+                .long("tls-client-ca-path")
+                .help("path to the CA certificate file")
+        )
         .get_matches();
 
     utils::print_package_info!();

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -185,6 +185,7 @@ fn load_certificates<R: std::io::Read>(
         .map_err(|_| {
             anyhow::anyhow!("Failed to retrieve the rsa private keys from the key file",)
         })?;
+
     if keys.is_empty() {
         anyhow::bail!("No keys found in the keys file");
     }


### PR DESCRIPTION
This PR configures components using rest protocols to speak tls.  It is dependent on [this PR in extensions repo](https://github.com/openebs/mayastor-extensions/pull/622). 

### Rest-api Clients 
- Modified certificate loading to use pkcs8_private_keys instead of rsa_private_keys.  This was a change I made to get the generated certificates to work, they were apparently created in pkcs8 format, not rsa - I attempted to convert them with no luck, and found the pkcs8_private_keys in the [rustl-pemfile crate](https://docs.rs/rustls-pemfile/latest/rustls_pemfile/)...
### Csi-controller and Diskpool operator:
- Added support for TLS configuration based on CA certificate path.
- if certs are provided, use https, if not use http.
-  error handling for HTTPS connections without a certificate etc


