### PR TITLE
fix: dsp migration was not considering topology

### DIFF
--- a/k8s/operators/src/pool/diskpool/crd/migration.rs
+++ b/k8s/operators/src/pool/diskpool/crd/migration.rs
@@ -128,12 +128,13 @@ pub(crate) async fn migrate_to_v1beta3(
                 let name = dsp.name_any();
                 let node = dsp.spec.node();
                 let disk = dsp.spec.disks();
+                let topology = dsp.spec.topology();
                 replace_with_v1beta3(
                     &k8s,
                     &name,
                     ns,
                     Some(res_ver.clone()),
-                    DiskPoolSpec::new(node, disk, None, None),
+                    DiskPoolSpec::new(node, disk, topology, None),
                 )
                 .await?;
                 info!(crd = ?dsp.name_any(), "CR creation successful");


### PR DESCRIPTION
- There was a bug where on v1beta2 to v1beta3 migration the topology were set as null, which is fixed now.