### PR TITLE
[ OEP 3903 ]: Pool cordon

### DIFF
--- a/control-plane/agents/src/bin/core/controller/resources/operations.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations.rs
@@ -8,18 +8,19 @@ use stor_port::types::v0::store::volume::VolumeSpec;
 pub(crate) trait ResourceCordon {
     type CordonOutput: Sync + Send + Sized;
     type UncordonOutput: Sync + Send + Sized;
+    type Request: Sync + Send + Sized;
 
     /// Cordon the resource.
     async fn cordon(
         &mut self,
         registry: &Registry,
-        label: String,
+        request: Self::Request,
     ) -> Result<Self::CordonOutput, SvcError>;
     /// Uncordon the resource.
     async fn uncordon(
         &mut self,
         registry: &Registry,
-        label: String,
+        request: Self::Request,
     ) -> Result<Self::UncordonOutput, SvcError>;
 }
 

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -8,6 +8,7 @@ use stor_port::types::v0::{
         nexus_child::NexusChild,
         nexus_persistence::{ChildInfo, NexusInfo},
         node::NodeSpec,
+        pool::CordonedState,
         replica::ReplicaSpec,
         snapshots::replica::ReplicaSnapshot,
         volume::VolumeSpec,
@@ -29,15 +30,22 @@ pub(crate) struct PoolItem {
     /// a Affinity Group and the already created volumes have replicas
     /// on this pool.
     pub(crate) ag_replica_count: Option<u64>,
+    cordoned: CordonedState,
 }
 
 impl PoolItem {
     /// Create a new `Self`.
-    pub(crate) fn new(node: NodeWrapper, pool: PoolWrapper, ag_replica_count: Option<u64>) -> Self {
+    pub(crate) fn new(
+        node: NodeWrapper,
+        pool: PoolWrapper,
+        ag_replica_count: Option<u64>,
+        cordoned: Option<CordonedState>,
+    ) -> Self {
         Self {
             node,
             pool,
             ag_replica_count,
+            cordoned: cordoned.unwrap_or_default(),
         }
     }
     /// Get the number of replicas in the pool.
@@ -51,6 +59,10 @@ impl PoolItem {
     /// Get a reference to the inner `PoolWrapper`.
     pub(crate) fn pool(&self) -> &PoolWrapper {
         &self.pool
+    }
+    /// Get the pool cordon.
+    pub(crate) fn cordoned(&self) -> &CordonedState {
+        &self.cordoned
     }
     /// Collect the item into a pool.
     pub(crate) fn collect(self) -> PoolWrapper {
@@ -75,37 +87,45 @@ impl PoolItemLister {
         registry: &Registry,
         pool_ag_rep: &Option<HashMap<PoolId, u64>>,
     ) -> Vec<PoolItem> {
-        let pools = Self::nodes(registry)
+        Self::nodes(registry)
             .await
-            .iter()
+            .into_iter()
             .flat_map(|n| {
                 n.pool_wrappers()
-                    .iter()
-                    .filter(|p| registry.specs().pool(&p.id).is_ok())
-                    .map(|p| {
+                    .into_iter()
+                    .filter_map(|p| {
+                        let cordoned = registry
+                            .specs()
+                            .pool_with(&p.id, |p| p.lock().cordoned().cloned());
+                        let cordoned = cordoned.ok()?;
                         let ag_rep_count =
                             pool_ag_rep.as_ref().and_then(|map| map.get(&p.id).cloned());
 
-                        PoolItem::new(n.clone(), p.clone(), ag_rep_count)
+                        Some(PoolItem::new(n.clone(), p, ag_rep_count, cordoned))
                     })
                     .collect::<Vec<_>>()
             })
-            .collect();
-        pools
+            .collect()
     }
     /// Get a list of pool items to create a snapshot on.
     pub(crate) async fn list_for_snaps(registry: &Registry, items: &[ChildItem]) -> Vec<PoolItem> {
         let nodes = Self::nodes(registry).await;
-        let pool_items = items
+        items
             .iter()
             .filter_map(|item| {
                 nodes
                     .iter()
                     .find(|node| node.id() == item.node())
-                    .map(|node| PoolItem::new(node.clone(), item.pool().clone(), None))
+                    .and_then(|node| {
+                        let cordoned = registry
+                            .specs()
+                            .pool_with(&item.pool().id, |p| p.lock().cordoned().cloned());
+                        let pool =
+                            PoolItem::new(node.clone(), item.pool().clone(), None, cordoned.ok()?);
+                        Some(pool)
+                    })
             })
-            .collect();
-        pool_items
+            .collect()
     }
     /// Get a list of replicas wrapped as ChildItem, for resize.
     pub(crate) async fn list_for_resize(registry: &Registry, spec: &VolumeSpec) -> Vec<ChildItem> {
@@ -147,17 +167,22 @@ impl PoolItemLister {
         let mut pool_items = vec![];
         for snapshot in snapshots {
             let pool_id = snapshot.spec().source_id().pool_id();
-            let Ok(pool_spec) = registry.specs().pool(pool_id) else {
+            let Some(pool_spec) = registry.specs().pool_rsc(pool_id) else {
                 continue;
             };
-            let Ok(node) = registry.node_wrapper(&pool_spec.node).await else {
+            let (node, cordoned) = {
+                let pool_spec = pool_spec.lock();
+                (pool_spec.node.clone(), pool_spec.cordoned().cloned())
+            };
+            let Ok(node) = registry.node_wrapper(&node).await else {
                 continue;
             };
+
             let Some(pool) = node.pool_wrapper(pool_id).await else {
                 continue;
             };
             let node = node.read().await.deref().clone();
-            pool_items.push(PoolItem::new(node, pool, None));
+            pool_items.push(PoolItem::new(node, pool, None, cordoned));
         }
         pool_items
     }

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
@@ -29,6 +29,7 @@ impl DefaultBasePolicy {
     fn filter_pools(request: AddVolumeReplica) -> AddVolumeReplica {
         request
             .filter(pool::PoolBaseFilters::usable)
+            .filter(pool::PoolBaseFilters::uncordoned_repl)
             .filter(pool::PoolBaseFilters::capacity)
             .filter(pool::PoolBaseFilters::min_free_space)
             .filter(pool::PoolBaseFilters::topology)
@@ -44,6 +45,7 @@ impl DefaultBasePolicy {
     fn filter_snapshot_pools(request: SnapshotVolumeReplica) -> SnapshotVolumeReplica {
         request
             .filter(pool::PoolBaseFilters::usable)
+            .filter(pool::PoolBaseFilters::uncordoned_snaps)
             .filter(pool::PoolBaseFilters::capacity)
             .filter(pool::PoolBaseFilters::min_free_space)
     }
@@ -58,6 +60,7 @@ impl DefaultBasePolicy {
     fn filter_clone_pools(request: CloneVolumeSnapshot) -> CloneVolumeSnapshot {
         request
             .filter(pool::PoolBaseFilters::usable)
+            .filter(pool::PoolBaseFilters::uncordoned_rest)
             .filter(pool::PoolBaseFilters::capacity)
             .filter(pool::PoolBaseFilters::min_free_space)
     }

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
@@ -90,6 +90,19 @@ impl PoolBaseFilters {
         item.pool.status != PoolStatus::Faulted && item.pool.status != PoolStatus::Unknown
     }
 
+    /// Should only attempt to use uncordoned pools.
+    pub(crate) fn uncordoned_repl(_: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        !item.cordoned().replicas
+    }
+    /// Should only attempt to use uncordoned pools.
+    pub(crate) fn uncordoned_snaps(_: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        !item.cordoned().snapshots
+    }
+    /// Should only attempt to use uncordoned pools.
+    pub(crate) fn uncordoned_rest(_: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        !item.cordoned().restores
+    }
+
     /// Should only attempt to use pools having specific creation label if topology has it.
     pub(crate) fn topology(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
         Self::topology_(request, request.registry(), &item.pool.id)

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -308,7 +308,7 @@ mod tests {
                 .take(replicas)
                 .collect::<Vec<_>>(),
         );
-        PoolItem::new(node_state, pool, ag_replica_count)
+        PoolItem::new(node_state, pool, ag_replica_count, None)
     }
     fn ag_sort_comparator(a: &PoolItem, b: &PoolItem) -> Ordering {
         let builder = SortBuilder::new();

--- a/control-plane/agents/src/bin/core/node/operations.rs
+++ b/control-plane/agents/src/bin/core/node/operations.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 impl ResourceCordon for OperationGuardArc<NodeSpec> {
     type CordonOutput = NodeSpec;
     type UncordonOutput = NodeSpec;
+    type Request = String;
 
     /// Cordon a node via operation guard functions.
     async fn cordon(

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -1,24 +1,26 @@
-use crate::controller::{
-    io_engine::PoolApi,
-    registry::Registry,
-    resources::{
-        operations::{ResourceLabel, ResourceLifecycle},
-        operations_helper::{GuardedOperationsHelper, OnCreateFail, OperationSequenceGuard},
-        OperationGuardArc,
+use crate::{
+    controller::{
+        io_engine::PoolApi,
+        registry::Registry,
+        resources::{
+            operations::{ResourceCordon, ResourceLabel, ResourceLifecycle},
+            operations_helper::{GuardedOperationsHelper, OnCreateFail, OperationSequenceGuard},
+            OperationGuardArc,
+        },
     },
+    pool::operations_helper::devlink_preflight_checks,
 };
-use crate::pool::operations_helper::devlink_preflight_checks;
 use agents::errors::{SvcError, SvcError::CordonedNode};
+use grpc::operations::pool::traits::PoolCordonRequest;
+use std::collections::HashMap;
 use stor_port::{
     transport_api::ResourceKind,
     types::v0::{
-        store::pool::{PoolOperation, PoolSpec},
+        store::pool::{PoolCordonOp, PoolOperation, PoolSpec},
         transport::{CreatePool, CtrlPoolState, DestroyPool, Pool},
     },
 };
 use utils::dsp_created_by_key;
-
-use std::collections::HashMap;
 
 #[async_trait::async_trait]
 impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
@@ -188,6 +190,52 @@ impl ResourceLabel for OperationGuardArc<PoolSpec> {
                 &cloned_pool_spec,
                 PoolOperation::Unlabel(label_key.into()),
             )
+            .await?;
+
+        self.complete_update(registry, Ok(()), spec_clone).await?;
+        Ok(self.as_ref().clone())
+    }
+}
+
+/// Resource Cordon Operations.
+#[async_trait::async_trait]
+impl ResourceCordon for OperationGuardArc<PoolSpec> {
+    type CordonOutput = PoolSpec;
+    type UncordonOutput = PoolSpec;
+    type Request = PoolCordonRequest;
+
+    async fn cordon(
+        &mut self,
+        registry: &Registry,
+        request: PoolCordonRequest,
+    ) -> Result<Self::CordonOutput, SvcError> {
+        let request = PoolCordonOp {
+            replicas: request.replicas,
+            snapshots: request.snapshots,
+            restores: request.restores,
+        };
+        let spec_clone = self.lock().clone();
+        let spec_clone = self
+            .start_update(registry, &spec_clone, PoolOperation::Cordon(request))
+            .await?;
+
+        self.complete_update(registry, Ok(()), spec_clone).await?;
+        Ok(self.as_ref().clone())
+    }
+
+    async fn uncordon(
+        &mut self,
+        registry: &Registry,
+        request: PoolCordonRequest,
+    ) -> Result<Self::UncordonOutput, SvcError> {
+        let request = PoolCordonOp {
+            replicas: request.replicas,
+            snapshots: request.snapshots,
+            restores: request.restores,
+        };
+        let spec_clone = self.lock().clone();
+        let spec_clone = self
+            .start_update(registry, &spec_clone, PoolOperation::Uncordon(request))
             .await?;
 
         self.complete_update(registry, Ok(()), spec_clone).await?;

--- a/control-plane/agents/src/bin/core/pool/service.rs
+++ b/control-plane/agents/src/bin/core/pool/service.rs
@@ -35,6 +35,7 @@ use stor_port::{
     },
 };
 
+use crate::controller::resources::{operations::ResourceCordon, ResourceUid};
 use grpc::operations::pool::traits::PoolCordonRequest;
 use snafu::OptionExt;
 
@@ -103,12 +104,16 @@ impl PoolOperations for Service {
         Ok(pool)
     }
 
-    async fn cordon(&self, _info: PoolCordonRequest) -> Result<Pool, ReplyError> {
-        todo!()
+    async fn cordon(&self, info: PoolCordonRequest) -> Result<Pool, ReplyError> {
+        let service = self.clone();
+        let pool = Context::spawn(async move { service.cordon(info).await }).await??;
+        Ok(pool)
     }
 
-    async fn uncordon(&self, _info: PoolCordonRequest) -> Result<Pool, ReplyError> {
-        todo!()
+    async fn uncordon(&self, info: PoolCordonRequest) -> Result<Pool, ReplyError> {
+        let service = self.clone();
+        let pool = Context::spawn(async move { service.uncordon(info).await }).await??;
+        Ok(pool)
     }
 }
 
@@ -396,6 +401,24 @@ impl Service {
             .unlabel(&self.registry, request.label_key())
             .await?;
         let state = self.registry.ctrl_pool_state(&request.pool_id).await.ok();
+        Ok(Pool::new(spec, state))
+    }
+
+    /// Cordon the specified pool.
+    #[tracing::instrument(level = "info", skip(self), err, fields(pool.id = %request.pool_id))]
+    async fn cordon(&self, request: PoolCordonRequest) -> Result<Pool, SvcError> {
+        let mut guarded_pool = self.specs().guarded_pool(&request.pool_id).await?;
+        let spec = guarded_pool.cordon(&self.registry, request).await?;
+        let state = self.registry.ctrl_pool_state(guarded_pool.uid()).await.ok();
+        Ok(Pool::new(spec, state))
+    }
+
+    /// Uncordon the specified pool.
+    #[tracing::instrument(level = "info", skip(self), err, fields(pool.id = %request.pool_id))]
+    async fn uncordon(&self, request: PoolCordonRequest) -> Result<Pool, SvcError> {
+        let mut guarded_pool = self.specs().guarded_pool(&request.pool_id).await?;
+        let spec = guarded_pool.uncordon(&self.registry, request).await?;
+        let state = self.registry.ctrl_pool_state(guarded_pool.uid()).await.ok();
         Ok(Pool::new(spec, state))
     }
 }

--- a/control-plane/agents/src/bin/core/pool/service.rs
+++ b/control-plane/agents/src/bin/core/pool/service.rs
@@ -35,7 +35,7 @@ use stor_port::{
     },
 };
 
-use grpc::operations::pool::traits::PoolCordonInfo;
+use grpc::operations::pool::traits::PoolCordonRequest;
 use snafu::OptionExt;
 
 #[derive(Debug, Clone)]
@@ -103,11 +103,11 @@ impl PoolOperations for Service {
         Ok(pool)
     }
 
-    async fn cordon(&self, _info: PoolCordonInfo) -> Result<Pool, ReplyError> {
+    async fn cordon(&self, _info: PoolCordonRequest) -> Result<Pool, ReplyError> {
         todo!()
     }
 
-    async fn uncordon(&self, _info: PoolCordonInfo) -> Result<Pool, ReplyError> {
+    async fn uncordon(&self, _info: PoolCordonRequest) -> Result<Pool, ReplyError> {
         todo!()
     }
 }

--- a/control-plane/agents/src/bin/core/pool/service.rs
+++ b/control-plane/agents/src/bin/core/pool/service.rs
@@ -35,6 +35,7 @@ use stor_port::{
     },
 };
 
+use grpc::operations::pool::traits::PoolCordonInfo;
 use snafu::OptionExt;
 
 #[derive(Debug, Clone)]
@@ -100,6 +101,14 @@ impl PoolOperations for Service {
         }
         let pool = Context::spawn(async move { service.unlabel(&req).await }).await??;
         Ok(pool)
+    }
+
+    async fn cordon(&self, _info: PoolCordonInfo) -> Result<Pool, ReplyError> {
+        todo!()
+    }
+
+    async fn uncordon(&self, _info: PoolCordonInfo) -> Result<Pool, ReplyError> {
+        todo!()
     }
 }
 

--- a/control-plane/agents/src/bin/core/pool/specs.rs
+++ b/control-plane/agents/src/bin/core/pool/specs.rs
@@ -103,6 +103,30 @@ impl SpecOperationsHelper for PoolSpec {
                     Ok(())
                 }
             }
+            PoolOperation::Cordon(cordon) => {
+                if !self.cordon_would_modify(cordon) {
+                    Err(SvcError::CordonResources {
+                        kind: ResourceKind::Pool,
+                        id: self.id().to_string(),
+                        resources: cordon.resources(),
+                    })
+                } else {
+                    self.start_op(op);
+                    Ok(())
+                }
+            }
+            PoolOperation::Uncordon(uncordon) => {
+                if !self.uncordon_would_modify(uncordon) {
+                    Err(SvcError::UncordonResources {
+                        kind: ResourceKind::Pool,
+                        id: self.id().to_string(),
+                        resources: uncordon.resources(),
+                    })
+                } else {
+                    self.start_op(op);
+                    Ok(())
+                }
+            }
             _ => {
                 self.start_op(op);
                 Ok(())

--- a/control-plane/agents/src/bin/core/pool/specs.rs
+++ b/control-plane/agents/src/bin/core/pool/specs.rs
@@ -404,6 +404,18 @@ impl ResourceSpecsLocked {
                 pool_id: id.to_owned(),
             })
     }
+    /// Run the given closure with the specified pool resource.
+    pub(crate) fn pool_with<R>(
+        &self,
+        id: &PoolId,
+        run: impl Fn(&ResourceMutex<PoolSpec>) -> R,
+    ) -> Result<R, SvcError> {
+        let specs = self.read();
+        let pool = specs.pools.get(id).ok_or(PoolNotFound {
+            pool_id: id.to_owned(),
+        })?;
+        Ok(run(pool))
+    }
     /// Get a pools's node from its spec for the given pool `id`, if it exists.
     pub(crate) fn spec_pool_node(&self, id: &PoolId) -> Option<NodeId> {
         let specs = self.read();

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -154,6 +154,7 @@ fn test_deserialization_v1_to_v2() {
                 operation: None,
                 creat_tsc: None,
                 encryption: None,
+                cordon_drain: None,
             }),
         },
         TestEntry {

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -48,6 +48,18 @@ pub enum SvcError {
     CordonLabel { node_id: String, label: String },
     #[snafu(display("Node {node_id} does not have a cordon label '{label}'"))]
     UncordonLabel { node_id: String, label: String },
+    #[snafu(display("{kind} {id} is already cordoned with resources '{resources}'"))]
+    CordonResources {
+        kind: ResourceKind,
+        id: String,
+        resources: String,
+    },
+    #[snafu(display("{kind} {id} does not have any of the cordon resources '{resources}'"))]
+    UncordonResources {
+        kind: ResourceKind,
+        id: String,
+        resources: String,
+    },
     #[snafu(display(
         "Timed out after '{:?}' attempting to connect to node '{}' via gRPC endpoint '{}'",
         timeout,
@@ -610,6 +622,20 @@ impl From<SvcError> for ReplyError {
             SvcError::CordonLabel { .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPrecondition,
                 resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+
+            SvcError::CordonResources { kind, .. } => ReplyError {
+                kind: ReplyErrorKind::AlreadyExists,
+                resource: kind,
+                source,
+                extra,
+            },
+
+            SvcError::UncordonResources { kind, .. } => ReplyError {
+                kind: ReplyErrorKind::AlreadyExists,
+                resource: kind,
                 source,
                 extra,
             },

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -48,6 +48,10 @@ message PoolSpec {
   optional common.StringMapValue labels = 5;
   // Encryption details
   optional common.EncryptionSecret secret = 6;
+  // Cordon Drain state
+  oneof CordonDrain {
+    CordonedState cordoned = 7;
+  }
 }
 
 // Pool information
@@ -170,6 +174,28 @@ message UnlabelPoolReply {
   }
 }
 
+message CordonPoolRequest {
+  optional string node_id = 1;
+  string pool_id = 2;
+  bool replicas = 3;
+  bool snapshots = 4;
+  bool restores = 5;
+}
+message CordonPoolReply {
+  oneof reply {
+    Pool pool = 1;
+    common.ReplyError error = 2;
+  }
+}
+
+message CordonedState {
+  // New replicas can't be created
+  bool replicas = 1;
+  // New snapshots can't be created
+  bool snapshots = 2;
+  // New restores can't be created
+  bool restores = 3;
+}
 
 // Service for managing storage pools
 service PoolGrpc {
@@ -178,4 +204,6 @@ service PoolGrpc {
   rpc GetPools (GetPoolsRequest) returns (GetPoolsReply) {}
   rpc LabelPool (LabelPoolRequest) returns (LabelPoolReply) {}
   rpc UnlabelPool (UnlabelPoolRequest) returns (UnlabelPoolReply) {}
+  rpc CordonPool (CordonPoolRequest) returns (CordonPoolReply) {}
+  rpc UncordonPool (CordonPoolRequest) returns (CordonPoolReply) {}
 }

--- a/control-plane/grpc/src/operations/pool/client.rs
+++ b/control-plane/grpc/src/operations/pool/client.rs
@@ -143,7 +143,7 @@ impl PoolOperations for PoolClient {
 
     async fn cordon(
         &self,
-        info: crate::operations::pool::traits::PoolCordonInfo,
+        info: crate::operations::pool::traits::PoolCordonRequest,
     ) -> Result<Pool, ReplyError> {
         let request = CordonPoolRequest::from(info);
         let response = self.client().cordon_pool(request).await?.into_inner();
@@ -158,7 +158,7 @@ impl PoolOperations for PoolClient {
 
     async fn uncordon(
         &self,
-        info: crate::operations::pool::traits::PoolCordonInfo,
+        info: crate::operations::pool::traits::PoolCordonRequest,
     ) -> Result<Pool, ReplyError> {
         let request = CordonPoolRequest::from(info);
         let response = self.client().uncordon_pool(request).await?.into_inner();

--- a/control-plane/grpc/src/operations/pool/client.rs
+++ b/control-plane/grpc/src/operations/pool/client.rs
@@ -1,10 +1,11 @@
+use super::traits::UnlabelPoolInfo;
 use crate::{
     common::{CommonFilter, NodeFilter, NodePoolFilter, PoolFilter},
     context::{Client, Context, TracedChannel},
     operations::pool::traits::{CreatePoolInfo, DestroyPoolInfo, LabelPoolInfo, PoolOperations},
     pool::{
-        create_pool_reply, get_pools_reply, get_pools_request, label_pool_reply,
-        pool_grpc_client::PoolGrpcClient, unlabel_pool_reply, GetPoolsRequest,
+        cordon_pool_reply, create_pool_reply, get_pools_reply, get_pools_request, label_pool_reply,
+        pool_grpc_client::PoolGrpcClient, unlabel_pool_reply, CordonPoolRequest, GetPoolsRequest,
     },
 };
 use std::{convert::TryFrom, ops::Deref};
@@ -13,8 +14,6 @@ use stor_port::{
     types::v0::transport::{Filter, MessageIdVs, Pool},
 };
 use tonic::transport::Uri;
-
-use super::traits::UnlabelPoolInfo;
 
 /// RPC Pool Client
 #[derive(Clone)]
@@ -137,6 +136,36 @@ impl PoolOperations for PoolClient {
             Some(unlabel_pool_reply) => match unlabel_pool_reply {
                 unlabel_pool_reply::Reply::Pool(pool) => Ok(Pool::try_from(pool)?),
                 unlabel_pool_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Pool)),
+        }
+    }
+
+    async fn cordon(
+        &self,
+        info: crate::operations::pool::traits::PoolCordonInfo,
+    ) -> Result<Pool, ReplyError> {
+        let request = CordonPoolRequest::from(info);
+        let response = self.client().cordon_pool(request).await?.into_inner();
+        match response.reply {
+            Some(reply) => match reply {
+                cordon_pool_reply::Reply::Pool(pool) => Ok(Pool::try_from(pool)?),
+                cordon_pool_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Pool)),
+        }
+    }
+
+    async fn uncordon(
+        &self,
+        info: crate::operations::pool::traits::PoolCordonInfo,
+    ) -> Result<Pool, ReplyError> {
+        let request = CordonPoolRequest::from(info);
+        let response = self.client().uncordon_pool(request).await?.into_inner();
+        match response.reply {
+            Some(reply) => match reply {
+                cordon_pool_reply::Reply::Pool(pool) => Ok(Pool::try_from(pool)?),
+                cordon_pool_reply::Reply::Error(err) => Err(err.into()),
             },
             None => Err(ReplyError::invalid_response(ResourceKind::Pool)),
         }

--- a/control-plane/grpc/src/operations/pool/mod.rs
+++ b/control-plane/grpc/src/operations/pool/mod.rs
@@ -101,8 +101,8 @@ mod test {
             operations::pool::{
                 test::TimeoutTester,
                 traits::{
-                    CreatePoolInfo, DestroyPoolInfo, LabelPoolInfo, PoolCordonInfo, PoolOperations,
-                    UnlabelPoolInfo,
+                    CreatePoolInfo, DestroyPoolInfo, LabelPoolInfo, PoolCordonRequest,
+                    PoolOperations, UnlabelPoolInfo,
                 },
             },
         };
@@ -154,11 +154,11 @@ mod test {
                 todo!()
             }
 
-            async fn cordon(&self, _info: PoolCordonInfo) -> Result<Pool, ReplyError> {
+            async fn cordon(&self, _info: PoolCordonRequest) -> Result<Pool, ReplyError> {
                 todo!()
             }
 
-            async fn uncordon(&self, _info: PoolCordonInfo) -> Result<Pool, ReplyError> {
+            async fn uncordon(&self, _info: PoolCordonRequest) -> Result<Pool, ReplyError> {
                 todo!()
             }
         }

--- a/control-plane/grpc/src/operations/pool/mod.rs
+++ b/control-plane/grpc/src/operations/pool/mod.rs
@@ -101,7 +101,8 @@ mod test {
             operations::pool::{
                 test::TimeoutTester,
                 traits::{
-                    CreatePoolInfo, DestroyPoolInfo, LabelPoolInfo, PoolOperations, UnlabelPoolInfo,
+                    CreatePoolInfo, DestroyPoolInfo, LabelPoolInfo, PoolCordonInfo, PoolOperations,
+                    UnlabelPoolInfo,
                 },
             },
         };
@@ -150,6 +151,14 @@ mod test {
                 _pool: &dyn UnlabelPoolInfo,
                 _ctx: Option<Context>,
             ) -> Result<Pool, ReplyError> {
+                todo!()
+            }
+
+            async fn cordon(&self, _info: PoolCordonInfo) -> Result<Pool, ReplyError> {
+                todo!()
+            }
+
+            async fn uncordon(&self, _info: PoolCordonInfo) -> Result<Pool, ReplyError> {
                 todo!()
             }
         }

--- a/control-plane/grpc/src/operations/pool/server.rs
+++ b/control-plane/grpc/src/operations/pool/server.rs
@@ -1,19 +1,18 @@
-use crate::misc::traits::ValidateRequestTypes;
 use crate::{
+    misc::traits::ValidateRequestTypes,
     operations::pool::traits::PoolOperations,
     pool,
     pool::{
-        create_pool_reply, get_pools_reply, label_pool_reply,
+        cordon_pool_reply, create_pool_reply, get_pools_reply, label_pool_reply,
         pool_grpc_server::{PoolGrpc, PoolGrpcServer},
-        unlabel_pool_reply, CreatePoolReply, CreatePoolRequest, DestroyPoolReply,
-        DestroyPoolRequest, GetPoolsReply, GetPoolsRequest, LabelPoolReply, LabelPoolRequest,
-        UnlabelPoolReply, UnlabelPoolRequest,
+        unlabel_pool_reply, CordonPoolReply, CordonPoolRequest, CreatePoolReply, CreatePoolRequest,
+        DestroyPoolReply, DestroyPoolRequest, GetPoolsReply, GetPoolsRequest, LabelPoolReply,
+        LabelPoolRequest, UnlabelPoolReply, UnlabelPoolRequest,
     },
 };
-use stor_port::types::v0::transport::Filter;
-
 use std::sync::Arc;
-use tonic::{Request, Response};
+use stor_port::types::v0::transport::Filter;
+use tonic::{Request, Response, Status};
 
 /// gRPC Pool Server
 #[derive(Clone)]
@@ -117,6 +116,34 @@ impl PoolGrpc for PoolServer {
             })),
             Err(err) => Ok(Response::new(UnlabelPoolReply {
                 reply: Some(unlabel_pool_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn cordon_pool(
+        &self,
+        request: Request<CordonPoolRequest>,
+    ) -> Result<Response<CordonPoolReply>, Status> {
+        match self.service.cordon(request.into_inner().into()).await {
+            Ok(node) => Ok(Response::new(CordonPoolReply {
+                reply: Some(cordon_pool_reply::Reply::Pool(node.into())),
+            })),
+            Err(err) => Ok(Response::new(CordonPoolReply {
+                reply: Some(cordon_pool_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn uncordon_pool(
+        &self,
+        request: Request<CordonPoolRequest>,
+    ) -> Result<Response<CordonPoolReply>, Status> {
+        match self.service.uncordon(request.into_inner().into()).await {
+            Ok(node) => Ok(Response::new(CordonPoolReply {
+                reply: Some(cordon_pool_reply::Reply::Pool(node.into())),
+            })),
+            Err(err) => Ok(Response::new(CordonPoolReply {
+                reply: Some(cordon_pool_reply::Reply::Error(err.into())),
             })),
         }
     }

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -4,10 +4,11 @@ use crate::{
     misc::traits::{StringValue, ValidateRequestTypes},
     pool,
     pool::{
-        get_pools_request, CreatePoolRequest, DestroyPoolRequest, LabelPoolRequest,
-        UnlabelPoolRequest,
+        get_pools_request, CordonPoolRequest, CreatePoolRequest, DestroyPoolRequest,
+        LabelPoolRequest, UnlabelPoolRequest,
     },
 };
+use std::{collections::HashMap, convert::TryFrom};
 use stor_port::{
     transport_api::{v0::Pools, ReplyError, ResourceKind},
     types::v0::{
@@ -19,8 +20,6 @@ use stor_port::{
     },
     IntoOption,
 };
-
-use std::{collections::HashMap, convert::TryFrom};
 
 /// Trait implemented by services which support pool operations.
 #[tonic::async_trait]
@@ -51,6 +50,11 @@ pub trait PoolOperations: Send + Sync {
         pool: &dyn UnlabelPoolInfo,
         ctx: Option<Context>,
     ) -> Result<Pool, ReplyError>;
+    /// Cordon the pool with the given info and associate the label with the cordoned pool.
+    async fn cordon(&self, info: PoolCordonInfo) -> Result<Pool, ReplyError>;
+    /// Uncordon the pool with the given info by removing the associated label.
+    /// All cordon labels must be removed in order to uncordon the node.
+    async fn uncordon(&self, info: PoolCordonInfo) -> Result<Pool, ReplyError>;
 }
 
 impl TryFrom<pool::PoolDefinition> for PoolSpec {
@@ -174,6 +178,7 @@ impl From<PoolSpec> for pool::PoolDefinition {
                         }
                     },
                 },
+                cordon_drain: None,
             }),
             metadata: Some(pool::Metadata {
                 uuid: None,
@@ -579,5 +584,40 @@ impl From<EncryptionSecret> for common::EncryptionSecret {
 impl From<common::EncryptionSecret> for EncryptionSecret {
     fn from(value: common::EncryptionSecret) -> Self {
         Self { name: value.name }
+    }
+}
+
+/// Pool cordon and uncordon information.
+pub struct PoolCordonInfo {
+    /// Node ID of where the pool resides on.
+    /// This is optional and may be used for stricter checks.
+    pub node_id: Option<NodeId>,
+    /// The ID of the pool to cordon/uncordon.
+    pub pool_id: PoolId,
+    replicas: bool,
+    snapshots: bool,
+    restores: bool,
+}
+
+impl From<CordonPoolRequest> for PoolCordonInfo {
+    fn from(value: CordonPoolRequest) -> Self {
+        Self {
+            node_id: value.node_id.map(Into::into),
+            pool_id: value.pool_id.into(),
+            replicas: value.replicas,
+            snapshots: value.snapshots,
+            restores: value.restores,
+        }
+    }
+}
+impl From<PoolCordonInfo> for CordonPoolRequest {
+    fn from(value: PoolCordonInfo) -> Self {
+        Self {
+            pool_id: value.pool_id.into(),
+            node_id: value.node_id.map(Into::into),
+            replicas: value.replicas,
+            snapshots: value.snapshots,
+            restores: value.restores,
+        }
     }
 }

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -12,7 +12,10 @@ use std::{collections::HashMap, convert::TryFrom};
 use stor_port::{
     transport_api::{v0::Pools, ReplyError, ResourceKind},
     types::v0::{
-        store::pool::{Encryption, EncryptionSecret, PoolLabel, PoolSpec, PoolSpecStatus},
+        store::pool::{
+            CordonDrainState, CordonedState, Encryption, EncryptionSecret, PoolLabel, PoolSpec,
+            PoolSpecStatus,
+        },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, Filter, LabelPool, NodeId, Pool, PoolDeviceUri,
             PoolId, PoolState, PoolStatus, UnlabelPool, VolumeId,
@@ -104,6 +107,18 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
             encryption: pool_spec
                 .secret
                 .map(|details| Encryption::Secret(EncryptionSecret { name: details.name })),
+            cordon_drain: match pool_spec.cordon_drain {
+                Some(state) => match state {
+                    pool::pool_spec::CordonDrain::Cordoned(state) => {
+                        Some(CordonDrainState::Cordoned(CordonedState {
+                            replicas: state.replicas,
+                            snapshots: state.snapshots,
+                            restores: state.restores,
+                        }))
+                    }
+                },
+                None => None,
+            },
         })
     }
 }
@@ -178,7 +193,19 @@ impl From<PoolSpec> for pool::PoolDefinition {
                         }
                     },
                 },
-                cordon_drain: None,
+                cordon_drain: match pool_spec.cordon_drain {
+                    Some(cordon_drain) => {
+                        let co = match cordon_drain {
+                            CordonDrainState::Cordoned(state) => pool::CordonedState {
+                                replicas: state.replicas,
+                                snapshots: state.snapshots,
+                                restores: state.restores,
+                            },
+                        };
+                        Some(pool::pool_spec::CordonDrain::Cordoned(co))
+                    }
+                    None => None,
+                },
             }),
             metadata: Some(pool::Metadata {
                 uuid: None,
@@ -588,6 +615,7 @@ impl From<common::EncryptionSecret> for EncryptionSecret {
 }
 
 /// Pool cordon and uncordon information.
+#[derive(Debug)]
 pub struct PoolCordonRequest {
     /// Node ID of where the pool resides on.
     /// This is optional and may be used for stricter checks.

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -51,10 +51,10 @@ pub trait PoolOperations: Send + Sync {
         ctx: Option<Context>,
     ) -> Result<Pool, ReplyError>;
     /// Cordon the pool with the given info and associate the label with the cordoned pool.
-    async fn cordon(&self, info: PoolCordonInfo) -> Result<Pool, ReplyError>;
+    async fn cordon(&self, info: PoolCordonRequest) -> Result<Pool, ReplyError>;
     /// Uncordon the pool with the given info by removing the associated label.
     /// All cordon labels must be removed in order to uncordon the node.
-    async fn uncordon(&self, info: PoolCordonInfo) -> Result<Pool, ReplyError>;
+    async fn uncordon(&self, info: PoolCordonRequest) -> Result<Pool, ReplyError>;
 }
 
 impl TryFrom<pool::PoolDefinition> for PoolSpec {
@@ -588,18 +588,21 @@ impl From<common::EncryptionSecret> for EncryptionSecret {
 }
 
 /// Pool cordon and uncordon information.
-pub struct PoolCordonInfo {
+pub struct PoolCordonRequest {
     /// Node ID of where the pool resides on.
     /// This is optional and may be used for stricter checks.
     pub node_id: Option<NodeId>,
     /// The ID of the pool to cordon/uncordon.
     pub pool_id: PoolId,
-    replicas: bool,
-    snapshots: bool,
-    restores: bool,
+    /// Cordon or uncordon replicas.
+    pub replicas: bool,
+    /// Cordon or uncordon snapshots.
+    pub snapshots: bool,
+    /// Cordon or uncordon restores.
+    pub restores: bool,
 }
 
-impl From<CordonPoolRequest> for PoolCordonInfo {
+impl From<CordonPoolRequest> for PoolCordonRequest {
     fn from(value: CordonPoolRequest) -> Self {
         Self {
             node_id: value.node_id.map(Into::into),
@@ -610,8 +613,8 @@ impl From<CordonPoolRequest> for PoolCordonInfo {
         }
     }
 }
-impl From<PoolCordonInfo> for CordonPoolRequest {
-    fn from(value: PoolCordonInfo) -> Self {
+impl From<PoolCordonRequest> for CordonPoolRequest {
+    fn from(value: PoolCordonRequest) -> Self {
         Self {
             pool_id: value.pool_id.into(),
             node_id: value.node_id.map(Into::into),

--- a/control-plane/plugin/src/lib.rs
+++ b/control-plane/plugin/src/lib.rs
@@ -149,7 +149,11 @@ impl ExecuteOperation for GetResources {
                 GetCordonArgs::Node { id: node_id } => {
                     cordon::NodeCordon::get(node_id, &cli_args.output).await
                 }
-                GetCordonArgs::Nodes => cordon::NodeCordons::list(&cli_args.output).await,
+                GetCordonArgs::Nodes => cordon::NodeCordon::list(&cli_args.output).await,
+                GetCordonArgs::Pool { id: pool_id } => {
+                    cordon::PoolCordon::get(pool_id, &cli_args.output).await
+                }
+                GetCordonArgs::Pools => cordon::PoolCordon::list(&cli_args.output).await,
             },
             GetResources::Drain(get_drain_resource) => match get_drain_resource {
                 GetDrainArgs::Node { id: node_id } => {
@@ -241,6 +245,9 @@ impl ExecuteOperation for CordonResources {
             CordonResources::Node { id, label } => {
                 node::Node::cordon(id, label, &cli_args.output).await
             }
+            CordonResources::Pool { id, resources } => {
+                pool::Pool::cordon(id, resources, &cli_args.output).await
+            }
         }
     }
 }
@@ -253,6 +260,9 @@ impl ExecuteOperation for UnCordonResources {
         match self {
             UnCordonResources::Node { id, label } => {
                 node::Node::uncordon(id, label, &cli_args.output).await
+            }
+            UnCordonResources::Pool { id, resources } => {
+                pool::Pool::uncordon(id, resources, &cli_args.output).await
             }
         }
     }

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -192,8 +192,19 @@ pub trait GetSnapshotTopology {
 #[async_trait(?Send)]
 pub trait Cordoning {
     type ID;
-    async fn cordon(id: &Self::ID, label: &str, output: &utils::OutputFormat) -> PluginResult;
-    async fn uncordon(id: &Self::ID, label: &str, output: &utils::OutputFormat) -> PluginResult;
+    type CREQ: ?Sized;
+    type UREQ: ?Sized;
+
+    async fn cordon(
+        id: &Self::ID,
+        label: &Self::CREQ,
+        output: &utils::OutputFormat,
+    ) -> PluginResult;
+    async fn uncordon(
+        id: &Self::ID,
+        label: &Self::UREQ,
+        output: &utils::OutputFormat,
+    ) -> PluginResult;
 }
 
 /// Delete trait.

--- a/control-plane/plugin/src/resources/cordon.rs
+++ b/control-plane/plugin/src/resources/cordon.rs
@@ -1,5 +1,5 @@
 pub struct NodeCordon {}
-pub struct NodeCordons {}
+pub struct PoolCordon {}
 
 use async_trait::async_trait;
 use openapi::models::CordonDrainState;
@@ -9,8 +9,9 @@ use crate::{
     resources::{
         error::Error,
         node::{node_display_print, node_display_print_one, NodeDisplayFormat},
-        utils::OutputFormat,
-        NodeId,
+        pool::PoolDisplay,
+        utils::{print_table, OutputFormat},
+        NodeId, PoolId,
     },
     rest_wrapper::RestClient,
 };
@@ -33,9 +34,8 @@ impl Get for NodeCordon {
         Ok(())
     }
 }
-
 #[async_trait(?Send)]
-impl List for NodeCordons {
+impl List for NodeCordon {
     async fn list(output: &OutputFormat) -> PluginResult {
         match RestClient::client().nodes_api().get_nodes(None).await {
             Ok(nodes) => {
@@ -59,6 +59,66 @@ impl List for NodeCordons {
             }
             Err(e) => {
                 return Err(Error::ListNodesError { source: e });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl Get for PoolCordon {
+    type ID = PoolId;
+    async fn get(id: &Self::ID, output: &OutputFormat) -> PluginResult {
+        match RestClient::client().pools_api().get_pool(id).await {
+            Ok(pool) => {
+                let display = PoolDisplay::new(pool.into_body(), false, true);
+                match output {
+                    OutputFormat::Yaml | OutputFormat::Json => {
+                        print_table(output, display.inner);
+                    }
+                    OutputFormat::None => {
+                        print_table(output, display);
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(Error::GetPoolError {
+                    id: id.to_string(),
+                    source: e,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl List for PoolCordon {
+    async fn list(output: &OutputFormat) -> PluginResult {
+        match RestClient::client().pools_api().get_pools(None).await {
+            Ok(pools) => {
+                // iterate through the nodes and filter for only those that have cordon or drain
+                // labels
+                let mut pools = pools.into_body();
+                // remove nodes with no cordon or drain labels
+                pools.retain(|i| {
+                    i.spec
+                        .as_ref()
+                        .map(|spec| spec.cordon_drain.is_some())
+                        .unwrap_or_default()
+                });
+                let display = PoolDisplay::new_pools(pools, false, true);
+                match output {
+                    OutputFormat::Yaml | OutputFormat::Json => {
+                        print_table(output, display.inner);
+                    }
+                    OutputFormat::None => {
+                        print_table(output, display);
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(Error::ListPoolsError { source: e });
             }
         }
         Ok(())

--- a/control-plane/plugin/src/resources/error.rs
+++ b/control-plane/plugin/src/resources/error.rs
@@ -23,6 +23,12 @@ pub enum Error {
         id: String,
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,
     },
+    /// Error when pool cordon request fails.
+    #[snafu(display("Failed to cordon pool {id}. Error {source}"))]
+    PoolCordonError {
+        id: String,
+        source: openapi::tower::client::Error<openapi::models::RestJsonError>,
+    },
     #[snafu(display("Invalid label format: {source}"))]
     NodeLabelFormat { source: TopologyError },
     #[snafu(display("{source}"))]
@@ -31,10 +37,15 @@ pub enum Error {
     PoolLabelFormat { source: TopologyError },
     #[snafu(display("{source}"))]
     PoolLabel { source: OpError },
-
     /// Error when node uncordon request fails.
     #[snafu(display("Failed to uncordon node {id}. Error {source}"))]
     NodeUncordonError {
+        id: String,
+        source: openapi::tower::client::Error<openapi::models::RestJsonError>,
+    },
+    /// Error when node uncordon request fails.
+    #[snafu(display("Failed to uncordon pool {id}. Error {source}"))]
+    PoolUncordonError {
         id: String,
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,
     },

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -105,6 +105,14 @@ pub enum SetVolumeProperties {
 pub enum CordonResources {
     /// Cordon the node with the given ID by applying the cordon label to that node.
     Node { id: NodeId, label: String },
+    /// Cordon the pool with the given ID by applying the cordon constraints to that pool{n}
+    /// By default all resources are cordoned. Otherwise you may individually select specific constraints.
+    Pool {
+        /// Id of the pool to cordon.
+        id: PoolId,
+        #[clap(flatten)]
+        resources: Option<pool::CordonReq>,
+    },
 }
 
 /// The types of resources that support uncordoning.
@@ -113,16 +121,28 @@ pub enum UnCordonResources {
     /// Removes the cordon label from the node.
     /// When the node has no more cordon labels, it is effectively uncordoned.
     Node { id: NodeId, label: String },
+    /// Removes the cordon constraints from the pool.
+    /// When the pool has no more cordon labels, it is effectively uncordoned{n}
+    /// By default all resources are cordoned. Otherwise you may individually select specific constraints removal.
+    Pool {
+        /// Id of the pool to uncordon.
+        id: PoolId,
+        #[clap(flatten)]
+        resources: Option<pool::UncordonReq>,
+    },
 }
 
 /// The types of resources that support the 'get cordon' operation.
 #[derive(clap::Subcommand, Debug)]
 pub enum GetCordonArgs {
     /// Get the cordon for the node with the given ID.
-    Node {
-        id: NodeId,
-    },
+    Node { id: NodeId },
+    /// Get all nodes which are cordoned.
     Nodes,
+    /// Get the cordon for the pool with the given ID.
+    Pool { id: PoolId },
+    /// Get all pools which are cordoned.
+    Pools,
 }
 
 /// The types of resources that support the 'drain' operation.

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -248,7 +248,7 @@ impl GetWithArgs for Node {
 }
 
 /// Get the cordon labels from whichever state.
-fn cordon_labels_from_state(ds: &CordonDrainState) -> Vec<String> {
+pub(super) fn cordon_labels_from_state(ds: &CordonDrainState) -> Vec<String> {
     match ds {
         CordonDrainState::cordonedstate(state) => state.cordonlabels.clone(),
         CordonDrainState::drainingstate(state) => state.cordonlabels.clone(),
@@ -256,7 +256,7 @@ fn cordon_labels_from_state(ds: &CordonDrainState) -> Vec<String> {
     }
 }
 
-fn drain_labels_from_state(ds: &CordonDrainState) -> Vec<String> {
+pub(super) fn drain_labels_from_state(ds: &CordonDrainState) -> Vec<String> {
     match ds {
         CordonDrainState::cordonedstate(_) => Vec::<String>::new(),
         CordonDrainState::drainingstate(state) => state.drainlabels.clone(),
@@ -267,6 +267,9 @@ fn drain_labels_from_state(ds: &CordonDrainState) -> Vec<String> {
 #[async_trait(?Send)]
 impl Cordoning for Node {
     type ID = NodeId;
+    type CREQ = str;
+    type UREQ = str;
+
     async fn cordon(id: &Self::ID, label: &str, output: &OutputFormat) -> PluginResult {
         // is node already cordoned with the label?
         let already_has_cordon_label: bool =

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -1,7 +1,7 @@
 extern crate utils as external_utils;
 use super::VolumeId;
 use crate::{
-    operations::{GetWithArgs, Label, ListWithArgs, PluginResult},
+    operations::{Cordoning, GetWithArgs, Label, ListWithArgs, PluginResult},
     resources::{
         error::{Error, LabelAssignSnafu, OpError, TopologyError},
         utils,
@@ -15,15 +15,21 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use openapi::apis::StatusCode;
+use openapi::{apis::StatusCode, models, models::PoolCordonDrain};
 use prettytable::{Cell, Row};
 use serde::Serialize;
 use snafu::ResultExt;
 use std::collections::HashMap;
+use strum_macros::{AsRefStr, Display, EnumString};
 
 /// Pools resource.
 #[derive(clap::Args, Debug)]
 pub struct Pools {}
+
+#[derive(AsRefStr, EnumString, Display)]
+enum PoolCordonDrainState {
+    Cordoned,
+}
 
 impl CreateRow for openapi::models::Pool {
     fn row(&self) -> Row {
@@ -49,12 +55,18 @@ impl CreateRow for openapi::models::Pool {
             0
         };
         let disks = state.disks.join(", ");
+        let statuses = match spec.cordon_drain {
+            None => format!("{:?}", state.status),
+            Some(_) => {
+                format!("{:?}, {}", state.status, PoolCordonDrainState::Cordoned)
+            }
+        };
         row![
             self.id,
             disks,
             managed,
             state.node,
-            state.status,
+            statuses,
             ::utils::bytes::into_human(state.capacity),
             ::utils::bytes::into_human(state.used),
             ::utils::bytes::into_human(free),
@@ -80,6 +92,9 @@ pub struct GetPoolArgs {
     /// Show the labels of the pool.
     #[clap(long, default_value = "false")]
     show_labels: bool,
+    /// Show the cordoned resources.
+    #[clap(long)]
+    show_cordons: bool,
 }
 
 impl GetPoolArgs {
@@ -90,6 +105,10 @@ impl GetPoolArgs {
     /// Return whether to show the labels of the pool.
     pub fn show_labels(&self) -> bool {
         self.show_labels
+    }
+    /// Return whether to show the cordoned resources of the pool.
+    pub fn show_cordons(&self) -> bool {
+        self.show_cordons
     }
 }
 
@@ -113,6 +132,10 @@ pub struct GetPoolsArgs {
     /// Show the labels of the pool.
     #[clap(long, default_value = "false")]
     show_labels: bool,
+
+    /// Show the cordoned resources.
+    #[clap(long)]
+    show_cordons: bool,
 }
 
 impl GetPoolsArgs {
@@ -134,6 +157,11 @@ impl GetPoolsArgs {
     /// Return whether to show the labels of the pool.
     pub fn show_labels(&self) -> bool {
         self.show_labels
+    }
+
+    /// Return whether to show the cordoned resources of the pool.
+    pub fn show_cordons(&self) -> bool {
+        self.show_cordons
     }
 }
 
@@ -168,7 +196,8 @@ impl ListWithArgs for Pools {
             None => true,
         });
 
-        let pools_display = PoolDisplay::new_pools(pools.clone(), args.show_labels());
+        let pools_display =
+            PoolDisplay::new_pools(pools.clone(), args.show_labels, args.show_cordons);
         match output {
             OutputFormat::Yaml | OutputFormat::Json => {
                 print_table(output, pools_display.inner);
@@ -199,7 +228,7 @@ impl GetWithArgs for Pool {
                 OutputFormat::None => {
                     print_table(
                         output,
-                        PoolDisplay::new(pool.into_body(), args.show_labels()),
+                        PoolDisplay::new(pool.into_body(), args.show_labels, args.show_cordons),
                     );
                 }
             },
@@ -343,22 +372,30 @@ pub struct PoolDisplay {
     pub inner: Vec<openapi::models::Pool>,
     #[serde(skip)]
     show_labels: bool,
+    #[serde(skip)]
+    show_cordons: bool,
 }
 
 impl PoolDisplay {
     /// Create a new `PoolDisplay` instance.
-    pub(crate) fn new(pool: openapi::models::Pool, show_labels: bool) -> Self {
+    pub(crate) fn new(pool: openapi::models::Pool, show_labels: bool, show_cordons: bool) -> Self {
         let vec: Vec<openapi::models::Pool> = vec![pool];
         Self {
             inner: vec,
             show_labels,
+            show_cordons,
         }
     }
     /// Create a new `PoolDisplay` instance from a vector of pools.
-    pub(crate) fn new_pools(pools: Vec<openapi::models::Pool>, show_labels: bool) -> Self {
+    pub(crate) fn new_pools(
+        pools: Vec<openapi::models::Pool>,
+        show_labels: bool,
+        show_cordons: bool,
+    ) -> Self {
         Self {
             inner: pools,
             show_labels,
+            show_cordons,
         }
     }
 
@@ -371,7 +408,7 @@ impl PoolDisplay {
             if let Some(ds) = &spec.labels {
                 pools_labels = ds
                     .iter()
-                    // Dont return the created_by_dsp label for the gets
+                    // Don't return the created_by_dsp label for the gets
                     .filter(|(key, _)| *key != &internal_label)
                     .map(|(key, value)| format!("{}={}", key, value))
                     .collect();
@@ -388,6 +425,9 @@ impl GetHeaderRow for PoolDisplay {
         if self.show_labels {
             header.extend(vec!["LABELS"]);
         }
+        if self.show_cordons {
+            header.extend(vec!["CORDONS"]);
+        }
         header
     }
 }
@@ -402,8 +442,180 @@ impl CreateRows for PoolDisplay {
                 // Add the pool labels to each row.
                 row.add_cell(Cell::new(&labelstring));
             }
+            if self.show_cordons {
+                row.add_cell(Cell::new(&pool_cordon_resources(pool)));
+            }
             rows.push(row);
         }
         rows
+    }
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct CordonReq {
+    /// No new replicas can be created on the pool.
+    #[clap(long)]
+    pub replicas: bool,
+    /// No new snapshots can be created on the pool.
+    #[clap(long)]
+    pub snapshots: bool,
+    /// No new restores can be created on the pool.
+    #[clap(long)]
+    pub restores: bool,
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct UncordonReq {
+    /// New replicas can be created on the pool.
+    #[clap(long)]
+    pub replicas: bool,
+    /// New snapshots can be created on the pool.
+    #[clap(long)]
+    pub snapshots: bool,
+    /// New restores can be created on the pool.
+    #[clap(long)]
+    pub restores: bool,
+}
+
+#[async_trait(?Send)]
+impl Cordoning for Pool {
+    type ID = PoolId;
+    type CREQ = Option<CordonReq>;
+    type UREQ = Option<UncordonReq>;
+
+    async fn cordon(id: &Self::ID, resources: &Self::CREQ, output: &OutputFormat) -> PluginResult {
+        let resources = resources.clone().unwrap_or(CordonReq {
+            replicas: true,
+            snapshots: false,
+            restores: true,
+        });
+        let body = models::PoolCordonReq::new_all(
+            resources.replicas,
+            resources.snapshots,
+            resources.restores,
+        );
+        match RestClient::client()
+            .pools_api()
+            .put_pool_cordon(id, body)
+            .await
+        {
+            Ok(node) => match output {
+                OutputFormat::Yaml | OutputFormat::Json => {
+                    // Print json or yaml based on output format.
+                    utils::print_table(output, node.into_body());
+                }
+                OutputFormat::None => {
+                    // In case the output format is not specified, show a success message.
+                    println!("Pool {id} cordoned successfully")
+                }
+            },
+            Err(source) => {
+                if source.error_body().map(|b| b.kind)
+                    == Some(models::rest_json_error::Kind::AlreadyExists)
+                {
+                    println!("Pool {id} already cordoned");
+                } else {
+                    return Err(Error::PoolCordonError {
+                        id: id.to_string(),
+                        source,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn uncordon(
+        id: &Self::ID,
+        resources: &Self::UREQ,
+        output: &OutputFormat,
+    ) -> PluginResult {
+        let resources = resources.clone().unwrap_or(UncordonReq {
+            replicas: true,
+            snapshots: true,
+            restores: true,
+        });
+        let body = models::PoolCordonReq::new_all(
+            resources.replicas,
+            resources.snapshots,
+            resources.restores,
+        );
+        let (failed, pool) = match RestClient::client()
+            .pools_api()
+            .del_pool_cordon(id, body)
+            .await
+        {
+            Ok(pool) => Ok((false, pool)),
+            Err(source)
+                if source.error_body().map(|b| b.kind)
+                    == Some(models::rest_json_error::Kind::AlreadyExists) =>
+            {
+                RestClient::client()
+                    .pools_api()
+                    .get_pool(id)
+                    .await
+                    .map_err(|source| Error::GetPoolError {
+                        id: id.to_string(),
+                        source,
+                    })
+                    .map(|p| (true, p))
+            }
+            Err(source) => Err(Error::PoolUncordonError {
+                id: id.to_string(),
+                source,
+            }),
+        }?;
+        match output {
+            OutputFormat::Yaml | OutputFormat::Json => {
+                // Print json or yaml based on output format.
+                utils::print_table(output, pool.into_body());
+            }
+            OutputFormat::None => {
+                // In case the output format is not specified, show a success message.
+                let resources = pool_cordon_resources(&pool.into_body());
+                if failed {
+                    if resources.is_empty() {
+                        println!("Pool {id} already uncordoned");
+                    } else {
+                        println!("Pool {id} already partially uncordoned. Remaining cordoned resources: {resources:?}");
+                    }
+                } else if resources.is_empty() {
+                    println!("Pool {id} successfully uncordoned");
+                } else {
+                    println!("Pool {id} partially uncordoned. Remaining cordoned resources: {resources:?}");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn resource(yes: bool, name: &str) -> &str {
+    if yes {
+        name
+    } else {
+        ""
+    }
+}
+fn cordon_resources(rsc: &models::PoolCordon) -> String {
+    [
+        resource(rsc.replicas, "replicas"),
+        resource(rsc.snapshots, "snapshots"),
+        resource(rsc.restores, "restores"),
+    ]
+    .into_iter()
+    .filter(|s| !s.is_empty())
+    .collect::<Vec<&str>>()
+    .join(",")
+}
+fn pool_cordon_resources(pool: &models::Pool) -> String {
+    match &pool.spec {
+        Some(spec) => match &spec.cordon_drain {
+            Some(cds) => match cds {
+                PoolCordonDrain::cordoned(rsc) => cordon_resources(rsc),
+            },
+            None => String::new(),
+        },
+        None => String::new(),
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1403,6 +1403,65 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: [ ]
+  '/pools/{pool_id}/cordon':
+    put:
+      tags:
+        - Pools
+      operationId: put_pool_cordon
+      parameters:
+        - in: path
+          name: pool_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PoolCordonReq'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pool'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
+    delete:
+      tags:
+        - Pools
+      operationId: del_pool_cordon
+      parameters:
+        - in: path
+          name: pool_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PoolCordonReq'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pool'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
   /replicas:
     get:
       tags:
@@ -3462,6 +3521,10 @@ components:
           oneOf:
             - required:
                 - secret
+        cordonDrain:
+          description: the cordon and drain state
+          allOf:
+            - $ref: '#/components/schemas/PoolCordonDrain'
       required:
         - disks
         - id
@@ -4256,8 +4319,48 @@ components:
         - allocated
         - allocated_snapshots
         - allocated_all_snapshots
+    PoolCordonDrain:
+      description: The cordon and drain for a pool
+      type: object
+      properties:
+        cordoned:
+          $ref: '#/components/schemas/PoolCordon'
+      oneOf:
+        - required:
+            - cordoned
+    PoolCordonReq:
+      description: Cordon or uncordon the following resources
+      type: object
+      properties:
+        replicas:
+          type: boolean
+        snapshots:
+          type: boolean
+        restores:
+          type: boolean
+      required:
+        - replicas
+        - snapshots
+        - restores
+    PoolCordon:
+      description: The pool is cordoned with the following resource constraints
+      type: object
+      properties:
+        replicas:
+          description: No new replicas can be created on this pool
+          type: boolean
+        snapshots:
+          description: No new snapshots can be created on this pool
+          type: boolean
+        restores:
+          description: No new restores can be created on this pool
+          type: boolean
+      required:
+        - replicas
+        - snapshots
+        - restores
     CordonDrainState:
-      description: The drain state
+      description: The cordon and drain state
       type: object
       properties:
         cordonedstate:

--- a/control-plane/rest/service/src/v0/pools.rs
+++ b/control-plane/rest/service/src/v0/pools.rs
@@ -1,5 +1,5 @@
 use super::*;
-use grpc::operations::pool::traits::PoolOperations;
+use grpc::operations::pool::traits::{PoolCordonRequest, PoolOperations};
 use rest_client::versions::v0::apis::Uuid;
 use std::collections::HashMap;
 use stor_port::{
@@ -131,6 +131,36 @@ impl apis::actix_server::Pools for RestApi {
         };
 
         let pool = client().unlabel(&unlabel_pool_request, None).await?;
+        Ok(pool.into())
+    }
+
+    async fn put_pool_cordon(
+        Path(pool_id): Path<String>,
+        Body(body): Body<models::PoolCordonReq>,
+    ) -> Result<models::Pool, RestError<RestJsonError>> {
+        let request = PoolCordonRequest {
+            node_id: None,
+            pool_id: pool_id.into(),
+            replicas: body.replicas,
+            snapshots: body.snapshots,
+            restores: body.restores,
+        };
+        let pool = client().cordon(request).await?;
+        Ok(pool.into())
+    }
+
+    async fn del_pool_cordon(
+        Path(pool_id): Path<String>,
+        Body(body): Body<models::PoolCordonReq>,
+    ) -> Result<models::Pool, RestError<RestJsonError>> {
+        let request = PoolCordonRequest {
+            node_id: None,
+            pool_id: pool_id.into(),
+            replicas: body.replicas,
+            snapshots: body.snapshots,
+            restores: body.restores,
+        };
+        let pool = client().uncordon(request).await?;
         Ok(pool.into())
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/mod.rs
+++ b/control-plane/stor-port/src/types/v0/store/mod.rs
@@ -85,7 +85,7 @@ pub trait SpecTransaction<Operation> {
         false
     }
     /// Check if an operation needs to be performed as a transaction
-    /// (ie if we need to log the opertion to the pstor before attempting to perform it)
+    /// (ie if we need to log the operation to the pstor before attempting to perform it)
     /// and if we need to update pstor on completion.
     fn log_op(&self, _operation: &Operation) -> (bool, bool) {
         (true, true)

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -38,7 +38,11 @@ impl CordonedState {
     }
     /// Remove a cordon label from a CordonedState object.
     pub fn remove_label(&mut self, label: &str) {
-        self.cordonlabels.retain(|l| l != label)
+        self.cordonlabels.retain(|l| l != label);
+    }
+    /// Remove cordon labels from a CordonedState object.
+    pub fn remove_labels(&mut self, labels: &[String]) {
+        self.cordonlabels.retain(|l| !labels.contains(l));
     }
 }
 
@@ -64,6 +68,11 @@ impl DrainState {
         self.cordonlabels.retain(|l| l != label);
         self.drainlabels.retain(|l| l != label);
     }
+    /// Remove labels from a DrainState object.
+    pub fn remove_labels(&mut self, labels: &[String]) {
+        self.cordonlabels.retain(|l| !labels.contains(l));
+        self.drainlabels.retain(|l| !labels.contains(l));
+    }
     /// Add a drain label to a DrainState object.
     pub fn add_drain_label(&mut self, label: &str) {
         self.drainlabels.push(label.to_string());
@@ -82,17 +91,23 @@ pub enum CordonDrainState {
 }
 
 impl CordonDrainState {
+    /// Add the given labels to the cordon labels.
+    pub fn add_cordon_labels(&mut self, labels: Vec<String>) {
+        for label in labels {
+            self.add_cordon_label(label)
+        }
+    }
     /// Add the given label to the cordon labels.
-    pub fn add_cordon_label(&mut self, label: &str) {
+    pub fn add_cordon_label(&mut self, label: String) {
         match self {
-            CordonDrainState::Draining(state) => state.cordonlabels.push(label.to_string()),
-            CordonDrainState::Drained(state) => state.cordonlabels.push(label.to_string()),
-            CordonDrainState::Cordoned(state) => state.cordonlabels.push(label.to_string()),
+            CordonDrainState::Draining(state) => state.cordonlabels.push(label),
+            CordonDrainState::Drained(state) => state.cordonlabels.push(label),
+            CordonDrainState::Cordoned(state) => state.cordonlabels.push(label),
         }
     }
     /// Returns a new Cordoned enum with the given cordon label.
-    pub fn cordon(label: &str) -> Self {
-        CordonDrainState::Cordoned(CordonedState::new(vec![String::from(label)]))
+    pub fn cordon(labels: Vec<String>) -> Self {
+        CordonDrainState::Cordoned(CordonedState::new(labels))
     }
 
     /// Returns whether the state has the specified cordon label.
@@ -297,11 +312,11 @@ impl NodeSpec {
     pub fn cordon(&mut self, label: String) {
         match &mut self.cordon_drain_state {
             Some(ds) => {
-                ds.add_cordon_label(&label);
+                ds.add_cordon_label(label);
             }
             None => {
                 //add the label and set the state to cordoned
-                self.cordon_drain_state = Some(CordonDrainState::cordon(&label));
+                self.cordon_drain_state = Some(CordonDrainState::cordon(vec![label]));
             }
         }
         self.resolve();

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -10,8 +10,9 @@ use crate::types::v0::{
 };
 
 // PoolLabel is the type for the labels
-pub type PoolLabel = std::collections::HashMap<String, String>;
+pub type PoolLabel = HashMap<String, String>;
 
+use crate::IntoOption;
 use pstor::ApiVersion;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::From, fmt::Debug};
@@ -54,6 +55,7 @@ impl From<&CreatePool> for PoolSpec {
             operation: None,
             creat_tsc: None,
             encryption: request.encryption.clone(),
+            cordon_drain: None,
         }
     }
 }
@@ -105,17 +107,23 @@ pub struct PoolSpec {
     /// status of the pool
     pub status: PoolSpecStatus,
     /// labels to be set on the pool
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<PoolLabel>,
     /// Update in progress
     #[serde(skip)]
     pub sequencer: OperationSequence,
     /// Record of the operation in progress
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub operation: Option<PoolOperationState>,
     /// Last modification timestamp.
     #[serde(skip)]
     pub creat_tsc: Option<std::time::SystemTime>,
     /// Use to create/import encrypted pool
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encryption: Option<Encryption>,
+    /// Cordon/drain state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cordon_drain: Option<CordonDrainState>,
 }
 
 impl PoolSpec {
@@ -172,6 +180,61 @@ impl PoolSpec {
 
         (existing_conflicts, conflict)
     }
+
+    /// Ensure the state is consistent.
+    pub fn resolve(&mut self) {
+        if let Some(ds) = &mut self.cordon_drain {
+            match ds {
+                CordonDrainState::Cordoned(state) => {
+                    if !state.cordoned() {
+                        self.cordon_drain = None;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Cordon the pool.
+    pub fn cordon(&mut self, op: PoolCordonOp) {
+        match &mut self.cordon_drain {
+            Some(ds) => {
+                ds.add_cordon(op);
+            }
+            None => {
+                self.cordon_drain = Some(CordonDrainState::Cordoned(CordonedState::from(op)));
+            }
+        }
+        self.resolve();
+    }
+
+    /// Uncordon the pool.
+    pub fn uncordon(&mut self, op: PoolCordonOp) {
+        if let Some(ds) = &mut self.cordon_drain {
+            ds.rm_cordon(op);
+        }
+        self.resolve();
+    }
+
+    /// Returns whether the node is cordoned.
+    pub fn cordoned(&self) -> bool {
+        self.cordon_drain.is_some()
+    }
+
+    /// Returns true if all labels are already present.
+    pub fn cordon_would_modify(&self, op: &PoolCordonOp) -> bool {
+        match &self.cordon_drain {
+            Some(ds) => ds.would_modify(op, true),
+            None => true,
+        }
+    }
+
+    /// Returns true if all labels are already present.
+    pub fn uncordon_would_modify(&self, op: &PoolCordonOp) -> bool {
+        match &self.cordon_drain {
+            Some(ds) => ds.would_modify(op, false),
+            None => false,
+        }
+    }
 }
 
 impl From<&PoolSpec> for ImportPool {
@@ -207,7 +270,13 @@ impl From<PoolSpec> for models::PoolSpec {
             },
         };
         Self::new_all(
-            src.disks, src.id, src.labels, src.node, src.status, encryption, None,
+            src.disks,
+            src.id,
+            src.labels,
+            src.node,
+            src.status,
+            encryption,
+            src.cordon_drain.into_opt(),
         )
     }
 }
@@ -240,6 +309,12 @@ impl SpecTransaction<PoolOperation> for PoolSpec {
                 PoolOperation::Unlabel(PoolUnLabelOp { label_key }) => {
                     self.unlabel(&label_key);
                 }
+                PoolOperation::Cordon(op) => {
+                    self.cordon(op);
+                }
+                PoolOperation::Uncordon(op) => {
+                    self.uncordon(op);
+                }
             }
         }
         self.clear_op();
@@ -269,8 +344,15 @@ impl SpecTransaction<PoolOperation> for PoolSpec {
         self.operation.as_ref().map(|o| &o.operation)
     }
 
-    fn log_op(&self, _operation: &PoolOperation) -> (bool, bool) {
-        (false, true)
+    fn log_op(&self, operation: &PoolOperation) -> (bool, bool) {
+        match operation {
+            PoolOperation::Create => (true, true),
+            PoolOperation::Destroy => (true, true),
+            PoolOperation::Label(_) => (false, true),
+            PoolOperation::Unlabel(_) => (false, true),
+            PoolOperation::Cordon(_) => (false, true),
+            PoolOperation::Uncordon(_) => (false, true),
+        }
     }
 }
 
@@ -281,6 +363,40 @@ pub enum PoolOperation {
     Destroy,
     Label(PoolLabelOp),
     Unlabel(PoolUnLabelOp),
+    Cordon(PoolCordonOp),
+    Uncordon(PoolCordonOp),
+}
+
+/// Parameter for adding/removing pool cordons.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PoolCordonOp {
+    /// No new replicas can be created on this pool
+    pub replicas: bool,
+    /// No new snapshots can be created on this pool
+    pub snapshots: bool,
+    /// No new restores can be created on this pool
+    pub restores: bool,
+}
+impl PoolCordonOp {
+    fn resource(yes: bool, name: &str) -> &str {
+        if yes {
+            name
+        } else {
+            ""
+        }
+    }
+    /// Convert cordon resources to a comma separated string.
+    pub fn resources(&self) -> String {
+        [
+            Self::resource(self.replicas, "replicas"),
+            Self::resource(self.snapshots, "snapshots"),
+            Self::resource(self.restores, "restores"),
+        ]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<&str>>()
+        .join(",")
+    }
 }
 
 /// Parameter for adding pool labels.
@@ -369,6 +485,113 @@ impl From<models::Encryption> for Encryption {
     fn from(value: models::Encryption) -> Self {
         match value {
             models::Encryption::secret(secret_name) => Self::Secret(secret_name.into()),
+        }
+    }
+}
+
+/// Data relating to the cordoning of a pool.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CordonedState {
+    // todo: or should these be negated, ie: by default all blocked?
+    /// No new replicas can be created on this pool
+    pub replicas: bool,
+    /// No new snapshots can be created on this pool
+    pub snapshots: bool,
+    /// No new restores can be created on this pool
+    pub restores: bool,
+}
+impl CordonedState {
+    fn cordoned(&self) -> bool {
+        self.replicas || self.snapshots || self.restores
+    }
+}
+
+impl From<PoolCordonOp> for CordonedState {
+    fn from(value: PoolCordonOp) -> Self {
+        Self {
+            replicas: value.replicas,
+            snapshots: value.snapshots,
+            restores: value.restores,
+        }
+    }
+}
+
+impl CordonedState {
+    fn set_if(ifset: bool, set: &mut bool, val: bool) {
+        if ifset {
+            *set = val;
+        }
+    }
+    /// Add cordon resources.
+    pub fn add_cordon(&mut self, op: PoolCordonOp) {
+        Self::set_if(op.replicas, &mut self.replicas, true);
+        Self::set_if(op.snapshots, &mut self.snapshots, true);
+        Self::set_if(op.restores, &mut self.restores, true);
+    }
+    /// Remove cordon resources.
+    pub fn rm_cordon(&mut self, op: PoolCordonOp) {
+        Self::set_if(op.replicas, &mut self.replicas, false);
+        Self::set_if(op.snapshots, &mut self.snapshots, false);
+        Self::set_if(op.restores, &mut self.restores, false);
+    }
+    fn if_modify(current: bool, op: bool, cordon: bool) -> bool {
+        if cordon {
+            !current && op
+        } else {
+            current && op
+        }
+    }
+    /// Returns whether the operation would yield changes.
+    pub fn would_modify(&self, op: &PoolCordonOp, cordon: bool) -> bool {
+        Self::if_modify(self.replicas, op.replicas, cordon)
+            || Self::if_modify(self.snapshots, op.snapshots, cordon)
+            || Self::if_modify(self.restores, op.restores, cordon)
+    }
+}
+
+/// Enum variant encompassing data related to a cordoned or draining pool.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub enum CordonDrainState {
+    /// The pool is being cordoned.
+    Cordoned(CordonedState),
+}
+
+impl CordonDrainState {
+    /// Update cordon with the given options.
+    pub fn add_cordon(&mut self, cordon: PoolCordonOp) {
+        match self {
+            CordonDrainState::Cordoned(state) => {
+                state.add_cordon(cordon);
+            }
+        }
+    }
+    /// Update cordon with the given options.
+    pub fn rm_cordon(&mut self, cordon: PoolCordonOp) {
+        match self {
+            CordonDrainState::Cordoned(state) => {
+                state.rm_cordon(cordon);
+            }
+        }
+    }
+    /// Returns whether the state has all the specified cordon labels.
+    pub fn would_modify(&self, op: &PoolCordonOp, cordon: bool) -> bool {
+        match self {
+            CordonDrainState::Cordoned(state) => state.would_modify(op, cordon),
+        }
+    }
+}
+
+impl From<CordonDrainState> for models::PoolCordonDrain {
+    fn from(node_ds: CordonDrainState) -> Self {
+        match node_ds {
+            CordonDrainState::Cordoned(state) => {
+                let cs = models::PoolCordon {
+                    replicas: state.replicas,
+                    snapshots: state.snapshots,
+                    restores: state.restores,
+                };
+                Self::cordoned(cs)
+            }
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -1,14 +1,12 @@
 //! Definition of pool types that can be saved to the persistent store.
 
-use crate::types::v0::transport::ImportPool;
 use crate::types::v0::{
-    openapi::models,
-    openapi::models::PoolSpecEncryption,
+    openapi::{models, models::PoolSpecEncryption},
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
         AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
     },
-    transport::{self, CreatePool, NodeId, PoolDeviceUri, PoolId},
+    transport::{self, CreatePool, ImportPool, NodeId, PoolDeviceUri, PoolId},
 };
 
 // PoolLabel is the type for the labels
@@ -209,7 +207,7 @@ impl From<PoolSpec> for models::PoolSpec {
             },
         };
         Self::new_all(
-            src.disks, src.id, src.labels, src.node, src.status, encryption,
+            src.disks, src.id, src.labels, src.node, src.status, encryption, None,
         )
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -215,9 +215,11 @@ impl PoolSpec {
         self.resolve();
     }
 
-    /// Returns whether the node is cordoned.
-    pub fn cordoned(&self) -> bool {
-        self.cordon_drain.is_some()
+    /// Returns whether the pool is cordoned and its state.
+    pub fn cordoned(&self) -> Option<&CordonedState> {
+        self.cordon_drain.as_ref().map(|s| match s {
+            CordonDrainState::Cordoned(cordoned) => cordoned,
+        })
     }
 
     /// Returns true if all labels are already present.
@@ -490,7 +492,7 @@ impl From<models::Encryption> for Encryption {
 }
 
 /// Data relating to the cordoning of a pool.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CordonedState {
     // todo: or should these be negated, ie: by default all blocked?
     /// No new replicas can be created on this pool

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import uuid
 from datetime import datetime
 
 import pytest
@@ -216,6 +217,13 @@ class Deployer(object):
         return f"io-engine-{id + 1}"
 
     @staticmethod
+    def pool_name(id: int = None):
+        if id is None:
+            return f"pool-{uuid.uuid4()}"
+        assert id >= 0
+        return f"pool-{id + 1}"
+
+    @staticmethod
     def csi_node_name(id: int):
         assert id >= 0
         return f"csi-node-{id + 1}"
@@ -251,8 +259,20 @@ class Deployer(object):
         return pytest.deployer_options.cache_period
 
     @staticmethod
+    def update_period():
+        cache_period = common.human_time_to_float(pytest.deployer_options.cache_period)
+        reconcile_period = common.human_time_to_float(
+            pytest.deployer_options.reconcile_period
+        )
+        max(cache_period, reconcile_period) * 2
+
+    @staticmethod
     def restart_node(node_name):
         Docker.restart_container(node_name)
+
+    @staticmethod
+    def stop_node(node_name):
+        Docker.stop_container(node_name)
 
 
 def workspace_tmp():

--- a/tests/bdd/common/operations.py
+++ b/tests/bdd/common/operations.py
@@ -13,8 +13,11 @@ from common.docker import Docker
 from common.fio import Fio
 from openapi.exceptions import NotFoundException
 from openapi.model.node_status import NodeStatus
+from openapi.model.pool_status import PoolStatus
+from openapi.model.volume_status import VolumeStatus
 from openapi.model.publish_volume_body import PublishVolumeBody
 from openapi.model.volume_share_protocol import VolumeShareProtocol
+from openapi.model.pool_cordon import PoolCordon
 
 
 class Pool(object):
@@ -35,6 +38,48 @@ class Pool(object):
                 all_deleted = False
                 pass
         return all_deleted
+
+    @staticmethod
+    def delete(pool):
+        try:
+            if hasattr(pool, "id"):
+                Pool.__pools_api().del_pool(pool.id)
+            else:
+                Pool.__pools_api().del_pool(pool)
+        except NotFoundException:
+            pass
+
+    @staticmethod
+    def cleanup(pool):
+        if Cluster.fixture_cleanup():
+            try:
+                Pool.delete(pool)
+            except openapi.exceptions.ApiException:
+                pass
+
+    @staticmethod
+    def label_parts(label):
+        try:
+            key, value = label.split("=")
+            return key, value
+        except ValueError:
+            return label, ""
+
+    @staticmethod
+    def cordon(pool, replicas=True, snapshots=False, restores=True):
+        rsc = PoolCordon(replicas, snapshots, restores)
+        return Pool.__pools_api().put_pool_cordon(pool.id, pool_cordon_req=rsc)
+
+    @staticmethod
+    def uncordon(pool, replicas=True, snapshots=True, restores=True):
+        rsc = PoolCordon(replicas, snapshots, restores)
+        return Pool.__pools_api().del_pool_cordon(pool.id, pool_cordon_req=rsc)
+
+    @staticmethod
+    def update(pool, cached=True):
+        if not cached:
+            Cluster.wait_cache_update()
+        return Pool.__pools_api().get_pool(pool.id)
 
 
 class Volume(object):
@@ -166,6 +211,11 @@ class Cluster(object):
         time.sleep(cache + slack)
 
     @staticmethod
+    def wait_update(slack=0.1):
+        cache = common.human_time_to_float(Deployer.update_period())
+        time.sleep(cache + slack)
+
+    @staticmethod
     def restart_node(node_name):
         Deployer.restart_node(node_name)
 
@@ -175,9 +225,32 @@ def wait_node_online(node_id):
     assert ApiClient.nodes_api().get_node(node_id).state.status == NodeStatus("Online")
 
 
+@retry(wait_fixed=10, stop_max_attempt_number=200)
+def wait_node_status(node_id, expected):
+    status = ApiClient.nodes_api().get_node(node_id).state.status
+    if isinstance(expected, list):
+        assert status in expected
+    else:
+        assert status == expected
+
+
+@retry(wait_fixed=10, stop_max_attempt_number=200)
+def wait_pool_online(pool):
+    assert ApiClient.pools_api().get_pool(pool.id).state.status == PoolStatus("Online")
+
+
 @retry(wait_fixed=10, stop_max_attempt_number=100)
 def wait_core_online():
     assert ApiClient.specs_api().get_specs()
+
+
+@retry(wait_fixed=10, stop_max_attempt_number=200)
+def wait_volume_status(volume, status):
+    if isinstance(status, str):
+        status = VolumeStatus(status)
+    volume = ApiClient.volumes_api().get_volume(volume.spec.uuid)
+    assert volume.state.status == status
+    return volume
 
 
 @retry(wait_fixed=100, stop_max_attempt_number=100)

--- a/tests/bdd/features/pool/cordon/feature.feature
+++ b/tests/bdd/features/pool/cordon/feature.feature
@@ -1,0 +1,78 @@
+Feature: Pool Cordoning
+
+  Background:
+    Given multiple uncordoned nodes
+
+  Scenario: Cordoning a pool
+    Given an uncordoned pool
+    When we issue a cordon command
+    Then the command will succeed
+    And new resources cannot be scheduled on the cordoned pool
+
+  Scenario Outline: Cordoning a pool with resources
+    Given an uncordoned pool with test resources
+    When we issue a cordon command with resource <resource>
+    Then the command will succeed
+    And new <resource> resources cannot be scheduled on the cordoned pool
+    But other resources can
+    Examples:
+      | resource  |
+      | replicas  |
+      | snapshots |
+      | restores  |
+
+  Scenario: Cordoning a cordoned pool
+    Given a cordoned pool
+    When we issue a cordon command with additional constraints
+    Then the command will succeed
+    And the pool should remain cordoned
+    And new resources cannot be scheduled on the cordoned pool
+
+  Scenario: Uncordoning a pool
+    Given a cordoned pool
+    When we issue an uncordon command with the cordoned resources
+    Then the command will succeed
+    And new resources can be scheduled on the cordoned pool
+
+  Scenario: Deleting resources on a cordoned pool
+    Given a cordoned pool with resources
+    When we attempt to delete resources on the cordoned pool
+    Then the resources should be deleted
+
+  Scenario: Restarting a cordoned pool
+    Given a cordoned pool with resources
+    When the cordoned pool is restarted
+    Then the pool should be imported successfully
+    And all pool resources should be Online
+
+  Scenario: No replica rebuild due to pool cordon
+    Given a published volume with multiple replicas
+    And a cordoned pool, otherwise schedulable for the volume
+    When the volume becomes degraded
+    And there are insufficient uncordoned pools to accommodate new replicas
+    Then the volume will remain in a degraded state
+    When the pool is uncordoned
+    Then the volume shall eventually rebuild become healthy
+
+  Scenario: No replica count increase due to pool cordon
+    Given a published volume with multiple replicas
+    And a cordoned pool, otherwise schedulable for the volume
+    When we attempt to increase the replica count
+    And there are insufficient uncordoned pools to accommodate new replicas
+    Then the request should fail with insufficient storage
+    When the pool is uncordoned
+    And we attempt to increase the replica count
+    Then a new set-replica request should succeed
+
+  Scenario: Pool should be cordoned if there is at least one cordon applied
+    Given a cordoned pool with multiple cordon resources
+    When we issue an uncordon command without all resources
+    Then the command will succeed
+    And the pool should remain cordoned
+
+  Scenario: Pool should be uncordoned when all cordons have been removed
+    Given a cordoned pool with multiple cordon resources
+    When we issue an uncordon command with all resources
+    Then the command will succeed
+    And the pool should be uncordoned
+

--- a/tests/bdd/features/pool/cordon/test_feature.py
+++ b/tests/bdd/features/pool/cordon/test_feature.py
@@ -1,0 +1,535 @@
+"""Pool Cordoning feature tests."""
+
+from pytest_bdd import given, scenario, then, when, parsers
+
+import pytest
+import uuid
+import http
+import openapi.exceptions
+from common.apiclient import ApiClient
+from common.operations import wait_pool_online, wait_volume_status, wait_node_status
+from common.operations import Cluster
+from common.deployer import Deployer
+from openapi.model.topology import Topology
+from openapi.model.pool_topology import PoolTopology
+from openapi.model.labelled_topology import LabelledTopology
+from common.operations import Pool as PoolOps
+from common.operations import Volume as VolumeOps
+from common.operations import Snapshot as SnapshotOps
+from openapi.model.create_pool_body import CreatePoolBody
+from openapi.model.create_volume_body import CreateVolumeBody
+from openapi.model.node_status import NodeStatus
+from openapi.model.volume_status import VolumeStatus
+from openapi.model.volume_policy import VolumePolicy
+from openapi.model.publish_volume_body import PublishVolumeBody
+from openapi.model.volume_share_protocol import VolumeShareProtocol
+from openapi.model.pool_status import PoolStatus
+from openapi.model.volume import Volume
+
+
+VOLUME_SIZE = 10 * 1024 * 1024
+
+
+@pytest.fixture(scope="module")
+def init():
+    Deployer.start(
+        3, cache_period="50ms", reconcile_period="80ms", faulted_child_wait_period="0ms"
+    )
+    yield
+    Deployer.stop()
+
+
+@pytest.fixture
+def disks(init):
+    yield Deployer.create_disks(3, size=100 * 1024 * 1024)
+    Cluster.cleanup()
+    Deployer.cleanup_disks(3)
+
+
+@scenario("feature.feature", "Cordoning a cordoned pool")
+def test_cordoning_a_cordoned_pool():
+    """Cordoning a cordoned pool."""
+
+
+@scenario("feature.feature", "Cordoning a pool with resources")
+def test_cordoning_a_pool_with_resources():
+    """Cordoning a pool with resources."""
+
+
+@scenario("feature.feature", "Cordoning a pool")
+def test_cordoning_a_pool():
+    """Cordoning a pool."""
+
+
+@scenario("feature.feature", "Deleting resources on a cordoned pool")
+def test_deleting_resources_on_a_cordoned_pool():
+    """Deleting resources on a cordoned pool."""
+
+
+@scenario(
+    "feature.feature", "Pool should be cordoned if there is at least one cordon applied"
+)
+def test_pool_should_be_cordoned_if_there_is_at_least_one_cordon_applied():
+    """Pool should be cordoned if there is at least one cordon applied."""
+
+
+@scenario(
+    "feature.feature", "Pool should be uncordoned when all cordons have been removed"
+)
+def test_pool_should_be_uncordoned_when_all_cordons_have_been_removed():
+    """Pool should be uncordoned when all cordons have been removed."""
+
+
+@scenario("feature.feature", "Restarting a cordoned pool")
+def test_restarting_a_cordoned_pool():
+    """Restarting a cordoned pool."""
+
+
+@scenario("feature.feature", "Uncordoning a pool")
+def test_uncordoning_a_pool():
+    """Uncordoning a pool."""
+
+
+@scenario("feature.feature", "No replica rebuild due to pool cordon")
+def test_no_replica_rebuild_due_to_pool_cordon():
+    """No replica rebuild due to pool cordon."""
+
+
+@scenario("feature.feature", "No replica count increase due to pool cordon")
+def test_no_replica_count_increase_due_to_pool_cordon():
+    """No replica count increase due to pool cordon."""
+
+
+@given("a cordoned pool", target_fixture="pool")
+def _(disks):
+    """a cordoned pool."""
+    pool = ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(0), Deployer.pool_name(), CreatePoolBody([f"{disks[0]}"])
+    )
+    pool = PoolOps.cordon(pool)
+    yield pool
+    PoolOps.cleanup(pool)
+
+
+@given("a cordoned pool with multiple cordon resources", target_fixture="pool")
+def _(disks):
+    """a cordoned pool with multiple cordon resources."""
+    pool = ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(0), Deployer.pool_name(), CreatePoolBody([f"{disks[0]}"])
+    )
+    pool = PoolOps.cordon(pool)
+    yield pool
+    PoolOps.cleanup(pool)
+
+
+@given("a cordoned pool with resources", target_fixture="pool_resources")
+def _(disks):
+    """a cordoned pool with resources."""
+    pool = ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(0), Deployer.pool_name(), CreatePoolBody([f"{disks[0]}"])
+    )
+    # create volumes
+    volume_1 = ApiClient.volumes_api().put_volume(
+        str(uuid.uuid4()),
+        CreateVolumeBody(VolumePolicy(True), 1, VOLUME_SIZE, True, False),
+    )
+    volume_2 = ApiClient.volumes_api().put_volume(
+        str(uuid.uuid4()),
+        CreateVolumeBody(VolumePolicy(True), 1, VOLUME_SIZE, True, False),
+    )
+    # then cordon
+    pool = PoolOps.cordon(pool)
+    yield {
+        "pool": pool,
+        "volumes": [volume_1, volume_2],
+    }
+    VolumeOps.cleanup(volume_1)
+    VolumeOps.cleanup(volume_2)
+    PoolOps.cleanup(pool)
+
+
+@pytest.fixture
+def pool(pool_resources):
+    return pool_resources["pool"]
+
+
+@given("a published volume with multiple replicas", target_fixture="volume")
+def _(disks):
+    """a published volume with multiple replicas."""
+    pool_1 = ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(0), Deployer.pool_name(), CreatePoolBody([f"{disks[0]}"])
+    )
+    pool_2 = ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(1), Deployer.pool_name(), CreatePoolBody([f"{disks[1]}"])
+    )
+    volume = ApiClient.volumes_api().put_volume(
+        str(uuid.uuid4()),
+        CreateVolumeBody(VolumePolicy(True), 2, VOLUME_SIZE, True, False),
+    )
+    volume = ApiClient.volumes_api().put_volume_target(
+        volume.spec.uuid,
+        publish_volume_body=PublishVolumeBody(
+            {}, VolumeShareProtocol("nvmf"), node=Deployer.node_name(0)
+        ),
+    )
+    yield volume
+    VolumeOps.cleanup(volume)
+    PoolOps.cleanup(pool_1)
+    PoolOps.cleanup(pool_2)
+
+
+@given("a cordoned pool, otherwise schedulable for the volume", target_fixture="pool")
+def _(disks):
+    """a cordoned pool, otherwise schedulable for the volume."""
+    pool = ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(2), Deployer.pool_name(), CreatePoolBody([f"{disks[2]}"])
+    )
+    pool = PoolOps.cordon(pool)
+    yield pool
+    PoolOps.cleanup(pool)
+
+
+@given("an uncordoned pool", target_fixture="pool")
+def _(disks):
+    """an uncordoned pool."""
+    pool = ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(0), Deployer.pool_name(), CreatePoolBody([f"{disks[0]}"])
+    )
+    yield pool
+    PoolOps.cleanup(pool)
+
+
+@given("an uncordoned pool with test resources", target_fixture="pool")
+def _(disks):
+    """an uncordoned pool with test resources."""
+    pool = ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(0), Deployer.pool_name(), CreatePoolBody([f"{disks[0]}"])
+    )
+    # Create test requirements, ie snapshots need volume present
+    volume = schedule_repl(pool, False, False)
+    snapshot = ApiClient.snapshots_api().put_volume_snapshot(
+        volume.spec.uuid, str(uuid.uuid4())
+    )
+    pool.volume = volume.spec.uuid
+    pool.snapshot = snapshot.definition.spec.uuid
+    yield pool
+    PoolOps.cleanup(pool)
+
+
+@given("multiple uncordoned nodes")
+def _(disks):
+    """multiple uncordoned nodes."""
+    pass
+
+
+@when("the pool is uncordoned")
+def _(pool):
+    """the pool is uncordoned."""
+    PoolOps.uncordon(pool)
+
+
+@when("the cordoned pool is restarted")
+def _(pool):
+    """the cordoned pool is restarted."""
+    node = pool.spec.node
+    Deployer.stop_node(node)
+    wait_node_status(node, [NodeStatus("Offline"), NodeStatus("Unknown")])
+    Deployer.restart_node(node)
+
+
+@when("the volume becomes degraded")
+def _(volume):
+    """the volume becomes degraded."""
+    Deployer.stop_node(Deployer.node_name(1))
+    wait_volume_status(volume, VolumeStatus("Degraded"))
+    yield
+    Deployer.restart_node(Deployer.node_name(1))
+    wait_node_status(Deployer.node_name(1), NodeStatus("Online"))
+
+
+@when("there are insufficient uncordoned pools to accommodate new replicas")
+def _():
+    """there are insufficient uncordoned pools to accommodate new replicas."""
+    pass
+
+
+@when("we attempt to delete resources on the cordoned pool")
+def _(pool_resources):
+    """we attempt to delete resources on the cordoned pool."""
+    for volume in pool_resources["volumes"]:
+        ApiClient.volumes_api().del_volume(volume.spec.uuid)
+
+
+@when("we issue a cordon command")
+def _(pool):
+    """we issue a cordon command."""
+    PoolOps.cordon(pool)
+
+
+@when("we issue a cordon command with additional constraints")
+def _(pool):
+    """we issue a cordon command with additional constraints."""
+    PoolOps.cordon(pool, True, True, True)
+
+
+@when("we issue an uncordon command with all resources")
+def _(pool):
+    """we issue an uncordon command with all resources."""
+    remove_all_cordons(pool)
+
+
+@when("we issue an uncordon command with the cordoned resources")
+def _(pool):
+    """we issue an uncordon command with the cordoned resources."""
+    remove_all_cordons(pool)
+
+
+@when("we issue an uncordon command without all resources")
+def _(pool):
+    """we issue an uncordon command without all resources."""
+    resources = cordon_resources(pool)
+    assert resources is not None
+    assert resources["replicas"] == True
+    assert resources["snapshots"] == False
+    assert resources["restores"] == True
+    PoolOps.uncordon(pool, True, False, False)
+
+
+@when("we attempt to increase the replica count", target_fixture="set_repl_request")
+@then("we attempt to increase the replica count", target_fixture="set_repl_request")
+def _(volume):
+    """we attempt to increase the replica count."""
+
+    def set_repl(volume):
+        try:
+            response = ApiClient.volumes_api().put_volume_replica_count(
+                volume.spec.uuid, volume.spec.num_replicas + 1
+            )
+        except openapi.exceptions.ApiException as e:
+            response = e
+            pass
+        return response
+
+    yield set_repl
+    VolumeOps.cleanup(volume)
+
+
+@when(
+    parsers.parse("we issue a cordon command with resource {resource}"),
+    target_fixture="resources",
+)
+def _(pool, resource):
+    """we issue a cordon command with resource <resource>."""
+    assert resource in ["replicas", "snapshots", "restores"]
+    cordon = {
+        "replicas": resource == "replicas",
+        "snapshots": resource == "snapshots",
+        "restores": resource == "restores",
+    }
+    PoolOps.cordon(pool, cordon["replicas"], cordon["snapshots"], cordon["restores"])
+    yield cordon
+
+
+@then(
+    parsers.parse("new {resource} resources cannot be scheduled on the cordoned pool")
+)
+def _(pool, resource, resources):
+    """new <resource> resources cannot be scheduled on the cordoned pool."""
+    pool_rsc = cordon_resources(PoolOps.update(pool))
+    assert pool_rsc, f"{pool.id} is not cordoned!"
+    assert pool_rsc["replicas"] == resources["replicas"]
+    assert pool_rsc["snapshots"] == resources["snapshots"]
+    assert pool_rsc["restores"] == resources["restores"]
+    assert pool_rsc[resource] == True
+
+    if resource == "replicas":
+        schedule_repl(pool, True)
+    elif resource == "snapshots":
+        schedule_snap(pool, True)
+    elif resource == "restores":
+        schedule_restore(pool, True)
+
+
+@then("other resources can")
+def _(pool, resources):
+    """other resources can."""
+    if not resources["replicas"]:
+        schedule_repl(pool, False)
+    if not resources["snapshots"]:
+        schedule_snap(pool, False)
+    if not resources["restores"]:
+        schedule_restore(pool, False)
+
+
+@then("a new set-replica request should succeed")
+def _(volume, set_repl_request):
+    """a new set-replica request should succeed."""
+    response = set_repl_request(volume)
+    assert isinstance(response, Volume)
+    assert response.spec.num_replicas, volume.spec.num_replicas + 1
+
+
+@then("the request should fail with insufficient storage")
+def _(volume, set_repl_request):
+    """the request should fail with insufficient storage."""
+    response = set_repl_request(volume)
+    assert isinstance(response, openapi.exceptions.ApiException)
+    assert response.status == http.HTTPStatus.INSUFFICIENT_STORAGE
+    assert ApiClient.exception_to_error(response).kind == "ResourceExhausted"
+
+
+@then("all pool resources should be Online")
+def _(pool):
+    """all pool resources should be Online."""
+    pool = PoolOps.update(pool, False)
+    assert pool.state is not None
+    assert pool.state.status == PoolStatus("Online")
+
+
+@then("new resources can be scheduled on the cordoned pool")
+def _(pool):
+    """new resources can be scheduled on the cordoned pool."""
+    schedule_repl(pool, False)
+
+
+@then("new resources cannot be scheduled on the cordoned pool")
+def _(pool):
+    """new resources cannot be scheduled on the cordoned pool."""
+    schedule_repl(pool, True)
+
+
+@then("the command will succeed")
+def _():
+    """the command will succeed."""
+    pass
+
+
+@then("the pool should be imported successfully")
+def _(pool):
+    """the pool should be imported successfully."""
+    wait_pool_online(pool)
+
+
+@then("the pool should be uncordoned")
+def _(pool):
+    """the pool should be uncordoned."""
+    pool = PoolOps.update(pool)
+    assert not is_cordoned(pool)
+
+
+@then("the pool should remain cordoned")
+def _(pool):
+    """the pool should remain cordoned."""
+    pool = PoolOps.update(pool)
+    assert is_cordoned(pool)
+
+
+@then("the resources should be deleted")
+def _(pool_resources):
+    """the resources should be deleted."""
+    pool = PoolOps.update(pool_resources["pool"])
+    assert pool.state.used == 0
+
+
+@then("the volume shall eventually rebuild become healthy")
+def _(volume):
+    """the volume shall eventually rebuild become healthy."""
+    wait_volume_status(volume, VolumeStatus("Online"))
+
+
+@then("the volume will remain in a degraded state")
+def _(volume):
+    """the volume will remain in a degraded state."""
+    Cluster.wait_cache_update(0.1)
+    volume = VolumeOps.update(volume)
+    assert volume.state.status == VolumeStatus("Degraded")
+
+
+def is_cordoned(pool):
+    pool = ApiClient.pools_api().get_pool(pool.id)
+    return cordon_resources(pool) is not None
+
+
+def cordon_resources(pool):
+    cordon = pool.spec.get("cordon_drain")
+    if cordon is None:
+        return None
+    # cast to a dic to get around openapi bug with AllOf
+    cordoned = cordon.__dict__["_data_store"]["cordoned"]
+    if cordoned is None:
+        return None
+    return cordoned
+
+
+def remove_all_cordons(pool):
+    if is_cordoned(pool):
+        PoolOps.uncordon(pool)
+
+
+def schedule_repl(pool, cordoned, cleanup=True):
+    try:
+        key = "openebs.io/name"
+        ApiClient.pools_api().put_pool_label(pool.id, "openebs.io/name", pool.id)
+        volume = ApiClient.volumes_api().put_volume(
+            str(uuid.uuid4()),
+            CreateVolumeBody(
+                VolumePolicy(True),
+                1,
+                VOLUME_SIZE,
+                True,
+                False,
+                topology=Topology(
+                    pool_topology=PoolTopology(
+                        labelled=LabelledTopology(
+                            exclusion={},
+                            inclusion={key: pool.id},
+                        )
+                    )
+                ),
+            ),
+        )
+        if cleanup:
+            VolumeOps.cleanup(volume)
+        assert not cordoned
+        return volume
+
+    except openapi.exceptions.ApiException as exception:
+        assert cordoned
+        assert exception.status == http.HTTPStatus.INSUFFICIENT_STORAGE
+        assert ApiClient.exception_to_error(exception).kind == "ResourceExhausted"
+        return None
+
+
+def schedule_snap(pool, cordoned):
+    try:
+        snapshot = ApiClient.snapshots_api().put_volume_snapshot(
+            pool.volume, str(uuid.uuid4())
+        )
+        SnapshotOps.cleanup(snapshot)
+        assert not cordoned
+
+    except openapi.exceptions.ApiException as exception:
+        assert cordoned
+        assert exception.status == http.HTTPStatus.INSUFFICIENT_STORAGE
+        assert ApiClient.exception_to_error(exception).kind == "ResourceExhausted"
+
+
+def schedule_restore(pool, cordoned):
+    try:
+        body = CreateVolumeBody(
+            VolumePolicy(True),
+            replicas=1,
+            size=VOLUME_SIZE,
+            thin=True,
+            encrypted=False,
+        )
+        volume = ApiClient.volumes_api().put_snapshot_volume(
+            pool.snapshot, str(uuid.uuid4()), body
+        )
+        VolumeOps.cleanup(volume)
+        assert not cordoned
+
+    except openapi.exceptions.ApiException as exception:
+        assert cordoned
+        assert exception.status == http.HTTPStatus.PRECONDITION_FAILED
+        assert ApiClient.exception_to_error(exception).kind == "FailedPrecondition"


### PR DESCRIPTION
    test(pool/cordon): add bdd specs and test code

---

    feat(pool/cordon): add rest-plugin cordon/uncordon
    
---

    feat(pool/cordon): add controller implementation
    
    It's implemented similar to the nodes, which means we get a lot of duplicate
    code that behaves the same as the nodes, because it was implemented directly
    in the node rather than in some other type which knows about cordon.
    
    todo: try to lift this out into some generic way
    
---

    feat(pool/cordon): add openapi spec and impl
    
---

    feat(pool/cordon): pool cordon grpc transport
    
    Adds proto specification for pool cordon and uncordon.
    Adds implementation of traits, client and server.
