### PR TITLE
ci(gha): disable man-pages update

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -29,6 +29,8 @@ jobs:
         run: nix-shell --run "cargo build --bins"
       - name: Setup Test Pre-Requisites
         run: |
+          sudo debconf-communicate <<< "set man-db/auto-update false" || true
+          sudo dpkg-reconfigure man-db || true
           sudo sysctl -w vm.nr_hugepages=3072
           sudo apt-get install linux-modules-extra-$(uname -r)
           sudo modprobe nvme_tcp

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -33,6 +33,8 @@ jobs:
         run: nix-shell --run "./scripts/rust/test.sh --no-run"
       - name: Setup Test Pre-Requisites
         run: |
+          sudo debconf-communicate <<< "set man-db/auto-update false" || true
+          sudo dpkg-reconfigure man-db || true
           sudo sysctl -w vm.nr_hugepages=2560
           sudo apt-get install linux-modules-extra-$(uname -r)
           sudo modprobe nvme_tcp


### PR DESCRIPTION
When running image test we install kernel modules which triggers a very
 slow update of man-pages.