### PR TITLE
make thin by default during snapshot restore

### DIFF
--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -405,6 +405,11 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
                 let volume = match volume_content_source {
                     Some(snapshot_uuid) => {
+                        // This is to determine if user has passed `thin` arg.
+                        // This will help us not restore into thin volume if user has passed
+                        // thin:false explicitly.
+                        let thin_arg_passed = args.parameters.contains_key("thin");
+                        let thin = !thin_arg_passed || thin;
                         RestApiClient::get_client()
                             .create_snapshot_volume(
                                 &parsed_vol_uuid,


### PR DESCRIPTION
We do not support snapshot restore into thick volume as of now. With this change user does not need to recreate `thick` sc as `thin` during snapshot restore.  Unless user has specified `thin: false` in sc while resore. We will pass `thin: true`. 

This will fix backup usecase also as currently backup fails if ns has thick provisioned volumes.