### PR TITLE
feat(pool): allow changing blobstore cluster size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,7 @@ dependencies = [
  "nix",
  "nvmeadm",
  "once_cell",
+ "parse-size",
  "prost",
  "prost-types",
  "regex",

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -7,6 +7,7 @@ use stor_port::{
     transport_api::ResourceKind,
     types::v0::{
         openapi::apis::IntoVec,
+        store::pool::POOL_BS_CLUSTER_SIZE_DEFAULT,
         transport::{
             self, ChildState, ChildStateReason, Nexus, NexusId, NexusNvmePreemption,
             NexusNvmfConfig, NexusStatus, NodeId, NvmeReservation, PoolState, Protocol, Replica,
@@ -91,6 +92,7 @@ impl IoEngineToAgent for v0::Pool {
             used: self.used,
             committed: None,
             encrypted: false,
+            cluster_size: POOL_BS_CLUSTER_SIZE_DEFAULT,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -659,6 +659,7 @@ impl IoEngineToAgent for v1::pool::Pool {
                 Some(self.committed)
             },
             encrypted: self.encrypted.unwrap_or_default(),
+            cluster_size: self.cluster_size,
         }
     }
 }
@@ -672,7 +673,7 @@ impl AgentToIoEngine for transport::CreatePool {
             disks: self.disks.iter().map(|d| d.to_string()).collect(),
             uuid: None,
             pooltype: v1::pool::PoolType::Lvs as i32,
-            cluster_size: None,
+            cluster_size: self.cluster_size,
             md_args: None,
             encryption: self
                 .encryption

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -39,6 +39,7 @@ use stor_port::{
     types::v0::{
         store::{
             nexus_persistence::{delete_all_v1_nexus_info, NexusInfo},
+            pool::POOL_BS_CLUSTER_SIZE_DEFAULT,
             registry::{ControlPlaneService, CoreRegistryConfig, NodeRegistration},
             volume::InitiatorAC,
         },
@@ -118,6 +119,9 @@ pub(crate) struct RegistryInner<S: Store> {
     allow_non_persistent_devlinks: bool,
     /// Prefer encrypted pools for volume replicas.
     encrypted_pools_soft_scheduling: bool,
+    /// Blobstore cluster size(in bytes) required for pool creation and replica scheduling. This is
+    /// not per-pool.
+    pool_bs_cluster_size: Option<u32>,
 }
 
 impl Registry {
@@ -146,6 +150,7 @@ impl Registry {
         no_volume_health: bool,
         allow_non_persistent_devlinks: bool,
         encrypted_pools_soft_scheduling: bool,
+        pool_bs_cluster_size: Option<u32>,
     ) -> Result<Self, SvcError> {
         let store_endpoint = Self::format_store_endpoint(&store_url);
         tracing::info!("Connecting to persistent store at {}", store_endpoint);
@@ -207,6 +212,7 @@ impl Registry {
                 etcd_max_page_size,
                 allow_non_persistent_devlinks,
                 encrypted_pools_soft_scheduling,
+                pool_bs_cluster_size: pool_bs_cluster_size.or(Some(POOL_BS_CLUSTER_SIZE_DEFAULT)),
             }),
         };
         registry.init().await?;
@@ -241,6 +247,11 @@ impl Registry {
     /// Check if pool creation using non-persistent devlink is allowed.
     pub(crate) fn allow_non_persistent_devlinks(&self) -> bool {
         self.allow_non_persistent_devlinks
+    }
+
+    /// Get the configured pool cluster_size.
+    pub(crate) fn pool_bs_cluster_size(&self) -> Option<u32> {
+        self.pool_bs_cluster_size
     }
 
     /// Check if the partial rebuilds are disabled.

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -121,7 +121,7 @@ pub(crate) struct RegistryInner<S: Store> {
     encrypted_pools_soft_scheduling: bool,
     /// Blobstore cluster size(in bytes) required for pool creation and replica scheduling. This is
     /// not per-pool.
-    pool_bs_cluster_size: Option<u32>,
+    pool_cluster_size: Option<u32>,
 }
 
 impl Registry {
@@ -150,7 +150,7 @@ impl Registry {
         no_volume_health: bool,
         allow_non_persistent_devlinks: bool,
         encrypted_pools_soft_scheduling: bool,
-        pool_bs_cluster_size: Option<u32>,
+        pool_cluster_size: Option<u32>,
     ) -> Result<Self, SvcError> {
         let store_endpoint = Self::format_store_endpoint(&store_url);
         tracing::info!("Connecting to persistent store at {}", store_endpoint);
@@ -212,7 +212,7 @@ impl Registry {
                 etcd_max_page_size,
                 allow_non_persistent_devlinks,
                 encrypted_pools_soft_scheduling,
-                pool_bs_cluster_size: pool_bs_cluster_size.or(Some(POOL_BS_CLUSTER_SIZE_DEFAULT)),
+                pool_cluster_size: pool_cluster_size.or(Some(POOL_BS_CLUSTER_SIZE_DEFAULT)),
             }),
         };
         registry.init().await?;
@@ -250,8 +250,8 @@ impl Registry {
     }
 
     /// Get the configured pool cluster_size.
-    pub(crate) fn pool_bs_cluster_size(&self) -> Option<u32> {
-        self.pool_bs_cluster_size
+    pub(crate) fn pool_cluster_size(&self) -> Option<u32> {
+        self.pool_cluster_size
     }
 
     /// Check if the partial rebuilds are disabled.

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
@@ -62,6 +62,11 @@ impl PoolBaseFilters {
         }
         use_this
     }
+    /// Should only use the pools that match blobstore cluster size as specified via storage class,
+    /// or if nothing specified match against a default blobstore cluster size.
+    pub(crate) fn cluster_size(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        item.pool.cluster_size() == request.cluster_size
+    }
     /// Return true if the pool has enough capacity to resize the replica by the requested
     /// value.
     pub(crate) fn min_free_space_repl_resize(

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -41,6 +41,7 @@ impl ResourcePolicy<AddVolumeReplica> for SimplePolicy {
         DefaultBasePolicy::filter(to)
             .filter(PoolBaseFilters::min_free_space)
             .filter(PoolBaseFilters::encrypted)
+            .filter(PoolBaseFilters::cluster_size)
             .filter(affinity_group::SingleReplicaPolicy::replica_anti_affinity)
             .filter_param(&self, SimplePolicy::min_free_space)
             .filter_param(&self, SimplePolicy::pool_overcommit)

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -266,7 +266,10 @@ mod tests {
         cmp::Ordering,
         net::{IpAddr, Ipv4Addr},
     };
-    use stor_port::types::v0::transport::{NodeState, NodeStatus, PoolState, PoolStatus, Replica};
+    use stor_port::types::v0::{
+        store::pool::POOL_BS_CLUSTER_SIZE_DEFAULT,
+        transport::{NodeState, NodeStatus, PoolState, PoolStatus, Replica},
+    };
 
     fn make_node(name: &str) -> NodeWrapper {
         let state = NodeState::new(
@@ -298,6 +301,7 @@ mod tests {
             used,
             committed: None,
             encrypted: false,
+            cluster_size: POOL_BS_CLUSTER_SIZE_DEFAULT,
         };
         let replica = Replica::default();
         let pool = PoolWrapper::new(

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/thick.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/thick.rs
@@ -24,6 +24,7 @@ impl ResourcePolicy<AddVolumeReplica> for ThickPolicy {
         DefaultBasePolicy::filter(to)
             .filter(PoolBaseFilters::min_free_space_full_rebuild)
             .filter(PoolBaseFilters::encrypted)
+            .filter(PoolBaseFilters::cluster_size)
             .filter(affinity_group::SingleReplicaPolicy::replica_anti_affinity)
             .sort_ctx(ThickPolicy::sort_pools)
     }

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -156,6 +156,12 @@ pub(crate) struct CliArgs {
     /// a non-encryption storage class.
     #[clap(long)]
     encrypted_pools_soft_scheduling: bool,
+
+    /// Blobstore cluster size(in bytes) required for pool creation. This is
+    /// not configurable per-pool here. However, the create pool request can be used
+    /// to configure cluster size per-pool.
+    #[clap(long)]
+    pool_bs_cluster_size: Option<u32>,
 }
 impl CliArgs {
     fn args() -> Self {
@@ -235,6 +241,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.no_volume_health,
         cli_args.allow_non_persistent_devlink,
         cli_args.encrypted_pools_soft_scheduling,
+        cli_args.pool_bs_cluster_size,
     )
     .await?;
 

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -161,7 +161,7 @@ pub(crate) struct CliArgs {
     /// not configurable per-pool here. However, the create pool request can be used
     /// to configure cluster size per-pool.
     #[clap(long)]
-    pool_bs_cluster_size: Option<u32>,
+    pool_cluster_size: Option<u32>,
 }
 impl CliArgs {
     fn args() -> Self {
@@ -241,7 +241,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.no_volume_health,
         cli_args.allow_non_persistent_devlink,
         cli_args.encrypted_pools_soft_scheduling,
-        cli_args.pool_bs_cluster_size,
+        cli_args.pool_cluster_size,
     )
     .await?;
 

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -46,7 +46,6 @@ impl OperationGuardArc<PoolSpec> {
             }
             CreatePool::from(spec.deref())
         };
-
         let node = registry.node_wrapper(&request.node).await?;
         if node.pool(&request.id).await.is_none() {
             return Ok(());

--- a/control-plane/agents/src/bin/core/pool/service.rs
+++ b/control-plane/agents/src/bin/core/pool/service.rs
@@ -51,8 +51,12 @@ impl PoolOperations for Service {
         pool: &dyn CreatePoolInfo,
         _ctx: Option<Context>,
     ) -> Result<Pool, ReplyError> {
-        let req = pool.into();
+        let mut req: CreatePool = pool.into();
         let service = self.clone();
+        // Set the cluster_size which is potentially configured via cli args.
+        // Setting it as early as possible otherwise we'll have to make CreatePool
+        // request mutable in the ResourceLifecycle trait.
+        req.cluster_size = pool.cluster_size().or(self.registry.pool_bs_cluster_size());
         let pool = Context::spawn(async move { service.create_pool(&req).await }).await??;
         Ok(pool)
     }

--- a/control-plane/agents/src/bin/core/pool/service.rs
+++ b/control-plane/agents/src/bin/core/pool/service.rs
@@ -56,7 +56,7 @@ impl PoolOperations for Service {
         // Set the cluster_size which is potentially configured via cli args.
         // Setting it as early as possible otherwise we'll have to make CreatePool
         // request mutable in the ResourceLifecycle trait.
-        req.cluster_size = pool.cluster_size().or(self.registry.pool_bs_cluster_size());
+        req.cluster_size = pool.cluster_size().or(self.registry.pool_cluster_size());
         let pool = Context::spawn(async move { service.create_pool(&req).await }).await??;
         Ok(pool)
     }

--- a/control-plane/agents/src/bin/core/pool/wrapper.rs
+++ b/control-plane/agents/src/bin/core/pool/wrapper.rs
@@ -116,8 +116,7 @@ impl PoolWrapper {
     }
 
     /// Get the pool's blobstore cluster size.
-    #[allow(dead_code)]
-    pub(crate) fn bs_cluster_size(&self) -> u32 {
+    pub(crate) fn cluster_size(&self) -> u32 {
         self.cluster_size
     }
 

--- a/control-plane/agents/src/bin/core/pool/wrapper.rs
+++ b/control-plane/agents/src/bin/core/pool/wrapper.rs
@@ -115,6 +115,12 @@ impl PoolWrapper {
         self.encrypted
     }
 
+    /// Get the pool's blobstore cluster size.
+    #[allow(dead_code)]
+    pub(crate) fn bs_cluster_size(&self) -> u32 {
+        self.cluster_size
+    }
+
     /// Set pool state as unknown.
     #[allow(dead_code)]
     pub(crate) fn set_unknown(&mut self) {

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -67,7 +67,7 @@ fn validate_deserialization(entries: &[TestEntry]) {
 fn test_deserialization_v1_to_v2() {
     let test_entries = vec![
         TestEntry {
-            json_str: r#"{"uuid":"456122b1-7e19-4148-a890-579ca785a119","size":2147483648,"labels":{"local":"true"},"num_replicas":3,"status":{"Created":"Online"},"target":{"node":"mayastor-node4","nexus":"d6ccbb97-d13e-4ffb-91a0-c7607bb01f8f","protocol":"nvmf"},"policy":{"self_heal":true},"topology":{"node":{"Explicit":{"allowed_nodes":["mayastor-node2","mayastor-master","mayastor-node3","mayastor-node1","mayastor-node4"],"preferred_nodes":["mayastor-node2","mayastor-node3","mayastor-node4","mayastor-master","mayastor-node1"]}},"pool":{"Labelled":{"exclusion":{},"inclusion":{"org.com/created-by":"msp-operator"}}}},"last_nexus_id":"d6ccbb97-d13e-4ffb-91a0-c7607bb01f8f","operation":null}"#,
+            json_str: r#"{"uuid":"456122b1-7e19-4148-a890-579ca785a119","size":2147483648,"labels":{"local":"true"},"num_replicas":3,"status":{"Created":"Online"},"target":{"node":"mayastor-node4","nexus":"d6ccbb97-d13e-4ffb-91a0-c7607bb01f8f","protocol":"nvmf"},"policy":{"self_heal":true},"topology":{"node":{"Explicit":{"allowed_nodes":["mayastor-node2","mayastor-master","mayastor-node3","mayastor-node1","mayastor-node4"],"preferred_nodes":["mayastor-node2","mayastor-node3","mayastor-node4","mayastor-master","mayastor-node1"]}},"pool":{"Labelled":{"exclusion":{},"inclusion":{"org.com/created-by":"msp-operator"}}}},"last_nexus_id":"d6ccbb97-d13e-4ffb-91a0-c7607bb01f8f","operation":null,"cluster_size":4194304}"#,
             expected: Expected::VolumeSpec(VolumeSpec {
                 uuid: VolumeId::try_from("456122b1-7e19-4148-a890-579ca785a119").unwrap(),
                 size: 2147483648,
@@ -132,11 +132,12 @@ fn test_deserialization_v1_to_v2() {
                 )),
                 publish_context: None,
                 affinity_group: None,
+                cluster_size: 4194304,
                 .. Default::default()
             }),
         },
         TestEntry {
-            json_str: r#"{"node":"mayastor-node1","id":"pool-1-on-mayastor-node1","disks":["/dev/sdb"],"status":{"Created":"Online"},"labels":{"org.com/created-by":"msp-operator"},"operation":null, "cluster_size": 4194304}"#,
+            json_str: r#"{"node":"mayastor-node1","id":"pool-1-on-mayastor-node1","disks":["/dev/sdb"],"status":{"Created":"Online"},"labels":{"org.com/created-by":"msp-operator"},"operation":null, "cluster_size":4194304}"#,
             expected: Expected::PoolSpec(PoolSpec {
                 node: "mayastor-node1".into(),
                 id: "pool-1-on-mayastor-node1".into(),

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -136,7 +136,7 @@ fn test_deserialization_v1_to_v2() {
             }),
         },
         TestEntry {
-            json_str: r#"{"node":"mayastor-node1","id":"pool-1-on-mayastor-node1","disks":["/dev/sdb"],"status":{"Created":"Online"},"labels":{"org.com/created-by":"msp-operator"},"operation":null}"#,
+            json_str: r#"{"node":"mayastor-node1","id":"pool-1-on-mayastor-node1","disks":["/dev/sdb"],"status":{"Created":"Online"},"labels":{"org.com/created-by":"msp-operator"},"operation":null, "cluster_size": 4194304}"#,
             expected: Expected::PoolSpec(PoolSpec {
                 node: "mayastor-node1".into(),
                 id: "pool-1-on-mayastor-node1".into(),
@@ -155,6 +155,7 @@ fn test_deserialization_v1_to_v2() {
                 creat_tsc: None,
                 encryption: None,
                 cordon_drain: None,
+                cluster_size: 4194304,
             }),
         },
         TestEntry {

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -59,6 +59,7 @@ async fn pool() {
                 disks: vec!["malloc:///disk0?size_mb=100".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )
@@ -72,11 +73,13 @@ async fn pool() {
                 disks: vec!["malloc:///disk1?size_mb=100".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )
         .await
         .unwrap();
+
     tracing::info!("Pools: {:?}", pool);
 
     let pools = pool_client.get(Filter::None, None).await.unwrap();
@@ -268,6 +271,64 @@ async fn pool() {
         .unwrap()
         .0
         .is_empty());
+}
+
+// Tests creation and import of pool with larger blobstore cluster size.
+// Create a few replicas, restart the node. Pool should import again without issue.
+#[tokio::test]
+async fn pool_larger_cluster_size() {
+    let cluster = ClusterBuilder::builder()
+        .with_rest(false)
+        .with_tmpfs_pool(POOL_SIZE_BYTES)
+        .with_options(|o| o.with_pool_bs_cluster_size(Some(POOL_BS_CLUSTER_SIZE as u32)))
+        .build()
+        .await
+        .unwrap();
+
+    let node_client = cluster.grpc_client().node();
+    let pool_client = cluster.grpc_client().pool();
+    let rep_client = cluster.grpc_client().replica();
+
+    let io_engine = cluster.node(0);
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
+    tracing::info!("Nodes: {:?}", nodes);
+    let pools = pool_client.get(Filter::None, None).await.unwrap();
+    let poolid = pools.0[0].id();
+
+    for repl_idx in 1..=2 {
+        let _ = rep_client
+            .create(
+                &CreateReplica {
+                    node: io_engine.clone(),
+                    uuid: ReplicaId::new(),
+                    entity_id: None,
+                    pool_id: poolid.clone(),
+                    pool_uuid: None,
+                    size: 52428800, // 50MiB. Actual will be 64MiB(2 clusters)
+                    thin: repl_idx % 2 == 0,
+                    share: Protocol::None,
+                    name: None,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    cluster.composer().stop("io-engine-1").await.unwrap();
+    cluster
+        .wait_node_status(NodeId::from("io-engine-1"), NodeStatus::Unknown)
+        .await
+        .unwrap();
+    cluster.composer().start("io-engine-1").await.unwrap();
+    cluster.wait_pool_online(poolid.clone()).await.unwrap();
+    let replicas = rep_client.get(Filter::None, None).await.unwrap();
+    replicas.into_inner().iter().all(|r| {
+        assert!(r.online());
+        assert_eq!(r.space.as_ref().unwrap().cluster_size, POOL_BS_CLUSTER_SIZE);
+        true
+    });
 }
 
 /// The tests below revolve around transactions and are dependent on the core agent's command line
@@ -542,7 +603,8 @@ async fn replica_transaction_store() {
 const RECONCILE_TIMEOUT_SECS: u64 = 7;
 const POOL_FILE_NAME: &str = "disk1.img";
 const POOL_FILE_NAME_2: &str = "disk2.img";
-const POOL_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+const POOL_SIZE_BYTES: u64 = 200 * 1024 * 1024;
+const POOL_BS_CLUSTER_SIZE: u64 = 33554432;
 
 /// Creates a pool on a io_engine instance, which will have both spec and state.
 /// Stops/Kills the io_engine container. At some point we will have no pool state, because the node
@@ -1040,6 +1102,7 @@ async fn destroy_after_restart() {
         disks: pool.state().cloned().unwrap().disks,
         labels: None,
         encryption: None,
+        cluster_size: None,
     };
 
     client.pool().destroy(&destroy, None).await.unwrap();
@@ -1075,6 +1138,7 @@ async fn slow_create() {
             disks: vec![lvol.path().into()],
             labels: Some(PoolLabel::from([("a".into(), "b".into())])),
             encryption: None,
+            cluster_size: None,
         };
 
         let result = client.pool().create(&create, None).await;
@@ -1233,6 +1297,7 @@ async fn reject_devlink_reuse() {
             encryption: Some(Encryption::Secret(EncryptionSecret {
                 name: SECRETFILE.to_string(),
             })),
+            cluster_size: None,
         };
 
         client
@@ -1253,6 +1318,7 @@ async fn reject_devlink_reuse() {
             encryption: Some(Encryption::Secret(EncryptionSecret {
                 name: SECRETFILE.to_string(),
             })),
+            cluster_size: None,
         };
 
         client
@@ -1303,6 +1369,7 @@ async fn reject_devlink_reuse() {
             .into()],
             labels: None,
             encryption: None,
+            cluster_size: None,
         };
 
         client

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -1,15 +1,20 @@
+use anyhow::{anyhow, Result};
 use deployer_cluster::{Cluster, ClusterBuilder};
 use grpc::{
     context::Context,
     operations::{
         node::traits::NodeOperations, pool::traits::PoolOperations,
         registry::traits::RegistryOperations, replica::traits::ReplicaOperations,
+        volume::traits::VolumeOperations,
     },
 };
 use itertools::Itertools;
 use std::{collections::HashMap, convert::TryFrom, thread::sleep, time::Duration};
-use stor_port::types::v0::store::pool::{Encryption, EncryptionSecret};
 use stor_port::types::v0::transport::{GetBlockDevices, NodeStatus};
+use stor_port::types::v0::{
+    store::pool::{Encryption, EncryptionSecret},
+    transport::Volume,
+};
 use stor_port::{
     pstor::{etcd::Etcd, StoreObj},
     transport_api::{ReplyError, ReplyErrorKind, ResourceKind, TimeoutOptions},
@@ -280,7 +285,7 @@ async fn pool_larger_cluster_size() {
     let cluster = ClusterBuilder::builder()
         .with_rest(false)
         .with_tmpfs_pool(POOL_SIZE_BYTES)
-        .with_options(|o| o.with_pool_bs_cluster_size(Some(POOL_BS_CLUSTER_SIZE as u32)))
+        .with_options(|o| o.with_pool_cluster_size(Some(POOL_BS_CLUSTER_SIZE as u32)))
         .build()
         .await
         .unwrap();
@@ -331,6 +336,123 @@ async fn pool_larger_cluster_size() {
     });
 }
 
+// Create multiple pools, having different cluster sizes. Create volumes with varying cluster size
+// requirements. Assert that the replicas are placed as expected on matching pools.
+#[tokio::test]
+async fn volume_repl_placement_with_cluster_size() {
+    let cluster = ClusterBuilder::builder()
+        .with_io_engines(3)
+        .with_reconcile_period(Duration::from_secs(10), Duration::from_secs(10))
+        .build()
+        .await
+        .unwrap();
+
+    let client = cluster.grpc_client();
+    let rest_client = cluster.rest_v00();
+    let volume_client = cluster.grpc_client().volume();
+    let volumes_api = rest_client.volumes_api();
+
+    let pool_4m_1 = CreatePool {
+        node: cluster.node(0),
+        id: "pool_cs_4m_1".into(),
+        disks: vec!["malloc:///disk0?size_mb=200".into()],
+        labels: None,
+        encryption: None,
+        cluster_size: None,
+    };
+
+    let pool_32m_1 = CreatePool {
+        node: cluster.node(1),
+        id: "pool_cs_32m_1".into(),
+        disks: vec!["malloc:///disk1?size_mb=200".into()],
+        labels: None,
+        encryption: None,
+        cluster_size: Some(33554432),
+    };
+
+    let pool_32m_2 = CreatePool {
+        node: cluster.node(2),
+        id: "pool_cs_32m_2".into(),
+        disks: vec!["malloc:///disk2?size_mb=200".into()],
+        labels: None,
+        encryption: None,
+        cluster_size: Some(33554432),
+    };
+
+    let _ = client.pool().create(&pool_4m_1, None).await.unwrap();
+    let _ = client.pool().create(&pool_32m_1, None).await.unwrap();
+    let _ = client.pool().create(&pool_32m_2, None).await.unwrap();
+    // Create two volumes. Expect replica placement on 32MiB cluster sized pools.
+    // For each volume, validate the cluster size of chosen pool by looking into replica.
+    for _ in 0..2 {
+        let body = CreateVolumeBody::new_all(
+            VolumePolicy::default(),
+            1,
+            62914560u64,
+            false,
+            models::Topology::new(),
+            HashMap::new(),
+            None,
+            Some(10),
+            false,
+            Some(33554432),
+        );
+        let volume = VolumeId::new();
+        volumes_api.put_volume(&volume, body).await.unwrap();
+        let vol = volume_client
+            .get(Filter::Volume(volume), false, None, None)
+            .await
+            .unwrap();
+        assert_eq!(vol.entries.len(), 1);
+        validate_vol_repl_cluster_size(&cluster, &vol.entries[0], 33554432)
+            .await
+            .unwrap();
+    }
+
+    // Create one more volume. Expect replica placement on 4MiB cluster sized pool.
+    // For this volume also, validate the cluster size of chosen pool by looking into replica.
+    let body = CreateVolumeBody::new(VolumePolicy::default(), 1, 62914560u64, false, false);
+    let volume = VolumeId::new();
+    volumes_api.put_volume(&volume, body).await.unwrap();
+    let vol = volume_client
+        .get(Filter::Volume(volume), false, None, None)
+        .await
+        .unwrap();
+    assert_eq!(vol.entries.len(), 1);
+    validate_vol_repl_cluster_size(&cluster, &vol.entries[0], 4194304)
+        .await
+        .unwrap();
+}
+
+async fn validate_vol_repl_cluster_size(
+    cluster: &Cluster,
+    volume: &Volume,
+    expected_cluster_size: u64,
+) -> Result<()> {
+    let vstate: Vec<_> = volume.state().replica_topology.keys().cloned().collect();
+    for r in vstate {
+        let repl_client = cluster.grpc_client().replica();
+        let hdl = tokio::spawn(async move {
+            println!("Validate replica {r} cluster size to be {expected_cluster_size}");
+            let repl = repl_client
+                .get(Filter::Replica(r.clone()), None)
+                .await
+                .unwrap();
+            assert_eq!(repl.0.len(), 1);
+            let repl_cluster_size = repl.0[0].space.as_ref().unwrap().cluster_size;
+            if repl_cluster_size != expected_cluster_size {
+                return Err(anyhow!(
+                    "Replica {r} has cluster_size {}, expected {}",
+                    repl_cluster_size,
+                    expected_cluster_size
+                ));
+            }
+            Ok(())
+        });
+        hdl.await.unwrap()?
+    }
+    Ok(())
+}
 /// The tests below revolve around transactions and are dependent on the core agent's command line
 /// arguments for timeouts.
 /// This is required because as of now, we don't have a good mocking strategy

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -53,6 +53,7 @@ stor-port = { path = "../stor-port" }
 utils = { path = "../../utils/utils-lib" }
 shutdown = { path = "../../utils/shutdown" }
 serde = { version = "1.0.214", features = ["derive"] }
+parse-size = "1.1.0"
 
 [target.'cfg(target_os="linux")'.dependencies]
 udev = "0.9.1"

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -264,6 +264,7 @@ impl RestApiClient {
         affinity_group: Option<AffinityGroup>,
         max_snapshots: Option<u32>,
         encrypted: bool,
+        cluster_size: Option<u64>,
     ) -> Result<Volume, ApiClientError> {
         let topology =
             Topology::new_all(volume_topology.node_topology, volume_topology.pool_topology);
@@ -278,6 +279,7 @@ impl RestApiClient {
             affinity_group,
             max_snapshots,
             encrypted,
+            cluster_size,
         };
 
         let result = self
@@ -318,6 +320,7 @@ impl RestApiClient {
             affinity_group,
             max_snapshots,
             encrypted,
+            cluster_size: None,
         };
         let result = self
             .rest_client

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -411,6 +411,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                 let affinity_group_name = sts_affinity_group_info.as_ref().map(|info| info.name());
                 let max_snapshots = context.max_snapshots();
                 let encrypted = context.encrypted().unwrap_or_default();
+                let pool_cluster_size = context.pool_cluster_size();
 
                 let volume = match volume_content_source {
                     Some(snapshot_uuid) => {
@@ -444,6 +445,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                                 affinity_group_name.map(AffinityGroup::new),
                                 max_snapshots,
                                 encrypted,
+                                pool_cluster_size,
                             )
                             .await?
                     }

--- a/control-plane/csi-driver/src/context.rs
+++ b/control-plane/csi-driver/src/context.rs
@@ -2,6 +2,7 @@ use crate::filesystem::FileSystem;
 use k8s_openapi::api::core::v1::PersistentVolumeClaim;
 use kube::api::{Patch, PatchParams};
 use kube::{Api, Client};
+use parse_size::parse_size;
 use regex::Regex;
 use std::{
     collections::HashMap,
@@ -79,6 +80,8 @@ pub enum Parameters {
     FormatOptions,
     #[strum(serialize = "overrideGlobalFormatOpts")]
     OverrideGlobalFormatOpts,
+    #[strum(serialize = "pool_cluster_size")]
+    PoolAllocationUnitSize,
 }
 impl Parameters {
     fn parse_human_time(
@@ -260,6 +263,18 @@ impl Parameters {
         value: Option<&String>,
     ) -> Result<Option<bool>, ParseBoolError> {
         Self::parse_bool(value)
+    }
+    /// Parse the value for `Self::PoolAllocationUnitSize`
+    pub fn pool_cluster_size(value: Option<&String>) -> Result<Option<u64>, tonic::Status> {
+        if let Some(value) = value {
+            let alloc_unit_bytes = parse_size(value).ok();
+            if alloc_unit_bytes.is_none() {
+                return Err(tonic::Status::invalid_argument(format!(
+                    "Invalid `PoolClusterSize` value {value:?}, expected a number with capacity unit suffix"
+                )));
+            }
+        }
+        Ok(None)
     }
 }
 
@@ -492,6 +507,7 @@ pub struct CreateParams {
     encrypted: Option<bool>,
     pvc_name: Option<String>,
     pvc_namespace: Option<String>,
+    pool_cluster_size: Option<u64>,
 }
 impl CreateParams {
     /// Get the `Parameters::PublishParams` value.
@@ -517,6 +533,10 @@ impl CreateParams {
     /// Get the `Parameters::Encrypted` value.
     pub fn encrypted(&self) -> Option<bool> {
         self.encrypted
+    }
+    /// Get the `Parameters::PoolAllocationUnitSize` value.
+    pub fn pool_cluster_size(&self) -> Option<u64> {
+        self.pool_cluster_size
     }
     /// Get the sts_affinity_group name from annotations if exists else generate it.
     pub async fn sts_affinity_group(&self) -> Result<Option<StsAffinityGroupInfo>, tonic::Status> {
@@ -692,6 +712,9 @@ impl TryFrom<&HashMap<String, String>> for CreateParams {
                 tonic::Status::invalid_argument("Invalid `Encrypted` value, expected a boolean")
             })?;
 
+        let pool_cluster_size =
+            Parameters::pool_cluster_size(args.get(Parameters::PoolAllocationUnitSize.as_ref()))?;
+
         Ok(Self {
             publish_params,
             share_protocol,
@@ -702,6 +725,7 @@ impl TryFrom<&HashMap<String, String>> for CreateParams {
             encrypted,
             pvc_name,
             pvc_namespace,
+            pool_cluster_size,
         })
     }
 }

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -52,6 +52,8 @@ message PoolSpec {
   oneof CordonDrain {
     CordonedState cordoned = 7;
   }
+  // Blobstore cluster size required for this pool
+  optional uint32 cluster_size = 8;
 }
 
 // Pool information
@@ -72,6 +74,8 @@ message PoolState {
   optional uint64 committed = 7;
   // Is the pool encrypted.
   optional bool encrypted = 8;
+  // Blobstore cluster size required for this pool
+  optional uint32 cluster_size = 9;
 }
 
 // status of the pool
@@ -111,6 +115,8 @@ message CreatePoolRequest {
   oneof encryption {
     common.EncryptionSecret secret = 6;
   }
+  // Blobstore cluster size required for this pool
+  optional uint32 cluster_size = 7;
 }
 
 // Destroy Pool Request

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -79,6 +79,8 @@ message VolumeSpec {
 
   // Data encryption.
   optional bool encrypted = 14;
+  // Blobstore cluster size required for pools hosting this volume's replicas.
+  optional uint32 cluster_size = 15;
 }
 
 message Metadata {
@@ -298,6 +300,8 @@ message CreateVolumeRequest {
   optional uint32 max_snapshots = 11;
   // Data encryption.
   optional bool encrypted = 12;
+  // Blobstore cluster size required for pools hosting this volume's replicas.
+  optional uint32 cluster_size = 13;
 }
 
 // Publish a volume on a node

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -14,7 +14,7 @@ use stor_port::{
     types::v0::{
         store::pool::{
             CordonDrainState, CordonedState, Encryption, EncryptionSecret, PoolLabel, PoolSpec,
-            PoolSpecStatus,
+            PoolSpecStatus, POOL_BS_CLUSTER_SIZE_DEFAULT,
         },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, Filter, LabelPool, NodeId, Pool, PoolDeviceUri,
@@ -120,6 +120,9 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
                 },
                 None => None,
             },
+            cluster_size: pool_spec
+                .cluster_size
+                .unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
         })
     }
 }
@@ -146,6 +149,9 @@ impl TryFrom<pool::PoolState> for PoolState {
             used: pool_state.used,
             committed: pool_state.committed,
             encrypted: pool_state.encrypted.unwrap_or_default(),
+            cluster_size: pool_state
+                .cluster_size
+                .unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
         })
     }
 }
@@ -208,6 +214,7 @@ impl From<PoolSpec> for pool::PoolDefinition {
                     }
                     None => None,
                 },
+                cluster_size: Some(pool_spec.cluster_size),
             }),
             metadata: Some(pool::Metadata {
                 uuid: None,
@@ -228,6 +235,7 @@ impl From<PoolState> for pool::PoolState {
             used: pool_state.used,
             committed: pool_state.committed,
             encrypted: Some(pool_state.encrypted),
+            cluster_size: Some(pool_state.cluster_size),
         }
     }
 }
@@ -300,6 +308,8 @@ pub trait CreatePoolInfo: Send + Sync + std::fmt::Debug {
     fn labels(&self) -> Option<PoolLabel>;
     /// Encryption parameters for the pool.
     fn encryption(&self) -> Option<Encryption>;
+    /// Requested cluster size for blobstore.
+    fn cluster_size(&self) -> Option<u32>;
 }
 
 /// DestroyPoolInfo trait for the pool deletion to be implemented by entities which want to avail
@@ -330,6 +340,10 @@ impl CreatePoolInfo for CreatePool {
 
     fn encryption(&self) -> Option<Encryption> {
         self.encryption.clone()
+    }
+
+    fn cluster_size(&self) -> Option<u32> {
+        self.cluster_size
     }
 }
 
@@ -363,6 +377,10 @@ impl CreatePoolInfo for ValidatedCreatePoolRequest {
     fn encryption(&self) -> Option<Encryption> {
         self.encryption.clone()
     }
+
+    fn cluster_size(&self) -> Option<u32> {
+        self.inner.cluster_size
+    }
 }
 
 impl ValidateRequestTypes for CreatePoolRequest {
@@ -392,6 +410,7 @@ impl From<&dyn CreatePoolInfo> for CreatePoolRequest {
                 .labels()
                 .map(|labels| crate::common::StringMapValue { value: labels }),
             encryption: data.encryption().into_opt(),
+            cluster_size: data.cluster_size(),
         }
     }
 }
@@ -404,6 +423,7 @@ impl From<&dyn CreatePoolInfo> for CreatePool {
             disks: data.disks(),
             labels: data.labels(),
             encryption: data.encryption(),
+            cluster_size: data.cluster_size(),
         }
     }
 }

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -18,9 +18,12 @@ use std::{borrow::Borrow, collections::HashMap, convert::TryFrom};
 use stor_port::{
     transport_api::{v0::Volumes, ReplyError, ResourceKind},
     types::v0::{
-        store::volume::{
-            AffinityGroupSpec, FrontendConfig, InitiatorAC, TargetConfig, VolumeContentSource,
-            VolumeMetadata, VolumeSpec, VolumeTarget,
+        store::{
+            pool::POOL_BS_CLUSTER_SIZE_DEFAULT,
+            volume::{
+                AffinityGroupSpec, FrontendConfig, InitiatorAC, TargetConfig, VolumeContentSource,
+                VolumeMetadata, VolumeSpec, VolumeTarget,
+            },
         },
         transport::{
             AffinityGroup, CreateSnapshotVolume, CreateVolume, DestroyShutdownTargets,
@@ -168,6 +171,7 @@ impl From<VolumeSpec> for volume::VolumeDefinition {
                 num_snapshots: volume_spec.metadata.num_snapshots() as u32,
                 max_snapshots: volume_spec.max_snapshots,
                 encrypted: Some(volume_spec.encrypted),
+                cluster_size: Some(volume_spec.cluster_size),
             }),
             metadata: Some(volume::Metadata {
                 spec_status: spec_status as i32,
@@ -380,6 +384,9 @@ impl TryFrom<volume::VolumeDefinition> for VolumeSpec {
             num_snapshots: volume_spec.num_snapshots,
             max_snapshots: volume_spec.max_snapshots,
             encrypted: volume_spec.encrypted.unwrap_or_default(),
+            cluster_size: volume_spec
+                .cluster_size
+                .unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
         };
         Ok(volume_spec)
     }
@@ -938,6 +945,8 @@ pub trait CreateVolumeInfo: Send + Sync + std::fmt::Debug {
     fn max_snapshots(&self) -> Option<u32>;
     /// Data encryption.
     fn encrypted(&self) -> bool;
+    /// Pool's blobstore cluster size required for replicas of this volume.
+    fn cluster_size(&self) -> Option<u32>;
 }
 
 impl CreateVolumeInfo for CreateVolume {
@@ -983,6 +992,10 @@ impl CreateVolumeInfo for CreateVolume {
 
     fn encrypted(&self) -> bool {
         self.encrypted
+    }
+
+    fn cluster_size(&self) -> Option<u32> {
+        self.cluster_size
     }
 }
 
@@ -1044,6 +1057,10 @@ impl CreateVolumeInfo for ValidatedCreateVolumeRequest {
     fn encrypted(&self) -> bool {
         self.inner.encrypted.unwrap_or_default()
     }
+
+    fn cluster_size(&self) -> Option<u32> {
+        self.inner.cluster_size
+    }
 }
 
 impl ValidateRequestTypes for CreateVolumeRequest {
@@ -1083,6 +1100,7 @@ impl From<&dyn CreateVolumeInfo> for CreateVolume {
             cluster_capacity_limit: data.cluster_capacity_limit(),
             max_snapshots: data.max_snapshots(),
             encrypted: data.encrypted(),
+            cluster_size: data.cluster_size(),
         }
     }
 }
@@ -1103,6 +1121,7 @@ impl From<&dyn CreateVolumeInfo> for CreateVolumeRequest {
             cluster_capacity_limit: data.cluster_capacity_limit(),
             max_snapshots: data.max_snapshots(),
             encrypted: Some(data.encrypted()),
+            cluster_size: data.cluster_size(),
         }
     }
 }

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -48,6 +48,7 @@ impl CreateRow for openapi::models::Pool {
             used: 0,
             committed: None,
             encrypted: spec.encryption.is_some(),
+            cluster_size: Some(0),
         });
         let free = if state.capacity > state.used {
             state.capacity - state.used

--- a/control-plane/plugin/src/resources/tests.rs
+++ b/control-plane/plugin/src/resources/tests.rs
@@ -41,6 +41,7 @@ async fn setup() {
                 affinity_group: None,
                 max_snapshots: None,
                 encrypted: false,
+                cluster_size: None,
             },
         )
         .await
@@ -122,6 +123,7 @@ async fn get_volumes_paginated() {
                     affinity_group: None,
                     max_snapshots: None,
                     encrypted: false,
+                    cluster_size: None,
                 },
             )
             .await

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2558,6 +2558,15 @@ components:
             type: string
         encryption:
           $ref: '#/components/schemas/Encryption'
+        cluster_size:
+          type: integer
+          format: int64
+          minimum: 4194304
+          multipleOf: 4194304
+          description: |-
+           Blobstore cluster size for the pool, in bytes. Must be >= 4 MiB and in multiples of 4MiB.
+           This is an advanced option. Please refer documentation to understand the implications
+           of changing this.
       required:
         - disks
     HostNqn:
@@ -3182,6 +3191,12 @@ components:
         encrypted:
           description: Is the pool encrypted
           type: boolean
+        cluster_size:
+          description: Blobstore cluster size for this pool, in bytes
+          type: integer
+          format: int64
+          example: 4194304
+          minimum: 4194304
       required:
         - capacity
         - disks
@@ -3296,7 +3311,7 @@ components:
           minimum: 0
           default: 0
         cluster_size:
-          description: Cluster size in bytes.
+          description: Underlying pool's blobstore cluster size in bytes.
           example: 80241024
           type: integer
           format: int64

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2746,6 +2746,7 @@ components:
         topology: null
         affinity_group: null
         max_snapshots: 10
+        cluster_size: 33554432
       description: Create Volume Body
       type: object
       properties:
@@ -2784,6 +2785,14 @@ components:
         encrypted:
           description: flag to enable data encryption
           type: boolean
+        cluster_size:
+          description: |-
+           Choose only the pools matching this cluster_size for the replicas of this volume.
+           This is an advanced option. Please refer documentation to understand the usage.
+          type: integer
+          format: int64
+          minimum: 4194304
+          multipleOf: 4194304
       required:
         - policy
         - replicas

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -78,6 +78,8 @@ pub struct CreatePoolBody {
     pub labels: Option<PoolLabel>,
     /// Encryption parameters.
     pub encryption: Option<Encryption>,
+    /// Blobstore cluster size for the pool
+    pub cluster_size: Option<u32>,
 }
 impl From<models::CreatePoolBody> for CreatePoolBody {
     fn from(src: models::CreatePoolBody) -> Self {
@@ -85,6 +87,7 @@ impl From<models::CreatePoolBody> for CreatePoolBody {
             disks: src.disks.iter().cloned().map(From::from).collect(),
             labels: src.labels,
             encryption: src.encryption.into_opt(),
+            cluster_size: src.cluster_size.map(|v| v as u32),
         }
     }
 }
@@ -96,6 +99,7 @@ impl TryFrom<CreatePool> for CreatePoolBody {
             disks: create.disks,
             labels: create.labels,
             encryption: create.encryption.try_into_opt()?,
+            cluster_size: create.cluster_size,
         })
     }
 }
@@ -108,6 +112,7 @@ impl CreatePoolBody {
             disks: self.disks.clone(),
             labels: self.labels.clone(),
             encryption: self.encryption.clone().into_opt(),
+            cluster_size: self.cluster_size,
         }
     }
 }

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -213,6 +213,8 @@ pub struct CreateVolumeBody {
     pub max_snapshots: Option<u32>,
     /// Data encryption.
     pub encryption: bool,
+    /// Blobstore cluster size required for pools hosting this volume's replicas.
+    pub cluster_size: Option<u32>,
 }
 impl From<models::CreateVolumeBody> for CreateVolumeBody {
     fn from(src: models::CreateVolumeBody) -> Self {
@@ -226,6 +228,7 @@ impl From<models::CreateVolumeBody> for CreateVolumeBody {
             affinity_group: src.affinity_group.map(|ag| ag.into()),
             max_snapshots: src.max_snapshots,
             encryption: src.encrypted,
+            cluster_size: src.cluster_size.map(|c| c as u32),
         }
     }
 }
@@ -241,6 +244,7 @@ impl From<CreateVolume> for CreateVolumeBody {
             affinity_group: create.affinity_group,
             max_snapshots: create.max_snapshots,
             encryption: create.encrypted,
+            cluster_size: create.cluster_size,
         }
     }
 }
@@ -259,6 +263,7 @@ impl CreateVolumeBody {
             cluster_capacity_limit: None,
             max_snapshots: self.max_snapshots,
             encrypted: self.encryption,
+            cluster_size: self.cluster_size,
         }
     }
     /// Convert into rpc request type.

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -145,7 +145,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
         models::Pool::new_all(
             "pooloop",
             models::PoolSpec::new(vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::SpecStatus::Created),
-            models::PoolState::new_all(100663296u64, vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::PoolStatus::Online, 0u64, 0, false)
+            models::PoolState::new_all(100663296u64, vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::PoolStatus::Online, 0u64, 0, false, 4194304u64)
         )
     );
 

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -11,6 +11,10 @@ use crate::types::v0::{
 
 pub const POOL_BS_CLUSTER_SIZE_DEFAULT: u32 = 4194304;
 
+pub fn default_pool_cluster_size() -> u32 {
+    POOL_BS_CLUSTER_SIZE_DEFAULT
+}
+
 // PoolLabel is the type for the labels
 pub type PoolLabel = HashMap<String, String>;
 

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -9,6 +9,8 @@ use crate::types::v0::{
     transport::{self, CreatePool, ImportPool, NodeId, PoolDeviceUri, PoolId},
 };
 
+pub const POOL_BS_CLUSTER_SIZE_DEFAULT: u32 = 4194304;
+
 // PoolLabel is the type for the labels
 pub type PoolLabel = HashMap<String, String>;
 
@@ -56,6 +58,8 @@ impl From<&CreatePool> for PoolSpec {
             creat_tsc: None,
             encryption: request.encryption.clone(),
             cordon_drain: None,
+            // Default is 4MiB today.
+            cluster_size: request.cluster_size.unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
         }
     }
 }
@@ -67,6 +71,7 @@ impl From<&PoolSpec> for CreatePool {
             disks: pool.disks.clone(),
             labels: pool.labels.clone(),
             encryption: pool.encryption.clone(),
+            cluster_size: Some(pool.cluster_size),
         }
     }
 }
@@ -124,6 +129,8 @@ pub struct PoolSpec {
     /// Cordon/drain state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cordon_drain: Option<CordonDrainState>,
+    /// Blobstore cluster size used for this pool.
+    pub cluster_size: u32,
 }
 
 impl PoolSpec {
@@ -481,6 +488,7 @@ impl From<&PoolSpec> for transport::PoolState {
             used: 0,
             committed: None,
             encrypted: pool.encryption.is_some(),
+            cluster_size: pool.cluster_size,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -6,6 +6,7 @@ use crate::{
         store::{
             definitions::{ObjectKey, StorableObject, StorableObjectType},
             nexus_persistence::VolumeHealthKey,
+            pool::{default_pool_cluster_size, POOL_BS_CLUSTER_SIZE_DEFAULT},
             AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
         },
         transport::{
@@ -212,6 +213,9 @@ pub struct VolumeSpec {
     /// Data encryption.
     #[serde(default)]
     pub encrypted: bool,
+    /// Pool's blobstore cluster size required for replicas of this volume.
+    #[serde(default = "default_pool_cluster_size")]
+    pub cluster_size: u32,
 }
 
 /// Volume Content Source i.e the snapshot or a volume.
@@ -759,6 +763,7 @@ impl From<&CreateVolume> for VolumeSpec {
             affinity_group: request.affinity_group.clone(),
             max_snapshots: request.max_snapshots,
             encrypted: request.encrypted,
+            cluster_size: request.cluster_size.unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
             ..Default::default()
         }
     }

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -100,6 +100,8 @@ pub struct PoolState {
     pub committed: Option<u64>,
     /// Is the pool encrypted.
     pub encrypted: bool,
+    /// Blobstore cluster size used for this pool.
+    pub cluster_size: u32,
 }
 
 impl From<CtrlPoolState> for models::PoolState {
@@ -114,6 +116,7 @@ impl From<CtrlPoolState> for models::PoolState {
             src.used,
             src.committed,
             src.encrypted,
+            Some(src.cluster_size as u64),
         )
     }
 }
@@ -291,6 +294,8 @@ pub struct CreatePool {
     pub labels: Option<PoolLabel>,
     /// Encryption parameters for this pool.
     pub encryption: Option<Encryption>,
+    /// Blobstore cluster size in bytes.
+    pub cluster_size: Option<u32>,
 }
 
 impl CreatePool {
@@ -301,6 +306,7 @@ impl CreatePool {
         disks: &[PoolDeviceUri],
         labels: &Option<PoolLabel>,
         encryption: &Option<Encryption>,
+        cluster_size: &Option<u32>,
     ) -> Self {
         Self {
             node: node.clone(),
@@ -308,6 +314,7 @@ impl CreatePool {
             disks: disks.to_vec(),
             labels: labels.clone(),
             encryption: encryption.clone(),
+            cluster_size: *cluster_size,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -508,6 +508,8 @@ pub struct CreateVolume {
     pub max_snapshots: Option<u32>,
     /// Data encryption.
     pub encrypted: bool,
+    /// Pool's blobstore cluster size required for replicas of this volume.
+    pub cluster_size: Option<u32>,
 }
 
 /// Resize volume request.

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -74,8 +74,8 @@ impl ComponentAction for CoreAgent {
         if options.allow_non_persistent_devlink {
             binary = binary.with_args(vec!["--allow-non-persistent-devlink"]);
         }
-        if let Some(cluster_size) = options.pool_bs_cluster_size {
-            binary = binary.with_args(vec!["--pool-bs-cluster-size", &cluster_size.to_string()]);
+        if let Some(cluster_size) = options.pool_cluster_size {
+            binary = binary.with_args(vec!["--pool-cluster-size", &cluster_size.to_string()]);
         }
 
         Ok(cfg.add_container_spec(

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -74,6 +74,10 @@ impl ComponentAction for CoreAgent {
         if options.allow_non_persistent_devlink {
             binary = binary.with_args(vec!["--allow-non-persistent-devlink"]);
         }
+        if let Some(cluster_size) = options.pool_bs_cluster_size {
+            binary = binary.with_args(vec!["--pool-bs-cluster-size", &cluster_size.to_string()]);
+        }
+
         Ok(cfg.add_container_spec(
             ContainerSpec::from_binary(name, binary).with_portmap("50051", "50051"),
         ))

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -357,6 +357,11 @@ pub struct StartOptions {
     /// Allow non persistent devlink for pool creation.
     #[clap(long)]
     allow_non_persistent_devlink: bool,
+    /// Blobstore cluster size(in bytes) required for pool creation. This is
+    /// not configurable per-pool here. However, the create pool request can be used
+    /// to configure cluster size per-pool.
+    #[clap(long)]
+    pool_bs_cluster_size: Option<u32>,
 }
 
 /// List of KeyValues
@@ -613,6 +618,12 @@ impl StartOptions {
     /// Specify whether allow non peristent devlink is needed or not.
     pub fn with_allow_non_persistent_devlink(mut self, enabled: bool) -> Self {
         self.allow_non_persistent_devlink = enabled;
+        self
+    }
+
+    /// blobstore cluster size to be used for disk pools.
+    pub fn with_pool_bs_cluster_size(mut self, bs_cluster_size: Option<u32>) -> Self {
+        self.pool_bs_cluster_size = bs_cluster_size;
         self
     }
 

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -361,7 +361,7 @@ pub struct StartOptions {
     /// not configurable per-pool here. However, the create pool request can be used
     /// to configure cluster size per-pool.
     #[clap(long)]
-    pool_bs_cluster_size: Option<u32>,
+    pool_cluster_size: Option<u32>,
 }
 
 /// List of KeyValues
@@ -622,8 +622,8 @@ impl StartOptions {
     }
 
     /// blobstore cluster size to be used for disk pools.
-    pub fn with_pool_bs_cluster_size(mut self, bs_cluster_size: Option<u32>) -> Self {
-        self.pool_bs_cluster_size = bs_cluster_size;
+    pub fn with_pool_cluster_size(mut self, cluster_size: Option<u32>) -> Self {
+        self.pool_cluster_size = cluster_size;
         self
     }
 

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -277,7 +277,7 @@ impl ResourceContext {
             },
         };
 
-        let body = CreatePoolBody::new_all(self.spec.disks(), labels, encryption);
+        let body = CreatePoolBody::new_all(self.spec.disks(), labels, encryption, None); // TODO: fill cluster_size from DSP CR
         match self
             .pools_api()
             .put_node_pool(&self.spec.node(), &self.name_any(), body)

--- a/tests/io-engine/tests/pools.rs
+++ b/tests/io-engine/tests/pools.rs
@@ -92,6 +92,7 @@ async fn create_pool_idempotent() {
                 disks: vec!["malloc:///disk?size_mb=100".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )
@@ -106,6 +107,7 @@ async fn create_pool_idempotent() {
                 disks: vec!["malloc:///disk?size_mb=100".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )
@@ -126,6 +128,7 @@ async fn create_pool_idempotent_same_disk_different_query() {
                 disks: vec!["malloc:///disk?size_mb=100&blk_size=512".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )
@@ -140,6 +143,7 @@ async fn create_pool_idempotent_same_disk_different_query() {
                 disks: vec!["malloc:///disk?size_mb=200&blk_size=4096".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )
@@ -163,6 +167,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
                 disks: vec!["malloc:///disk?size_mb=100".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )
@@ -177,6 +182,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
                 disks: vec!["malloc:///disk?size_mb=100".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )
@@ -191,6 +197,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
                 disks: vec!["malloc:///disk?size_mb=100".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )
@@ -205,6 +212,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
                 disks: vec!["malloc:///disk?size_mb=100".into()],
                 labels: None,
                 encryption: None,
+                cluster_size: None,
             },
             None,
         )

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -1131,6 +1131,7 @@ impl ClusterBuilder {
                         disks: vec![pool.disk()],
                         labels: None,
                         encryption: None,
+                        cluster_size: None,
                     },
                     None,
                 )


### PR DESCRIPTION
The change in cluster size will apply to all the new pools that get created after setting this to desired value. Already created pools keep working fine. It is recommended to do due diligence w.r.t application usage patterns before changing this value. For example - Smaller cluster size provides better storage efficiency and less internal fragmentation, but more metadata overhead. Larger cluster size will provide better performance for large sequential IOs, and low metadata overhead.