### PR TITLE
DiskPool Operator: add quantity for a nicer print

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "openapi",
+ "parse-size",
  "schemars",
  "serde",
  "serde_json",

--- a/k8s/forward/src/pod_selection.rs
+++ b/k8s/forward/src/pod_selection.rs
@@ -21,6 +21,9 @@ impl PodSelection for AnyReady {
 }
 
 fn is_pod_ready(pod: &&Pod) -> bool {
+    if pod.status.as_ref().and_then(|s| s.phase.as_deref()) != Some("Running") {
+        return false;
+    }
     let conditions = pod.status.as_ref().and_then(|s| s.conditions.as_ref());
     conditions
         .map(|c| c.iter().any(|c| c.type_ == "Ready" && c.status == "True"))

--- a/k8s/operators/Cargo.toml
+++ b/k8s/operators/Cargo.toml
@@ -38,3 +38,4 @@ snafu = { version = "0.8.5", optional = true }
 tokio = { version = "1.41.0", features = ["full"], optional = true }
 humantime = { version = "2.1.0", optional = true }
 tracing = { version = "0.1.40", optional = true }
+parse-size = "1.1.0"

--- a/k8s/operators/src/lib.rs
+++ b/k8s/operators/src/lib.rs
@@ -4,4 +4,7 @@ pub mod diskpool {
     pub mod crd {
         include!("pool/diskpool/crd/v1beta3.rs");
     }
+    pub mod quantity {
+        include!("pool/diskpool/crd/quantity.rs");
+    }
 }

--- a/k8s/operators/src/pool/diskpool/crd/mod.rs
+++ b/k8s/operators/src/pool/diskpool/crd/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod migration;
+pub mod quantity;
 /// The DiskPool custom resource definition.
 pub(crate) mod v1alpha1;
 pub(crate) mod v1beta1;

--- a/k8s/operators/src/pool/diskpool/crd/quantity.rs
+++ b/k8s/operators/src/pool/diskpool/crd/quantity.rs
@@ -1,0 +1,109 @@
+use schemars::JsonSchema;
+use std::convert::TryFrom;
+
+/// A quantity represented as a humansize with up to 1 floating point.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct Quantity(pub u64);
+impl Quantity {
+    /// Create a [`Self`] from bytes.
+    pub fn from_bytes(bytes: u64) -> Self {
+        Self(bytes)
+    }
+    /// Get the bytes.
+    pub fn bytes(&self) -> u64 {
+        self.0
+    }
+}
+impl TryFrom<&str> for Quantity {
+    type Error = parse_size::Error;
+
+    fn try_from(quantity: &str) -> Result<Self, Self::Error> {
+        parse_size::parse_size(quantity).map(Self)
+    }
+}
+
+impl PartialEq for Quantity {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes() == other.bytes() || self.to_string() == other.to_string()
+    }
+}
+impl Eq for Quantity {}
+
+impl std::fmt::Display for Quantity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", utils::bytes::into_human(self.0))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Quantity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Quantity::try_from(String::deserialize(deserializer)?.as_str())
+            .map_err(serde::de::Error::custom)
+    }
+}
+impl serde::Serialize for Quantity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl JsonSchema for Quantity {
+    fn schema_name() -> String {
+        "Quantity".to_owned()
+    }
+
+    fn json_schema(__gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+            metadata: Some(Box::new(schemars::schema::Metadata {
+                description: Some(
+                    "Quantity represents a byte quantity with an appropriate SI unit, up to 1 decimal point".to_owned(),
+                ),
+                examples: vec![
+                    "100 GiB".into(),
+                    "1.4 MiB".into()
+                ],
+                ..Default::default()
+            })),
+            instance_type: Some(schemars::schema::SingleOrVec::Single(Box::new(
+                schemars::schema::InstanceType::String,
+            ))),
+            ..Default::default()
+        })
+    }
+}
+
+#[test]
+fn test() {
+    #[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, JsonSchema)]
+    struct Struct {
+        q: Quantity,
+    }
+    fn assert_size(bytes: u64, q_str: &str) {
+        let q = Quantity::from_bytes(bytes);
+        assert_eq!(q.bytes(), bytes);
+        assert_eq!(q.to_string(), q_str);
+        assert_eq!(Quantity::try_from(q_str).unwrap().to_string(), q_str);
+
+        let dsp = Struct { q };
+        let dsp_val = serde_json::json!({
+            "q": q_str
+        });
+        assert_eq!(serde_json::to_string(&dsp).unwrap(), dsp_val.to_string());
+        assert_eq!(dsp, serde_json::from_value(dsp_val).unwrap());
+    }
+    let mb = 1024 * 1024;
+    let gb = mb * 1024;
+
+    assert_size(100 * mb, "100 MiB");
+    assert_size(gb, "1 GiB");
+    assert_size(gb + 20 * mb, "1 GiB");
+    assert_size(gb + 25 * mb, "1 GiB");
+    assert_size(gb + 200 * mb, "1.2 GiB");
+    assert_size(1500 * 1000 * 1000, "1.4 GiB");
+}

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 #[cfg(feature = "openapi")]
 use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
 
+use super::quantity::Quantity;
+
 #[derive(
     CustomResource, Serialize, Deserialize, Default, Debug, Eq, PartialEq, Clone, JsonSchema,
 )]
@@ -24,9 +26,9 @@ use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
     printcolumn = r#"{ "name":"state", "type":"string", "description":"dsp cr state", "jsonPath":".status.cr_state"}"#,
     printcolumn = r#"{ "name":"pool_status", "type":"string", "description":"Control plane pool status", "jsonPath":".status.pool_status"}"#,
     printcolumn = r#"{ "name":"encrypted", "type":"boolean", "description":"encryption enabled", "jsonPath":".status.encrypted"}"#,
-    printcolumn = r#"{ "name":"capacity", "type":"integer", "format": "int64", "minimum" : "0", "description":"total bytes", "jsonPath":".status.capacity"}"#,
-    printcolumn = r#"{ "name":"used", "type":"integer", "format": "int64", "minimum" : "0", "description":"used bytes", "jsonPath":".status.used"}"#,
-    printcolumn = r#"{ "name":"available", "type":"integer", "format": "int64", "minimum" : "0", "description":"available bytes", "jsonPath":".status.available"}"#
+    printcolumn = r#"{ "name":"capacity", "type":"string", "nullable": "true", "description":"total bytes", "jsonPath":".status.capacity_q"}"#,
+    printcolumn = r#"{ "name":"used", "type":"string", "nullable": "true", "description":"used bytes", "jsonPath":".status.used_q"}"#,
+    printcolumn = r#"{ "name":"available", "type":"string", "nullable": "true", "description":"available bytes", "jsonPath":".status.available_q"}"#
 )]
 /// The pool spec which contains the parameters we use when creating the pool
 pub struct DiskPoolSpec {
@@ -143,6 +145,12 @@ pub struct DiskPoolStatus {
     pub used: u64,
     /// Available number of bytes.
     pub available: u64,
+    /// Total capacity.
+    pub capacity_q: Option<Quantity>,
+    /// Used capacity.
+    pub used_q: Option<Quantity>,
+    /// Available capacity.
+    pub available_q: Option<Quantity>,
     /// Encryption enabled.
     pub encrypted: Option<bool>,
 }
@@ -155,6 +163,9 @@ impl Default for DiskPoolStatus {
             capacity: 0,
             used: 0,
             available: 0,
+            capacity_q: None,
+            used_q: None,
+            available_q: None,
             encrypted: None,
         }
     }
@@ -186,6 +197,9 @@ impl DiskPoolStatus {
             used: state.used,
             available: free,
             encrypted: Some(state.encrypted),
+            capacity_q: Some(Quantity::from_bytes(state.capacity)),
+            used_q: Some(Quantity::from_bytes(state.used)),
+            available_q: Some(Quantity::from_bytes(free)),
         }
     }
 
@@ -236,6 +250,9 @@ impl From<Pool> for DiskPoolStatus {
                 used: state.used,
                 available: free,
                 encrypted: Some(state.encrypted),
+                capacity_q: Some(Quantity::from_bytes(state.capacity)),
+                used_q: Some(Quantity::from_bytes(state.used)),
+                available_q: Some(Quantity::from_bytes(free)),
             }
         } else {
             Self {

--- a/utils/utils-lib/src/bytes.rs
+++ b/utils/utils-lib/src/bytes.rs
@@ -16,7 +16,7 @@ pub fn into_human(bytes: u64) -> String {
 
     let floor = base.floor() as usize;
     match SUFFIX.get(floor) {
-        Some(units) => format!("{human_size_prefix}{units}"),
+        Some(units) => format!("{human_size_prefix} {units}"),
         None => format!("{bytes} B"),
     }
 }


### PR DESCRIPTION
    feat(operator/dsp): add quantity for a nicer print

    Adds quantity type for pool capacities.
    These are then used for CRD printcolumns, showing a nicer humansize
    value, rather than a large byte number.
    This value is the same as the kubectl-plugin one.
    Also fix a bug where no space was added between value and unit.

---

    fix(k8s/proxy): add phase to conditions check
