### PR TITLE
HA: ReShutdown the Target

### DIFF
--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -208,6 +208,7 @@ async fn lazy_delete_shutdown_targets() {
         .with_tmpfs_pool(POOL_SIZE_BYTES)
         .with_cache_period("1s")
         .with_reconcile_period(Duration::from_secs(1), Duration::from_secs(1))
+        .with_req_timeouts(Duration::from_secs(1), Duration::from_secs(1))
         .build()
         .await
         .unwrap();
@@ -301,6 +302,18 @@ async fn lazy_delete_shutdown_targets() {
         .unwrap();
 
     wait_till_target_deleted(&nx_cli, &first_target).await;
+
+    vol_cli
+        .destroy(
+            &DestroyVolume {
+                uuid: volume.uuid().clone(),
+            },
+            None,
+        )
+        .await
+        .expect("failed to delete volume");
+
+    reshutdown(&cluster).await;
 }
 
 async fn find_target(client: &impl RegistryOperations, target: &Nexus) -> Option<NexusSpec> {
@@ -689,4 +702,89 @@ async fn wait_till_pool_locked(cluster: &Cluster) -> bool {
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
+}
+
+async fn reshutdown(cluster: &Cluster) {
+    let client = cluster.grpc_client().volume();
+
+    client
+        .create(
+            &CreateVolume {
+                uuid: VOLUME_UUID.try_into().unwrap(),
+                size: 5242880,
+                replicas: 2,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let _volume = client
+        .publish(
+            &PublishVolume {
+                uuid: VOLUME_UUID.try_into().unwrap(),
+                share: Some(VolumeShareProtocol::Nvmf),
+                target_node: Some(cluster.node(1)),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![cluster.node(1).to_string()],
+            },
+            None,
+        )
+        .await
+        .expect("Volume publish should have succeeded.");
+
+    cluster.composer().pause(&cluster.node(1)).await.unwrap();
+    cluster.composer().pause(&cluster.node(0)).await.unwrap();
+
+    // Republishing volume after node restart.
+    let _volume = client
+        .republish(
+            &RepublishVolume {
+                uuid: VOLUME_UUID.try_into().unwrap(),
+                share: VolumeShareProtocol::Nvmf,
+                target_node: None,
+                reuse_existing: false,
+                frontend_node: cluster.node(1),
+                reuse_existing_fallback: false,
+            },
+            None,
+        )
+        .await
+        .expect_err("Volume republish should have not succeeded.");
+
+    cluster.composer().restart(&cluster.node(0)).await.unwrap();
+    cluster.composer().thaw(&cluster.node(1)).await.unwrap();
+
+    cluster
+        .wait_node_status(cluster.node(0), NodeStatus::Online)
+        .await
+        .unwrap();
+    cluster
+        .wait_node_status(cluster.node(1), NodeStatus::Online)
+        .await
+        .unwrap();
+
+    client
+        .destroy_shutdown_target(
+            &DestroyShutdownTargets::new(VOLUME_UUID.try_into().unwrap(), None),
+            None,
+        )
+        .await
+        .expect("Volume Destroy should succeed.");
+
+    let _volume = client
+        .republish(
+            &RepublishVolume {
+                uuid: VOLUME_UUID.try_into().unwrap(),
+                share: VolumeShareProtocol::Nvmf,
+                target_node: None,
+                reuse_existing: true,
+                frontend_node: cluster.node(1),
+                reuse_existing_fallback: true,
+            },
+            None,
+        )
+        .await
+        .expect("Volume republish should have succeeded.");
 }

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -498,7 +498,10 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         let mut older_nexus = specs.nexus(target_cfg.target().nexus()).await?;
         let mut move_nexus = true;
         let mut nexus_node = None;
-        match healthy_volume_replicas(&spec, &older_nexus.as_ref().node, registry).await {
+        let healthy_replicas_result =
+            healthy_volume_replicas(&spec, &older_nexus.as_ref().node, registry).await;
+        let healthy_replicas = healthy_replicas_result.is_ok();
+        match healthy_replicas_result {
             Ok(_) => {
                 let reuse_existing = match request.reuse_existing_fallback
                     && !request.reuse_existing
@@ -560,7 +563,10 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
 
         // Shutdown the older nexus before newer nexus creation.
         let result = older_nexus
-            .shutdown(registry, &ShutdownNexus::new(older_nexus_id, true))
+            .shutdown(
+                registry,
+                &ShutdownNexus::new(older_nexus_id, true, !healthy_replicas),
+            )
             .await;
         self.validate_update_step(registry, result, &spec_clone)
             .await?;

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -742,6 +742,10 @@ impl ResourceShutdownOperations for OperationGuardArc<VolumeSpec> {
         for nexus_res in shutdown_nexuses {
             match nexus_res.operation_guard_wait().await {
                 Ok(mut guard) => {
+                    if self.as_ref().target_uuid() == Some(nexus_res.uuid()) {
+                        // don't remove the current target!
+                        continue;
+                    }
                     if let Ok(nexus) = registry.nexus(nexus_res.uuid()).await {
                         if Self::target_registered(request.registered_targets(), nexus)? {
                             continue;

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -641,7 +641,9 @@ impl ResourceSpecsLocked {
             .values()
             .filter(|nexus| {
                 let nexus_spec = nexus.lock();
-                nexus_spec.name == id.as_str() && nexus_spec.status_info().shutdown_failed()
+                nexus_spec.name == id.as_str()
+                    && (nexus_spec.status_info().shutdown_failed()
+                        && !nexus_spec.status_info().reshutdown())
             })
             .cloned()
             .collect()

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -387,6 +387,10 @@ impl VolumeSpec {
             .filter(|t| t.active)
             .map(|t| &t.target)
     }
+    /// Get the currently active target uuid.
+    pub fn target_uuid(&self) -> Option<&NexusId> {
+        self.target().map(|t| &t.nexus)
+    }
     /// Get the target.
     pub fn target_mut(&mut self) -> Option<&mut VolumeTarget> {
         self.target_config.as_mut().map(|t| &mut t.target)

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -624,12 +624,18 @@ pub struct ShutdownNexus {
     /// Shutdown the nexus spec even if the node is offline.
     /// The reconcilers will pick up the slack.
     lazy: bool,
+    /// Confirm shutdown by re-issuing the shutdown.
+    confirm: bool,
 }
 
 impl ShutdownNexus {
     /// Create a new `ShutdownNexus` using `uuid`.
-    pub fn new(uuid: NexusId, lazy: bool) -> Self {
-        Self { uuid, lazy }
+    pub fn new(uuid: NexusId, lazy: bool, confirm: bool) -> Self {
+        Self {
+            uuid,
+            lazy,
+            confirm,
+        }
     }
     /// Get uuid of the nexus.
     pub fn uuid(&self) -> NexusId {
@@ -643,6 +649,10 @@ impl ShutdownNexus {
     /// Get the lazy flag.
     pub fn lazy(&self) -> bool {
         self.lazy
+    }
+    /// Get the shutdown confirmation flag.
+    pub fn confirm(&self) -> bool {
+        self.confirm
     }
 }
 


### PR DESCRIPTION
    fix(ha/shutdown): don't remove the current target
    
    Ensure we don't destroy the current target during a shutdown target removal
    call from the ha cluster agent.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(ha/target/shutdown): reshutdown current target
    
    When the only remaining healthy replica is local to a failed shutdown target,
    the volume will fail to republish.
    In this case, ensure we confirm the shutdown of the target, which will allow
    the volume to be re-published.
    
    Adds a test which simulates this condition.
