### PR TITLE
Add Volume Health Information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -2666,7 +2666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3710,15 +3710,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -4228,12 +4227,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"

--- a/control-plane/agents/src/bin/core/controller/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod io_engine;
 /// Various policies' definitions(e.g. rebuild policy)
 pub(crate) mod policies;
+mod pstor_cache;
 /// reconciliation logic
 pub(crate) mod reconciler;
 /// registry with node and all its resources

--- a/control-plane/agents/src/bin/core/controller/pstor_cache.rs
+++ b/control-plane/agents/src/bin/core/controller/pstor_cache.rs
@@ -6,12 +6,15 @@ use stor_port::{
     pstor::{error::DeserialiseValue, Error, ObjectKey, StorableObject, StoreWatchReceiver},
 };
 
+/// A persistent store cache, which fetches all entries and them allows reading
+/// them via the `pstor::StoreObj` interface.
 #[derive(Clone)]
 pub(crate) struct PStorCache {
     entries: BTreeMap<String, serde_json::Value>,
 }
 
 impl PStorCache {
+    /// Create a new `PStorCache`.
     pub(crate) async fn new(
         pstor: &mut impl pstor::StoreKv,
         page_size: i64,

--- a/control-plane/agents/src/bin/core/controller/pstor_cache.rs
+++ b/control-plane/agents/src/bin/core/controller/pstor_cache.rs
@@ -1,0 +1,51 @@
+use agents::errors::SvcError;
+use snafu::ResultExt;
+use std::collections::BTreeMap;
+use stor_port::{
+    pstor,
+    pstor::{error::DeserialiseValue, Error, ObjectKey, StorableObject, StoreWatchReceiver},
+};
+
+#[derive(Clone)]
+pub(crate) struct PStorCache {
+    entries: BTreeMap<String, serde_json::Value>,
+}
+
+impl PStorCache {
+    pub(crate) async fn new(
+        pstor: &mut impl pstor::StoreKv,
+        page_size: i64,
+        prefix: &str,
+    ) -> Result<Self, SvcError> {
+        let entries = pstor
+            .get_values_paged_all(prefix, page_size)
+            .await?
+            .into_iter()
+            .collect::<BTreeMap<_, _>>();
+
+        Ok(Self { entries })
+    }
+}
+
+#[async_trait::async_trait]
+impl pstor::StoreObj for PStorCache {
+    async fn put_obj<O: StorableObject>(&mut self, _object: &O) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    async fn get_obj<O: StorableObject>(&mut self, key: &O::Key) -> Result<O, Error> {
+        let key = key.key();
+        match self.entries.get(&key) {
+            Some(kv) => Ok(
+                serde_json::from_value(kv.clone()).context(DeserialiseValue {
+                    value: kv.to_string(),
+                })?,
+            ),
+            None => Err(Error::MissingEntry { key }),
+        }
+    }
+
+    async fn watch_obj<K: ObjectKey>(&mut self, _key: &K) -> Result<StoreWatchReceiver, Error> {
+        unimplemented!()
+    }
+}

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -386,6 +386,32 @@ impl Registry {
         }
     }
 
+    /// Serialized delete to the persistent store, with a prefix.
+    pub(crate) async fn delete_kv_prefix<K: StoreKey>(&self, key: &K) -> Result<(), SvcError> {
+        let store = self.store.clone();
+        match tokio::time::timeout(self.store_timeout, async move {
+            let mut store = store.lock().await;
+            let key = key.to_string();
+            Self::op_with_threshold(async move { store.delete_values_prefix(&key).await }).await
+        })
+        .await
+        {
+            Ok(result) => match result {
+                Ok(_) => Ok(()),
+                // already deleted, no problem
+                Err(StoreError::MissingEntry { .. }) => {
+                    tracing::warn!("Entry with key {} missing from store.", key.to_string());
+                    Ok(())
+                }
+                Err(error) => Err(SvcError::from(error)),
+            },
+            Err(_) => Err(SvcError::from(StoreError::Timeout {
+                operation: "Delete".to_string(),
+                timeout: self.store_timeout,
+            })),
+        }
+    }
+
     async fn op_with_threshold<F, O>(future: F) -> O
     where
         F: Future<Output = O>,

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -76,7 +76,7 @@ pub(crate) struct RegistryInner<S: Store> {
     nodes: NodesMapLocked,
     /// spec (aka desired state) of the various resources.
     specs: ResourceSpecsLocked,
-    health: VolumeHealthWatcher,
+    health: Option<VolumeHealthWatcher>,
     /// period to refresh the cache.
     cache_period: std::time::Duration,
     store: Arc<Mutex<S>>,
@@ -139,6 +139,7 @@ impl Registry {
         thin_args: ThinArgs,
         ha_enabled: bool,
         etcd_max_page_size: i64,
+        no_volume_health: bool,
     ) -> Result<Self, SvcError> {
         let store_endpoint = Self::format_store_endpoint(&store_url);
         tracing::info!("Connecting to persistent store at {}", store_endpoint);
@@ -168,7 +169,11 @@ impl Registry {
             inner: Arc::new(RegistryInner {
                 nodes: Default::default(),
                 specs: ResourceSpecsLocked::new(),
-                health: VolumeHealthWatcher::new(&store),
+                health: if no_volume_health {
+                    None
+                } else {
+                    Some(VolumeHealthWatcher::new(&store))
+                },
                 cache_period,
                 store: Arc::new(Mutex::new(store.clone())),
                 store_timeout,
@@ -327,8 +332,17 @@ impl Registry {
         &self.specs
     }
     /// Get a reference to the volume health watcher.
-    pub(crate) fn health(&self) -> &VolumeHealthWatcher {
-        &self.health
+    pub(crate) fn health(&self) -> Option<&VolumeHealthWatcher> {
+        self.health.as_ref()
+    }
+    /// Retain health info as per the given retain closure.
+    pub(crate) fn health_retain<F: FnMut(&uuid::Uuid, &mut Arc<NexusInfo>) -> bool>(
+        &self,
+        retain: F,
+    ) {
+        if let Some(h) = self.health() {
+            h.retain(retain)
+        }
     }
 
     /// Serialized write to the persistent store.
@@ -488,12 +502,15 @@ impl Registry {
     }
 
     async fn init_health(&self) -> Result<(), SvcError> {
-        self.health.init().await?;
+        let Some(health) = &self.health else {
+            return Ok(());
+        };
+        health.init().await?;
         let mut store = self.store.lock().await;
         let mut pstor_cache = PStorCache::new(
             store.deref_mut(),
             self.etcd_max_page_size,
-            self.health.key_prefix(),
+            health.key_prefix(),
         )
         .await?;
         for volume in self.specs.volumes_rsc() {
@@ -505,7 +522,7 @@ impl Registry {
             };
             info.uuid = nexus_info_key.nexus_id().clone();
             info.volume_uuid = Some(volume.uuid().clone());
-            self.health.if_empty_insert(info);
+            health.if_empty_insert(info);
         }
         Ok(())
     }

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -517,6 +517,7 @@ impl Registry {
             let Some(nexus_info_key) = volume.immutable_ref().health_info_key() else {
                 continue;
             };
+            let nexus_info_key = nexus_info_key.nexus_info_key();
             let Ok(mut info) = pstor_cache.get_obj::<NexusInfo>(&nexus_info_key).await else {
                 continue;
             };

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -16,7 +16,9 @@
 use super::{resources::operations_helper::*, wrapper::NodeWrapper};
 use crate::{
     controller::{
+        pstor_cache::PStorCache,
         reconciler::ReconcilerControl,
+        resources::VolumeHealthWatcher,
         task_poller::{PollEvent, PollTriggerEvent},
         wrapper::InternalOps,
     },
@@ -36,7 +38,7 @@ use stor_port::{
     },
     types::v0::{
         store::{
-            nexus_persistence::delete_all_v1_nexus_info,
+            nexus_persistence::{delete_all_v1_nexus_info, NexusInfo},
             registry::{ControlPlaneService, CoreRegistryConfig, NodeRegistration},
             volume::InitiatorAC,
         },
@@ -74,6 +76,7 @@ pub(crate) struct RegistryInner<S: Store> {
     nodes: NodesMapLocked,
     /// spec (aka desired state) of the various resources.
     specs: ResourceSpecsLocked,
+    health: VolumeHealthWatcher,
     /// period to refresh the cache.
     cache_period: std::time::Duration,
     store: Arc<Mutex<S>>,
@@ -165,6 +168,7 @@ impl Registry {
             inner: Arc::new(RegistryInner {
                 nodes: Default::default(),
                 specs: ResourceSpecsLocked::new(),
+                health: VolumeHealthWatcher::new(&store),
                 cache_period,
                 store: Arc::new(Mutex::new(store.clone())),
                 store_timeout,
@@ -322,6 +326,10 @@ impl Registry {
     pub(crate) fn specs(&self) -> &ResourceSpecsLocked {
         &self.specs
     }
+    /// Get a reference to the volume health watcher.
+    pub(crate) fn health(&self) -> &VolumeHealthWatcher {
+        &self.health
+    }
 
     /// Serialized write to the persistent store.
     pub(crate) async fn store_obj<O: StorableObject>(&self, object: &O) -> Result<(), SvcError> {
@@ -463,14 +471,41 @@ impl Registry {
 
     /// Initialise the registry with the content of the persistent store.
     async fn init(&self) -> Result<(), SvcError> {
+        {
+            let store = self.store.clone();
+            let mut store = store.lock().await;
+            self.specs
+                .init(
+                    store.deref_mut(),
+                    self.legacy_prefix_present,
+                    self.etcd_max_page_size,
+                )
+                .await?;
+        }
+        self.init_health().await?;
+
+        Ok(())
+    }
+
+    async fn init_health(&self) -> Result<(), SvcError> {
+        self.health.init().await?;
         let mut store = self.store.lock().await;
-        self.specs
-            .init(
-                store.deref_mut(),
-                self.legacy_prefix_present,
-                self.etcd_max_page_size,
-            )
-            .await?;
+        let mut pstor_cache = PStorCache::new(
+            store.deref_mut(),
+            self.etcd_max_page_size,
+            self.health.key_prefix(),
+        )
+        .await?;
+        for volume in self.specs.volumes_rsc() {
+            let Some(nexus_info_key) = volume.immutable_ref().health_info_key() else {
+                continue;
+            };
+            let Ok(mut info) = pstor_cache.get_obj::<NexusInfo>(&nexus_info_key).await else {
+                continue;
+            };
+            info.volume_uuid = Some(volume.uuid().clone());
+            self.health.if_empty_insert(info);
+        }
         Ok(())
     }
 

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -503,6 +503,7 @@ impl Registry {
             let Ok(mut info) = pstor_cache.get_obj::<NexusInfo>(&nexus_info_key).await else {
                 continue;
             };
+            info.uuid = nexus_info_key.nexus_id().clone();
             info.volume_uuid = Some(volume.uuid().clone());
             self.health.if_empty_insert(info);
         }

--- a/control-plane/agents/src/bin/core/controller/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/mod.rs
@@ -23,6 +23,8 @@ pub(crate) mod operations_helper;
 /// Generic resources map.
 pub(crate) mod resource_map;
 
+pub(crate) use volume::VolumeHealthWatcher;
+
 impl<T: OperationSequencer + Sized, R> Drop for OperationGuard<T, R> {
     fn drop(&mut self) {
         self.unlock();

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -974,23 +974,10 @@ impl ResourceSpecsLocked {
     where
         T: DeserializeOwned,
     {
-        let specs: Vec<Result<T, serde_json::Error>> = values
-            .iter()
-            .map(|v| serde_json::from_value(v.clone()))
-            .collect();
-
-        let mut result = vec![];
-        for spec in specs {
-            match spec {
-                Ok(s) => {
-                    result.push(s);
-                }
-                Err(e) => {
-                    return Err(e);
-                }
-            }
-        }
-        Ok(result)
+        values
+            .into_iter()
+            .map(serde_json::from_value)
+            .collect::<Result<Vec<_>, serde_json::Error>>()
     }
 
     /// Populate the resource specs with data from the persistent store.
@@ -1015,7 +1002,7 @@ impl ResourceSpecsLocked {
             .map_err(|e| SpecError::StoreGet {
                 source: Box::new(e),
             })?;
-        let store_values = store_entries.iter().map(|e| e.1.clone()).collect();
+        let store_values = store_entries.into_iter().map(|e| e.1).collect();
 
         let mut resource_specs = self.0.write();
         match spec_type {
@@ -1024,6 +1011,7 @@ impl ResourceSpecsLocked {
                     Self::deserialise_specs::<VolumeSpec>(store_values).context(Deserialise {
                         obj_type: StorableObjectType::VolumeSpec,
                     })?;
+                // Add the volume watch here for all the specs OR after this call.
                 let ag_specs = get_affinity_group_specs(&specs);
                 resource_specs.volumes.populate(specs);
                 // Load the ag specs in memory, ag specs are not persisted in memory so we don't

--- a/control-plane/agents/src/bin/core/controller/resources/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/volume/mod.rs
@@ -65,9 +65,8 @@ macro_rules! volume_span {
 crate::impl_trace_span!(volume_span, VolumeSpec);
 
 use pstor::{StoreKv, StoreKvWatcher};
+use stor_port::types::v0::transport::NexusId;
 
-/// A watcher for volume health information which issues a single watch for etcd, listening
-/// on the base prefix shared by all volumes health info.
 pub(crate) struct VolumeHealthWatcher {
     watcher: Box<dyn StoreKvWatcher>,
     key_prefix: String,
@@ -91,7 +90,7 @@ impl VolumeHealthWatcher {
             if arg.value.is_empty() {
                 match NexusInfoKey::parse_id(arg.updated_key) {
                     Ok(id) => {
-                        //tracing::warn!(key=%arg.updated_key, "Removing key");
+                        tracing::debug!(key=%arg.updated_key, %id, "Removing key");
                         health_cln.lock().remove(id.uuid());
                     }
                     Err(error) => {
@@ -112,7 +111,7 @@ impl VolumeHealthWatcher {
 
             match nexus_info.with_key(arg.updated_key) {
                 Ok(Some(info)) => {
-                    tracing::debug!(?info, "Adding Info");
+                    tracing::debug!(?info, "Updating Health info");
                     health_cln.lock().insert(*info.uuid, Arc::new(info));
                 }
                 Ok(None) => {
@@ -147,6 +146,10 @@ impl VolumeHealthWatcher {
         if health.get(&info.uuid).is_none() {
             health.insert(*info.uuid, Arc::new(info));
         }
+    }
+    /// Get the volume health info for the given target.
+    pub(crate) fn health(&self, target: &NexusId) -> Option<Arc<NexusInfo>> {
+        self.health.lock().get(target.uuid()).cloned()
     }
     /// Expose a retain interface, allowing clean up of objects.
     pub(crate) fn retain<F: FnMut(&uuid::Uuid, &mut Arc<NexusInfo>) -> bool>(&self, retain: F) {

--- a/control-plane/agents/src/bin/core/controller/resources/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/volume/mod.rs
@@ -1,9 +1,17 @@
 mod snapshot;
 
 use super::{ResourceMutex, ResourceUid};
-use stor_port::types::v0::{
-    store::volume::{AffinityGroupSpec, VolumeSpec},
-    transport::VolumeId,
+use parking_lot::Mutex;
+use std::{collections::BTreeMap, sync::Arc};
+use stor_port::{
+    pstor,
+    types::v0::{
+        store::{
+            nexus_persistence::{NexusInfo, NexusInfoKey},
+            volume::{AffinityGroupSpec, VolumeSpec},
+        },
+        transport::VolumeId,
+    },
 };
 
 impl ResourceMutex<VolumeSpec> {
@@ -55,3 +63,93 @@ macro_rules! volume_span {
     };
 }
 crate::impl_trace_span!(volume_span, VolumeSpec);
+
+use pstor::{StoreKv, StoreKvWatcher};
+
+/// A watcher for volume health information which issues a single watch for etcd, listening
+/// on the base prefix shared by all volumes health info.
+pub(crate) struct VolumeHealthWatcher {
+    watcher: Box<dyn StoreKvWatcher>,
+    key_prefix: String,
+    health: Arc<Mutex<BTreeMap<uuid::Uuid, Arc<NexusInfo>>>>,
+}
+impl std::fmt::Debug for VolumeHealthWatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VolumeHealthWatcher").finish()
+    }
+}
+
+impl VolumeHealthWatcher {
+    /// Create a new `Self`.
+    pub(crate) fn new(store: &impl StoreKv) -> Self {
+        let health = Arc::new(Mutex::new(BTreeMap::new()));
+
+        let health_cln = health.clone();
+        let watcher = store.kv_watcher(move |arg| {
+            let cnt = pstor::WatchResult::Continue;
+
+            if arg.value.is_empty() {
+                match NexusInfoKey::parse_id(arg.updated_key) {
+                    Ok(id) => {
+                        //tracing::warn!(key=%arg.updated_key, "Removing key");
+                        health_cln.lock().remove(id.uuid());
+                    }
+                    Err(error) => {
+                        tracing::warn!(key=%arg.updated_key, error, "Received unexpected PStor Update");
+                    }
+                }
+                return cnt;
+            }
+
+            let Ok(nexus_info) = serde_json::from_str::<NexusInfo>(arg.value) else {
+                tracing::error!(
+                    key = arg.updated_key,
+                    value = arg.value,
+                    "Failed to parse health value information"
+                );
+                return cnt;
+            };
+
+            match nexus_info.with_key(arg.updated_key) {
+                Ok(Some(info)) => {
+                    tracing::debug!(?info, "Adding Info");
+                    health_cln.lock().insert(*info.uuid, Arc::new(info));
+                }
+                Ok(None) => {
+                    tracing::warn!(key=%arg.updated_key, "Received unexpected PStor Update");
+                }
+                Err(error) => tracing::warn!(key=%arg.updated_key, %error, "Failed to parse uuids"),
+            }
+
+            cnt
+        });
+
+        Self {
+            watcher: Box::new(watcher),
+            key_prefix: NexusInfoKey::key_prefix(),
+            health,
+        }
+    }
+    /// Get the health key prefix.
+    pub(crate) fn key_prefix(&self) -> &str {
+        &self.key_prefix
+    }
+    /// Start the watcher.
+    /// All registered pstor key updates will be propagated via the callback.
+    pub(crate) async fn init(&self) -> Result<(), agents::errors::SvcError> {
+        self.watcher
+            .watch(pstor::WatchKey::new(NexusInfoKey::key_prefix()), ())?;
+        Ok(())
+    }
+    /// If the health info hasn't been added yet, insert it.
+    pub(crate) fn if_empty_insert(&self, info: NexusInfo) {
+        let mut health = self.health.lock();
+        if health.get(&info.uuid).is_none() {
+            health.insert(*info.uuid, Arc::new(info));
+        }
+    }
+    /// Expose a retain interface, allowing clean up of objects.
+    pub(crate) fn retain<F: FnMut(&uuid::Uuid, &mut Arc<NexusInfo>) -> bool>(&self, retain: F) {
+        self.health.lock().retain(retain);
+    }
+}

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -138,6 +138,10 @@ pub(crate) struct CliArgs {
     /// Use ANSI colors for the logs.
     #[clap(long, default_value_t = true, action = clap::ArgAction::Set)]
     ansi_colors: bool,
+
+    /// Disable volume health reporting which uses pstor watchers.
+    #[clap(long)]
+    no_volume_health: bool,
 }
 impl CliArgs {
     fn args() -> Self {
@@ -214,6 +218,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.thin_args,
         cli_args.disable_ha,
         cli_args.etcd_page_limit as i64,
+        cli_args.no_volume_health,
     )
     .await?;
 

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -1244,6 +1244,7 @@ async fn health() {
         .wait_node_status(cluster.node(1), transport::NodeStatus::Online)
         .await
         .unwrap();
+    cluster.wait_pool_online(cluster.pool(1, 0)).await.unwrap();
 
     let volume = volume_client
         .publish(

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -1128,7 +1128,7 @@ async fn health() {
         .with_io_engines(3)
         .with_tmpfs_pool(100 * 1024 * 1024)
         .with_cache_period("150ms")
-        .with_reconcile_period(Duration::from_millis(100), Duration::from_secs(100))
+        .with_reconcile_period(Duration::from_secs(100), Duration::from_secs(100))
         .build()
         .await
         .unwrap();

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -29,10 +29,10 @@ use stor_port::{
         openapi::{models, models::NodeStatus},
         store::nexus_persistence::{NexusInfo, NexusInfoKey},
         transport::{
-            Child, ChildState, CreateVolume, DestroyVolume, Filter, GetNexuses, GetReplicas,
+            self, Child, ChildState, CreateVolume, DestroyVolume, Filter, GetNexuses, GetReplicas,
             GetVolumes, Nexus, NodeId, PublishVolume, SetVolumeReplica, ShareVolume, Topology,
-            UnpublishVolume, UnshareVolume, Volume, VolumeId, VolumeShareProtocol, VolumeState,
-            VolumeStatus,
+            UnpublishVolume, UnshareVolume, Volume, VolumeHealth, VolumeId, VolumeShareProtocol,
+            VolumeState, VolumeStatus,
         },
     },
 };
@@ -1119,4 +1119,220 @@ async fn offline_node(cluster: &Cluster) {
             assert_eq!(err.kind, ReplyErrorKind::ResourceExhausted)
         }
     }
+}
+
+#[tokio::test]
+async fn health() {
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_io_engines(3)
+        .with_tmpfs_pool(100 * 1024 * 1024)
+        .with_cache_period("150ms")
+        .with_reconcile_period(Duration::from_millis(100), Duration::from_secs(100))
+        .build()
+        .await
+        .unwrap();
+
+    let volume_client = cluster.grpc_client().volume();
+    let volume = volume_client
+        .create(
+            &CreateVolume {
+                uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
+                size: 5242880,
+                replicas: 3,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume::new(
+                volume.spec().uuid.clone(),
+                Some(cluster.node(0)),
+                None,
+                HashMap::new(),
+                vec![],
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+    cluster.composer().kill(&cluster.node(2)).await.unwrap();
+
+    wait_for_health(
+        &volume.state(),
+        &volume_client,
+        Duration::from_secs(2),
+        |h| {
+            h.healthy_replicas == 2
+                && !h.clean_shutdown
+                && h.online_clean_replicas == 1
+                && h.clean_replicas == 1
+                && h.live_healthy_replicas == 2
+                && h.online_healthy_replicas == 2
+        },
+    )
+    .await
+    .unwrap();
+
+    let volume = volume_client
+        .unpublish(
+            &UnpublishVolume::new(&volume.spec().uuid, false, vec![]),
+            None,
+        )
+        .await
+        .unwrap();
+
+    wait_for_health(
+        &volume.state(),
+        &volume_client,
+        Duration::from_secs(2),
+        |h| {
+            h.healthy_replicas == 2
+                && h.clean_shutdown
+                && h.online_clean_replicas == 2
+                && h.clean_replicas == 2
+                && h.live_healthy_replicas == 0
+                && h.online_healthy_replicas == 2
+        },
+    )
+    .await
+    .unwrap();
+
+    cluster.composer().stop(&cluster.node(1)).await.unwrap();
+
+    wait_for_health(
+        &volume.state(),
+        &volume_client,
+        Duration::from_secs(2),
+        |h| {
+            h.healthy_replicas == 2
+                && h.clean_shutdown
+                && h.online_clean_replicas == 1
+                && h.clean_replicas == 2
+                && h.live_healthy_replicas == 0
+                && h.online_healthy_replicas == 1
+        },
+    )
+    .await
+    .unwrap();
+
+    cluster.composer().stop(&cluster.node(0)).await.unwrap();
+
+    wait_for_health(
+        &volume.state(),
+        &volume_client,
+        Duration::from_secs(2),
+        |h| {
+            h.healthy_replicas == 2
+                && h.clean_shutdown
+                && h.online_clean_replicas == 0
+                && h.clean_replicas == 2
+                && h.live_healthy_replicas == 0
+                && h.online_healthy_replicas == 0
+        },
+    )
+    .await
+    .unwrap();
+
+    cluster.composer().start(&cluster.node(1)).await.unwrap();
+    cluster
+        .wait_node_status(cluster.node(1), transport::NodeStatus::Online)
+        .await
+        .unwrap();
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume::new(
+                volume.spec().uuid.clone(),
+                Some(cluster.node(1)),
+                None,
+                HashMap::new(),
+                vec![],
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+    wait_for_health(
+        &volume.state(),
+        &volume_client,
+        Duration::from_secs(2),
+        |h| {
+            h.healthy_replicas == 1
+                && !h.clean_shutdown
+                && h.online_clean_replicas == 1
+                && h.clean_replicas == 1
+                && h.live_healthy_replicas == 1
+                && h.online_healthy_replicas == 1
+        },
+    )
+    .await
+    .unwrap();
+
+    cluster.composer().start(&cluster.node(2)).await.unwrap();
+    wait_for_health(
+        &volume.state(),
+        &volume_client,
+        Duration::from_secs(2),
+        |h| {
+            h.healthy_replicas == 2
+                && !h.clean_shutdown
+                && h.online_clean_replicas == 1
+                && h.clean_replicas == 1
+                && h.live_healthy_replicas == 2
+                && h.online_healthy_replicas == 2
+        },
+    )
+    .await
+    .unwrap();
+
+    // a stop is a clean shutdown and should be so marked in the health info!
+    cluster.composer().stop(&cluster.node(1)).await.unwrap();
+    cluster
+        .wait_node_status(cluster.node(1), transport::NodeStatus::Unknown)
+        .await
+        .unwrap();
+
+    wait_for_health(
+        &volume.state(),
+        &volume_client,
+        Duration::from_secs(2),
+        |h| {
+            h.healthy_replicas == 2
+                && h.clean_shutdown
+                && h.online_clean_replicas == 1
+                && h.clean_replicas == 2
+                && h.live_healthy_replicas == 0
+                && h.online_healthy_replicas == 1
+        },
+    )
+    .await
+    .unwrap();
+}
+
+async fn wait_for_health<F: FnMut(&VolumeHealth) -> bool>(
+    volume: &VolumeState,
+    client: &dyn VolumeOperations,
+    timeout: std::time::Duration,
+    mut cb: F,
+) -> Result<VolumeState, Option<VolumeHealth>> {
+    let now = std::time::Instant::now();
+    let mut health = None;
+    while now.elapsed() < timeout {
+        let volume = get_volume(volume, client).await;
+        health = volume.state().health;
+        if let Some(health) = &health {
+            if cb(health) {
+                return Ok(volume.state());
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    Err(health)
 }

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -109,7 +109,7 @@ impl ResourceLifecycle for OperationGuardArc<VolumeSpec> {
         // When nexus is destroyed ahead of the volume destroy, then
         // delete_nexus_info in previous will not be called since nexus won't be present.
         // So invoke delete_nexus_info explicitly using the nexus id in target_config if present.
-        self.delete_all_info(registry).await;
+        self.delete_all_nexusinfo(registry).await;
 
         let replicas = specs.volume_replicas(&request.uuid);
         for replica in replicas {

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -383,6 +383,8 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
             .await;
         }
 
+        self.prune_health(registry);
+
         let volume = registry.volume(&request.uuid).await?;
         registry
             .notify_if_degraded(&volume, PollTriggerEvent::VolumeDegraded)
@@ -590,6 +592,7 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         };
 
         self.complete_update(registry, result, spec_clone).await?;
+        self.prune_health(registry);
 
         let volume = registry.volume(&request.uuid).await?;
         registry

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -109,15 +109,7 @@ impl ResourceLifecycle for OperationGuardArc<VolumeSpec> {
         // When nexus is destroyed ahead of the volume destroy, then
         // delete_nexus_info in previous will not be called since nexus won't be present.
         // So invoke delete_nexus_info explicitly using the nexus id in target_config if present.
-        if let Some(config) = self.as_ref().config() {
-            let nexus_id = config.target().nexus();
-            // Delete the NexusInfo entry persisted by the IoEngine.
-            ResourceSpecsLocked::delete_nexus_info(
-                &NexusInfoKey::new(&Some(self.uuid().clone()), nexus_id),
-                registry,
-            )
-            .await;
-        }
+        self.delete_all_info(registry).await;
 
         let replicas = specs.volume_replicas(&request.uuid);
         for replica in replicas {

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -23,11 +23,13 @@ use agents::errors::{NotEnough, SvcError, SvcError::ReplicaRemovalNoCandidates};
 
 use grpc::operations::volume::traits::PublishVolumeInfo;
 use stor_port::{
+    pstor::ObjectKey,
     transport_api::ErrorChain,
     types::v0::{
         store::{
             nexus::{NexusSpec, ReplicaUri},
             nexus_child::NexusChild,
+            nexus_persistence::NexusInfoKey,
             replica::ReplicaSpec,
             volume::{FrontendConfig, TargetConfig, VolumeOperation, VolumeSpec, VolumeTarget},
         },
@@ -810,7 +812,42 @@ impl OperationGuardArc<VolumeSpec> {
         }
     }
 
+    /// Check if volume has snapshots.
     pub fn has_snapshots(&self) -> bool {
         self.as_ref().metadata.has_snapshots()
+    }
+
+    /// Delete all NexusInfo keys from the persistent store.
+    /// If deletion fails we just log it and continue.
+    pub(super) async fn delete_all_info(&self, registry: &Registry) {
+        // this is just a placeholder id, since we're deleting all anyway
+        // but this allows us to skip this step if we never published, even once.
+        let Some(nexus_id) = self.as_ref().health_info_id() else {
+            return;
+        };
+
+        let info =
+            NexusInfoKey::new(&Some(self.uuid().clone()), nexus_id).with_rm_all_nexuses(true);
+        let vol_id = match info.volume_id() {
+            Some(v) => v.as_str(),
+            None => "",
+        };
+        match registry.delete_kv_prefix(&info.key()).await {
+            Ok(_) => {
+                tracing::trace!(
+                    volume.uuid = %vol_id,
+                    nexus.uuid = %info.nexus_id(),
+                    "Deleted NexusInfo entry from persistent store",
+                );
+            }
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    volume.uuid = %vol_id,
+                    nexus.uuid = %info.nexus_id(),
+                    "Failed to delete NexusInfo entry from persistent store",
+                );
+            }
+        }
     }
 }

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -46,6 +46,41 @@ use stor_port::{
 use http::Uri;
 
 impl OperationGuardArc<VolumeSpec> {
+    /// Prune volume health from older targets.
+    pub(crate) fn prune_health(&self, registry: &Registry) {
+        let Some(target) = self.lock().health_info_id().cloned() else {
+            return;
+        };
+        let volume_uuid = self.uuid();
+        registry.health().retain(|k, v| {
+            let Some(vol_entry) = &v.volume_uuid else {
+                // we're not interested in these test nexuses
+                return false;
+            };
+            if vol_entry != volume_uuid {
+                // only interested in the given volume
+                return true;
+            }
+            if k != target.uuid() {
+                // remove older targets.
+                return false;
+            }
+            false
+        });
+    }
+
+    /// Remove volume health from this volume.
+    pub(crate) fn remove_health(&self, registry: &Registry) {
+        let volume_uuid = self.uuid();
+        registry.health().retain(|_k, v| {
+            let Some(vol_entry) = &v.volume_uuid else {
+                // we're not interested in these test nexuses
+                return false;
+            };
+            vol_entry != volume_uuid
+        });
+    }
+
     /// Check if the volume is published.
     pub(super) fn published(&self) -> bool {
         self.as_ref().target().is_some()
@@ -849,5 +884,7 @@ impl OperationGuardArc<VolumeSpec> {
                 );
             }
         }
+
+        self.remove_health(registry);
     }
 }

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -29,7 +29,6 @@ use stor_port::{
         store::{
             nexus::{NexusSpec, ReplicaUri},
             nexus_child::NexusChild,
-            nexus_persistence::NexusInfoKey,
             replica::ReplicaSpec,
             volume::{FrontendConfig, TargetConfig, VolumeOperation, VolumeSpec, VolumeTarget},
         },
@@ -44,6 +43,7 @@ use stor_port::{
 };
 
 use http::Uri;
+use stor_port::types::v0::store::nexus_persistence::VolumeHealthPrefix;
 
 impl OperationGuardArc<VolumeSpec> {
     /// Prune volume health from older targets.
@@ -851,33 +851,25 @@ impl OperationGuardArc<VolumeSpec> {
 
     /// Delete all NexusInfo keys from the persistent store.
     /// If deletion fails we just log it and continue.
-    pub(super) async fn delete_all_info(&self, registry: &Registry) {
-        // this is just a placeholder id, since we're deleting all anyway
-        // but this allows us to skip this step if we never published, even once.
-        let Some(nexus_id) = self.as_ref().health_info_id() else {
+    pub(super) async fn delete_all_nexusinfo(&self, registry: &Registry) {
+        // this allows us to skip this procedure if we never published, even once.
+        if self.as_ref().health_info_id().is_none() {
             return;
-        };
+        }
 
-        let info =
-            NexusInfoKey::new(&Some(self.uuid().clone()), nexus_id).with_rm_all_nexuses(true);
-        let vol_id = match info.volume_id() {
-            Some(v) => v.as_str(),
-            None => "",
-        };
+        let info = VolumeHealthPrefix::new(self.uuid().clone());
         match registry.delete_kv_prefix(&info.key()).await {
             Ok(_) => {
                 tracing::trace!(
-                    volume.uuid = %vol_id,
-                    nexus.uuid = %info.nexus_id(),
+                    volume.uuid = %self.uuid(),
                     "Deleted NexusInfo entry from persistent store",
                 );
             }
             Err(error) => {
                 tracing::error!(
                     %error,
-                    volume.uuid = %vol_id,
-                    nexus.uuid = %info.nexus_id(),
-                    "Failed to delete NexusInfo entry from persistent store",
+                    volume.uuid = %self.uuid(),
+                    "Failed to delete volume NexusInfo entry from persistent store",
                 );
             }
         }

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -61,11 +61,8 @@ impl OperationGuardArc<VolumeSpec> {
                 // only interested in the given volume
                 return true;
             }
-            if k != target.uuid() {
-                // remove older targets.
-                return false;
-            }
-            false
+            // remove older targets
+            k == target.uuid()
         });
     }
 

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -52,7 +52,7 @@ impl OperationGuardArc<VolumeSpec> {
             return;
         };
         let volume_uuid = self.uuid();
-        registry.health().retain(|k, v| {
+        registry.health_retain(|k, v| {
             let Some(vol_entry) = &v.volume_uuid else {
                 // we're not interested in these test nexuses
                 return false;
@@ -69,7 +69,7 @@ impl OperationGuardArc<VolumeSpec> {
     /// Remove volume health from this volume.
     pub(crate) fn remove_health(&self, registry: &Registry) {
         let volume_uuid = self.uuid();
-        registry.health().retain(|_k, v| {
+        registry.health_retain(|_k, v| {
             let Some(vol_entry) = &v.volume_uuid else {
                 // we're not interested in these test nexuses
                 return false;

--- a/control-plane/agents/src/bin/core/volume/registry.rs
+++ b/control-plane/agents/src/bin/core/volume/registry.rs
@@ -16,13 +16,15 @@ use stor_port::{
     types::v0::{
         store::{
             nexus::NexusSpec,
+            nexus_persistence::NexusInfo,
             replica::ReplicaSpec,
             snapshots::{replica::ReplicaSnapshotSpec, volume::VolumeSnapshot},
             volume::VolumeSpec,
         },
         transport::{
-            uri_with_hostnqn, Nexus, NexusStatus, NodeBugFix, ReplicaSnapshot, ReplicaStatus,
-            ReplicaTopology, SnapshotId, Volume, VolumeId, VolumeState, VolumeStatus, VolumeUsage,
+            uri_with_hostnqn, ChildState, Nexus, NexusStatus, NodeBugFix, ReplicaSnapshot,
+            ReplicaStatus, ReplicaTopology, SnapshotId, Volume, VolumeHealth, VolumeId,
+            VolumeState, VolumeStatus, VolumeUsage,
         },
     },
     IntoOption,
@@ -67,6 +69,10 @@ impl Registry {
             }
         };
 
+        let health = volume_spec
+            .health_info_id()
+            .and_then(|i| self.health().health(i));
+
         let mut total_replica = 0;
         let mut total_snapshots = 0;
         let mut largest_replica = 0;
@@ -76,7 +82,7 @@ impl Registry {
         // Construct the topological information for the volume replicas.
         let mut replica_topology = HashMap::new();
         for replica_spec in &replica_specs {
-            let replica = self.replica_topology(replica_spec, &nexus).await;
+            let replica = self.replica_topology(replica_spec, &nexus, &health).await;
             if let Some(usage) = replica.usage() {
                 let allocated = usage.allocated();
                 let allocated_snaps = usage.allocated_snapshots();
@@ -106,8 +112,37 @@ impl Registry {
             total_snapshots,
         ));
 
-        // todo: fill in info from the pstor(etcd)
-        let health = None;
+        let health = health.map(|info| {
+            let healthy = info.children.iter().filter(|c| c.healthy);
+            let online_healthy = healthy.clone().filter(|c| {
+                replica_topology
+                    .iter()
+                    .any(|(r, t)| r == &c.uuid && t.status().online())
+            });
+            let online_healthy_replicas = online_healthy.count() as u8;
+            VolumeHealth {
+                clean_shutdown: info.clean_shutdown,
+                healthy_replicas: info.nr_healthy_replicas(),
+                clean_replicas: if info.clean_shutdown {
+                    info.nr_healthy_replicas()
+                } else {
+                    info.nr_healthy_replicas().min(1)
+                },
+                online_healthy_replicas,
+                online_clean_replicas: if info.clean_shutdown {
+                    online_healthy_replicas
+                } else {
+                    online_healthy_replicas.min(1)
+                },
+                live_healthy_replicas: healthy
+                    .filter(|c| {
+                        replica_topology.iter().any(|(r, t)| {
+                            r == &c.uuid && matches!(t.child_status(), Some(ChildState::Online))
+                        })
+                    })
+                    .count() as u8,
+            }
+        });
 
         Ok(if let Some((nexus, mut nexus_state)) = nexus {
             let ah = nexus.lock().allowed_hosts.clone();
@@ -129,20 +164,34 @@ impl Registry {
                 health,
             }
         } else {
+            let mut status = match volume_spec.health_info_id() {
+                // Volume never published, any replica may be used
+                None => VolumeStatus::Online,
+                Some(_) => {
+                    match &health {
+                        // for some reason, we don't have the etcd health information!?
+                        None => VolumeStatus::Unknown,
+                        Some(h) => {
+                            if h.online_clean_replicas >= volume_spec.num_replicas {
+                                VolumeStatus::Online
+                            } else if h.online_clean_replicas > 0 {
+                                VolumeStatus::Degraded
+                            } else {
+                                VolumeStatus::Faulted
+                            }
+                        }
+                    }
+                }
+            };
+            if volume_spec.target().is_some() && status == VolumeStatus::Online {
+                // If the target is not coming up, mark volume status as degraded?
+                // This is mixing the target and replica status may lead to confusion.
+                status = VolumeStatus::Degraded;
+            }
             VolumeState {
                 uuid: volume_spec.uuid.to_owned(),
                 size: volume_spec.size,
-                status: if volume_spec.target().is_none() {
-                    if replica_specs.len() >= volume_spec.num_replicas as usize {
-                        VolumeStatus::Online
-                    } else if replica_specs.is_empty() {
-                        VolumeStatus::Faulted
-                    } else {
-                        VolumeStatus::Degraded
-                    }
-                } else {
-                    VolumeStatus::Unknown
-                },
+                status,
                 target: None,
                 replica_topology,
                 usage,
@@ -157,9 +206,12 @@ impl Registry {
         &self,
         spec: &ReplicaSpec,
         nexus: &Option<(ResourceMutex<NexusSpec>, Nexus)>,
+        health: &Option<std::sync::Arc<NexusInfo>>,
     ) -> ReplicaTopology {
         // todo: fill in info from the pstor(etcd)
-        let healthy = None;
+        let healthy = health
+            .as_ref()
+            .map(|health| health.is_replica_healthy(&spec.uuid));
         match self.replica(&spec.uuid).await {
             Ok(state) => {
                 let child = nexus.as_ref().and_then(|(_, n)| n.child(&state.uri));

--- a/control-plane/agents/src/bin/core/volume/registry.rs
+++ b/control-plane/agents/src/bin/core/volume/registry.rs
@@ -30,6 +30,7 @@ use stor_port::{
     IntoOption,
 };
 
+use crate::controller::resources::VolumeHealthWatcher;
 use std::collections::HashMap;
 
 impl Registry {
@@ -41,7 +42,19 @@ impl Registry {
         let volume_spec = self.specs().volume_clone(volume_uuid)?;
         let replica_specs = self.specs().volume_replicas_cln(volume_uuid);
 
-        self.volume_state_with_replicas(&volume_spec, &replica_specs)
+        self.volume_state_with_replicas(&volume_spec, &replica_specs, None)
+            .await
+    }
+
+    /// Get the volume state for the specified volume, with added health information.
+    pub(crate) async fn volume_state_health(
+        &self,
+        volume_uuid: &VolumeId,
+    ) -> Result<VolumeState, SvcError> {
+        let volume_spec = self.specs().volume_clone(volume_uuid)?;
+        let replica_specs = self.specs().volume_replicas_cln(volume_uuid);
+
+        self.volume_state_with_replicas(&volume_spec, &replica_specs, self.health())
             .await
     }
 
@@ -51,6 +64,7 @@ impl Registry {
         &self,
         volume_spec: &VolumeSpec,
         replicas: &[ReplicaSpec],
+        health: Option<&VolumeHealthWatcher>,
     ) -> Result<VolumeState, SvcError> {
         let replica_specs = replicas
             .iter()
@@ -71,7 +85,7 @@ impl Registry {
 
         let health = volume_spec
             .health_info_id()
-            .and_then(|i| self.health().health(i));
+            .and_then(|i| health.and_then(|h| h.health(i)));
 
         let mut total_replica = 0;
         let mut total_snapshots = 0;
@@ -170,7 +184,19 @@ impl Registry {
                 Some(_) => {
                     match &health {
                         // for some reason, we don't have the etcd health information!?
-                        None => VolumeStatus::Unknown,
+                        None => {
+                            if volume_spec.target().is_none() {
+                                if replica_specs.len() >= volume_spec.num_replicas as usize {
+                                    VolumeStatus::Online
+                                } else if replica_specs.is_empty() {
+                                    VolumeStatus::Faulted
+                                } else {
+                                    VolumeStatus::Degraded
+                                }
+                            } else {
+                                VolumeStatus::Unknown
+                            }
+                        }
                         Some(h) => {
                             if h.online_clean_replicas >= volume_spec.num_replicas {
                                 VolumeStatus::Online
@@ -265,7 +291,10 @@ impl Registry {
         let replicas = self.specs().replicas_cloned();
         let mut volumes = Vec::with_capacity(volume_specs.len());
         for spec in volume_specs {
-            if let Ok(state) = self.volume_state_with_replicas(&spec, &replicas).await {
+            if let Ok(state) = self
+                .volume_state_with_replicas(&spec, &replicas, self.health())
+                .await
+            {
                 volumes.push(Volume::new(spec, state));
             }
         }
@@ -281,7 +310,7 @@ impl Registry {
         let mut volumes = Vec::with_capacity(volume_specs.len());
         let last = volume_specs.last();
         for spec in volume_specs.result() {
-            if let Ok(state) = self.volume_state(&spec.uuid).await {
+            if let Ok(state) = self.volume_state_health(&spec.uuid).await {
                 volumes.push(Volume::new(spec, state));
             }
         }
@@ -292,7 +321,7 @@ impl Registry {
     pub(crate) async fn volume(&self, id: &VolumeId) -> Result<Volume, SvcError> {
         Ok(Volume::new(
             self.specs().volume_clone(id)?,
-            self.volume_state(id).await?,
+            self.volume_state_health(id).await?,
         ))
     }
 

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -62,7 +62,8 @@ lazy_static! {
         "SNAPSHOTS",
         "CHILD-STATUS",
         "REASON",
-        "REBUILD"
+        "REBUILD",
+        "HEALTHY",
     ];
     pub static ref SNAPSHOT_TOPOLOGY_PREFIX: Row = row!["SNAPSHOT-ID"];
     pub static ref SNAPSHOT_TOPOLOGY_HEADERS: Row = row![

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -28,6 +28,7 @@ lazy_static! {
         "ALLOCATED",
         "SNAPSHOTS",
         "SOURCE",
+        "CLEAN-SHUTDOWN",
     ];
     pub static ref SNAPSHOT_HEADERS: Row = row![
         "ID",

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -40,10 +40,15 @@ pub struct VolumesArgs {
 impl CreateRow for openapi::models::Volume {
     fn row(&self) -> Row {
         let state = &self.state;
+        let target_node = match state.target.clone().map(|t| t.node) {
+            Some(node) => Some(node),
+            None if self.spec.target.is_some() => Some("<missing>".to_string()),
+            None => None,
+        };
         row![
             state.uuid,
             self.spec.num_replicas,
-            optional_cell(state.target.clone().map(|t| t.node)),
+            optional_cell(target_node),
             optional_cell(state.target.as_ref().and_then(target_protocol)),
             state.status.clone(),
             ::utils::bytes::into_human(state.size),

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -64,6 +64,7 @@ impl CreateRow for openapi::models::Volume {
                     VolumeContentSource::snapshot(_) => "Snapshot",
                 }
             })),
+            optional_cell(state.health.as_ref().map(|h| h.clean_shutdown))
         ]
     }
 }

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -382,6 +382,7 @@ impl CreateRows for HashMap<String, openapi::models::ReplicaTopology> {
                     optional_cell(topology.child_status.as_ref().map(|s| s.to_string())),
                     optional_cell(topology.child_status_reason.as_ref().map(|s| s.to_string())),
                     optional_cell(topology.rebuild_progress.map(|p| format!("{p}%"))),
+                    optional_cell(topology.healthy),
                 ]
             })
             .collect()

--- a/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
@@ -37,6 +37,24 @@ impl NexusInfo {
     pub fn no_healthy_replicas(&self) -> bool {
         self.children.iter().all(|c| !c.healthy) || self.children.is_empty()
     }
+
+    /// Modify the self with the given key information.
+    pub fn with_key(self, key: &str) -> Result<Option<Self>, uuid::Error> {
+        let Some((volume, nexus)) = parse_info_key(key) else {
+            return Ok(None);
+        };
+        let uuid = NexusId::try_from(nexus)?;
+
+        let Some(volume) = volume else {
+            return Ok(Some(Self { uuid, ..self }));
+        };
+
+        Ok(Some(Self {
+            uuid,
+            volume_uuid: Some(volume.try_into()?),
+            ..self
+        }))
+    }
 }
 
 /// Definition of the child information that gets saved in the persistent
@@ -68,6 +86,15 @@ impl NexusInfoKey {
             rm_all_nexuses: false,
         }
     }
+    /// Create a new NexusInfoKey.
+    pub fn new_(volume_id: VolumeId, nexus_id: NexusId) -> Self {
+        Self {
+            volume_id: Some(volume_id),
+            nexus_id,
+            mayastor_compat_v1: false,
+            rm_all_nexuses: false,
+        }
+    }
     /// Set the `mayastor_compat_v1`.
     pub fn with_mayastor_compat_v1(mut self, compat: bool) -> Self {
         self.mayastor_compat_v1 = compat;
@@ -92,6 +119,15 @@ impl NexusInfoKey {
     fn nexus_key_mayastor_v1(&self) -> String {
         // compatibility mode, return key at the root!
         self.nexus_id.to_string()
+    }
+
+    /// The key prefix which is shared by all `Self`.
+    /// # Warning
+    /// This doesn't support compatible v1 nexus health info.
+    pub fn key_prefix() -> String {
+        let dummy = Self::new(&Some(VolumeId::new()), &NexusId::new());
+        let namespace = key_prefix(dummy.version());
+        format!("{namespace}/volume/")
     }
 
     /// Parse the nexus id out of the given key.

--- a/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
@@ -55,6 +55,7 @@ pub struct NexusInfoKey {
     volume_id: Option<VolumeId>,
     nexus_id: NexusId,
     mayastor_compat_v1: bool,
+    rm_all_nexuses: bool,
 }
 
 impl NexusInfoKey {
@@ -64,11 +65,17 @@ impl NexusInfoKey {
             volume_id: volume_id.clone(),
             nexus_id: nexus_id.clone(),
             mayastor_compat_v1: false,
+            rm_all_nexuses: false,
         }
     }
     /// Set the `mayastor_compat_v1`.
     pub fn with_mayastor_compat_v1(mut self, compat: bool) -> Self {
         self.mayastor_compat_v1 = compat;
+        self
+    }
+    /// Set the `rm_all_nexuses`.
+    pub fn with_rm_all_nexuses(mut self, rm_all_nexuses: bool) -> Self {
+        self.rm_all_nexuses = rm_all_nexuses;
         self
     }
 
@@ -86,6 +93,28 @@ impl NexusInfoKey {
         // compatibility mode, return key at the root!
         self.nexus_id.to_string()
     }
+
+    /// Parse the nexus id out of the given key.
+    pub fn parse_id(key: &str) -> Result<NexusId, String> {
+        let Some((_, n)) = parse_info_key(key) else {
+            return Err("Failed to match nexus info format".into());
+        };
+
+        n.try_into().map_err(|e: uuid::Error| e.to_string())
+    }
+}
+
+fn parse_info_key(key: &str) -> Option<(Option<&str>, &str)> {
+    // $prefix/volume/{volume_uuid}/nexus/{nexus_uuid}/info
+    let values = key.split('/').collect::<Vec<_>>();
+    if let [.., "volume", volume, "nexus", nexus, "info"] = values[..] {
+        return Some((Some(volume), nexus));
+    }
+    if let [.., "nexus", nexus, "info"] = values[..] {
+        return Some((None, nexus));
+    }
+
+    None
 }
 
 impl ObjectKey for NexusInfoKey {
@@ -98,6 +127,9 @@ impl ObjectKey for NexusInfoKey {
         let namespace = key_prefix(self.version());
         let nexus_uuid = self.nexus_id.clone();
         match &self.volume_id {
+            Some(volume_uuid) if self.rm_all_nexuses => {
+                format!("{namespace}/volume/{volume_uuid}/nexus/")
+            }
             Some(volume_uuid) => {
                 format!("{namespace}/volume/{volume_uuid}/nexus/{nexus_uuid}/info")
             }
@@ -130,6 +162,7 @@ impl StorableObject for NexusInfo {
             volume_id: self.volume_uuid.clone(),
             nexus_id: self.uuid.clone(),
             mayastor_compat_v1: false,
+            rm_all_nexuses: false,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
@@ -33,9 +33,14 @@ impl NexusInfo {
         }
     }
 
-    /// Check if no replica is healthy
+    /// Check if no replica is healthy.
     pub fn no_healthy_replicas(&self) -> bool {
         self.children.iter().all(|c| !c.healthy) || self.children.is_empty()
+    }
+
+    /// Get number of healthy replicas.
+    pub fn nr_healthy_replicas(&self) -> u8 {
+        self.children.iter().filter(|c| c.healthy).count() as u8
     }
 
     /// Modify the self with the given key information.

--- a/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
@@ -78,7 +78,6 @@ pub struct NexusInfoKey {
     volume_id: Option<VolumeId>,
     nexus_id: NexusId,
     mayastor_compat_v1: bool,
-    rm_all_nexuses: bool,
 }
 
 impl NexusInfoKey {
@@ -88,26 +87,11 @@ impl NexusInfoKey {
             volume_id: volume_id.clone(),
             nexus_id: nexus_id.clone(),
             mayastor_compat_v1: false,
-            rm_all_nexuses: false,
-        }
-    }
-    /// Create a new NexusInfoKey.
-    pub fn new_(volume_id: VolumeId, nexus_id: NexusId) -> Self {
-        Self {
-            volume_id: Some(volume_id),
-            nexus_id,
-            mayastor_compat_v1: false,
-            rm_all_nexuses: false,
         }
     }
     /// Set the `mayastor_compat_v1`.
     pub fn with_mayastor_compat_v1(mut self, compat: bool) -> Self {
         self.mayastor_compat_v1 = compat;
-        self
-    }
-    /// Set the `rm_all_nexuses`.
-    pub fn with_rm_all_nexuses(mut self, rm_all_nexuses: bool) -> Self {
-        self.rm_all_nexuses = rm_all_nexuses;
         self
     }
 
@@ -158,6 +142,92 @@ fn parse_info_key(key: &str) -> Option<(Option<&str>, &str)> {
     None
 }
 
+enum NexusInfoKind<'a> {
+    Nexus(&'a NexusId),
+    Volume(&'a VolumeId, &'a NexusId),
+    VolumePrefix(&'a VolumeId),
+}
+
+impl NexusInfoKind<'_> {
+    fn key(&self, prefix: String) -> String {
+        match &self {
+            Self::Nexus(nexus_uuid) => format!("{prefix}/nexus/{nexus_uuid}/info"),
+            Self::Volume(volume_uuid, nexus_uuid) => {
+                format!("{prefix}/volume/{volume_uuid}/nexus/{nexus_uuid}/info")
+            }
+            Self::VolumePrefix(volume_uuid) => {
+                format!("{prefix}/volume/{volume_uuid}/nexus/")
+            }
+        }
+    }
+}
+
+/// Key used by the store to uniquely identify a NexusInfo structure.
+/// The volume is optional because a nexus can be created which is not associated with a volume.
+pub struct VolumeHealthKey {
+    volume_id: VolumeId,
+    nexus_id: NexusId,
+}
+impl VolumeHealthKey {
+    /// Create a new `VolumeHealthKey`.
+    pub fn new(volume_id: VolumeId, nexus_id: NexusId) -> Self {
+        Self {
+            volume_id,
+            nexus_id,
+        }
+    }
+    /// Get the id of the nexus.
+    pub fn nexus_id(&self) -> &NexusId {
+        &self.nexus_id
+    }
+    /// Get the id of the volume.
+    pub fn volume_id(&self) -> &VolumeId {
+        &self.volume_id
+    }
+    /// Convert into a `NexusInfoKey`.
+    pub fn nexus_info_key(self) -> NexusInfoKey {
+        NexusInfoKey {
+            volume_id: Some(self.volume_id),
+            nexus_id: self.nexus_id,
+            mayastor_compat_v1: false,
+        }
+    }
+}
+
+/// A pstor helper for referencing all [`NexusInfo`] for the given volume.
+pub struct VolumeHealthPrefix {
+    volume_id: VolumeId,
+}
+impl VolumeHealthPrefix {
+    /// Create a new `Self`, which can reference all volume health info.
+    pub fn new(volume_id: VolumeId) -> VolumeHealthPrefix {
+        Self { volume_id }
+    }
+}
+
+impl ObjectKey for VolumeHealthPrefix {
+    type Kind = StorableObjectType;
+
+    fn key(&self) -> String {
+        let namespace = key_prefix(self.version());
+        NexusInfoKind::VolumePrefix(&self.volume_id).key(namespace)
+    }
+
+    fn version(&self) -> ApiVersion {
+        ApiVersion::V0
+    }
+
+    fn key_type(&self) -> StorableObjectType {
+        // The key is generated directly from the `key()` function above.
+        unreachable!()
+    }
+
+    fn key_uuid(&self) -> String {
+        // The key is generated directly from the `key()` function above.
+        unreachable!()
+    }
+}
+
 impl ObjectKey for NexusInfoKey {
     type Kind = StorableObjectType;
 
@@ -166,17 +236,10 @@ impl ObjectKey for NexusInfoKey {
             return self.nexus_key_mayastor_v1();
         }
         let namespace = key_prefix(self.version());
-        let nexus_uuid = self.nexus_id.clone();
+        let nexus_uuid = &self.nexus_id;
         match &self.volume_id {
-            Some(volume_uuid) if self.rm_all_nexuses => {
-                format!("{namespace}/volume/{volume_uuid}/nexus/")
-            }
-            Some(volume_uuid) => {
-                format!("{namespace}/volume/{volume_uuid}/nexus/{nexus_uuid}/info")
-            }
-            None => {
-                format!("{namespace}/nexus/{nexus_uuid}/info")
-            }
+            Some(volume_uuid) => NexusInfoKind::Volume(volume_uuid, nexus_uuid).key(namespace),
+            None => NexusInfoKind::Nexus(nexus_uuid).key(namespace),
         }
     }
 
@@ -203,7 +266,6 @@ impl StorableObject for NexusInfo {
             volume_id: self.volume_uuid.clone(),
             nexus_id: self.uuid.clone(),
             mayastor_compat_v1: false,
-            rm_all_nexuses: false,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -5,7 +5,7 @@ use crate::{
         openapi::models,
         store::{
             definitions::{ObjectKey, StorableObject, StorableObjectType},
-            nexus_persistence::NexusInfoKey,
+            nexus_persistence::VolumeHealthKey,
             AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
         },
         transport::{
@@ -16,7 +16,6 @@ use crate::{
     },
     IntoOption,
 };
-
 use pstor::ApiVersion;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -440,10 +439,10 @@ impl VolumeSpec {
         }
         self.target_config.as_ref().map(|c| &c.target.nexus)
     }
-    /// Get the [`NexusInfoKey`] for the [`Self::health_info_id`].
-    pub fn health_info_key(&self) -> Option<NexusInfoKey> {
+    /// Get the [`VolumeHealthKey`] for the [`Self::health_info_id`].
+    pub fn health_info_key(&self) -> Option<VolumeHealthKey> {
         self.health_info_id()
-            .map(|target| NexusInfoKey::new_(self.uuid.clone(), target.clone()))
+            .map(|target| VolumeHealthKey::new(self.uuid.clone(), target.clone()))
     }
     /// Set the content source.
     pub fn set_content_source(&mut self, content_source: Option<VolumeContentSource>) {

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -5,6 +5,7 @@ use crate::{
         openapi::models,
         store::{
             definitions::{ObjectKey, StorableObject, StorableObjectType},
+            nexus_persistence::NexusInfoKey,
             AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
         },
         transport::{
@@ -438,6 +439,11 @@ impl VolumeSpec {
             return Some(id);
         }
         self.target_config.as_ref().map(|c| &c.target.nexus)
+    }
+    /// Get the [`NexusInfoKey`] for the [`Self::health_info_id`].
+    pub fn health_info_key(&self) -> Option<NexusInfoKey> {
+        self.health_info_id()
+            .map(|target| NexusInfoKey::new_(self.uuid.clone(), target.clone()))
     }
     /// Set the content source.
     pub fn set_content_source(&mut self, content_source: Option<VolumeContentSource>) {

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -83,7 +83,7 @@ pub struct VolumeHealth {
     pub healthy_replicas: u8,
     /// Indicates how many volume healthy replicas were part of a clean shutdown.
     /// If cleanShutdown is true, then this is equal to healthyReplicas.
-    /// If cleanShutdown is true, then this is equal to 1.
+    /// If cleanShutdown is false, then this is equal to 1.
     pub clean_replicas: u8,
     /// Indicates how many volume healthyReplicas are online.
     pub online_healthy_replicas: u8,

--- a/deployer/src/infra/etcd.rs
+++ b/deployer/src/infra/etcd.rs
@@ -6,11 +6,16 @@ use stor_port::pstor::etcd::Etcd as EtcdStore;
 impl ComponentAction for Etcd {
     fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
         Ok(if !options.no_etcd {
+            let etcd_data = if options.persistent_etcd {
+                "/host-tmp/etcd-data"
+            } else {
+                "/tmp/etcd-data"
+            };
             let container_spec = ContainerSpec::from_binary(
                 "etcd",
                 Binary::from_path("etcd").with_args(vec![
                     "--data-dir",
-                    "/tmp/etcd-data",
+                    etcd_data,
                     "--advertise-client-urls",
                     "http://[::]:2379",
                     "--listen-client-urls",
@@ -22,6 +27,11 @@ impl ComponentAction for Etcd {
             )
             .with_portmap("2379", "2379")
             .with_portmap("2380", "2380");
+            let container_spec = if options.persistent_etcd {
+                container_spec.with_bind("/tmp/", "/host-tmp")
+            } else {
+                container_spec
+            };
 
             #[cfg(target_arch = "aarch64")]
             let container_spec = container_spec.with_env("ETCD_UNSUPPORTED_ARCH", "arm64");

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -261,6 +261,10 @@ pub struct StartOptions {
     #[clap(long)]
     pub no_etcd: bool,
 
+    /// Make the etcd service data persistent across etcd restarts.
+    #[clap(long)]
+    pub persistent_etcd: bool,
+
     /// The period at which the registry updates its cache of all
     /// resources from all nodes.
     #[clap(long)]

--- a/utils/pstor/src/api.rs
+++ b/utils/pstor/src/api.rs
@@ -57,7 +57,7 @@ pub trait StoreKv: Sync + Send + Clone {
 /// Trait defining the operations that can be performed on a key-value store using object semantics.
 /// It allows for abstracting the key component into the `StorableObject` itself.
 #[async_trait]
-pub trait StoreObj: StoreKv + Sync + Send + Clone {
+pub trait StoreObj: Sync + Send + Clone {
     /// Puts the given `O` object into the store.
     async fn put_obj<O: StorableObject>(&mut self, object: &O) -> Result<(), Error>;
     /// Gets the object `O` through its `O::Key`.
@@ -77,9 +77,9 @@ pub struct WatchKey {
 }
 impl WatchKey {
     /// Create a new `Self` with the given key prefix.
-    pub fn new(prefix: &str) -> Self {
+    pub fn new(prefix: impl Into<String>) -> Self {
         Self {
-            prefix: prefix.to_string(),
+            prefix: prefix.into(),
             rev: None,
         }
     }
@@ -104,11 +104,13 @@ pub struct WatchCbArg<'a, Ctx> {
     pub cb_ctx: &'a Ctx,
     /// The actual key which was updated (which contains the prefix of `key_prefix`).
     pub updated_key: &'a str,
+    /// The latest value returned by the watch event.
+    pub value: &'a str,
 }
 
 /// Trait defining the operations that can be performed on a key-value store using object semantics.
 /// It allows for abstracting the key component into the `StorableObject` itself.
-pub trait StoreKvWatcher<Ctx: Send + Sync + 'static> {
+pub trait StoreKvWatcher<Ctx: Send + Sync + 'static = ()>: Send + Sync {
     /// Watch for the key prefix specified in the [`WatchKey`].
     /// Callbacks are received by the global [`WatchCallback`].
     fn watch(&self, key: WatchKey, ctx: Ctx) -> Result<(), Error>;

--- a/utils/pstor/src/etcd.rs
+++ b/utils/pstor/src/etcd.rs
@@ -67,8 +67,11 @@ impl Etcd {
             .map_err(|error| Error::NotReady {
                 reason: format!("Platform not ready: {error}"),
             })?;
-
-        let client = Client::connect(endpoints, None).await.context(Connect {})?;
+        let options =
+            etcd_client::ConnectOptions::new().with_keep_alive(lease_time, lease_time * 3);
+        let client = Client::connect(endpoints, Some(options))
+            .await
+            .context(Connect {})?;
 
         let lease_info = EtcdSingletonLock::start(client.clone(), service_kind, lease_time).await?;
         Ok(Self::from(&client, Some(lease_info)))

--- a/utils/pstor/src/etcd_watcher.rs
+++ b/utils/pstor/src/etcd_watcher.rs
@@ -61,21 +61,22 @@ impl<Ctx: Send + Sync + 'static> WatchConfig<Ctx> {
         tracing::info!("Removing watch key: {key}");
         self.keys.remove(key);
     }
-    fn update(&mut self, key: &str, rev: i64, updated_key: &str) -> WatchResult {
-        let Some(value) = self.keys.get_mut(key) else {
+    fn update(&mut self, key: &str, rev: i64, updated_key: &str, value: &str) -> WatchResult {
+        let Some(config) = self.keys.get_mut(key) else {
             // todo: if we can't find the key, should we request watch removal?
             return WatchResult::Continue;
         };
 
-        let old_rev = value.rev;
+        let old_rev = config.rev;
         tracing::trace!("Updating {key} from revision {old_rev} to {rev} due to {updated_key}");
-        value.rev = rev;
+        config.rev = rev;
 
         // callback and update the data, ex: volume update callback!
         (self.ctx_cb)(WatchCbArg {
             updated_key,
             key_prefix: key,
-            cb_ctx: &value.ctx,
+            cb_ctx: &config.ctx,
+            value,
         })
     }
     fn update_rev(&mut self, header: Option<&ResponseHeader>) {
@@ -223,7 +224,7 @@ impl StreamedWatcher {
             };
 
             if matches!(
-                config.update(registrant_key, kv.mod_revision(), k),
+                config.update(registrant_key, kv.mod_revision(), k, v),
                 WatchResult::Remove
             ) && unregister.is_none()
             {

--- a/utils/pstor/src/etcd_watcher.rs
+++ b/utils/pstor/src/etcd_watcher.rs
@@ -15,10 +15,8 @@ const WATCH_ALL_TMO: Duration = Duration::from_secs(15);
 /// When a watch is requested, we expect etcd to accept it within this timeframe, and return
 /// a created event.
 const WATCH_ACCEPT_TMO: Duration = Duration::from_secs(10);
-/// Timeout for response when checking the client status.
-const HEALTH_CHECK_TMO: Duration = Duration::from_secs(5);
 /// We should be receiving progress reports every 10 minutes or so.
-const NO_PROGRESS_TMO: Duration = Duration::from_secs(60 * 20);
+const NO_PROGRESS_TMO: Duration = Duration::from_secs(60 * 12);
 
 enum WatchRequest<Ctx: Send + Sync + 'static> {
     Register(WatchRegister<Ctx>),
@@ -46,6 +44,7 @@ struct WatchConfig<Ctx: Send + Sync + 'static> {
     // Timestamp of the last watch event.
     updated: Option<std::time::Instant>,
     closed: bool,
+    requested_progress: bool,
 }
 impl<Ctx: Send + Sync + 'static> WatchConfig<Ctx> {
     fn register(&mut self, register: WatchRegister<Ctx>) {
@@ -68,8 +67,10 @@ impl<Ctx: Send + Sync + 'static> WatchConfig<Ctx> {
         };
 
         let old_rev = config.rev;
-        tracing::trace!("Updating {key} from revision {old_rev} to {rev} due to {updated_key}");
-        config.rev = rev;
+        if rev != old_rev {
+            tracing::trace!("Updating {key} from revision {old_rev} to {rev} due to {updated_key}");
+            config.rev = rev;
+        }
 
         // callback and update the data, ex: volume update callback!
         (self.ctx_cb)(WatchCbArg {
@@ -87,6 +88,7 @@ impl<Ctx: Send + Sync + 'static> WatchConfig<Ctx> {
     fn update_response(&mut self, response: &WatchResponse) {
         self.update_rev(response.header());
         self.updated = Some(std::time::Instant::now());
+        self.requested_progress = false;
     }
 }
 
@@ -138,7 +140,8 @@ impl StreamedWatcher {
         &mut self,
         data: &WatchConfig<Ctx>,
     ) -> Result<(), etcd_client::Error> {
-        let rev = data.rev;
+        // don't bother receiving the same event again
+        let rev = data.rev.map(|r| r + 1);
         for (key, cfg) in &data.keys {
             self.watch_key_prefix(key.clone(), rev.or(Some(cfg.rev)))
                 .await?;
@@ -254,6 +257,7 @@ impl<Ctx: Send + Sync + 'static> EtcdWatchRunner<Ctx> {
                 ctx_cb: Box::new(ctx_cb),
                 rev: None,
                 updated: None,
+                requested_progress: false,
             },
         }
     }
@@ -391,6 +395,7 @@ impl<Ctx: Send + Sync + 'static> EtcdWatchRunner<Ctx> {
     /// When in the [`WatchState::Connecting`] state we attempt the first connection, and we connect
     /// all the registered keys in the [`WatchConfig].
     async fn handle_connecting(&mut self) -> WatchState {
+        self.config.requested_progress = false;
         if self.config.closed {
             return WatchState::Closed;
         }
@@ -437,7 +442,7 @@ impl<Ctx: Send + Sync + 'static> EtcdWatchRunner<Ctx> {
         }
     }
 
-    async fn health_check(&mut self, watcher: StreamedWatcher) -> WatchState {
+    async fn health_check(&mut self, mut watcher: StreamedWatcher) -> WatchState {
         for (id, registered) in &watcher.waiting_ids {
             if registered.elapsed() > WATCH_ACCEPT_TMO {
                 return self.handle_error_msg(format!(
@@ -446,20 +451,25 @@ impl<Ctx: Send + Sync + 'static> EtcdWatchRunner<Ctx> {
                 ));
             }
         }
-        match tokio::time::timeout(HEALTH_CHECK_TMO, self.client.status()).await {
-            Ok(Ok(status)) => {
-                self.config.update_rev(status.header());
-                if let Some(updated) = self.config.updated {
-                    if updated.elapsed() > NO_PROGRESS_TMO {
-                        return self.handle_error_msg(format!(
-                            "No progress notification within {NO_PROGRESS_TMO:?}"
-                        ));
-                    }
-                }
-                WatchState::Watching(watcher)
+        if let Some(updated) = self.config.updated {
+            if updated.elapsed() > NO_PROGRESS_TMO && self.requested_progress(&mut watcher).await {
+                return self.handle_error_msg(format!(
+                    "No progress notification within {NO_PROGRESS_TMO:?}"
+                ));
             }
-            Ok(Err(error)) => self.handle_error(&error, "Fetching client status"),
-            Err(error) => self.handle_error(&error, "Fetching client status"),
+        }
+        WatchState::Watching(watcher)
+    }
+
+    /// If there are no keys matching our watches, then we get no progress from the etcd.
+    /// In this case, let's try to request progress anyway, only once.
+    async fn requested_progress(&mut self, watcher: &mut StreamedWatcher) -> bool {
+        if self.config.requested_progress {
+            true
+        } else {
+            watcher.watcher.request_progress().await.ok();
+            self.config.requested_progress = true;
+            false
         }
     }
 }


### PR DESCRIPTION
    refactor(pstor/etcd-watcher): remove watch status update
    
    The keep alive is already useful for triggering watch restarts in case the
    connection is in a zombie state.
    Also, to address what happens when no progress status is received within
    the timeout, we can also issue an explicit request for progress and update
    the internal rev this way. This is also a much safer way of updating the
    rev as there might some race between getting the status and watches?
    
---

    feat(pstor/etcd): add http2 keep-alives
    
    This helps recover from half open connections automatically.
    
---

    test(etcd): allow for persistent data
    
    Allows testing etcd restarts, whilst persisting its data.
    
---

    refactor: add new volume health info keys
    
    Use new types for volume health info and info prefix, rather than
    modify the existing NexusInfoKey.
    We should also split the NexusInfoKey into non-volume info keys (which
    are only used for testing anyway) and volume info keys.
    
---

    security(GHSA-4p46-pwfr-66x6): update ring dependency
    
    advisory: https://github.com/advisories/GHSA-4p46-pwfr-66x6
    
---

    feat(health): add knob to disable volume health usage
    
---

    test(volume/watcher): add test for the various conditions
    
    Checks the volume health as replicas are faulted, rebuilt and
    targets shutdown cleanly or otherwise.

---

    fix(rest-plugin): show missing target if missing
    
    If the target is meant to be there, but it's missing, state that.
    
---

    feat(rest-plugin): add clean shutdown to volume output
    
---

    feat(rest-plugin): add replica topology health info
    
---

    feat(rest): add health information
    
    Enhance the volume with pstor health information which is retried from
    etcd using watches.
    
---

    feat(core/watcher): add pstor watcher for volume health info
    
    Add a volume health watcher which caches updates from etcd for every volume.
    When etcd entry is deleted, the equivalent entry in the cache is also deleted.
    
    When volume is republished sucessfully, the older target health information are
    also removed from the cache.
    
---

    fix: remove volume health entries on delete
    
    When a volume is deleted, destroy all related health entries.
    It has been observed that upon republished, the previous info
    is not deleted, so even if we fix that a lot of entries may
    already be leaked, so let's ensure we delete all entries for
    a given volume on volume deletion.
    
---

    refactor(pstor/watcher): add missing value on watch callback
    