### PR TITLE
add support for formatoptions

### DIFF
--- a/control-plane/agents/src/bin/core/tests/snapshot/fs_cons_snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/snapshot/fs_cons_snapshot.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use deployer_cluster::{Cluster, ClusterBuilder};
+use std::collections::HashMap;
 use std::time::Duration;
 use stor_port::types::v0::openapi::models;
 
@@ -263,9 +264,14 @@ async fn preflight_failure(cluster: &Cluster, volume: &models::Volume) {
         .await
         .expect("Failed to get volume");
 
-    node.node_stage_volume_fs(&volume, "ext4", publish_result.publish_context.clone())
-        .await
-        .expect("Failed to stage volume");
+    node.node_stage_volume_fs(
+        &volume,
+        "ext4",
+        publish_result.publish_context.clone(),
+        HashMap::new(),
+    )
+    .await
+    .expect("Failed to stage volume");
     node.node_publish_volume_fs(&volume, "ext4", publish_result.publish_context)
         .await
         .expect("Failed to publish volume");

--- a/control-plane/agents/src/bin/core/tests/volume/format_options.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/format_options.rs
@@ -1,0 +1,146 @@
+#![cfg(test)]
+
+use deployer_cluster::ClusterBuilder;
+use stor_port::types::v0::openapi::models;
+use stor_port::types::v0::transport::VolumeId;
+
+use std::{collections::HashMap, time::Duration};
+
+const VOLUME_SIZE: u64 = 32u64 * 1024 * 1024;
+const POOL_SIZE: u64 = 140u64 * 1024 * 1024;
+const BYTES_PER_INODE: u64 = 64u64 * 1024;
+
+struct DeviceDisconnect(nvmeadm::NvmeTarget);
+impl Drop for DeviceDisconnect {
+    fn drop(&mut self) {
+        if self.0.disconnect().is_err() {
+            std::process::Command::new(env!("SUDO"))
+                .args(["nvme", "disconnect-all"])
+                .status()
+                .unwrap();
+        }
+    }
+}
+
+/// Creates a volume and format using formatOption = bytes-per-inode.
+/// Mounts the fs onto the mount path inside csi-node container.
+/// Inspects tune2fs output for the device and ensure inode count is correct.
+#[tokio::test]
+async fn filesystem_volume_format_options() {
+    let cache_period = Duration::from_millis(3);
+    let reconcile_period = Duration::from_millis(3);
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_io_engines(1)
+        .with_tmpfs_pool_ix(0, POOL_SIZE)
+        .with_csi(true, true)
+        .with_cache_period(&humantime::Duration::from(cache_period).to_string())
+        .with_reconcile_period(reconcile_period, reconcile_period)
+        .build()
+        .await
+        .expect("Cluster to be built");
+
+    let api_client = cluster.rest_v00();
+    let volumes_api = api_client.volumes_api();
+    let vol_id = VolumeId::new();
+    let volume = volumes_api
+        .put_volume(
+            &vol_id,
+            models::CreateVolumeBody::new(
+                models::VolumePolicy::new(true),
+                1,
+                VOLUME_SIZE,
+                false,
+                false,
+            ),
+        )
+        .await
+        .expect("Volume to be created");
+
+    let mut node = cluster
+        .csi_node_client(0)
+        .await
+        .expect("To get node client");
+
+    let mut controller = cluster
+        .csi_controller_client()
+        .await
+        .expect("To get controller client");
+
+    let publish_result = controller
+        .controller_publish_volume(&volume, &cluster.csi_node(0))
+        .await
+        .expect("To publish volume");
+
+    let uri = publish_result
+        .publish_context
+        .get("uri")
+        .expect("To get publish uri")
+        .to_string();
+
+    let _nvme_io_subsys = DeviceDisconnect(nvmeadm::NvmeTarget::try_from(uri).unwrap());
+
+    let mut volume_context = HashMap::new();
+    let flags = format!("-i {}", BYTES_PER_INODE);
+    volume_context.insert("formatOptions".to_string(), flags);
+
+    let vol = volumes_api
+        .get_volume(&vol_id)
+        .await
+        .expect("To get the volume");
+
+    node.node_stage_volume_fs(
+        &vol,
+        "ext4",
+        publish_result.publish_context.clone(),
+        volume_context,
+    )
+    .await
+    .expect("To stage volume");
+
+    node.node_publish_volume_fs(&volume, "ext4", publish_result.publish_context)
+        .await
+        .expect("To publish volume");
+
+    let path = format!("/var/tmp/target/mount/{}", volume.spec.uuid);
+    let expected_inodes = VOLUME_SIZE / BYTES_PER_INODE;
+    let composer = cluster.composer().clone();
+
+    // Gets device backing the mountpath.
+    let findmnt_args: Vec<&str> = vec!["findmnt", "-n", "-o", "SOURCE", "--target", path.as_str()];
+    let (_, device) = composer.exec("csi-node-1", findmnt_args).await.unwrap();
+
+    // Gets tune2fs output of the device.
+    let tune2fs_args: Vec<&str> = vec!["tune2fs", "-l", device.trim()];
+    let (_, tune2fs) = composer.exec("csi-node-1", tune2fs_args).await.unwrap();
+
+    // We expect actual inode count to be lesser as we don't get the actual device size of the
+    // created volume. Its almost 4 to 5 Mb lesser. This affects the number of inode count
+    // when we use -i as it creates inode for each block (65k in this test).
+    let mut inode_count: u64 = 1000;
+    for line in tune2fs.trim().lines() {
+        if line.starts_with("Inode count:") {
+            let i_count = line.split_whitespace().nth(2).unwrap_or("Unknown");
+            inode_count = i_count
+                .parse::<u64>()
+                .expect("To parse inode count into u64");
+            break;
+        }
+    }
+
+    assert!(
+        inode_count < expected_inodes,
+        "inode count was greater then expected"
+    );
+
+    node.node_unpublish_volume(&volume)
+        .await
+        .expect("To unpublish volume");
+    node.node_unstage_volume(&volume)
+        .await
+        .expect("To unstage volume");
+    controller
+        .controller_unpublish_volume(&volume, &cluster.csi_node(0))
+        .await
+        .expect("To Controller Unpublish volume");
+}

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -3,6 +3,7 @@
 mod affinity_group;
 mod capacity;
 mod capacity_limit;
+mod format_options;
 mod garbage_collection;
 mod helpers;
 mod hotspare;

--- a/control-plane/csi-driver/src/bin/node/filesystem_ops.rs
+++ b/control-plane/csi-driver/src/bin/node/filesystem_ops.rs
@@ -91,7 +91,7 @@ impl FileSystem {
 #[async_trait]
 pub(crate) trait FileSystemOps: Send + Sync {
     /// Create the filesystem using its fs util.
-    async fn create(&self, device: &str) -> Result<(), Error>;
+    async fn create(&self, device: &str, format_options: &str) -> Result<(), Error>;
     /// Get the default mount options along with the user passed options for specific filesystems.
     fn mount_flags(&self, mount_flags: Vec<String>) -> Vec<String>;
     /// Unmount the filesystem if the filesystem uuid and the provided uuid differ.
@@ -132,10 +132,18 @@ pub(crate) trait FileSystemOps: Send + Sync {
 
 #[async_trait]
 impl FileSystemOps for Ext4Fs {
-    async fn create(&self, device: &str) -> Result<(), Error> {
+    async fn create(&self, device: &str, format_options: &str) -> Result<(), Error> {
         let binary = "mkfs.ext4";
-        let output = Command::new(binary)
-            .arg(device)
+        let mut cmd = Command::new(binary);
+        cmd.arg(device);
+        let arg_vec = format_options
+            .split_whitespace()
+            .map(str::to_string)
+            .collect::<Vec<String>>();
+        if !format_options.is_empty() {
+            cmd.args(arg_vec);
+        }
+        let output = cmd
             .output()
             .await
             .map_err(|error| format!("failed to execute {binary}: {error}"))?;
@@ -245,18 +253,18 @@ impl FileSystemOps for Ext4Fs {
 
 #[async_trait]
 impl FileSystemOps for XFs {
-    async fn create(&self, device: &str) -> Result<(), Error> {
+    async fn create(&self, device: &str, format_options: &str) -> Result<(), Error> {
         let binary = "mkfs.xfs";
-        let args = match std::env::var("MKFS_XFS_ARGS") {
-            Ok(args) => args
-                .split_whitespace()
-                .map(str::to_string)
-                .collect::<Vec<_>>(),
-            _ => vec![],
-        };
-        let output = Command::new(binary)
-            .args(args)
-            .arg(device)
+        let mut cmd = Command::new(binary);
+        cmd.arg(device);
+        let arg_vec = format_options
+            .split_whitespace()
+            .map(str::to_string)
+            .collect::<Vec<String>>();
+        if !format_options.is_empty() {
+            cmd.args(arg_vec);
+        }
+        let output = cmd
             .output()
             .await
             .map_err(|error| format!("failed to execute {binary}: {error}"))?;
@@ -345,10 +353,18 @@ impl FileSystemOps for XFs {
 
 #[async_trait]
 impl FileSystemOps for BtrFs {
-    async fn create(&self, device: &str) -> Result<(), Error> {
+    async fn create(&self, device: &str, format_options: &str) -> Result<(), Error> {
         let binary = "mkfs.btrfs";
-        let output = Command::new(binary)
-            .arg(device)
+        let mut cmd = Command::new(binary);
+        cmd.arg(device);
+        let arg_vec = format_options
+            .split_whitespace()
+            .map(str::to_string)
+            .collect::<Vec<String>>();
+        if !format_options.is_empty() {
+            cmd.args(arg_vec);
+        }
+        let output = cmd
             .output()
             .await
             .map_err(|error| format!("failed to execute {binary}: {error}"))?;

--- a/control-plane/csi-driver/src/bin/node/filesystem_vol.rs
+++ b/control-plane/csi-driver/src/bin/node/filesystem_vol.rs
@@ -28,6 +28,8 @@ pub(crate) async fn stage_fs_volume(
     device_path: &str,
     mnt: &MountVolume,
     filesystems: &[FileSystem],
+    mut format_options: &str,
+    override_global_format_opts: bool,
 ) -> Result<(), Status> {
     let volume_uuid = Uuid::parse_str(&msg.volume_id).map_err(|error| {
         failure!(
@@ -77,6 +79,14 @@ pub(crate) async fn stage_fs_volume(
             }
         }
     };
+
+    let xfs_global_args = std::env::var("MKFS_XFS_ARGS").unwrap_or_default();
+
+    let combined_format_opts = format!("{xfs_global_args} {format_options}");
+
+    if fstype == &Fs::Xfs.into() && !override_global_format_opts {
+        format_options = combined_format_opts.as_str()
+    }
 
     if let Some(existing) = mount::find_mount(Some(device_path), Some(fs_staging_path)) {
         debug!(
@@ -147,8 +157,15 @@ pub(crate) async fn stage_fs_volume(
         })?
         .mount_flags(mnt.mount_flags.clone());
 
-    if let Err(error) =
-        prepare_device(fstype, device_path, fs_staging_path, &mount_flags, fs_id).await
+    if let Err(error) = prepare_device(
+        fstype,
+        device_path,
+        fs_staging_path,
+        &mount_flags,
+        fs_id,
+        format_options.trim(),
+    )
+    .await
     {
         return Err(failure!(
             Code::Internal,

--- a/control-plane/csi-driver/src/bin/node/format.rs
+++ b/control-plane/csi-driver/src/bin/node/format.rs
@@ -1,7 +1,7 @@
 //! Utility function for formatting a device with filesystem
 use crate::filesystem_ops::FileSystem;
 
-use tracing::debug;
+use tracing::{debug, info};
 use uuid::Uuid;
 
 /// Prepare the filesystem before mount, change parameters if requested.
@@ -11,6 +11,7 @@ pub(crate) async fn prepare_device(
     staging_path: &str,
     options: &[String],
     fs_id: &Option<Uuid>,
+    format_options: &str,
 ) -> Result<(), String> {
     debug!("Probing device {}", device);
     let fs = FileSystem::property(device, "TYPE");
@@ -27,6 +28,6 @@ pub(crate) async fn prepare_device(
         }
         return Ok(());
     }
-    debug!("Creating new filesystem ({}) on device {}", fstype, device);
-    fs_ops.create(device).await
+    info!(%format_options, "Formatting device {device} with filesystem {fstype}");
+    fs_ops.create(device, format_options).await
 }

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -10,6 +10,7 @@ use csi_driver::{
     csi::volume_capability::{access_mode::Mode, AccessType},
     filesystem::FileSystem as Fs,
     limiter::VolumeOpGuard,
+    Parameters,
 };
 use once_cell::sync::OnceCell;
 use rpc::{
@@ -792,12 +793,29 @@ impl node_server::Node for Node {
                 devpath
             }
         };
-
+        let format_options = match msg.volume_context.get(Parameters::FormatOptions.as_ref()) {
+            Some(opts) => opts,
+            None => "",
+        };
+        let override_global_format_opts = match Parameters::override_global_format_opts(
+            msg.volume_context
+                .get(Parameters::OverrideGlobalFormatOpts.as_ref()),
+        ) {
+            Ok(opts_bool) => opts_bool.unwrap_or(false),
+            Err(_) => false,
+        };
         // Attach successful, now stage mount if required.
         match access_type {
             AccessType::Mount(mnt) => {
-                if let Err(fsmount_error) =
-                    stage_fs_volume(&msg, &device_path, mnt, &self.filesystems).await
+                if let Err(fsmount_error) = stage_fs_volume(
+                    &msg,
+                    &device_path,
+                    mnt,
+                    &self.filesystems,
+                    format_options,
+                    override_global_format_opts,
+                )
+                .await
                 {
                     let mounts = crate::mount::find_src_mounts(&device_path, None);
                     // If the device is mounted elsewhere, don't detach it!

--- a/control-plane/csi-driver/src/context.rs
+++ b/control-plane/csi-driver/src/context.rs
@@ -70,6 +70,10 @@ pub enum Parameters {
     NodeSpreadTopologyKey,
     #[strum(serialize = "encrypted")]
     Encrypted,
+    #[strum(serialize = "formatOptions")]
+    FormatOptions,
+    #[strum(serialize = "overrideGlobalFormatOpts")]
+    OverrideGlobalFormatOpts,
 }
 impl Parameters {
     fn parse_human_time(
@@ -244,6 +248,12 @@ impl Parameters {
     }
     /// Parse the value for `Self::Encrypted`.
     pub fn encrypted(value: Option<&String>) -> Result<Option<bool>, ParseBoolError> {
+        Self::parse_bool(value)
+    }
+    /// Parse the value for `Self::OverrideGlobalFormatOpts`
+    pub fn override_global_format_opts(
+        value: Option<&String>,
+    ) -> Result<Option<bool>, ParseBoolError> {
         Self::parse_bool(value)
     }
 }

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -264,7 +264,7 @@ impl Cluster {
             let node = node_cli
                 .get(Filter::Node(node_id.clone()), true, None)
                 .await
-                .expect("Cant get node object");
+                .expect("To get node object");
             if let Some(node) = node.0.first() {
                 if node.state().map(|n| &n.status) == Some(&status) {
                     return Ok(());
@@ -406,7 +406,7 @@ impl Cluster {
     pub async fn remove_store_lock(&self, name: ControlPlaneService) {
         let mut store = etcd_client::Client::connect(["[::]:2379"], None)
             .await
-            .expect("Failed to connect to etcd.");
+            .expect("To connect to etcd.");
         store
             .delete(
                 StoreLeaseLockKey::new(&name).key(),
@@ -1252,11 +1252,18 @@ impl CsiNodeClient {
         volume: &Volume,
         fs_type: &str,
         publish_context: HashMap<String, String>,
+        volume_context: HashMap<String, String>,
     ) -> Result<NodeStageVolumeResponse, Error> {
         let mut context = std::collections::HashMap::new();
         context.insert(
             "uri".into(),
-            volume.state.target.as_ref().unwrap().device_uri.to_string(),
+            volume
+                .state
+                .target
+                .as_ref()
+                .expect("volume target to exist")
+                .device_uri
+                .to_string(),
         );
         context.extend(publish_context);
         let request = rpc::csi::NodeStageVolumeRequest {
@@ -1276,7 +1283,7 @@ impl CsiNodeClient {
                 )),
             }),
             secrets: Default::default(),
-            volume_context: Default::default(),
+            volume_context,
         };
         let response = self.csi.node_stage_volume(request).await?;
         Ok(response.into_inner())


### PR DESCRIPTION
This PR adds 2 new storageClass parameter. `overrideGlobalFormatOpts` and `formatOptions`

formatOptions allows user to pass extra filesystem format flags depending on the `fsType`.

`overrideGlobalFormatOpts` will allows `xfs` users to override global format options set via helm values.