### PR TITLE
feat(encryption): restrict different devlink of same device for pool creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "opentelemetry",
  "parking_lot",
  "prost-types",
+ "regex",
  "reqwest",
  "rpc",
  "serde",
@@ -2716,7 +2717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,6 +5097,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "regex",
  "strum",
  "strum_macros",
  "tracing",

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -58,6 +58,7 @@ tracing = "0.1.40"
 nix = { version = "0.29.0", default-features = false }
 prost-types = "0.13.3"
 url = "2.5.4"
+regex = "1.11.1"
 
 grpc = { path = "../grpc" }
 shutdown = { path = "../../utils/shutdown" }

--- a/control-plane/agents/src/bin/core/controller/io_engine/client.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/client.rs
@@ -85,10 +85,6 @@ impl GrpcContext {
         self.lock.clone().lock_owned().await
     }
     /// Use this context to connect a grpc client and return it.
-    pub(crate) async fn connect(&self) -> Result<GrpcClient, SvcError> {
-        GrpcClient::new(self).await
-    }
-    /// Use this context to connect a grpc client and return it.
     /// This client differs from `GrpcClient` from `Self::connect` in that it ensures only 1 request
     /// is sent at a time among all `GrpcClientLocked` clients.
     pub(crate) async fn connect_locked(

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -114,6 +114,8 @@ pub(crate) struct RegistryInner<S: Store> {
     ha_disabled: bool,
     /// Etcd max page size.
     etcd_max_page_size: i64,
+    /// Allow pool creation using non-persistent devlinks.
+    allow_non_persistent_devlinks: bool,
 }
 
 impl Registry {
@@ -140,6 +142,7 @@ impl Registry {
         ha_enabled: bool,
         etcd_max_page_size: i64,
         no_volume_health: bool,
+        allow_non_persistent_devlinks: bool,
     ) -> Result<Self, SvcError> {
         let store_endpoint = Self::format_store_endpoint(&store_url);
         tracing::info!("Connecting to persistent store at {}", store_endpoint);
@@ -199,6 +202,7 @@ impl Registry {
                 thin_args,
                 ha_disabled: ha_enabled,
                 etcd_max_page_size,
+                allow_non_persistent_devlinks,
             }),
         };
         registry.init().await?;
@@ -228,6 +232,11 @@ impl Registry {
     /// Check if the HA feature is disabled.
     pub(crate) fn ha_disabled(&self) -> bool {
         self.ha_disabled
+    }
+
+    /// Check if pool creation using non-persistent devlink is allowed.
+    pub(crate) fn allow_non_persistent_devlinks(&self) -> bool {
+        self.allow_non_persistent_devlinks
     }
 
     /// Check if the partial rebuilds are disabled.

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -142,6 +142,10 @@ pub(crate) struct CliArgs {
     /// Disable volume health reporting which uses pstor watchers.
     #[clap(long)]
     no_volume_health: bool,
+
+    /// Allow pools to be created using non persistent devlinks.
+    #[clap(long)]
+    allow_non_persistent_devlink: bool,
 }
 impl CliArgs {
     fn args() -> Self {
@@ -219,6 +223,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.disable_ha,
         cli_args.etcd_page_limit as i64,
         cli_args.no_volume_health,
+        cli_args.allow_non_persistent_devlink,
     )
     .await?;
 

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -13,6 +13,7 @@ use stor_port::types::v0::transport::{
     Deregister, Filter, Node, NodeId, NodeState, NodeStatus, Register,
 };
 
+use crate::controller::io_engine::HostApi;
 use crate::controller::wrapper::InternalOps;
 use grpc::{
     context::Context,
@@ -367,9 +368,7 @@ impl Service {
     ) -> Result<BlockDevices, SvcError> {
         let node = self.registry.node_wrapper(&request.node).await?;
 
-        let grpc = node.read().await.grpc_context()?;
-        let client = grpc.connect().await?;
-        client.list_blockdevices(request).await
+        node.list_blockdevices(request).await
     }
 
     /// Cordon the specified node.

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -1,3 +1,4 @@
+use crate::controller::io_engine::HostApi;
 use crate::{
     controller::{
         io_engine::{
@@ -15,8 +16,11 @@ use crate::{
     NumRebuilds,
 };
 use agents::{errors::SvcError, eventing::EventWithMeta};
+use async_trait::async_trait;
 use events_api::event::{EventAction, EventCategory, EventMessage, EventMeta, EventSource};
 use grpc::operations::snapshot::SnapshotInfo;
+use stor_port::transport_api::v0::BlockDevices;
+use stor_port::types::v0::transport::GetBlockDevices;
 use stor_port::{
     transport_api::{Message, MessageId, ResourceKind},
     types::v0::{
@@ -36,7 +40,6 @@ use stor_port::{
     },
 };
 
-use async_trait::async_trait;
 use parking_lot::RwLock;
 use std::{future::Future, ops::DerefMut, sync::Arc};
 use tracing::{debug, trace, warn};
@@ -1752,5 +1755,18 @@ impl ReplicaSnapshotApi for Arc<tokio::sync::RwLock<NodeWrapper>> {
 impl From<&NodeWrapper> for NodeState {
     fn from(node: &NodeWrapper) -> Self {
         node.node_state().clone()
+    }
+}
+
+#[async_trait]
+impl HostApi for Arc<tokio::sync::RwLock<NodeWrapper>> {
+    async fn liveness_probe(&self) -> Result<Register, SvcError> {
+        let dataplane = self.read().await.grpc_client().await?;
+        dataplane.liveness_probe().await
+    }
+
+    async fn list_blockdevices(&self, request: &GetBlockDevices) -> Result<BlockDevices, SvcError> {
+        let dataplane = self.read().await.grpc_client().await?;
+        dataplane.list_blockdevices(request).await
     }
 }

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -1,3 +1,5 @@
+use crate::controller::io_engine::HostApi;
+use crate::node::wrapper::NodeWrapper;
 use crate::{
     controller::{
         io_engine::PoolApi,
@@ -11,8 +13,8 @@ use crate::{
     node::wrapper::GetterOps,
 };
 use agents::{errors, errors::SvcError};
-use snafu::OptionExt;
-use std::ops::Deref;
+use stor_port::transport_api::ResourceKind;
+use stor_port::types::v0::transport::{GetBlockDevices, PoolDeviceUri};
 use stor_port::types::v0::{
     store::{
         pool::PoolSpec,
@@ -20,6 +22,13 @@ use stor_port::types::v0::{
     },
     transport::{CreatePool, DestroyReplica, NodeId, ReplicaOwners},
 };
+
+use itertools::Itertools;
+use snafu::OptionExt;
+use std::collections::HashSet;
+use std::ops::Deref;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 impl OperationGuardArc<PoolSpec> {
     /// Retries the creation of the pool which is being done in the background by the io-engine.
@@ -129,4 +138,87 @@ impl OperationGuardArc<ReplicaSpec> {
             disowners: by,
         }
     }
+}
+
+pub(crate) async fn devlink_preflight_checks(
+    request: &CreatePool,
+    node: Arc<RwLock<NodeWrapper>>,
+    registry: &Registry,
+) -> Result<(), SvcError> {
+    let request_disks: HashSet<String> = request
+        .disks
+        .iter()
+        .map(|disk| utils::disk::normalize_disk(disk.as_str()))
+        .collect();
+
+    let node_pools = registry
+        .get_node_opt_pools(Some(request.node.clone()))
+        .await?;
+
+    if !node_pools.is_empty() {
+        let node_pools_disks: Vec<PoolDeviceUri> = node_pools
+            .into_iter()
+            .filter_map(|pool| pool.spec().map(|spec| spec.disks))
+            .flatten()
+            .collect();
+
+        let node_pools_disks_normalized: HashSet<String> = node_pools_disks
+            .iter()
+            .map(|disk| utils::disk::normalize_disk(disk.as_str()))
+            .collect();
+
+        let common_disks: HashSet<_> = request_disks
+            .intersection(&node_pools_disks_normalized)
+            .cloned()
+            .collect();
+
+        // Same devpaths or devlinks should be rejected.
+        if !common_disks.is_empty() {
+            return Err(SvcError::InUse {
+                kind: ResourceKind::Block,
+                id: common_disks.iter().join(","),
+            });
+        }
+
+        let node_block_devices = node
+            .list_blockdevices(&GetBlockDevices {
+                node: request.node.clone(),
+                all: true,
+            })
+            .await?
+            .into_inner();
+
+        let matched_devices: Vec<_> = node_block_devices
+            .iter()
+            .filter(|device| {
+                request_disks.contains(&device.devname)
+                    || request_disks.contains(&device.devpath)
+                    || device
+                        .devlinks
+                        .iter()
+                        .any(|link| request_disks.contains(link))
+            })
+            .collect();
+
+        // If the requested disk was not found, that could be because it could be a malloc or a file,
+        // in that case ignore and move ahead to allow tests. If it is an actual disk that was not
+        // detected by blockdevice api then the disk might not be visible to io-engine, so let it fail from io-engine
+        // rather than bailing out from control-plane to keep the behaviour as before.
+        if !matched_devices.is_empty() {
+            if let Some(conflict) = matched_devices.iter().find(|bd| {
+                node_pools_disks_normalized.contains(&bd.devname)
+                    || node_pools_disks_normalized.contains(&bd.devpath)
+                    || bd
+                        .devlinks
+                        .iter()
+                        .any(|link| node_pools_disks_normalized.contains(link))
+            }) {
+                return Err(SvcError::InUse {
+                    kind: ResourceKind::Block,
+                    id: conflict.devname.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
 }

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -24,6 +24,7 @@ use stor_port::types::v0::{
 };
 
 use itertools::Itertools;
+use regex::Regex;
 use snafu::OptionExt;
 use std::collections::HashSet;
 use std::ops::Deref;
@@ -150,6 +151,22 @@ pub(crate) async fn devlink_preflight_checks(
         .iter()
         .map(|disk| utils::disk::normalize_disk(disk.as_str()))
         .collect();
+
+    if !registry.allow_non_persistent_devlinks() {
+        fn is_persistent_devlink(pattern: &str) -> Result<bool, SvcError> {
+            let re = Regex::new(utils::DEVLINK_REGEX).map_err(|_| SvcError::InvalidArguments {})?;
+            Ok(re.is_match(pattern))
+        }
+
+        if request_disks
+            .iter()
+            // Only attempt to validate if it starts with "/dev".
+            .filter(|disk| disk.starts_with("/dev"))
+            .any(|disk| !is_persistent_devlink(disk).is_ok_and(|val| val))
+        {
+            return Err(SvcError::InvalidDevlink {});
+        }
+    }
 
     let node_pools = registry
         .get_node_opt_pools(Some(request.node.clone()))

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -44,7 +44,8 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
             });
         }
 
-        if let Ok(pool) = registry.specs().pool(&request.id) {
+        let pool_get_result = registry.specs().pool(&request.id);
+        if let Ok(pool) = &pool_get_result {
             if pool.status.created() {
                 return Err(SvcError::AlreadyExists {
                     kind: ResourceKind::Pool,
@@ -61,8 +62,10 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
             });
         }
 
-        // If the devlink for a device is used for multiple pools, reject new creation.
-        devlink_preflight_checks(request, node.clone(), registry).await?;
+        if pool_get_result.is_err() {
+            // If the devlink for a device is used for multiple pools, reject new creation.
+            devlink_preflight_checks(request, node.clone(), registry).await?
+        }
 
         let mut pool = specs
             .get_or_create_pool(request)

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -7,8 +7,8 @@ use crate::controller::{
         OperationGuardArc,
     },
 };
+use crate::pool::operations_helper::devlink_preflight_checks;
 use agents::errors::{SvcError, SvcError::CordonedNode};
-use std::collections::HashMap;
 use stor_port::{
     transport_api::ResourceKind,
     types::v0::{
@@ -17,6 +17,8 @@ use stor_port::{
     },
 };
 use utils::dsp_created_by_key;
+
+use std::collections::HashMap;
 
 #[async_trait::async_trait]
 impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
@@ -35,6 +37,7 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
                 node_id: request.node.to_string(),
             });
         }
+
         if request.disks.len() != 1 {
             return Err(SvcError::InvalidPoolDeviceNum {
                 disks: request.disks.clone(),
@@ -57,6 +60,9 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
                 node: request.node.clone(),
             });
         }
+
+        // If the devlink for a device is used for multiple pools, reject new creation.
+        devlink_preflight_checks(request, node.clone(), registry).await?;
 
         let mut pool = specs
             .get_or_create_pool(request)

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -7,6 +7,7 @@ use grpc::{
     },
 };
 use itertools::Itertools;
+use regex::Regex;
 use std::{collections::HashMap, convert::TryFrom, thread::sleep, time::Duration};
 use stor_port::types::v0::store::pool::{Encryption, EncryptionSecret};
 use stor_port::types::v0::transport::{GetBlockDevices, NodeStatus};
@@ -1345,5 +1346,36 @@ async fn reject_devlink_reuse() {
                 });
             }
         }
+    }
+}
+
+#[tokio::test]
+async fn persistent_devlink_regex() {
+    fn is_persistent_devlink(pattern: &str) -> bool {
+        let re = Regex::new(utils::DEVLINK_REGEX).expect("DEVLINK_REGEX should be valid");
+        re.is_match(pattern)
+    }
+
+    let test_suite = [
+        ("/dev/some/path", false),
+        ("/dev/mapper/some/path", false),
+        ("/dev/disk/some/path", false),
+        ("/dev/disk/by-something/path", false),
+        ("/devil/disk/by-something/path", false),
+        ("/dev/diskxyz/by-something/path", false),
+        ("/dev/disk/something-by/path", false),
+        ("/dev/disk/by-/path", false),
+        ("something", false),
+        ("/dev/somevg/lv0", false), // LVM Paths are to be used via the /dev/mapper or by /dev/disk/by-id
+        ("/dev/disk/by-id/somepath", true),
+        ("/dev/disk/by-path/somepath", true),
+        ("/dev/disk/by-label/somepath", true),
+        ("/dev/disk/by-partuuid/somepath", true),
+        ("/dev/disk/by-partlabel/somepath", true),
+        ("/dev/mapper/dm0", true),
+    ];
+
+    for test in test_suite {
+        assert_eq!(is_persistent_devlink(test.0), test.1);
     }
 }

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -7,7 +7,6 @@ use grpc::{
     },
 };
 use itertools::Itertools;
-use regex::Regex;
 use std::{collections::HashMap, convert::TryFrom, thread::sleep, time::Duration};
 use stor_port::types::v0::store::pool::{Encryption, EncryptionSecret};
 use stor_port::types::v0::transport::{GetBlockDevices, NodeStatus};
@@ -1362,36 +1361,5 @@ async fn reject_devlink_reuse() {
                 });
             }
         }
-    }
-}
-
-#[tokio::test]
-async fn persistent_devlink_regex() {
-    fn is_persistent_devlink(pattern: &str) -> bool {
-        let re = Regex::new(utils::DEVLINK_REGEX).expect("DEVLINK_REGEX should be valid");
-        re.is_match(pattern)
-    }
-
-    let test_suite = [
-        ("/dev/some/path", false),
-        ("/dev/mapper/some/path", false),
-        ("/dev/disk/some/path", false),
-        ("/dev/disk/by-something/path", false),
-        ("/devil/disk/by-something/path", false),
-        ("/dev/diskxyz/by-something/path", false),
-        ("/dev/disk/something-by/path", false),
-        ("/dev/disk/by-/path", false),
-        ("something", false),
-        ("/dev/somevg/lv0", false), // LVM Paths are to be used via the /dev/mapper or by /dev/disk/by-id
-        ("/dev/disk/by-id/somepath", true),
-        ("/dev/disk/by-path/somepath", true),
-        ("/dev/disk/by-label/somepath", true),
-        ("/dev/disk/by-partuuid/somepath", true),
-        ("/dev/disk/by-partlabel/somepath", true),
-        ("/dev/mapper/dm0", true),
-    ];
-
-    for test in test_suite {
-        assert_eq!(is_persistent_devlink(test.0), test.1);
     }
 }

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -8,6 +8,8 @@ use grpc::{
 };
 use itertools::Itertools;
 use std::{collections::HashMap, convert::TryFrom, thread::sleep, time::Duration};
+use stor_port::types::v0::store::pool::{Encryption, EncryptionSecret};
+use stor_port::types::v0::transport::{GetBlockDevices, NodeStatus};
 use stor_port::{
     pstor::{etcd::Etcd, StoreObj},
     transport_api::{ReplyError, ReplyErrorKind, ResourceKind, TimeoutOptions},
@@ -1128,5 +1130,220 @@ async fn slow_create() {
 
         let pool = client.pool().create(&create, None).await.unwrap();
         assert!(pool.spec().unwrap().status.created());
+    }
+}
+
+/// Tests that a different devlink for same device cannot be used across multiple storage pools.
+///
+/// The test performs the following steps:
+/// 1. Writes a secret file containing encryption config.
+/// 2. Creates a volume group and a logical volume so that we have devlinks.
+/// 3. Verifies that the block device has at least two devlinks.
+/// 4. Creates "pool-1" using the first devlink with encryption enabled (expected to succeed).
+/// 5. Attempts to create "pool-2" using a second devlink from the same device with encryption enabled (expected to fail).
+/// 6. Destroys "pool-1" and attempts to destroy "pool-2" (expected to fail since it wasn't created).
+/// 7. Recreates "pool-2" after releasing the devlink(by destroying pool-1) (expected to succeed).
+/// 8. Restarts the cluster and verifies that creating "pool-3" without encryption using an already used devlink(since pool-2 is imported) with aio prefix (expected to fail).
+/// 9. Finally, attempts to destroy "pool-3" (expected to fail as it was never created).
+#[tokio::test]
+async fn reject_devlink_reuse() {
+    use serde_json::json;
+    use std::env;
+    use std::path::PathBuf;
+    use tokio::fs::File;
+    use tokio::io::AsyncWriteExt;
+
+    const SECRETFILE: &str = "secretfile";
+
+    let _file = SecretFileCreator::new()
+        .await
+        .expect("Failed to create secret file");
+
+    const POOL_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+    let vg = deployer_cluster::lvm::VolGroup::new("reject-devlink-vg", POOL_SIZE_BYTES)
+        .expect("Failed to create volume group");
+    let lvol = vg
+        .create_lvol("reject-devlink-lv", POOL_SIZE_BYTES / 2)
+        .expect("Failed to create logical volume");
+
+    {
+        let cluster = ClusterBuilder::builder()
+            .with_io_engines(1)
+            .with_mount_host_dev_udev(true)
+            .with_options(|o| o.with_io_engine_devices(vec![lvol.path()]))
+            .compose_build(|b| b.with_clean(true))
+            .await
+            .expect("Failed to build cluster");
+
+        let client = cluster.grpc_client();
+
+        let bds = client
+            .node()
+            .get_block_devices(
+                &GetBlockDevices {
+                    node: cluster.node(0),
+                    all: false,
+                },
+                None,
+            )
+            .await
+            .expect("Failed to get block devices")
+            .into_inner();
+
+        let dev_path = lvol.path();
+        let matched_device = bds
+            .iter()
+            .find(|bd| {
+                bd.devlinks.iter().any(|link| link == &dev_path.to_string())
+                    || bd.devname == dev_path
+                    || bd.devpath == dev_path
+            })
+            .expect("Block device should exist");
+
+        let device_devlinks = &matched_device.devlinks;
+        assert!(
+            device_devlinks.len() >= 2,
+            "Expected at least 2 devlinks, found {}",
+            device_devlinks.len()
+        );
+
+        let create_pool_1_request = CreatePool {
+            node: cluster.node(0),
+            id: "pool-1".into(),
+            disks: vec![device_devlinks
+                .first()
+                .expect("At least one devlink should be present")
+                .into()],
+            labels: None,
+            encryption: Some(Encryption::Secret(EncryptionSecret {
+                name: SECRETFILE.to_string(),
+            })),
+        };
+
+        client
+            .pool()
+            .create(&create_pool_1_request, None)
+            .await
+            .expect("Pool-1 creation should succeed");
+
+        let create_pool_2_request = CreatePool {
+            node: cluster.node(0),
+            id: "pool-2".into(),
+            disks: vec![device_devlinks
+                .get(1)
+                .expect("Another devlink should be present")
+                .into()],
+            labels: None,
+            encryption: Some(Encryption::Secret(EncryptionSecret {
+                name: SECRETFILE.to_string(),
+            })),
+        };
+
+        client
+            .pool()
+            .create(&create_pool_2_request, None)
+            .await
+            .expect_err("Pool-2 creation should fail");
+
+        let destroy = DestroyPool::from(create_pool_1_request.clone());
+        client
+            .pool()
+            .destroy(&destroy, None)
+            .await
+            .expect("Pool-1 destruction should succeed");
+
+        let destroy = DestroyPool::from(create_pool_2_request.clone());
+        client
+            .pool()
+            .destroy(&destroy, None)
+            .await
+            .expect_err("Pool-2 destruction should fail");
+
+        client
+            .pool()
+            .create(&create_pool_2_request, None)
+            .await
+            .expect("Pool-2 creation should succeed now");
+
+        cluster
+            .composer()
+            .restart(&cluster.node(0))
+            .await
+            .expect("Cluster restart failed");
+        cluster
+            .wait_node_status(cluster.node(0), NodeStatus::Online)
+            .await
+            .expect("Node service liveness check failed");
+
+        let create_pool_3_request = CreatePool {
+            node: cluster.node(0),
+            id: "pool-3".into(),
+            disks: vec![format!(
+                "aio://{}",
+                device_devlinks
+                    .first()
+                    .expect("At least one devlink should be present")
+            )
+            .into()],
+            labels: None,
+            encryption: None,
+        };
+
+        client
+            .pool()
+            .create(&create_pool_3_request, None)
+            .await
+            .expect_err("Creating pool-3 with pool-1 devlink should fail");
+
+        client
+            .pool()
+            .destroy(&DestroyPool::from(create_pool_2_request.clone()), None)
+            .await
+            .expect("Destroying pool-2 should succeed");
+
+        client
+            .pool()
+            .destroy(&DestroyPool::from(create_pool_3_request.clone()), None)
+            .await
+            .expect_err("Destroying pool-3 should fail");
+    }
+
+    pub struct SecretFileCreator {
+        file_path: Option<PathBuf>,
+    }
+
+    impl SecretFileCreator {
+        pub async fn new() -> std::io::Result<Self> {
+            let root = env::var("WORKSPACE_ROOT").expect("WORKSPACE_ROOT is not set");
+            let path = PathBuf::from(&root).join(".tmp");
+
+            let data = json!({
+                "cipher": "AesXts",
+                "key": "2b7e151628aed2a6abf7158809cf4f3c",
+                "key_len": 128,
+                "key2": "2b7e151628aed2a6abf7158809cf4f3d",
+                "key2_len": 128
+            });
+
+            let file_path = path.join(SECRETFILE);
+            let mut file = File::create(&file_path).await?;
+            file.write_all(data.to_string().as_bytes()).await?;
+
+            Ok(Self {
+                file_path: Some(file_path),
+            })
+        }
+    }
+
+    impl Drop for SecretFileCreator {
+        fn drop(&mut self) {
+            if let Some(ref path) = self.file_path {
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    let _ = std::fs::remove_file(path);
+                    println!("Removed secretfile");
+                });
+            }
+        }
     }
 }

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -1059,6 +1059,7 @@ async fn slow_create() {
     {
         let cluster = ClusterBuilder::builder()
             .with_io_engines(1)
+            .with_allow_non_persistent_devlink(true)
             .with_reconcile_period(Duration::from_millis(250), Duration::from_millis(250))
             .with_cache_period("200ms")
             .with_options(|o| o.with_io_engine_devices(vec![lvol.path()]))
@@ -1176,6 +1177,7 @@ async fn reject_devlink_reuse() {
             .await
             .expect("Failed to build cluster");
 
+        let dev_path = lvol.path();
         let client = cluster.grpc_client();
 
         let bds = client
@@ -1191,17 +1193,29 @@ async fn reject_devlink_reuse() {
             .expect("Failed to get block devices")
             .into_inner();
 
-        let dev_path = lvol.path();
         let matched_device = bds
             .iter()
             .find(|bd| {
-                bd.devlinks.iter().any(|link| link == &dev_path.to_string())
-                    || bd.devname == dev_path
-                    || bd.devpath == dev_path
+                let dev_path_str = dev_path.to_string();
+                bd.devname == dev_path_str
+                    || bd.devpath == dev_path_str
+                    || bd.devlinks.iter().any(|link| link == &dev_path_str)
             })
             .expect("Block device should exist");
 
-        let device_devlinks = &matched_device.devlinks;
+        let device_devlinks: Vec<&str> = matched_device
+            .devlinks
+            .iter()
+            .filter_map(|link| link.strip_prefix("/dev/disk/by-"))
+            .map(|s| {
+                &matched_device
+                    .devlinks
+                    .iter()
+                    .find(|l| l.ends_with(s))
+                    .unwrap()[..]
+            })
+            .collect();
+
         assert!(
             device_devlinks.len() >= 2,
             "Expected at least 2 devlinks, found {}",
@@ -1214,6 +1228,7 @@ async fn reject_devlink_reuse() {
             disks: vec![device_devlinks
                 .first()
                 .expect("At least one devlink should be present")
+                .to_string()
                 .into()],
             labels: None,
             encryption: Some(Encryption::Secret(EncryptionSecret {
@@ -1233,6 +1248,7 @@ async fn reject_devlink_reuse() {
             disks: vec![device_devlinks
                 .get(1)
                 .expect("Another devlink should be present")
+                .to_string()
                 .into()],
             labels: None,
             encryption: Some(Encryption::Secret(EncryptionSecret {

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -420,6 +420,8 @@ pub enum SvcError {
         replica: String,
         source: tonic::Status,
     },
+    #[snafu(display("Invalid devlink, use a persistent devlink for pool creation"))]
+    InvalidDevlink {},
 }
 
 impl SvcError {
@@ -1108,6 +1110,12 @@ impl From<SvcError> for ReplyError {
             SvcError::ReplicaSetPropertyFailed { .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPersist,
                 resource: ResourceKind::Replica,
+                source,
+                extra,
+            },
+            SvcError::InvalidDevlink { .. } => ReplyError {
+                kind: ReplyErrorKind::InvalidArgument,
+                resource: ResourceKind::Block,
                 source,
                 extra,
             },

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -71,6 +71,9 @@ impl ComponentAction for CoreAgent {
         if let Some(max_rebuilds) = &options.max_rebuilds {
             binary = binary.with_args(vec!["--max-rebuilds", &max_rebuilds.to_string()]);
         }
+        if options.allow_non_persistent_devlink {
+            binary = binary.with_args(vec!["--allow-non-persistent-devlink"]);
+        }
         Ok(cfg.add_container_spec(
             ContainerSpec::from_binary(name, binary).with_portmap("50051", "50051"),
         ))

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -57,6 +57,12 @@ impl ComponentAction for IoEngine {
             .with_bind(&host_tmp, "/host/tmp")
             .with_bind("/var/run/dpdk", "/var/run/dpdk");
 
+            if options.mount_host_dev_udev {
+                spec = spec
+                    .with_bind("/dev", "/dev")
+                    .with_bind("/run/udev", "/run/udev");
+            }
+
             let core_list = match options.io_engine_isolate {
                 true => {
                     let cores = 1.max(options.io_engine_cores);

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -351,6 +351,9 @@ pub struct StartOptions {
     /// Add custom RUST_LOG_SILENCE env to all containers.
     #[clap(long)]
     rust_log_silence: Option<String>,
+    /// Mount host dev and udev.
+    #[clap(long)]
+    mount_host_dev_udev: bool,
 }
 
 /// List of KeyValues
@@ -595,6 +598,12 @@ impl StartOptions {
     /// Specify whether eventing is enabled or not.
     pub fn with_eventing(mut self, enabled: bool) -> Self {
         self.eventing = enabled;
+        self
+    }
+
+    /// Specify whether host's mount dev and udev is needed or not.
+    pub fn with_mount_host_dev_udev(mut self, enabled: bool) -> Self {
+        self.mount_host_dev_udev = enabled;
         self
     }
 

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -354,6 +354,9 @@ pub struct StartOptions {
     /// Mount host dev and udev.
     #[clap(long)]
     mount_host_dev_udev: bool,
+    /// Allow non persistent devlink for pool creation.
+    #[clap(long)]
+    allow_non_persistent_devlink: bool,
 }
 
 /// List of KeyValues
@@ -604,6 +607,12 @@ impl StartOptions {
     /// Specify whether host's mount dev and udev is needed or not.
     pub fn with_mount_host_dev_udev(mut self, enabled: bool) -> Self {
         self.mount_host_dev_udev = enabled;
+        self
+    }
+
+    /// Specify whether allow non peristent devlink is needed or not.
+    pub fn with_allow_non_persistent_devlink(mut self, enabled: bool) -> Self {
+        self.allow_non_persistent_devlink = enabled;
         self
     }
 

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -1,17 +1,18 @@
+use super::v1beta3_api;
 use super::{
     diskpool::crd::v1beta3::{CrPoolState, DiskPool, DiskPoolStatus},
     error::Error,
 };
-use super::{normalize_disk, v1beta3_api};
+use crate::diskpool::crd::v1beta3::EncryptionSource;
 use openapi::models::{Encryption, EncryptionSecret};
 use openapi::{
     apis::StatusCode,
     clients,
     models::{CreatePoolBody, Pool},
 };
-use utils::dsp_created_by_key;
+use tracing::{debug, error, info};
+use utils::{disk::normalize_disk, dsp_created_by_key};
 
-use crate::diskpool::crd::v1beta3::EncryptionSource;
 use chrono::Utc;
 use k8s_openapi::{api::core::v1::Event, apimachinery::pkg::apis::meta::v1::MicroTime};
 use kube::api::{Patch, PostParams};
@@ -27,7 +28,6 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-use tracing::{debug, error, info};
 
 const WHO_AM_I: &str = "DiskPool Operator";
 const WHO_AM_I_SHORT: &str = "dsp-operator";

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -369,11 +369,13 @@ mod test {
             "uring:///dev/null",
             "uring://dev/null", // this URL is invalid
             "pcie:///0000:01:00.0",
+            "pcie:///00:01:00.0",
         ];
 
         assert_eq!(utils::disk::normalize_disk(disks[0]), "/dev/null");
         assert_eq!(utils::disk::normalize_disk(disks[1]), "/dev/null");
         assert_eq!(utils::disk::normalize_disk(disks[2]), "uring://dev/null");
         assert_eq!(utils::disk::normalize_disk(disks[3]), "/0000:01:00.0");
+        assert_eq!(utils::disk::normalize_disk(disks[4]), "/0000:01:00.0");
     }
 }

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -11,6 +11,7 @@ mod mayastorpool;
 use crate::diskpool::client::{
     create_crd, create_missing_cr, create_v1beta3_cr, get_api_version, v1beta3_api,
 };
+
 use context::OperatorContext;
 use diskpool::crd::{
     migration::ensure_and_migrate_crd,
@@ -19,6 +20,7 @@ use diskpool::crd::{
 use error::Error;
 use mayastorpool::client::{check_crd, delete, list};
 use openapi::clients::{self, tower::Url};
+use tracing::{error, info, trace, warn};
 use utils::tracing_telemetry::{FmtLayer, FmtStyle};
 
 use chrono::Utc;
@@ -33,7 +35,6 @@ use kube::{
     Client, ResourceExt,
 };
 use std::{collections::HashMap, sync::Arc, time::Duration};
-use tracing::{error, info, trace, warn};
 
 const PAGINATION_LIMIT: u32 = 100;
 const BACKOFF_PERIOD: u64 = 20;
@@ -310,18 +311,6 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Normalize the disks if they have a schema, we dont want to change anything
-/// or do any error checking -- the loop will converge to the error state eventually
-fn normalize_disk(disk: &str) -> String {
-    Url::parse(disk).map_or(disk.to_string(), |u| {
-        u.to_file_path()
-            .unwrap_or_else(|_| disk.into())
-            .as_path()
-            .display()
-            .to_string()
-    })
-}
-
 /// Migrate from MayastorPool.
 pub(crate) async fn migrate_and_clean_msps(k8s: &Client, namespace: &str) -> Result<(), Error> {
     // Check if the MayastorPool CRD is present, and migrate from it if it is.
@@ -375,15 +364,16 @@ mod test {
 
     #[test]
     fn normalize_disk() {
-        use super::*;
         let disks = [
             "aio:///dev/null",
             "uring:///dev/null",
             "uring://dev/null", // this URL is invalid
+            "pcie:///0000:01:00.0",
         ];
 
-        assert_eq!(normalize_disk(disks[0]), "/dev/null");
-        assert_eq!(normalize_disk(disks[1]), "/dev/null");
-        assert_eq!(normalize_disk(disks[2]), "uring://dev/null");
+        assert_eq!(utils::disk::normalize_disk(disks[0]), "/dev/null");
+        assert_eq!(utils::disk::normalize_disk(disks[1]), "/dev/null");
+        assert_eq!(utils::disk::normalize_disk(disks[2]), "uring://dev/null");
+        assert_eq!(utils::disk::normalize_disk(disks[3]), "/0000:01:00.0");
     }
 }

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -358,24 +358,3 @@ pub(crate) async fn migrate_and_clean_msps(k8s: &Client, namespace: &str) -> Res
     }
     Ok(())
 }
-
-#[cfg(test)]
-mod test {
-
-    #[test]
-    fn normalize_disk() {
-        let disks = [
-            "aio:///dev/null",
-            "uring:///dev/null",
-            "uring://dev/null", // this URL is invalid
-            "pcie:///0000:01:00.0",
-            "pcie:///00:01:00.0",
-        ];
-
-        assert_eq!(utils::disk::normalize_disk(disks[0]), "/dev/null");
-        assert_eq!(utils::disk::normalize_disk(disks[1]), "/dev/null");
-        assert_eq!(utils::disk::normalize_disk(disks[2]), "uring://dev/null");
-        assert_eq!(utils::disk::normalize_disk(disks[3]), "/0000:01:00.0");
-        assert_eq!(utils::disk::normalize_disk(disks[4]), "/0000:01:00.0");
-    }
-}

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -41,6 +41,7 @@ class StartOptions:
     rust_log: str = None
     rust_log_silence: str = None
     rest_core_health_freq: str = None
+    mount_host_dev_udev: bool = False
 
     def args(self):
         args = [
@@ -115,6 +116,9 @@ class StartOptions:
             if self.ha_cluster_agent_fast is not None:
                 args.append(f"--cluster-fast-requeue={self.ha_cluster_agent_fast}")
 
+        if self.mount_host_dev_udev:
+            args.append("--mount-host-dev-udev")
+
         args.append(agent_arg)
 
         return args
@@ -150,6 +154,7 @@ class Deployer(object):
         rust_log: str = None,
         rust_log_silence: str = None,
         rest_core_health_freq: str = None,
+        mount_host_dev_udev=False,
     ):
         options = StartOptions(
             io_engines,
@@ -178,6 +183,7 @@ class Deployer(object):
             rust_log=rust_log,
             rust_log_silence=rust_log_silence,
             rest_core_health_freq=rest_core_health_freq,
+            mount_host_dev_udev=mount_host_dev_udev,
         )
         pytest.deployer_options = options
         Deployer.start_with_opts(options)

--- a/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
+++ b/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
@@ -10,6 +10,7 @@ from pytest_bdd import (
 )
 import pytest
 import subprocess
+from retrying import retry
 
 from common.deployer import Deployer
 from common.apiclient import ApiClient
@@ -179,6 +180,7 @@ def publish_to_node_2(background):
 
 
 @pytest.fixture
+@retry(wait_fixed=10, stop_max_attempt_number=200)
 def connect_to_node_2(publish_to_node_2):
     device = nvme_connect(publish_to_node_2)
     desc = nvme_list_subsystems(device)

--- a/tests/bdd/features/pool/create/test_disks.py
+++ b/tests/bdd/features/pool/create/test_disks.py
@@ -125,7 +125,9 @@ def disks():
 
 @pytest.fixture
 def attempt_create_pool_nonexistent_disk(context, attempt_create_pool):
-    context["attempt"] = attempt_create_pool(POOL_NAME, POOL_NODE, ["/dev/no_there"])
+    context["attempt"] = attempt_create_pool(
+        POOL_NAME, POOL_NODE, ["/dev/disk/by-id/no_there"]
+    )
 
 
 @pytest.fixture

--- a/tests/bdd/features/pool/create/test_name.py
+++ b/tests/bdd/features/pool/create/test_name.py
@@ -107,8 +107,8 @@ def the_pool_creation_should_fail_with_error_already_exists(pool_attempt):
 @then('the pool creation should fail with error "InvalidArgument"')
 def the_pool_creation_should_fail_with_error_internal_error(pool_attempt):
     """the pool creation should fail with error InvalidArgument"."""
-    assert pool_attempt.status == http.HTTPStatus.BAD_REQUEST
-    assert ApiClient.exception_to_error(pool_attempt).kind == "InvalidArgument"
+    assert pool_attempt.status == http.HTTPStatus.CONFLICT
+    assert ApiClient.exception_to_error(pool_attempt).kind == "InUse"
 
 
 @then("the pool creation should succeed")

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -988,6 +988,11 @@ impl ClusterBuilder {
         self.opts = self.opts.with_eventing(enabled);
         self
     }
+    /// Specify whether host's mount dev and udev is needed or not.
+    pub fn with_mount_host_dev_udev(mut self, enabled: bool) -> Self {
+        self.opts = self.opts.with_mount_host_dev_udev(enabled);
+        self
+    }
     /// Build into the resulting Cluster using a composer closure, eg:
     /// .compose_build(|c| c.with_logs(false)).
     pub async fn compose_build<F>(mut self, set: F) -> Result<Cluster, Error>

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -993,6 +993,11 @@ impl ClusterBuilder {
         self.opts = self.opts.with_mount_host_dev_udev(enabled);
         self
     }
+    /// Specify whether allow non peristent devlink is needed or not.
+    pub fn with_allow_non_persistent_devlink(mut self, enabled: bool) -> Self {
+        self.opts = self.opts.with_allow_non_persistent_devlink(enabled);
+        self
+    }
     /// Build into the resulting Cluster using a composer closure, eg:
     /// .compose_build(|c| c.with_logs(false)).
     pub async fn compose_build<F>(mut self, set: F) -> Result<Cluster, Error>

--- a/utils/utils-lib/Cargo.toml
+++ b/utils/utils-lib/Cargo.toml
@@ -23,6 +23,7 @@ url = "2.5.4"
 strum = "0.26.3"
 strum_macros = "0.26.4"
 heck = "0.5.0"
+regex = "1.11.1"
 
 version-info = { path = "../dependencies/version-info", default-features = false }
 git-version-macro = { path = "../dependencies/git-version-macro" }

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -184,3 +184,7 @@ pub fn nvme_controller_model_id() -> String {
 
 /// Max limit for etcd pagination.
 pub const ETCD_MAX_PAGE_LIMIT: &str = "500";
+
+/// Regex to match persistent disks.
+pub const DEVLINK_REGEX: &str =
+    r"^(/dev/(disk/by-(id|uuid|label|path|partuuid|partlabel)/[^/\s]+|mapper/[^/\s]+))$";

--- a/utils/utils-lib/src/disk.rs
+++ b/utils/utils-lib/src/disk.rs
@@ -3,11 +3,33 @@ use url::Url;
 /// Normalize the disks if they have a schema, we dont want to change anything
 /// or do any error checking -- the loop will converge to the error state eventually
 pub fn normalize_disk(disk: &str) -> String {
-    Url::parse(disk).map_or(disk.to_string(), |u| {
+    let disk = if disk.starts_with("pcie://") {
+        canonical_pcie_address(disk).unwrap_or_else(|| disk.to_string())
+    } else {
+        disk.to_string()
+    };
+
+    Url::parse(&disk).map_or(disk.to_string(), |u| {
         u.to_file_path()
             .unwrap_or_else(|_| disk.into())
             .as_path()
             .display()
             .to_string()
     })
+}
+
+fn canonical_pcie_address(addr: &str) -> Option<String> {
+    let stripped = addr.strip_prefix("pcie://")?;
+
+    let parts: Vec<&str> = stripped.split([':', '.']).collect();
+    if parts.len() != 4 {
+        return None;
+    }
+
+    let domain = format!("{:04x}", u16::from_str_radix(parts[0], 16).ok()?);
+    let bus = format!("{:02x}", u8::from_str_radix(parts[1], 16).ok()?);
+    let device = format!("{:02x}", u8::from_str_radix(parts[2], 16).ok()?);
+    let function = format!("{}", parts[3].parse::<u8>().ok()?);
+
+    Some(format!("pcie:///{domain}:{bus}:{device}.{function}"))
 }

--- a/utils/utils-lib/src/disk.rs
+++ b/utils/utils-lib/src/disk.rs
@@ -1,0 +1,13 @@
+use url::Url;
+
+/// Normalize the disks if they have a schema, we dont want to change anything
+/// or do any error checking -- the loop will converge to the error state eventually
+pub fn normalize_disk(disk: &str) -> String {
+    Url::parse(disk).map_or(disk.to_string(), |u| {
+        u.to_file_path()
+            .unwrap_or_else(|_| disk.into())
+            .as_path()
+            .display()
+            .to_string()
+    })
+}

--- a/utils/utils-lib/src/disk.rs
+++ b/utils/utils-lib/src/disk.rs
@@ -1,7 +1,7 @@
 use url::Url;
 
-/// Normalize the disks if they have a schema, we dont want to change anything
-/// or do any error checking -- the loop will converge to the error state eventually
+/// Normalize the disks if they have a schema, we don't want to change anything
+/// or do any error checking.
 pub fn normalize_disk(disk: &str) -> String {
     let disk = if disk.starts_with("pcie://") {
         canonical_pcie_address(disk).unwrap_or_else(|| disk.to_string())
@@ -19,7 +19,7 @@ pub fn normalize_disk(disk: &str) -> String {
 }
 
 fn canonical_pcie_address(addr: &str) -> Option<String> {
-    let stripped = addr.strip_prefix("pcie://")?;
+    let stripped = addr.strip_prefix("pcie:///")?;
 
     let parts: Vec<&str> = stripped.split([':', '.']).collect();
     if parts.len() != 4 {
@@ -32,4 +32,81 @@ fn canonical_pcie_address(addr: &str) -> Option<String> {
     let function = format!("{}", parts[3].parse::<u8>().ok()?);
 
     Some(format!("pcie:///{domain}:{bus}:{device}.{function}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::disk::{canonical_pcie_address, normalize_disk};
+    use regex::Regex;
+
+    #[test]
+    fn persistent_devlink_regex() {
+        fn is_persistent_devlink(pattern: &str) -> bool {
+            let re = Regex::new(crate::DEVLINK_REGEX).expect("DEVLINK_REGEX should be valid");
+            re.is_match(pattern)
+        }
+
+        let test_suite = [
+            ("/dev/some/path", false),
+            ("/dev/mapper/some/path", false),
+            ("/dev/disk/some/path", false),
+            ("/dev/disk/by-something/path", false),
+            ("/devil/disk/by-something/path", false),
+            ("/dev/diskxyz/by-something/path", false),
+            ("/dev/disk/something-by/path", false),
+            ("/dev/disk/by-/path", false),
+            ("something", false),
+            ("/dev/somevg/lv0", false),
+            ("/dev/disk/by-id/somepath", true),
+            ("/dev/disk/by-path/somepath", true),
+            ("/dev/disk/by-label/somepath", true),
+            ("/dev/disk/by-partuuid/somepath", true),
+            ("/dev/disk/by-partlabel/somepath", true),
+            ("/dev/mapper/dm0", true),
+        ];
+
+        for test in test_suite {
+            assert_eq!(is_persistent_devlink(test.0), test.1);
+        }
+    }
+
+    #[test]
+    fn normalize_disk_test() {
+        let test_suite = [
+            ("aio:///dev/null", "/dev/null"),
+            ("uring:///dev/null", "/dev/null"),
+            ("uring://dev/null", "uring://dev/null"),
+            ("pcie:///0000:01:00.0", "/0000:01:00.0"),
+            ("pcie:///00:01:00.0", "/0000:01:00.0"),
+            ("pcie:///12454:01:00.0", "/12454:01:00.0"),
+        ];
+        for test in test_suite {
+            assert_eq!(normalize_disk(test.0), test.1);
+        }
+    }
+
+    #[test]
+    fn canonical_pcie_address_test() {
+        let test_suite = [
+            (
+                "pcie:///0000:01:00.0",
+                Some("pcie:///0000:01:00.0".to_string()),
+            ),
+            (
+                "pcie:///00:01:00.0",
+                Some("pcie:///0000:01:00.0".to_string()),
+            ),
+            (
+                "pcie:///12454:01:00.0", // Invalid address
+                None,
+            ),
+            (
+                "pcie:///0011:0111:00.0", // Invalid address
+                None,
+            ),
+        ];
+        for test in test_suite {
+            assert_eq!(canonical_pcie_address(test.0), test.1);
+        }
+    }
 }

--- a/utils/utils-lib/src/lib.rs
+++ b/utils/utils-lib/src/lib.rs
@@ -13,6 +13,8 @@ pub use version_info::{version_info as version_info_inner, VersionInfo};
 
 /// Byte conversion helpers.
 pub mod bytes;
+/// Dev path normalizer helpers.
+pub mod disk;
 
 /// Check for the presence of nvme ana multipath.
 pub fn check_nvme_core_ana() -> Result<bool, std::io::Error> {


### PR DESCRIPTION
## Issue

Since we can't read the metadata of an encrypted pool, there isn't any definitive way in data-plane to stop a encrypted pool from getting recreated with a different devlink of a same device with a different pool name.

## Solution

Compare the devlinks across all pools on the specified node, if any pool shares a devlink with the requested disk's devlink/devpath/devname then reject the creation.

## Test

Adds a test to validate the scenario by creating an lvm lv on a loop device and using it's devlinks across multiple creations.