### PR TITLE
feat(encryption): relaxed replica scheduling during pool migration

### DIFF
--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -116,6 +116,8 @@ pub(crate) struct RegistryInner<S: Store> {
     etcd_max_page_size: i64,
     /// Allow pool creation using non-persistent devlinks.
     allow_non_persistent_devlinks: bool,
+    /// Prefer encrypted pools for volume replicas.
+    encrypted_pools_soft_scheduling: bool,
 }
 
 impl Registry {
@@ -143,6 +145,7 @@ impl Registry {
         etcd_max_page_size: i64,
         no_volume_health: bool,
         allow_non_persistent_devlinks: bool,
+        encrypted_pools_soft_scheduling: bool,
     ) -> Result<Self, SvcError> {
         let store_endpoint = Self::format_store_endpoint(&store_url);
         tracing::info!("Connecting to persistent store at {}", store_endpoint);
@@ -203,6 +206,7 @@ impl Registry {
                 ha_disabled: ha_enabled,
                 etcd_max_page_size,
                 allow_non_persistent_devlinks,
+                encrypted_pools_soft_scheduling,
             }),
         };
         registry.init().await?;
@@ -352,6 +356,11 @@ impl Registry {
         if let Some(h) = self.health() {
             h.retain(retain)
         }
+    }
+    /// If we should enforce encrypted pool requirement softly, i.e. if encrypted pool not
+    /// found, go ahead with non-encrypted one.
+    pub(crate) fn encryption_preference_soft(&self) -> bool {
+        self.encrypted_pools_soft_scheduling
     }
 
     /// Serialized write to the persistent store.

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
@@ -56,7 +56,11 @@ impl PoolBaseFilters {
     }
     /// Should only attempt to use encrypted pools.
     pub(crate) fn encrypted(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
-        request.encrypted() == item.pool.encrypted
+        let use_this = request.encrypted() == item.pool.encrypted;
+        if !use_this && request.encrypted() && request.registry().encryption_preference_soft() {
+            return !use_this;
+        }
+        use_this
     }
     /// Return true if the pool has enough capacity to resize the replica by the requested
     /// value.

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -44,8 +44,7 @@ impl ResourcePolicy<AddVolumeReplica> for SimplePolicy {
             .filter(affinity_group::SingleReplicaPolicy::replica_anti_affinity)
             .filter_param(&self, SimplePolicy::min_free_space)
             .filter_param(&self, SimplePolicy::pool_overcommit)
-            // sort pools in order of total weight of certain field values.
-            .sort_ctx(SimplePolicy::sort_by_weights)
+            .sort_ctx(SimplePolicy::sort_pools)
     }
 }
 
@@ -127,6 +126,31 @@ impl SimplePolicy {
             |item| item.pool().over_commitment().into(),
         )
     }
+
+    /// A note about sort upon encryption status:
+    /// If encrypted_pools_soft_scheduling is set in registry, it means system is under some
+    /// kind of migration for volumes from non-encrypted to encrypted pools. In such case,
+    /// give preference to encrypted pool if available. During such migration, volume can
+    /// possibly have some replicas on encrypted pool and some on non-encrypted.
+    pub(crate) fn sort_pools(
+        request: &GetSuitablePoolsContext,
+        a: &PoolItem,
+        b: &PoolItem,
+    ) -> std::cmp::Ordering {
+        match request.registry().encryption_preference_soft() {
+            true => match b.pool.encrypted().partial_cmp(&a.pool.encrypted()) {
+                Some(Ordering::Greater) => Ordering::Greater,
+                Some(Ordering::Less) => Ordering::Less,
+                None | Some(Ordering::Equal) => {
+                    // sort pools in order of total weight of certain field values.
+                    SimplePolicy::sort_by_weights(request, a, b)
+                }
+            },
+            // sort pools in order of total weight of certain field values.
+            false => SimplePolicy::sort_by_weights(request, a, b),
+        }
+    }
+
     /// Sort pools using weights between:
     /// 1. number of replicas or number of replicas of a ag (N_REPL_WEIGHT %)
     /// 2. free space         (FREE_SPACE_WEIGHT %)

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/thick.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/thick.rs
@@ -25,8 +25,7 @@ impl ResourcePolicy<AddVolumeReplica> for ThickPolicy {
             .filter(PoolBaseFilters::min_free_space_full_rebuild)
             .filter(PoolBaseFilters::encrypted)
             .filter(affinity_group::SingleReplicaPolicy::replica_anti_affinity)
-            // sort pools in order of preference (from least to most number of replicas)
-            .sort_ctx(ThickPolicy::sort_by_weights)
+            .sort_ctx(ThickPolicy::sort_pools)
     }
 }
 
@@ -81,6 +80,31 @@ impl ThickPolicy {
             |item| item.len().into(),
         )
     }
+
+    /// A note about sort upon encryption status:
+    /// If encrypted_pools_soft_scheduling is set in registry, it means system is under some
+    /// kind of migration for volumes from non-encrypted to encrypted pools. In such case,
+    /// give preference to encrypted pool if available. During such migration, volume can
+    /// possibly have some replicas on encrypted pool and some on non-encrypted.
+    pub(crate) fn sort_pools(
+        request: &GetSuitablePoolsContext,
+        a: &PoolItem,
+        b: &PoolItem,
+    ) -> std::cmp::Ordering {
+        match request.registry().encryption_preference_soft() {
+            true => match b.pool.encrypted().partial_cmp(&a.pool.encrypted()) {
+                Some(Ordering::Greater) => Ordering::Greater,
+                Some(Ordering::Less) => Ordering::Less,
+                None | Some(Ordering::Equal) => {
+                    // sort pools in order of preference (from least to most number of replicas)
+                    ThickPolicy::sort_by_weights(request, a, b)
+                }
+            },
+            // sort pools in order of preference (from least to most number of replicas)
+            false => ThickPolicy::sort_by_weights(request, a, b),
+        }
+    }
+
     /// Sort pools by state and then by using weights between:
     /// 1. number of replicas or number of replicas of a ag (N_REPL_WEIGHT %)
     /// 2. free space         (FREE_SPACE_WEIGHT %)

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -150,6 +150,12 @@ pub(crate) struct CliArgs {
     /// Allow pools to be created using non persistent devlinks.
     #[clap(long)]
     allow_non_persistent_devlink: bool,
+
+    /// Prefer to use encrypted pools for volume replicas if the this is set in addition to
+    /// encryption on volume spec. Applicable if the volume was initially provisioned via
+    /// a non-encryption storage class.
+    #[clap(long)]
+    encrypted_pools_soft_scheduling: bool,
 }
 impl CliArgs {
     fn args() -> Self {
@@ -228,6 +234,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.etcd_page_limit as i64,
         cli_args.no_volume_health,
         cli_args.allow_non_persistent_devlink,
+        cli_args.encrypted_pools_soft_scheduling,
     )
     .await?;
 

--- a/control-plane/agents/src/bin/core/pool/wrapper.rs
+++ b/control-plane/agents/src/bin/core/pool/wrapper.rs
@@ -110,6 +110,11 @@ impl PoolWrapper {
         self.free_space
     }
 
+    /// Get the pool's encryption status.
+    pub(crate) fn encrypted(&self) -> bool {
+        self.encrypted
+    }
+
     /// Set pool state as unknown.
     #[allow(dead_code)]
     pub(crate) fn set_unknown(&mut self) {


### PR DESCRIPTION
This change handles the new option prefer-encrypted-pools enabled via helm chart. Once migration activity is finished, the option MUST be disabled from the helm chart.