### PR TITLE
Cherry-pick PR 955

### DIFF
--- a/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
@@ -128,7 +128,9 @@ impl TryFrom<&Url> for NvmfAttach {
         let hostnqn = hash_query.get("hostnqn").map(ToString::to_string);
 
         Ok(NvmfAttach::new(
-            host.to_string(),
+            host.trim_start_matches("[")
+                .trim_end_matches("]")
+                .to_string(),
             port,
             transport,
             uuid,


### PR DESCRIPTION
In rust, in case of ipv6 we must remove the [ ] from the url host. This is because with ipv6 the url is like so:
http://[$ip]:$port

The host returned by the url library is [$ip] which is not a valid ipv6!

For the testing, the python urllib is already removing the [] and so no changes are required there, though I haven't tested running CI on an ipv6 only linux system.