### PR TITLE
Cherry-pick PR 950

### DIFF
--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -170,7 +170,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Check whether ana is enabled or not.
-    let ana_enabled: bool = utils::check_nvme_core_ana().unwrap_or_default();
+    let ana_enabled = utils::check_nvme_core_ana()?;
     // Instantiate path failure detector along with Nvme cache object.
     let detector = PathFailureDetector::new(&cli_args, ana_enabled);
 

--- a/control-plane/csi-driver/src/bin/node/dev.rs
+++ b/control-plane/csi-driver/src/bin/node/dev.rs
@@ -118,6 +118,8 @@ impl Device {
         enumerator.match_subsystem("block")?;
         enumerator.match_property("DEVTYPE", "disk")?;
 
+        let multipath = utils::check_nvme_core_ana()?;
+
         for device in enumerator.scan_devices()? {
             if let Some((devname, path)) = match_dev::match_iscsi_device(&device) {
                 let value = iscsi::IscsiDetach::from_path(devname.to_string(), path)?;
@@ -129,7 +131,9 @@ impl Device {
                 continue;
             }
 
-            if let Some(devname) = match_dev::match_nvmf_device_valid(&device, &nvmf_key)? {
+            if let Some(devname) =
+                match_dev::match_nvmf_device_valid(&device, &nvmf_key, Some(multipath))?
+            {
                 let nqn = if std::env::var("MOAC").is_ok() {
                     format!("{}:nexus-{uuid}", nvme_target_nqn_prefix())
                 } else {

--- a/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
@@ -82,9 +82,11 @@ impl NvmfAttach {
         enumerator.match_subsystem("block")?;
         enumerator.match_property("DEVTYPE", "disk")?;
 
+        let multipath = utils::check_nvme_core_ana()?;
+
         let mut first_error = Ok(None);
         for device in enumerator.scan_devices()? {
-            match match_device(&device, &key, &self.warn_bad) {
+            match match_device(&device, &key, Some(multipath), &self.warn_bad) {
                 Ok(name) if name.is_some() => {
                     return Ok(Some(device));
                 }
@@ -240,17 +242,8 @@ impl Attach for NvmfAttach {
         let device = self
             .get_device()?
             .ok_or_else(|| DeviceError::new("NVMe device not found"))?;
-        let dev_name = device.sysname().to_str().unwrap();
-        let captures = DEVICE_REGEX.captures(dev_name).ok_or_else(|| {
-            DeviceError::new(&format!(
-                "NVMe device \"{}\" does not match \"{}\"",
-                dev_name, *DEVICE_REGEX,
-            ))
-        })?;
-        let major = captures.get(1).unwrap().as_str();
-        let nid = captures.get(2).unwrap().as_str();
 
-        let pattern = format!("/sys/class/block/nvme{major}c*n{nid}/queue");
+        let pattern = block_dev_q(&device, None)?;
         let glob = glob(&pattern).unwrap();
         let result = glob
             .into_iter()
@@ -271,7 +264,7 @@ impl Attach for NvmfAttach {
                     }
                     Err(error) => {
                         // This should never happen as we should always have permissions to list.
-                        tracing::error!(%error, "Unable to collect sysfs for /dev/nvme{major}");
+                        tracing::error!(%error, "Unable to collect sysfs for {pattern}");
                         Err(DeviceError::new(error.to_string().as_str()))
                     }
                 }
@@ -332,7 +325,7 @@ impl Detach for NvmfDetach {
 }
 
 /// Get the sysfs block device queue path for the given udev::Device.
-fn block_dev_q(device: &Device) -> Result<String, DeviceError> {
+fn block_dev_q(device: &Device, multipath: Option<bool>) -> Result<String, DeviceError> {
     let dev_name = device.sysname().to_str().unwrap();
     let captures = DEVICE_REGEX.captures(dev_name).ok_or_else(|| {
         DeviceError::new(&format!(
@@ -342,7 +335,12 @@ fn block_dev_q(device: &Device) -> Result<String, DeviceError> {
     })?;
     let major = captures.get(1).unwrap().as_str();
     let nid = captures.get(2).unwrap().as_str();
-    Ok(format!("/sys/class/block/nvme{major}c*n{nid}/queue"))
+    // without multipath enabled on the system, there's a simpler representation of the namespace
+    // since there can't be more than 1 controller.
+    Ok(match multipath.unwrap_or(utils::check_nvme_core_ana()?) {
+        true => format!("/sys/class/block/nvme{major}c*n{nid}/queue"),
+        false => format!("/sys/class/block/nvme{major}n{nid}/queue"),
+    })
 }
 
 /// Check if the given device is a valid NVMf device.
@@ -353,13 +351,14 @@ fn block_dev_q(device: &Device) -> Result<String, DeviceError> {
 pub(crate) fn match_device<'a>(
     device: &'a Device,
     key: &str,
+    multipath: Option<bool>,
     warn_bad: &std::sync::atomic::AtomicBool,
 ) -> Result<Option<&'a str>, DeviceError> {
     let Some(devname) = match_nvmf_device(device, key) else {
         return Ok(None);
     };
 
-    let glob = glob(&block_dev_q(device)?).unwrap();
+    let glob = glob(&block_dev_q(device, multipath)?).unwrap();
     if !glob.into_iter().any(|glob_result| glob_result.is_ok()) {
         if warn_bad.load(std::sync::atomic::Ordering::Relaxed) {
             let name = device.sysname().to_string_lossy();

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -287,8 +287,8 @@ pub(super) async fn main() -> anyhow::Result<()> {
 
     // Check for nvme ana multipath support and generate labels.
     let mut csi_labels = HashMap::new();
-    let nvme_enabled = utils::check_nvme_core_ana().unwrap_or_default().to_string();
-    csi_labels.insert(utils::csi_node_nvme_ana(), nvme_enabled.clone());
+    let nvme_enabled = utils::check_nvme_core_ana()?;
+    csi_labels.insert(utils::csi_node_nvme_ana(), nvme_enabled.to_string());
 
     // If running in k8s, label the nodes with generated labels.
     let node_name = matches.get_one::<String>("node-name").unwrap();
@@ -436,8 +436,9 @@ impl CsiServer {
 async fn check_ana_and_label_node(
     client: &kube::client::Client,
     node_name: &str,
-    nvme_enabled: String,
+    nvme_enabled: bool,
 ) -> anyhow::Result<()> {
+    let nvme_enabled = nvme_enabled.to_string();
     let node_patch = json!({
         "apiVersion": "v1",
         "kind": "Node",

--- a/control-plane/csi-driver/src/bin/node/match_dev.rs
+++ b/control-plane/csi-driver/src/bin/node/match_dev.rs
@@ -79,7 +79,8 @@ pub(super) fn match_nvmf_device<'a>(device: &'a Device, key: &str) -> Option<&'a
 pub(super) fn match_nvmf_device_valid<'a>(
     device: &'a Device,
     key: &str,
+    multipath: Option<bool>,
 ) -> Result<Option<&'a str>, DeviceError> {
     let cell = std::sync::atomic::AtomicBool::new(true);
-    super::dev::nvmf::match_device(device, key, &cell)
+    super::dev::nvmf::match_device(device, key, multipath, &cell)
 }

--- a/utils/utils-lib/src/lib.rs
+++ b/utils/utils-lib/src/lib.rs
@@ -14,14 +14,21 @@ pub use version_info::{version_info as version_info_inner, VersionInfo};
 /// Byte conversion helpers.
 pub mod bytes;
 
-use std::fs;
 /// Check for the presence of nvme ana multipath.
 pub fn check_nvme_core_ana() -> Result<bool, std::io::Error> {
-    match fs::read_to_string("/sys/module/nvme_core/parameters/multipath")?
-        .trim()
-        .to_uppercase()
-        .as_str()
-    {
+    let multipath = match std::fs::read_to_string("/sys/module/nvme_core/parameters/multipath") {
+        Ok(multipath) => Ok(multipath),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // check the nvme_core is enabled, otherwise all this is moot.
+            std::fs::exists("/sys/module/nvme_core")?;
+            // there's a race here where the module may be unloaded and reloaded, though this may
+            // happen even after we check here - also when a volume is attached the module cannot
+            // be unloaded, so we're safe to check it.
+            return Ok(false);
+        }
+        Err(error) => Err(error),
+    };
+    match multipath?.trim().to_uppercase().as_str() {
         "Y" => Ok(true),
         "N" => Ok(false),
         _ => Err(std::io::Error::new(


### PR DESCRIPTION
The csi-node may run on hosts which have nvme enabled, but multipath may be disabled in the nvme_core module.
In this case, there's no nvmeXcYn1 controller available. A regression was introduced on v2.7.2 and v2.8.0 which whilst aiming to fix some issues around controller reconnect for multipath seems to have broken the non-multipath case as it's relying solely on nvmeXcYn1.

The fix is simply to check for the nvmeXn1 if multipath is disabled!