### PR TITLE
chore(ci): inject github token post nix installation

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -10,23 +10,45 @@ env:
 jobs:
   bdd-tests:
     runs-on: ubuntu-latest-16-cores
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
+
       - run: echo "CI_REPORT_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+
       - uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          github-token: ''      ## Override the default the token
+
+      - name: Inject github token to nix config
+        run: |
+          cat <<EOF | sudo tee -a /etc/nix/nix.conf
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          trusted-users = root runner
+          EOF
+
+      - name: Restart Nix daemon
+        run: sudo systemctl restart nix-daemon
+
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
           echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
           nix-shell --run "echo" shell.nix
+
       - name: Handle Rust dependencies caching
         uses: Swatinem/rust-cache@v2
+
       - name: Build binaries
         run: nix-shell --run "cargo build --bins"
+
       - name: Setup Test Pre-Requisites
         run: |
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
@@ -34,20 +56,24 @@ jobs:
           sudo sysctl -w vm.nr_hugepages=3072
           sudo apt-get install linux-modules-extra-$(uname -r)
           sudo modprobe nvme_tcp
+
       - name: Run BDD Tests
         run: |
           nix-shell --run "deployer start --image-pull-policy always -w 60s && deployer stop"
           nix-shell --run "./scripts/python/test.sh"
+
       - name: Cleanup
         if: always()
         run: |
           nix-shell --run "./scripts/ci-report.sh"
           nix-shell --run "./scripts/python/test-residue-cleanup.sh"
+
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ci-report-bdd
           path: ./ci-report/ci-report.tar.gz
+
       - name: Pytest BDD Report
         if: always()
         uses: pmeier/pytest-results-action@main
@@ -57,6 +83,7 @@ jobs:
           display-options: a
           fail-on-empty: true
           title: Test results
+
       # debugging
       # - name: Setup tmate session
       #   if: ${{ failure() }}

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -10,27 +10,50 @@ env:
 jobs:
   int-tests:
     runs-on: ubuntu-latest-16-cores
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
+
       - run: echo "CI_REPORT_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+
       - uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          github-token: ''      ## Override the default the token
+
+      - name: Inject github token to nix config
+        run: |
+          cat <<EOF | sudo tee -a /etc/nix/nix.conf
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          trusted-users = root runner
+          EOF
+
+      - name: Restart Nix daemon
+        run: sudo systemctl restart nix-daemon
+
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
           echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
           nix-shell --run "echo" shell.nix
+
       - name: Handle Rust dependencies caching
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ startsWith(github.ref_name, 'release/') || github.ref_name == 'develop' }}
+
       - name: Build rust binaries
         run: nix-shell --run "cargo build --bins"
+
       - name: Build the tests
         run: nix-shell --run "./scripts/rust/test.sh --no-run"
+
       - name: Setup Test Pre-Requisites
         run: |
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
@@ -38,22 +61,26 @@ jobs:
           sudo sysctl -w vm.nr_hugepages=2560
           sudo apt-get install linux-modules-extra-$(uname -r)
           sudo modprobe nvme_tcp
+
       - name: Run Tests
         run: |
           # pre-pull the required container images
           nix-shell --run "deployer start --image-pull-policy always -w 60s && deployer stop"
           # includes both unit and integration tests
           nix-shell --run "./scripts/rust/test.sh"
+
       - name: Cleanup
         if: always()
         run: |
           nix-shell --run "./scripts/ci-report.sh"
           nix-shell --run "./scripts/rust/deployer-cleanup.sh"
+
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ci-report-int
           path: ./ci-report/ci-report.tar.gz
+
       # debugging
       # - name: Setup tmate session
       #   if: ${{ failure() }}

--- a/scripts/ci-report.sh
+++ b/scripts/ci-report.sh
@@ -10,8 +10,7 @@ set -eu
 mkdir -p "$ROOT_DIR/ci-report"
 cd "$ROOT_DIR/ci-report"
 
-# Disable until we find how some CI envs are being included
-journalctl --since="$CI_REPORT_START_DATE" -o short-precise > journalctl.txt
+journalctl --since="$CI_REPORT_START_DATE" -o short-precise | sed -E 's/ghs_[^[:space:]]+/ghs_***/g' > journalctl.txt
 journalctl -k -b0 -o short-precise > dmesg.txt
 lsblk -tfa > lsblk.txt
 $SUDO nvme list -v > nvme.txt

--- a/scripts/ci-report.sh
+++ b/scripts/ci-report.sh
@@ -11,7 +11,7 @@ mkdir -p "$ROOT_DIR/ci-report"
 cd "$ROOT_DIR/ci-report"
 
 # Disable until we find how some CI envs are being included
-# journalctl --since="$CI_REPORT_START_DATE" -o short-precise > journalctl.txt
+journalctl --since="$CI_REPORT_START_DATE" -o short-precise > journalctl.txt
 journalctl -k -b0 -o short-precise > dmesg.txt
 lsblk -tfa > lsblk.txt
 $SUDO nvme list -v > nvme.txt


### PR DESCRIPTION
This PR address the security advisory where the github token was being exposed.
As a solution: 
- We are first installing nix (without gh token) and then injecting the token in a seperate step.

Tested here : https://github.com/openebs/mayastor-control-plane/actions/runs/14901217891/job/41853358307

Please note : 
- Testing was carried out by disabling "if failure" flag so that the report could be generated 
- I have re-enabled the journalctl logs to present in the artifacts post testing.
- The if failure flag has been re-enabled.