### PR TITLE
feat(encryption): add diskpool operator and secret persistence changes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -90,6 +90,7 @@ impl IoEngineToAgent for v0::Pool {
             capacity: self.capacity,
             used: self.used,
             committed: None,
+            encrypted: false,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -11,18 +11,18 @@ use stor_port::{
     transport_api::ResourceKind,
     types::v0::{
         openapi::apis::IntoVec,
+        store::pool::{Encryption, EncryptionSecret},
         transport::{
-            self, ChildState, ChildStateReason, Cipher, Encryption, EncryptionKey, Nexus, NexusId,
-            NexusNvmePreemption, NexusNvmfConfig, NexusStatus, NodeId, NvmeReservation, PoolState,
-            PoolUuid, Protocol, Replica, ReplicaId, ReplicaKind, ReplicaName, ReplicaStatus,
-            SetReplicaEntityId, SnapshotId, VolumeId,
+            self, ChildState, ChildStateReason, Nexus, NexusId, NexusNvmePreemption,
+            NexusNvmfConfig, NexusStatus, NodeId, NvmeReservation, PoolState, PoolUuid, Protocol,
+            Replica, ReplicaId, ReplicaKind, ReplicaName, ReplicaStatus, SetReplicaEntityId,
+            SnapshotId, VolumeId,
         },
     },
     IntoOption,
 };
 
 use std::{convert::TryFrom, time::UNIX_EPOCH};
-use stor_port::types::v0::transport::{EncryptionData, EncryptionSecret};
 
 /// Trait for converting agent messages to io-engine messages.
 pub(super) trait AgentToIoEngine {
@@ -657,6 +657,7 @@ impl IoEngineToAgent for v1::pool::Pool {
             } else {
                 Some(self.committed)
             },
+            encrypted: self.encrypted.unwrap_or_default(),
         }
     }
 }
@@ -883,7 +884,6 @@ impl From<ExternalType<Encryption>> for v1::pb::create_pool_request::Encryption 
     fn from(value: ExternalType<Encryption>) -> Self {
         match value.0 {
             Encryption::Secret(secret) => Self::Secret(From::from(ExternalType(secret))),
-            Encryption::Data(data) => Self::Data(From::from(ExternalType(data))),
         }
     }
 }
@@ -892,17 +892,6 @@ impl From<ExternalType<Encryption>> for v1::pb::import_pool_request::Encryption 
     fn from(value: ExternalType<Encryption>) -> Self {
         match value.0 {
             Encryption::Secret(secret) => Self::Secret(From::from(ExternalType(secret))),
-            Encryption::Data(data) => Self::Data(From::from(ExternalType(data))),
-        }
-    }
-}
-
-impl From<ExternalType<EncryptionData>> for v1::pb::EncryptionData {
-    fn from(value: ExternalType<EncryptionData>) -> Self {
-        let cipher: v1::pb::Cipher = From::from(ExternalType(value.0.cipher));
-        Self {
-            cipher: cipher as i32,
-            key: Some(From::from(ExternalType(value.0.key))),
         }
     }
 }
@@ -910,28 +899,7 @@ impl From<ExternalType<EncryptionData>> for v1::pb::EncryptionData {
 impl From<ExternalType<EncryptionSecret>> for v1::pb::EncryptionSecret {
     fn from(value: ExternalType<EncryptionSecret>) -> Self {
         Self {
-            secret: value.0.secret,
-        }
-    }
-}
-
-impl From<ExternalType<Cipher>> for v1::pb::Cipher {
-    fn from(value: ExternalType<Cipher>) -> Self {
-        match value.0 {
-            Cipher::AesCbc => v1::pb::Cipher::AesCbc,
-            Cipher::AesXts => v1::pb::Cipher::AesXts,
-        }
-    }
-}
-
-impl From<ExternalType<EncryptionKey>> for v1::pb::EncryptionKey {
-    fn from(value: ExternalType<EncryptionKey>) -> Self {
-        Self {
-            key_name: value.0.key_name,
-            key: value.0.key,
-            key_length: value.0.key_length,
-            key2: value.0.key2,
-            key2_length: value.0.key2_length,
+            secret: value.0.name,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
@@ -145,7 +145,7 @@ async fn missing_pool_state_reconciler(
         async {
             pool_spec.warn_span(|| tracing::warn!("Attempting to recreate missing pool"));
 
-            let request = ImportPool::new(&pool_spec.node, &pool_spec.id, &pool_spec.disks);
+            let request = ImportPool::new(&pool_spec.node, &pool_spec.id, &pool_spec.disks, &pool_spec.encryption);
             match node.import_pool(&request).await {
                 Ok(_) => {
                     pool_spec.info_span(|| tracing::info!("Pool successfully recreated"));

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -272,6 +272,7 @@ mod tests {
             capacity,
             used,
             committed: None,
+            encrypted: false,
         };
         let replica = Replica::default();
         let pool = PoolWrapper::new(

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -153,6 +153,7 @@ fn test_deserialization_v1_to_v2() {
                 sequencer: Default::default(),
                 operation: None,
                 creat_tsc: None,
+                encryption: None,
             }),
         },
         TestEntry {

--- a/control-plane/grpc/proto/v1/misc/common.proto
+++ b/control-plane/grpc/proto/v1/misc/common.proto
@@ -216,36 +216,8 @@ message MapWrapper {
   map<string, string> map = 1;
 }
 
-// Cipher to use for encryption.
-enum Cipher {
-  AES_CBC = 0;
-  AES_XTS = 1;
-}
-
-// Represents an encryption key that can be used to encrypt an
-// entity like pool or lvol/replica.
-message EncryptionKey {
-  // Name of the key.
-  string key_name = 1;
-  // The AES encryption key.
-  bytes key = 2;
-  // AES Key length.
-  uint32 key_length = 3;
-  // key2 (required for AES_XTS).
-  optional bytes key2 = 4;
-  // The length of key2. Must be same as key_length.
-  optional uint32 key2_length = 5;
-}
-
-message EncryptionData {
-  // Cipher to be used.
-  Cipher cipher = 1;
-  // The encryption key.
-  EncryptionKey key = 2;
-}
-
 // This message represents name of the source for getting
 // key parameter details.
 message EncryptionSecret {
-  string secret = 1;
+  string name = 1;
 }

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -46,6 +46,8 @@ message PoolSpec {
   repeated string disks = 3;
   // labels to be set on the pool
   optional common.StringMapValue labels = 5;
+  // Encryption details
+  optional common.EncryptionSecret secret = 6;
 }
 
 // Pool information
@@ -64,6 +66,8 @@ message PoolState {
   uint64 used = 6;
   // total size of pool replicas
   optional uint64 committed = 7;
+  // Is the pool encrypted.
+  optional bool encrypted = 8;
 }
 
 // status of the pool
@@ -101,8 +105,7 @@ message CreatePoolRequest {
   // Encryption parameters for this pool. Either as raw key params, OR a name to a Kubernetes
   // Secret resource or a file.
   oneof encryption {
-    common.EncryptionData data = 6;
-    common.EncryptionSecret secret = 7;
+    common.EncryptionSecret secret = 6;
   }
 }
 

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -11,18 +11,16 @@ use crate::{
 use stor_port::{
     transport_api::{v0::Pools, ReplyError, ResourceKind},
     types::v0::{
-        store::pool::{PoolLabel, PoolSpec, PoolSpecStatus},
+        store::pool::{Encryption, EncryptionSecret, PoolLabel, PoolSpec, PoolSpecStatus},
         transport::{
-            Cipher, CreatePool, CtrlPoolState, DestroyPool, Encryption, EncryptionData,
-            EncryptionKey, Filter, LabelPool, NodeId, Pool, PoolDeviceUri, PoolId, PoolState,
-            PoolStatus, UnlabelPool, VolumeId,
+            CreatePool, CtrlPoolState, DestroyPool, Filter, LabelPool, NodeId, Pool, PoolDeviceUri,
+            PoolId, PoolState, PoolStatus, UnlabelPool, VolumeId,
         },
     },
     IntoOption,
 };
 
 use std::{collections::HashMap, convert::TryFrom};
-use stor_port::types::v0::transport::EncryptionSecret;
 
 /// Trait implemented by services which support pool operations.
 #[tonic::async_trait]
@@ -99,6 +97,9 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
             sequencer: Default::default(),
             operation: None,
             creat_tsc: None,
+            encryption: pool_spec
+                .secret
+                .map(|details| Encryption::Secret(EncryptionSecret { name: details.name })),
         })
     }
 }
@@ -124,6 +125,7 @@ impl TryFrom<pool::PoolState> for PoolState {
             capacity: pool_state.capacity,
             used: pool_state.used,
             committed: pool_state.committed,
+            encrypted: pool_state.encrypted.unwrap_or_default(),
         })
     }
 }
@@ -164,6 +166,14 @@ impl From<PoolSpec> for pool::PoolDefinition {
                 labels: pool_spec
                     .labels
                     .map(|labels| crate::common::StringMapValue { value: labels }),
+                secret: match pool_spec.encryption {
+                    None => None,
+                    Some(config) => match config {
+                        Encryption::Secret(details) => {
+                            Some(common::EncryptionSecret { name: details.name })
+                        }
+                    },
+                },
             }),
             metadata: Some(pool::Metadata {
                 uuid: None,
@@ -183,6 +193,7 @@ impl From<PoolState> for pool::PoolState {
             capacity: pool_state.capacity,
             used: pool_state.used,
             committed: pool_state.committed,
+            encrypted: Some(pool_state.encrypted),
         }
     }
 }
@@ -327,15 +338,6 @@ impl ValidateRequestTypes for CreatePoolRequest {
             encryption: match self.encryption.clone() {
                 None => None,
                 Some(encryption) => match encryption {
-                    pool::create_pool_request::Encryption::Data(data) => Some(Encryption::Data(
-                        EncryptionData::try_from(data).map_err(|error| {
-                            ReplyError::invalid_argument(
-                                ResourceKind::Pool,
-                                "create_pool_request.encryption",
-                                error.to_string(),
-                            )
-                        })?,
-                    )),
                     pool::create_pool_request::Encryption::Secret(secret) => {
                         Some(Encryption::Secret(secret.into()))
                     }
@@ -558,95 +560,24 @@ impl From<&dyn UnlabelPoolInfo> for UnlabelPool {
     }
 }
 
-impl From<common::Cipher> for Cipher {
-    fn from(value: common::Cipher) -> Self {
-        match value {
-            common::Cipher::AesCbc => Self::AesCbc,
-            common::Cipher::AesXts => Self::AesXts,
-        }
-    }
-}
-
-impl From<Cipher> for common::Cipher {
-    fn from(value: Cipher) -> Self {
-        match value {
-            Cipher::AesCbc => common::Cipher::AesCbc,
-            Cipher::AesXts => common::Cipher::AesXts,
-        }
-    }
-}
-
-impl TryFrom<common::EncryptionData> for EncryptionData {
-    type Error = ReplyError;
-
-    fn try_from(value: common::EncryptionData) -> Result<Self, Self::Error> {
-        let cipher: common::Cipher = common::Cipher::try_from(value.cipher).map_err(|error| {
-            ReplyError::invalid_argument(
-                ResourceKind::Volume,
-                "create_pool_request.encryption_params.cipher",
-                error.to_string(),
-            )
-        })?;
-        let key = value.key.ok_or(ReplyError::invalid_argument(
-            ResourceKind::Volume,
-            "create_pool_request.encryption_params.key",
-            "missing encryption key parameters".to_string(),
-        ))?;
-
-        Ok(Self {
-            cipher: cipher.into(),
-            key: EncryptionKey {
-                key_name: key.key_name,
-                key: key.key,
-                key_length: key.key_length,
-                key2: key.key2,
-                key2_length: key.key2_length,
-            },
-        })
-    }
-}
-
 impl From<Encryption> for pool::create_pool_request::Encryption {
     fn from(value: Encryption) -> Self {
         match value {
             Encryption::Secret(secret) => {
                 pool::create_pool_request::Encryption::Secret(secret.into())
             }
-            Encryption::Data(params) => {
-                let cipher: common::Cipher = params.cipher.into();
-                pool::create_pool_request::Encryption::Data(common::EncryptionData {
-                    cipher: cipher as i32,
-                    key: Some(params.key.into()),
-                })
-            }
-        }
-    }
-}
-
-impl From<EncryptionKey> for common::EncryptionKey {
-    fn from(value: EncryptionKey) -> Self {
-        Self {
-            key_name: value.key_name,
-            key: value.key,
-            key_length: value.key_length,
-            key2: value.key2,
-            key2_length: value.key2_length,
         }
     }
 }
 
 impl From<EncryptionSecret> for common::EncryptionSecret {
     fn from(value: EncryptionSecret) -> Self {
-        Self {
-            secret: value.secret,
-        }
+        Self { name: value.name }
     }
 }
 
 impl From<common::EncryptionSecret> for EncryptionSecret {
     fn from(value: common::EncryptionSecret) -> Self {
-        Self {
-            secret: value.secret,
-        }
+        Self { name: value.name }
     }
 }

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -41,6 +41,7 @@ impl CreateRow for openapi::models::Pool {
             status: openapi::models::PoolStatus::Unknown,
             used: 0,
             committed: None,
+            encrypted: spec.encryption.is_some(),
         });
         let free = if state.capacity > state.used {
             state.capacity - state.used

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2473,14 +2473,8 @@ components:
         disks:
           - "malloc:///disk?size_mb=100"
         encryption:
-          data:
-            cipher: AES_XTS
-            key:
-              key_name: encrkey
-              key: 2b7e151628aed2a6abf7158809cf4f3c
-              key_length: 128
-              key2: 2b7e151628aed2a6abf7158809cf4f3d
-              key2_length: 128
+          secret:
+            name: pool-secret-encr
       description: Create Pool Body
       type: object
       properties:
@@ -3109,6 +3103,9 @@ components:
           type: integer
           format: int64
           minimum: 0
+        encrypted:
+          description: Is the pool encrypted
+          type: boolean
       required:
         - capacity
         - disks
@@ -3116,6 +3113,7 @@ components:
         - node
         - status
         - used
+        - encrypted
     ReplicaState:
       description: state of the replica
       type: string
@@ -3435,6 +3433,15 @@ components:
           $ref: '#/components/schemas/NodeId'
         status:
           $ref: '#/components/schemas/SpecStatus'
+        encryption:
+          description: Encryption secret details.
+          type: object
+          properties:
+            secret:
+              $ref: '#/components/schemas/EncryptionSecret'
+          oneOf:
+            - required:
+                - secret
       required:
         - disks
         - id
@@ -4356,74 +4363,24 @@ components:
       required:
         - entries
     Encryption:
-      description: Encryption secret details or the encryption params.
-      type: object
-      properties:
-        secret:
-          $ref: '#/components/schemas/EncryptionSecret'
-        data:
-          $ref: '#/components/schemas/EncryptionData'
-      oneOf:
-        - required:
-            - secret
-        - required:
-            - data
-    EncryptionSecret:
       description: Encryption secret details.
       type: object
       properties:
         secret:
+          $ref: '#/components/schemas/EncryptionSecret'
+      oneOf:
+        - required:
+            - secret
+    EncryptionSecret:
+      description: Encryption secret details.
+      type: object
+      properties:
+        name:
           description: Encryption secret name, could be a file name.
           type: string
           example: pool-secret-encr
       required:
-        - secret
-    EncryptionData:
-      description: Encryption parameters.
-      type: object
-      properties:
-        cipher:
-          description: Cipher to use for encryption.
-          example: AES_XTS
-          type: string
-          enum:
-            - AES_CBC
-            - AES_XTS
-        key:
-          $ref: '#/components/schemas/EncryptionKey'
-      required:
-        - cipher
-        - key
-    EncryptionKey:
-      description: Represents an encryption key that can be used to encrypt an entity like pool or replica.
-      type: object
-      properties:
-        key_name:
-          description: Name of the key.
-          example: encrkey
-          type: string
-        key:
-          description: The AES encryption key.
-          example: 2b7e151628aed2a6abf7158809cf4f3c
-          type: string
-        key_length:
-          description: AES Key length.
-          example: 128
-          type: integer
-          format: uint32
-        key2:
-          description: Key2 (required for AES_XTS).
-          example: 2b7e151628aed2a6abf7158809cf4f3d
-          type: string
-        key2_length:
-          description: The length of key2. Must be same as key_length.
-          example: 128
-          type: integer
-          format: uint32
-      required:
-        - key_name
-        - key
-        - key_length
+        - name
   responses:
     ClientError:
       description: Client side error

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -145,7 +145,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
         models::Pool::new_all(
             "pooloop",
             models::PoolSpec::new(vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::SpecStatus::Created),
-            models::PoolState::new_all(100663296u64, vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::PoolStatus::Online, 0u64, 0)
+            models::PoolState::new_all(100663296u64, vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::PoolStatus::Online, 0u64, 0, false)
         )
     );
 

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -1,7 +1,9 @@
 //! Definition of pool types that can be saved to the persistent store.
 
+use crate::types::v0::transport::ImportPool;
 use crate::types::v0::{
     openapi::models,
+    openapi::models::PoolSpecEncryption,
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
         AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
@@ -12,7 +14,6 @@ use crate::types::v0::{
 // PoolLabel is the type for the labels
 pub type PoolLabel = std::collections::HashMap<String, String>;
 
-use crate::types::v0::transport::ImportPool;
 use pstor::ApiVersion;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::From, fmt::Debug};
@@ -54,6 +55,7 @@ impl From<&CreatePool> for PoolSpec {
             sequencer: OperationSequence::new(),
             operation: None,
             creat_tsc: None,
+            encryption: request.encryption.clone(),
         }
     }
 }
@@ -64,10 +66,11 @@ impl From<&PoolSpec> for CreatePool {
             id: pool.id.clone(),
             disks: pool.disks.clone(),
             labels: pool.labels.clone(),
-            encryption: None,
+            encryption: pool.encryption.clone(),
         }
     }
 }
+
 impl PartialEq<CreatePool> for PoolSpec {
     fn eq(&self, other: &CreatePool) -> bool {
         let mut other = PoolSpec::from(other);
@@ -76,6 +79,20 @@ impl PartialEq<CreatePool> for PoolSpec {
         other.creat_tsc = self.creat_tsc;
         &other == self
     }
+}
+
+/// Encryption parameters.
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub enum Encryption {
+    /// Name of the secret or file to parse the encryption parameters.
+    Secret(EncryptionSecret),
+}
+
+/// Encryption secret.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
+pub struct EncryptionSecret {
+    /// Name of the secret.
+    pub name: String,
 }
 
 /// User specification of a pool.
@@ -99,6 +116,8 @@ pub struct PoolSpec {
     /// Last modification timestamp.
     #[serde(skip)]
     pub creat_tsc: Option<std::time::SystemTime>,
+    /// Use to create/import encrypted pool
+    pub encryption: Option<Encryption>,
 }
 
 impl PoolSpec {
@@ -164,7 +183,7 @@ impl From<&PoolSpec> for ImportPool {
             id: value.id.clone(),
             disks: value.disks.clone(),
             uuid: None,
-            encryption: None,
+            encryption: value.encryption.clone(),
         }
     }
 }
@@ -181,7 +200,17 @@ impl AsOperationSequencer for PoolSpec {
 
 impl From<PoolSpec> for models::PoolSpec {
     fn from(src: PoolSpec) -> Self {
-        Self::new_all(src.disks, src.id, src.labels, src.node, src.status)
+        let encryption = match src.encryption {
+            None => None,
+            Some(encr) => match encr {
+                Encryption::Secret(details) => Some(PoolSpecEncryption::secret(
+                    openapi::models::EncryptionSecret { name: details.name },
+                )),
+            },
+        };
+        Self::new_all(
+            src.disks, src.id, src.labels, src.node, src.status, encryption,
+        )
     }
 }
 
@@ -327,6 +356,21 @@ impl From<&PoolSpec> for transport::PoolState {
             capacity: 0,
             used: 0,
             committed: None,
+            encrypted: pool.encryption.is_some(),
+        }
+    }
+}
+
+impl From<EncryptionSecret> for models::EncryptionSecret {
+    fn from(value: EncryptionSecret) -> Self {
+        Self { name: value.name }
+    }
+}
+
+impl From<models::Encryption> for Encryption {
+    fn from(value: models::Encryption) -> Self {
+        match value {
+            models::Encryption::secret(secret_name) => Self::Secret(secret_name.into()),
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::{
-    types::v0::store::pool::{PoolLabel, PoolSpec},
+    types::v0::store::pool::{Encryption, EncryptionSecret, PoolLabel, PoolSpec},
     IntoOption,
 };
 use serde::{Deserialize, Serialize};
@@ -98,6 +98,8 @@ pub struct PoolState {
     pub used: u64,
     /// Total pool commitment (in bytes) which is basically the accrued size of pool replicas.
     pub committed: Option<u64>,
+    /// Is the pool encrypted.
+    pub encrypted: bool,
 }
 
 impl From<CtrlPoolState> for models::PoolState {
@@ -111,6 +113,7 @@ impl From<CtrlPoolState> for models::PoolState {
             src.status,
             src.used,
             src.committed,
+            src.encrypted,
         )
     }
 }
@@ -327,13 +330,18 @@ pub struct ImportPool {
 
 impl ImportPool {
     /// Create new `Self` from the given parameters.
-    pub fn new(node: &NodeId, id: &PoolId, disks: &[PoolDeviceUri]) -> Self {
+    pub fn new(
+        node: &NodeId,
+        id: &PoolId,
+        disks: &[PoolDeviceUri],
+        encryption: &Option<Encryption>,
+    ) -> Self {
         Self {
             node: node.clone(),
             id: id.clone(),
             disks: disks.to_vec(),
             uuid: None,
-            encryption: None,
+            encryption: encryption.clone(),
         }
     }
 }
@@ -399,165 +407,18 @@ impl UnlabelPool {
     }
 }
 
-/// Encryption parameters.
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-pub enum Encryption {
-    /// Name of the secret or file to parse the encryption parameters.
-    Secret(EncryptionSecret),
-    /// The Encryption parameters.
-    Data(EncryptionData),
-}
-
-/// Encryption secret.
-#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
-pub struct EncryptionSecret {
-    /// Name of the secret.
-    pub secret: String,
-}
-
-/// Encryption parameters.
-#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
-pub struct EncryptionData {
-    /// Cipher to be used.
-    pub cipher: Cipher,
-    /// The encryption key.
-    pub key: EncryptionKey,
-}
-
-/// Represents an encryption key that can be used to encrypt an
-/// entity like pool or lvol/replica.
-#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
-pub struct EncryptionKey {
-    /// Name of the key.
-    pub key_name: String,
-    /// The AES encryption key.
-    pub key: Vec<u8>,
-    /// AES Key length.
-    pub key_length: u32,
-    /// key2 (required for AES_XTS).
-    pub key2: Option<Vec<u8>>,
-    /// The length of key2. Must be same as key_length.
-    pub key2_length: Option<u32>,
-}
-
-/// Cipher to use for encryption.
-#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
-pub enum Cipher {
-    #[default]
-    AesCbc,
-    AesXts,
-}
-
 impl TryFrom<Encryption> for models::Encryption {
     type Error = String;
 
     fn try_from(value: Encryption) -> Result<Self, Self::Error> {
         match value {
             Encryption::Secret(secret_name) => Ok(Self::secret(secret_name.into())),
-            Encryption::Data(data) => Ok(Self::data(data.try_into()?)),
-        }
-    }
-}
-
-impl TryFrom<EncryptionData> for models::EncryptionData {
-    type Error = String;
-
-    fn try_from(value: EncryptionData) -> Result<Self, Self::Error> {
-        Ok(Self {
-            cipher: value.cipher.into(),
-            key: value.key.try_into()?,
-        })
-    }
-}
-
-impl From<Cipher> for models::encryption_data::Cipher {
-    fn from(value: Cipher) -> Self {
-        match value {
-            Cipher::AesCbc => Self::AesCbc,
-            Cipher::AesXts => Self::AesXts,
-        }
-    }
-}
-
-impl TryFrom<EncryptionKey> for models::EncryptionKey {
-    type Error = String;
-
-    fn try_from(value: EncryptionKey) -> Result<Self, Self::Error> {
-        Ok(Self {
-            key_name: value.key_name,
-            key: String::from_utf8(value.key).map_err(|error| error.to_string())?,
-            key_length: value.key_length,
-            key2: match value.key2 {
-                None => None,
-                Some(value) => Some(String::from_utf8(value).map_err(|error| error.to_string())?),
-            },
-            key2_length: value.key2_length,
-        })
-    }
-}
-
-impl From<EncryptionSecret> for models::EncryptionSecret {
-    fn from(value: EncryptionSecret) -> Self {
-        Self {
-            secret: value.secret,
-        }
-    }
-}
-
-impl From<models::Encryption> for Encryption {
-    fn from(value: models::Encryption) -> Self {
-        match value {
-            models::Encryption::secret(secret_name) => Self::Secret(secret_name.into()),
-            models::Encryption::data(params) => Self::Data(params.into()),
-        }
-    }
-}
-
-impl From<models::EncryptionData> for EncryptionData {
-    fn from(value: models::EncryptionData) -> Self {
-        Self {
-            cipher: value.cipher.into(),
-            key: value.key.into(),
-        }
-    }
-}
-
-impl From<models::encryption_data::Cipher> for Cipher {
-    fn from(value: models::encryption_data::Cipher) -> Self {
-        match value {
-            models::encryption_data::Cipher::AesCbc => Self::AesCbc,
-            models::encryption_data::Cipher::AesXts => Self::AesXts,
-        }
-    }
-}
-
-impl From<models::EncryptionKey> for EncryptionKey {
-    // type Error = String;
-    //
-    // fn try_from(value: models::EncryptionKey) -> Result<Self, Self::Error> {
-    //     Ok(Self {
-    //         key_name: value.key_name,
-    //         key: Vec::from(value.key),
-    //         key_length: value.key_length,
-    //         key2: value.key2.map(|key| Vec::from(key)),
-    //         key2_length: value.key2_length,
-    //     })
-    // }
-    fn from(value: models::EncryptionKey) -> Self {
-        Self {
-            key_name: value.key_name,
-            key: Vec::from(value.key),
-            key_length: value.key_length,
-            key2: value.key2.map(Vec::from),
-            key2_length: value.key2_length,
         }
     }
 }
 
 impl From<models::EncryptionSecret> for EncryptionSecret {
     fn from(value: models::EncryptionSecret) -> Self {
-        Self {
-            secret: value.secret,
-        }
+        Self { name: value.name }
     }
 }

--- a/k8s/operators/src/lib.rs
+++ b/k8s/operators/src/lib.rs
@@ -2,6 +2,6 @@
 pub mod diskpool {
     /// The DiskPool custom resource definition.
     pub mod crd {
-        include!("pool/diskpool/crd/v1beta2.rs");
+        include!("pool/diskpool/crd/v1beta3.rs");
     }
 }

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -1,22 +1,25 @@
 use super::{
-    diskpool::crd::v1beta2::{CrPoolState, DiskPool, DiskPoolStatus},
+    diskpool::crd::v1beta3::{CrPoolState, DiskPool, DiskPoolStatus},
     error::Error,
 };
-use k8s_openapi::{api::core::v1::Event, apimachinery::pkg::apis::meta::v1::MicroTime};
-use kube::{
-    api::{Api, ObjectMeta, PatchParams},
-    runtime::{controller::Action, finalizer},
-    Client, Resource, ResourceExt,
-};
+use super::{normalize_disk, v1beta3_api};
+use openapi::models::{Encryption, EncryptionSecret};
 use openapi::{
     apis::StatusCode,
     clients,
     models::{CreatePoolBody, Pool},
 };
+use utils::dsp_created_by_key;
 
-use super::{normalize_disk, v1beta2_api};
+use crate::diskpool::crd::v1beta3::EncryptionSource;
 use chrono::Utc;
+use k8s_openapi::{api::core::v1::Event, apimachinery::pkg::apis::meta::v1::MicroTime};
 use kube::api::{Patch, PostParams};
+use kube::{
+    api::{Api, ObjectMeta, PatchParams},
+    runtime::{controller::Action, finalizer},
+    Client, Resource, ResourceExt,
+};
 use serde_json::json;
 use std::{
     collections::HashMap,
@@ -25,7 +28,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, error, info};
-use utils::dsp_created_by_key;
 
 const WHO_AM_I: &str = "DiskPool Operator";
 const WHO_AM_I_SHORT: &str = "dsp-operator";
@@ -183,7 +185,7 @@ impl ResourceContext {
 
     /// Construct an API handle for the resource
     fn api(&self) -> Api<DiskPool> {
-        v1beta2_api(&self.ctx.k8s, &self.namespace().unwrap())
+        v1beta3_api(&self.ctx.k8s, &self.namespace().unwrap())
     }
 
     /// Control plane pool handler.
@@ -261,7 +263,18 @@ impl ResourceContext {
             }
         }
 
-        let body = CreatePoolBody::new_all(self.spec.disks(), labels, None);
+        let encryption = match self.spec.encryption_config() {
+            None => None,
+            Some(config) => match config.source {
+                EncryptionSource::Secret(secret_config) => {
+                    Some(Encryption::secret(EncryptionSecret {
+                        name: secret_config.name,
+                    }))
+                }
+            },
+        };
+
+        let body = CreatePoolBody::new_all(self.spec.disks(), labels, encryption);
         match self
             .pools_api()
             .put_node_pool(&self.spec.node(), &self.name_any(), body)

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -1,5 +1,6 @@
 use super::crd::v1beta3::{DiskPool, DiskPoolSpec, EncryptionSource};
 use crate::{diskpool::crd::diskpools_name, error::Error, ApiVersion};
+use openapi::models::PoolSpecEncryption;
 use openapi::{apis::StatusCode, clients};
 
 use crate::diskpool::crd::v1beta3;
@@ -8,7 +9,6 @@ use kube::{
     api::{ListParams, Patch, PatchParams, PostParams},
     Api, Client, CustomResourceExt, ResourceExt,
 };
-use openapi::models::PoolSpecEncryptionConfig;
 use tracing::{info, warn};
 
 /// Get the DiskPool v1beta3 api.
@@ -88,10 +88,10 @@ pub(crate) async fn create_missing_cr(
                 Err(kube::Error::Api(e)) if e.code == StatusCode::NOT_FOUND => {
                     if let Some(spec) = &pool.spec {
                         warn!(pool.id, spec.node, "DiskPool CR is missing");
-                        let encryption = match spec.encryption_config.clone() {
+                        let encryption = match spec.encryption.clone() {
                             None => None,
                             Some(config) => match config {
-                                PoolSpecEncryptionConfig::secret(details) => {
+                                PoolSpecEncryption::secret(details) => {
                                     Some(v1beta3::EncryptionConfig {
                                         source: EncryptionSource::Secret(
                                             v1beta3::EncryptionSecretConfig { name: details.name },

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -1,27 +1,30 @@
-use super::crd::v1beta2::{DiskPool, DiskPoolSpec};
+use super::crd::v1beta3::{DiskPool, DiskPoolSpec, EncryptionSource};
 use crate::{diskpool::crd::diskpools_name, error::Error, ApiVersion};
+use openapi::{apis::StatusCode, clients};
+
+use crate::diskpool::crd::v1beta3;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::{
     api::{ListParams, Patch, PatchParams, PostParams},
     Api, Client, CustomResourceExt, ResourceExt,
 };
-use openapi::{apis::StatusCode, clients};
+use openapi::models::PoolSpecEncryptionConfig;
 use tracing::{info, warn};
 
-/// Get the DiskPool v1beta2 api.
-pub(crate) fn v1beta2_api(client: &Client, namespace: &str) -> Api<DiskPool> {
+/// Get the DiskPool v1beta3 api.
+pub(crate) fn v1beta3_api(client: &Client, namespace: &str) -> Api<DiskPool> {
     Api::namespaced(client.clone(), namespace)
 }
 
-/// Create a v1beta2 disk pool CR, with the given name and spec.
-pub(crate) async fn create_v1beta2_cr(
+/// Create a v1beta3 disk pool CR, with the given name and spec.
+pub(crate) async fn create_v1beta3_cr(
     client: &Client,
     namespace: &str,
     name: &str,
     spec: DiskPoolSpec,
 ) -> Result<(), Error> {
     let post_params = PostParams::default();
-    let api = v1beta2_api(client, namespace);
+    let api = v1beta3_api(client, namespace);
     let new_disk_pool: DiskPool = DiskPool::new(name, spec);
     match api.create(&post_params, &new_disk_pool).await {
         Ok(_) => Ok(()),
@@ -78,15 +81,31 @@ pub(crate) async fn create_missing_cr(
     namespace: &str,
 ) -> Result<(), Error> {
     if let Ok(pools) = control_client.pools_api().get_pools(None).await {
-        let pools_api: Api<DiskPool> = v1beta2_api(k8s, namespace);
+        let pools_api: Api<DiskPool> = v1beta3_api(k8s, namespace);
         let param = PostParams::default();
         for pool in pools.into_body().iter_mut() {
             match pools_api.get(&pool.id).await {
                 Err(kube::Error::Api(e)) if e.code == StatusCode::NOT_FOUND => {
                     if let Some(spec) = &pool.spec {
                         warn!(pool.id, spec.node, "DiskPool CR is missing");
-                        let cr_spec: DiskPoolSpec =
-                            DiskPoolSpec::new(spec.node.clone(), spec.disks.clone(), None);
+                        let encryption = match spec.encryption_config.clone() {
+                            None => None,
+                            Some(config) => match config {
+                                PoolSpecEncryptionConfig::secret(details) => {
+                                    Some(v1beta3::EncryptionConfig {
+                                        source: EncryptionSource::Secret(
+                                            v1beta3::EncryptionSecretConfig { name: details.name },
+                                        ),
+                                    })
+                                }
+                            },
+                        };
+                        let cr_spec: DiskPoolSpec = DiskPoolSpec::new(
+                            spec.node.clone(),
+                            spec.disks.clone(),
+                            None,
+                            encryption,
+                        );
                         let new_disk_pool: DiskPool = DiskPool::new(&pool.id, cr_spec);
                         if let Err(error) = pools_api.create(&param, &new_disk_pool).await {
                             info!(pool.id, spec.node, %error, "Failed to create CR for missing DiskPool");
@@ -135,11 +154,11 @@ pub(crate) async fn list_existing_cr(
 ) -> Result<Vec<DiskPool>, Error> {
     // Create the list params with pagination limit.
     let mut list_params = ListParams::default().limit(pagination_limit);
-    // Since v1alpha1/v1beta1 is not served at this stage we cannot use v1alpha1/v1beta1 api client
-    // to list existing CRs. Existing CRs which were created and stored as v1alpha1/v1beta1 can
-    // be retrieved using v1beta2 client. Kube api server performs the required conversions and
+    // Since v1alpha1/v1beta1/v1beta2 is not served at this stage we cannot use v1alpha1/v1beta1/v1beta2 api client
+    // to list existing CRs. Existing CRs which were created and stored as v1alpha1/v1beta1/v1beta2 can
+    // be retrieved using v1beta3 client. Kube api server performs the required conversions and
     // returns us the resources.
-    let pools_api: Api<DiskPool> = v1beta2_api(client, namespace);
+    let pools_api: Api<DiskPool> = v1beta3_api(client, namespace);
     let mut pools: Vec<DiskPool> = vec![];
     loop {
         let mut result = pools_api.list(&list_params).await?;
@@ -164,8 +183,12 @@ pub(crate) async fn get_api_version(k8s: Client) -> Option<ApiVersion> {
                 return Some(ApiVersion::V1Alpha1);
             } else if status.stored_versions == Some(vec!["v1beta1".to_string()]) {
                 return Some(ApiVersion::V1Beta1);
-            } else {
+            } else if status.stored_versions == Some(vec!["v1beta2".to_string()]) {
                 return Some(ApiVersion::V1Beta2);
+            } else if status.stored_versions == Some(vec!["v1beta3".to_string()]) {
+                return Some(ApiVersion::V1Beta3);
+            } else {
+                return None;
             }
         }
     }

--- a/k8s/operators/src/pool/diskpool/crd/migration.rs
+++ b/k8s/operators/src/pool/diskpool/crd/migration.rs
@@ -1,10 +1,11 @@
 use super::{
     v1alpha1::DiskPool as AlphaDiskPool,
     v1beta1::DiskPool as Beta1DiskPool,
-    v1beta2::{DiskPool, DiskPoolSpec},
+    v1beta2::DiskPool as Beta2DiskPool,
+    v1beta3::{DiskPool, DiskPoolSpec},
 };
 use crate::{
-    diskpool::client::{discard_older_schema, list_existing_cr, v1beta2_api},
+    diskpool::client::{discard_older_schema, list_existing_cr, v1beta3_api},
     error::Error,
     ApiVersion,
 };
@@ -19,7 +20,7 @@ use tracing::{error, info};
 
 const PAGINATION_LIMIT: u32 = 100;
 
-/// In case of v1alpha1 and v1beta1 check, ensure that crd exist and then migrate to v1beta2.
+/// In case of v1alpha1, v1beta1 and v1beta2 check, ensure that crd exist and then migrate to v1beta3.
 pub(crate) async fn ensure_and_migrate_crd(
     k8s: Client,
     namespace: &str,
@@ -41,8 +42,8 @@ pub(crate) async fn ensure_and_migrate_crd(
     Ok(())
 }
 
-/// Ensure the CRD is installed. This creates a chicken and egg problem. When the CRD is removed,
-/// the operator will fail to list the CRD going into a error loop.
+/// Ensure the CRD is installed. This creates a chicken-and-egg problem. When the CRD is removed,
+/// the operator will fail to list the CRD going into an error loop.
 ///
 /// To prevent that, we will simply panic, and hope we can make progress after restart. Keep
 /// running is not an option as the operator would be "running" and the only way to know something
@@ -52,10 +53,13 @@ pub(crate) async fn ensure_crd(
     api_version: &ApiVersion,
 ) -> Result<CustomResourceDefinition, Error> {
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
+
     let mut crd = if api_version == &ApiVersion::V1Alpha1 {
         AlphaDiskPool::crd()
-    } else {
+    } else if api_version == &ApiVersion::V1Beta1 {
         Beta1DiskPool::crd()
+    } else {
+        Beta2DiskPool::crd()
     };
 
     let crd_name = crd.metadata.name.as_ref().ok_or(Error::InvalidCRField {
@@ -65,7 +69,7 @@ pub(crate) async fn ensure_crd(
     let new_crd = DiskPool::crd();
     let all_crds = vec![crd.clone(), new_crd.clone()];
     let new_crd =
-        merge_crds(all_crds, "v1beta2").map_err(|source| Error::CrdMergeError { source })?;
+        merge_crds(all_crds, "v1beta3").map_err(|source| Error::CrdMergeError { source })?;
 
     // If diskpool exist then replace it with new generated one.
     let result = match crd_api.get(crd_name).await {
@@ -75,9 +79,11 @@ pub(crate) async fn ensure_crd(
                 serde_json::to_string_pretty(&new_crd).unwrap_or_default()
             );
             let param = if api_version == &ApiVersion::V1Alpha1 {
-                PatchParams::apply("merge_v1alpha1_v1beta2").force()
+                PatchParams::apply("merge_v1alpha1_v1beta3").force()
+            } else if api_version == &ApiVersion::V1Beta1 {
+                PatchParams::apply("merge_v1beta1_v1beta3").force()
             } else {
-                PatchParams::apply("merge_v1beta1_v1beta2").force()
+                PatchParams::apply("merge_v1beta2_v1beta3").force()
             };
             crd_api
                 .patch(&super::diskpools_name(), &param, &Patch::Apply(&new_crd))
@@ -90,7 +96,7 @@ pub(crate) async fn ensure_crd(
     Ok(crd)
 }
 
-/// Migrate existing v1alpha1/v1beta1 CR in cluster to v1beta2 CR.
+/// Migrate existing v1alpha1/v1beta1/v1beta2 CR in cluster to v1beta3 CR.
 async fn run_crd_migration(
     k8s: Client,
     namespace: &str,
@@ -98,20 +104,20 @@ async fn run_crd_migration(
     target_schema: &str,
 ) -> Result<(), Error> {
     match api_version {
-        ApiVersion::V1Alpha1 | ApiVersion::V1Beta1 => {
-            migrate_to_v1beta2(k8s.clone(), namespace, PAGINATION_LIMIT).await?;
+        ApiVersion::V1Alpha1 | ApiVersion::V1Beta1 | ApiVersion::V1Beta2 => {
+            migrate_to_v1beta3(k8s.clone(), namespace, PAGINATION_LIMIT).await?;
             _ = discard_older_schema(&k8s, target_schema).await;
         }
-        ApiVersion::V1Beta2 => {
+        ApiVersion::V1Beta3 => {
             info!("CRD has the latest schema. Skipping CRD Operations");
         }
     }
     Ok(())
 }
 
-/// Lists existing v1alpha1/v1beta1 CR in cluster and replaces them with v1beta2 CR.
-/// This ensures that there is no v1alpha1/v1beta1 stored objects in cluster.
-pub(crate) async fn migrate_to_v1beta2(
+/// Lists existing v1alpha1/v1beta1/v1beta2 CR in cluster and replaces them with v1beta3 CR.
+/// This ensures that there is no v1alpha1/v1beta1/v1beta2 stored objects in cluster.
+pub(crate) async fn migrate_to_v1beta3(
     k8s: Client,
     ns: &str,
     pagination_limit: u32,
@@ -122,12 +128,12 @@ pub(crate) async fn migrate_to_v1beta2(
                 let name = dsp.name_any();
                 let node = dsp.spec.node();
                 let disk = dsp.spec.disks();
-                replace_with_v1beta2(
+                replace_with_v1beta3(
                     &k8s,
                     &name,
                     ns,
                     Some(res_ver.clone()),
-                    DiskPoolSpec::new(node, disk, None),
+                    DiskPoolSpec::new(node, disk, None, None),
                 )
                 .await?;
                 info!(crd = ?dsp.name_any(), "CR creation successful");
@@ -146,8 +152,8 @@ pub(crate) async fn migrate_to_v1beta2(
     Ok(())
 }
 
-/// Replaces a given disk pool CR with v1beta2 schema CR.
-pub(crate) async fn replace_with_v1beta2(
+/// Replaces a given disk pool CR with v1beta3 schema CR.
+pub(crate) async fn replace_with_v1beta3(
     client: &Client,
     cr_name: &str,
     namespace: &str,
@@ -155,12 +161,12 @@ pub(crate) async fn replace_with_v1beta2(
     spec: DiskPoolSpec,
 ) -> Result<(), Error> {
     let post_params = PostParams::default();
-    let api = v1beta2_api(client, namespace);
+    let api = v1beta3_api(client, namespace);
     let mut new_disk_pool: DiskPool = DiskPool::new(cr_name, spec);
     new_disk_pool.metadata.resource_version = res_ver;
     info!(
         pool.cr_name = cr_name,
-        "Patching existing pool with v1beta2 schema"
+        "Patching existing pool with v1beta3 schema"
     );
     match api.replace(cr_name, &post_params, &new_disk_pool).await {
         Ok(_) => Ok(()),
@@ -168,7 +174,7 @@ pub(crate) async fn replace_with_v1beta2(
             error!(
                 ?error,
                 pool.cr_name = cr_name,
-                "Failed to patch pool with v1beta2 schema"
+                "Failed to patch pool with v1beta3 schema"
             );
             Err(error.into())
         }

--- a/k8s/operators/src/pool/diskpool/crd/mod.rs
+++ b/k8s/operators/src/pool/diskpool/crd/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod migration;
 pub(crate) mod v1alpha1;
 pub(crate) mod v1beta1;
 pub(crate) mod v1beta2;
+pub(crate) mod v1beta3;
 
 pub(crate) fn diskpools_name() -> String {
     use utils::constants::DSP_API_NAME;

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -10,22 +10,23 @@ use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
     CustomResource, Serialize, Deserialize, Default, Debug, Eq, PartialEq, Clone, JsonSchema,
 )]
 #[kube(
-group = "openebs.io",
-version = "v1beta2",
-kind = "DiskPool",
-plural = "diskpools",
-// The name of the struct that gets created that represents a resource
-namespaced,
-status = "DiskPoolStatus",
-derive = "PartialEq",
-derive = "Default",
-shortname = "dsp",
-printcolumn = r#"{ "name":"node", "type":"string", "description":"node the pool is on", "jsonPath":".spec.node"}"#,
-printcolumn = r#"{ "name":"state", "type":"string", "description":"dsp cr state", "jsonPath":".status.cr_state"}"#,
-printcolumn = r#"{ "name":"pool_status", "type":"string", "description":"Control plane pool status", "jsonPath":".status.pool_status"}"#,
-printcolumn = r#"{ "name":"capacity", "type":"integer", "format": "int64", "minimum" : "0", "description":"total bytes", "jsonPath":".status.capacity"}"#,
-printcolumn = r#"{ "name":"used", "type":"integer", "format": "int64", "minimum" : "0", "description":"used bytes", "jsonPath":".status.used"}"#,
-printcolumn = r#"{ "name":"available", "type":"integer", "format": "int64", "minimum" : "0", "description":"available bytes", "jsonPath":".status.available"}"#
+    group = "openebs.io",
+    version = "v1beta3",
+    kind = "DiskPool",
+    plural = "diskpools",
+    // The name of the struct that gets created that represents a resource
+    namespaced,
+    status = "DiskPoolStatus",
+    derive = "PartialEq",
+    derive = "Default",
+    shortname = "dsp",
+    printcolumn = r#"{ "name":"node", "type":"string", "description":"node the pool is on", "jsonPath":".spec.node"}"#,
+    printcolumn = r#"{ "name":"state", "type":"string", "description":"dsp cr state", "jsonPath":".status.cr_state"}"#,
+    printcolumn = r#"{ "name":"pool_status", "type":"string", "description":"Control plane pool status", "jsonPath":".status.pool_status"}"#,
+    printcolumn = r#"{ "name":"encrypted", "type":"boolean", "description":"encryption enabled", "jsonPath":".status.encrypted"}"#,
+    printcolumn = r#"{ "name":"capacity", "type":"integer", "format": "int64", "minimum" : "0", "description":"total bytes", "jsonPath":".status.capacity"}"#,
+    printcolumn = r#"{ "name":"used", "type":"integer", "format": "int64", "minimum" : "0", "description":"used bytes", "jsonPath":".status.used"}"#,
+    printcolumn = r#"{ "name":"available", "type":"integer", "format": "int64", "minimum" : "0", "description":"available bytes", "jsonPath":".status.available"}"#
 )]
 /// The pool spec which contains the parameters we use when creating the pool
 pub struct DiskPoolSpec {
@@ -35,6 +36,9 @@ pub struct DiskPoolSpec {
     pub disks: Vec<String>,
     /// The topology for data placement.
     pub topology: Option<Topology>,
+    /// Use to create encrypted pool.
+    #[serde(rename = "encryptionConfig")]
+    pub encryption_config: Option<EncryptionConfig>,
 }
 
 /// Placement pool topology used by volume operations.
@@ -45,31 +49,52 @@ pub struct Topology {
     pub labelled: HashMap<String, String>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
+pub struct EncryptionConfig {
+    pub source: EncryptionSource,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
+pub enum EncryptionSource {
+    Secret(EncryptionSecretConfig),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
+pub struct EncryptionSecretConfig {
+    pub name: String,
+}
+
 impl DiskPoolSpec {
     /// Create a new DiskPoolSpec from the node and the disks.
-    #[allow(dead_code)]
-    pub fn new(node: String, disks: Vec<String>, topology: Option<Topology>) -> Self {
+    pub fn new(
+        node: String,
+        disks: Vec<String>,
+        topology: Option<Topology>,
+        encryption_config: Option<EncryptionConfig>,
+    ) -> Self {
         Self {
             node,
             disks,
             topology,
+            encryption_config,
         }
     }
     /// The node the pool is placed on.
-    #[allow(dead_code)]
     pub fn node(&self) -> String {
         self.node.clone()
     }
     /// The disk devices that compose the pool.
-    #[allow(dead_code)]
     pub fn disks(&self) -> Vec<String> {
         self.disks.clone()
     }
 
     /// The topology that decides replica placement.
-    #[allow(dead_code)]
     pub fn topology(&self) -> Option<Topology> {
         self.topology.clone()
+    }
+    /// The encryption configuration.
+    pub fn encryption_config(&self) -> Option<EncryptionConfig> {
+        self.encryption_config.clone()
     }
 }
 
@@ -114,6 +139,9 @@ pub struct DiskPoolStatus {
     pub used: u64,
     /// Available number of bytes.
     pub available: u64,
+    /// Encryption enabled.
+    #[serde(default)]
+    pub encrypted: bool,
 }
 
 impl Default for DiskPoolStatus {
@@ -124,13 +152,13 @@ impl Default for DiskPoolStatus {
             capacity: 0,
             used: 0,
             available: 0,
+            encrypted: false,
         }
     }
 }
 
 impl DiskPoolStatus {
     /// Set when Pool is not found for some reason.
-    #[allow(dead_code)]
     pub fn not_found(status: &Option<Self>) -> Self {
         Self {
             cr_state: status.clone().unwrap_or_default().cr_state,
@@ -141,7 +169,6 @@ impl DiskPoolStatus {
 
     /// Set when operator is attempting to delete on pool.
     #[cfg(feature = "openapi")]
-    #[allow(dead_code)]
     pub fn terminating(p: Pool) -> Self {
         let state = p.state.unwrap_or_default();
         let free = if state.capacity > state.used {
@@ -155,11 +182,11 @@ impl DiskPoolStatus {
             capacity: state.capacity,
             used: state.used,
             available: free,
+            encrypted: state.encrypted,
         }
     }
 
     /// Set when deleting a Pool which is not accessible.
-    #[allow(dead_code)]
     pub fn terminating_when_unknown() -> Self {
         Self {
             cr_state: CrPoolState::Terminating,
@@ -168,7 +195,6 @@ impl DiskPoolStatus {
         }
     }
 
-    #[allow(dead_code)]
     pub fn mark_unknown() -> Self {
         Self {
             cr_state: CrPoolState::Created,
@@ -206,6 +232,7 @@ impl From<Pool> for DiskPoolStatus {
                 capacity: state.capacity,
                 used: state.used,
                 available: free,
+                encrypted: false,
             }
         } else {
             Self {

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -49,16 +49,20 @@ pub struct Topology {
     pub labelled: HashMap<String, String>,
 }
 
+/// Encryption configuration from a specified source.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
 pub struct EncryptionConfig {
     pub source: EncryptionSource,
 }
 
+/// Encryption configuration Sources.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
 pub enum EncryptionSource {
+    #[serde(rename = "secret")]
     Secret(EncryptionSecretConfig),
 }
 
+/// Encryption Secret source details.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
 pub struct EncryptionSecretConfig {
     pub name: String,
@@ -140,8 +144,7 @@ pub struct DiskPoolStatus {
     /// Available number of bytes.
     pub available: u64,
     /// Encryption enabled.
-    #[serde(default)]
-    pub encrypted: bool,
+    pub encrypted: Option<bool>,
 }
 
 impl Default for DiskPoolStatus {
@@ -152,7 +155,7 @@ impl Default for DiskPoolStatus {
             capacity: 0,
             used: 0,
             available: 0,
-            encrypted: false,
+            encrypted: None,
         }
     }
 }
@@ -182,7 +185,7 @@ impl DiskPoolStatus {
             capacity: state.capacity,
             used: state.used,
             available: free,
-            encrypted: state.encrypted,
+            encrypted: Some(state.encrypted),
         }
     }
 
@@ -232,7 +235,7 @@ impl From<Pool> for DiskPoolStatus {
                 capacity: state.capacity,
                 used: state.used,
                 available: free,
-                encrypted: false,
+                encrypted: Some(state.encrypted),
             }
         } else {
             Self {

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -9,16 +9,20 @@ pub(crate) mod error;
 mod mayastorpool;
 
 use crate::diskpool::client::{
-    create_crd, create_missing_cr, create_v1beta2_cr, get_api_version, v1beta2_api,
+    create_crd, create_missing_cr, create_v1beta3_cr, get_api_version, v1beta3_api,
 };
-use chrono::Utc;
-use clap::{Arg, ArgMatches};
 use context::OperatorContext;
 use diskpool::crd::{
     migration::ensure_and_migrate_crd,
-    v1beta2::{CrPoolState, DiskPool, DiskPoolSpec, DiskPoolStatus},
+    v1beta3::{CrPoolState, DiskPool, DiskPoolSpec, DiskPoolStatus},
 };
 use error::Error;
+use mayastorpool::client::{check_crd, delete, list};
+use openapi::clients::{self, tower::Url};
+use utils::tracing_telemetry::{FmtLayer, FmtStyle};
+
+use chrono::Utc;
+use clap::{Arg, ArgMatches};
 use futures::StreamExt;
 use kube::{
     api::Api,
@@ -28,15 +32,12 @@ use kube::{
     },
     Client, ResourceExt,
 };
-use mayastorpool::client::{check_crd, delete, list};
-use openapi::clients::{self, tower::Url};
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tracing::{error, info, trace, warn};
-use utils::tracing_telemetry::{FmtLayer, FmtStyle};
 
 const PAGINATION_LIMIT: u32 = 100;
 const BACKOFF_PERIOD: u64 = 20;
-const LATEST_API_VERSION: &str = "v1beta2";
+const LATEST_API_VERSION: &str = "v1beta3";
 /// Determine what we want to do when dealing with errors from the
 /// reconciliation loop
 fn error_policy(_object: Arc<DiskPool>, error: &Error, _ctx: Arc<OperatorContext>) -> Action {
@@ -92,6 +93,8 @@ pub enum ApiVersion {
     V1Beta1,
     /// Represents v1beta2
     V1Beta2,
+    /// Represents v1beta3
+    V1Beta3,
 }
 
 async fn pool_controller(args: ArgMatches) -> anyhow::Result<()> {
@@ -101,11 +104,11 @@ async fn pool_controller(args: ArgMatches) -> anyhow::Result<()> {
 
     match api_version {
         Some(version) => match version {
-            ApiVersion::V1Alpha1 | ApiVersion::V1Beta1 => {
+            ApiVersion::V1Alpha1 | ApiVersion::V1Beta1 | ApiVersion::V1Beta2 => {
                 ensure_and_migrate_crd(k8s.clone(), namespace, &version, LATEST_API_VERSION)
                     .await?;
             }
-            ApiVersion::V1Beta2 => {
+            ApiVersion::V1Beta3 => {
                 info!("CRD has the latest schema. Skipping CRD Operations");
             }
         },
@@ -117,7 +120,7 @@ async fn pool_controller(args: ArgMatches) -> anyhow::Result<()> {
     // Migrate the MayastorPool CRs to the DiskPool.
     migrate_and_clean_msps(&k8s, namespace).await?;
 
-    let newdsp: Api<DiskPool> = v1beta2_api(&k8s, namespace);
+    let newdsp: Api<DiskPool> = v1beta3_api(&k8s, namespace);
 
     let url = Url::parse(args.get_one::<String>("endpoint").unwrap())
         .expect("endpoint is not a valid URL");
@@ -332,12 +335,13 @@ pub(crate) async fn migrate_and_clean_msps(k8s: &Client, namespace: &str) -> Res
                     })?;
                     let node = msp.spec.node();
                     let disks = msp.spec.disks();
-                    // Create the corresponding v1beta2 DiskPool CRs.
-                    if let Err(error) = create_v1beta2_cr(
+                    // Create the corresponding v1beta3 DiskPool CRs.
+                    // Hardcoding encryption to be none as it did not exist at that point.
+                    if let Err(error) = create_v1beta3_cr(
                         k8s,
                         namespace,
                         &name,
-                        DiskPoolSpec::new(node, disks, None),
+                        DiskPoolSpec::new(node, disks, None, None),
                     )
                     .await
                     {


### PR DESCRIPTION
- Adds the v1beta3 CRD to support encryptionKeyConfig
- Adds the migration flows from v1alpha1, v1beta1, v1beta2 to v1beta3
- Adds a encrypted field to CR
- Updates the proto of control plane to pass only secret details.
- Stores secret details in pstor.
- Updates openapi as per the same.