### PR TITLE
feat: allow setting encryption property on volume spec

### DIFF
--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -391,6 +391,7 @@ message SetVolumePropertyRequest {
 message VolumeProperty {
   oneof attr {
     MaxSnapshotValue max_snapshots = 1;
+    bool encrypted = 2;
   }
 }
 // Max snapshots limit per volume.

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -1829,6 +1829,7 @@ impl From<SetVolumePropertyRequest> for Option<VolumeProperty> {
                 volume::volume_property::Attr::MaxSnapshots(volume::MaxSnapshotValue { value }) => {
                     VolumeProperty::MaxSnapshots(value)
                 }
+                volume::volume_property::Attr::Encrypted(value) => VolumeProperty::Encrypted(value),
             })
         })
     }
@@ -1841,6 +1842,9 @@ impl From<VolumeProperty> for volume::VolumeProperty {
                 attr: Some(volume::volume_property::Attr::MaxSnapshots(
                     volume::MaxSnapshotValue { value },
                 )),
+            },
+            VolumeProperty::Encrypted(value) => volume::VolumeProperty {
+                attr: Some(volume::volume_property::Attr::Encrypted(value)),
             },
         }
     }

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -91,6 +91,13 @@ pub enum SetPropertyResources {
 pub enum SetVolumeProperties {
     /// Max snapshot limit per volume.
     MaxSnapshots { max_snapshots: u32 },
+    #[clap(
+        about = "Encryption required for volume.\n\x1b[31m\x1b[1mCAUTION:\x1b[0m Use carefully during for example non-encrypted to encrypted pool migration. Refer to documentation for more details."
+    )]
+    Encryption {
+        #[clap(action = clap::ArgAction::Set)]
+        enabled: bool,
+    },
 }
 
 /// The types of resources that support cordoning.

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -277,33 +277,38 @@ impl SetProperty for Volume {
         property: &Self::Property,
         output: &utils::OutputFormat,
     ) -> PluginResult {
-        match property {
+        let property_body = match property {
             SetVolumeProperties::MaxSnapshots { max_snapshots } => {
-                let property_body = SetVolumePropertyBody::max_snapshots(*max_snapshots);
-                match RestClient::client()
-                    .volumes_api()
-                    .put_volume_property(id, property_body.clone())
-                    .await
-                {
-                    Ok(volume) => match output {
-                        OutputFormat::Yaml | OutputFormat::Json => {
-                            // Print json or yaml based on output format.
-                            utils::print_table(output, volume.into_body());
-                        }
-                        OutputFormat::None => {
-                            // In case the output format is not specified, show a success message.
-                            println!("Volume {id} property {:?} set successfully", property_body);
-                        }
-                    },
-                    Err(e) => {
-                        return Err(Error::SetVolumePropertyError {
-                            id: id.to_string(),
-                            source: e,
-                        });
-                    }
+                SetVolumePropertyBody::max_snapshots(*max_snapshots)
+            }
+            SetVolumeProperties::Encryption { enabled } => {
+                SetVolumePropertyBody::encrypted(*enabled)
+            }
+        };
+
+        match RestClient::client()
+            .volumes_api()
+            .put_volume_property(id, property_body.clone())
+            .await
+        {
+            Ok(volume) => match output {
+                OutputFormat::Yaml | OutputFormat::Json => {
+                    // Print json or yaml based on output format.
+                    utils::print_table(output, volume.into_body());
                 }
+                OutputFormat::None => {
+                    // In case the output format is not specified, show a success message.
+                    println!("Volume {id} property {:?} set successfully", property_body);
+                }
+            },
+            Err(e) => {
+                return Err(Error::SetVolumePropertyError {
+                    id: id.to_string(),
+                    source: e,
+                });
             }
         }
+
         Ok(())
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2726,12 +2726,17 @@ components:
       oneOf:
         - required:
             - max_snapshots
+        - required:
+            - encrypted
       properties:
         max_snapshots:
           description: Max Snapshots limit per volume.
           type: integer
           format: int32
           minimum: 0
+        encrypted:
+          description: Volume is required to be encrypted.
+          type: boolean
     AffinityGroup:
       example:
         id: "ag"

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -286,6 +286,9 @@ impl From<models::SetVolumePropertyBody> for SetVolumePropertyBody {
             models::SetVolumePropertyBody::max_snapshots(x) => Self {
                 property: VolumeProperty::MaxSnapshots(x),
             },
+            models::SetVolumePropertyBody::encrypted(b) => Self {
+                property: VolumeProperty::Encrypted(b),
+            },
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -529,6 +529,9 @@ impl SpecTransaction<VolumeOperation> for VolumeSpec {
                     VolumeProperty::MaxSnapshots(max_snapshots) => {
                         self.max_snapshots = Some(max_snapshots);
                     }
+                    VolumeProperty::Encrypted(encrypted) => {
+                        self.encrypted = encrypted;
+                    }
                 },
             }
         }

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -110,6 +110,8 @@ impl From<VolumeHealth> for models::VolumeHealth {
 pub enum VolumeProperty {
     /// Max number of snapshots allowed per volume.
     MaxSnapshots(u32),
+    /// Volume is required to be encrypted.
+    Encrypted(bool),
 }
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
This way of setting encryption property should be used with caution when the user knows what they are doing, e.g. planned manual migration of pools from non-encrypted to encrypted.