### PR TITLE
feat: handle data integrity in republish path

### DIFF
--- a/control-plane/agents/src/bin/core/controller/pstor_cache.rs
+++ b/control-plane/agents/src/bin/core/controller/pstor_cache.rs
@@ -36,19 +36,30 @@ impl pstor::StoreObj for PStorCache {
         unimplemented!()
     }
 
-    async fn get_obj<O: StorableObject>(&mut self, key: &O::Key) -> Result<O, Error> {
+    async fn get_obj<O: StorableObject>(&mut self, key: &O::Key) -> Result<(O, i64), Error> {
         let key = key.key();
         match self.entries.get(&key) {
             Some(kv) => Ok(
-                serde_json::from_value(kv.clone()).context(DeserialiseValue {
-                    value: kv.to_string(),
-                })?,
+                (
+                    serde_json::from_value(kv.clone()).context(DeserialiseValue {
+                        value: kv.to_string(),
+                    })?,
+                    i64::MIN,
+                ), // todo: If required later - store mod_rev in pstor_cache.
             ),
             None => Err(Error::MissingEntry { key }),
         }
     }
 
     async fn watch_obj<K: ObjectKey>(&mut self, _key: &K) -> Result<StoreWatchReceiver, Error> {
+        unimplemented!()
+    }
+
+    async fn put_obj_cas<O: StorableObject>(
+        &mut self,
+        _object: &O,
+        _expected_mod_rev: i64,
+    ) -> Result<(), Error> {
         unimplemented!()
     }
 }

--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/garbage_collector.rs
@@ -423,7 +423,12 @@ async fn is_replica_healthy(
         None => {
             *nexus_info = context
                 .registry()
-                .nexus_info(Some(&volume_spec.uuid), volume_spec.health_info_id(), true)
+                .nexus_info(
+                    Some(&volume_spec.uuid),
+                    volume_spec.health_info_id(),
+                    true,
+                    None,
+                )
                 .await?;
             match nexus_info {
                 Some(info) => info,

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -269,7 +269,7 @@ impl Registry {
     ) -> Result<CoreRegistryConfig, StoreError> {
         let config = CoreRegistryConfig::new(NodeRegistration::Automatic);
         let mut config = match store.get_obj(&config.key()).await {
-            Ok(config) => config,
+            Ok((config, _mod_rev)) => config,
             Err(StoreError::MissingEntry { .. }) => {
                 store.put_obj(&config).await?;
                 config
@@ -383,8 +383,36 @@ impl Registry {
         }
     }
 
+    /// Serialized write to the persistent store. Compare and Swap with expected value.
+    pub(crate) async fn store_obj_cas<O: StorableObject>(
+        &self,
+        object: &O,
+        expected_mod_rev: i64,
+    ) -> Result<(), SvcError> {
+        let store = self.store.clone();
+        match tokio::time::timeout(self.store_timeout, async move {
+            let mut store = store.lock().await;
+            Self::op_with_threshold(
+                async move { store.put_obj_cas(object, expected_mod_rev).await },
+            )
+            .await
+        })
+        .await
+        {
+            Ok(result) => result.map_err(Into::into),
+            Err(_) => Err(StoreError::Timeout {
+                operation: "Put_CAS".to_string(),
+                timeout: self.store_timeout,
+            }
+            .into()),
+        }
+    }
+
     /// Serialized read from the persistent store.
-    pub(crate) async fn load_obj<O: StorableObject>(&self, key: &O::Key) -> Result<O, SvcError> {
+    pub(crate) async fn load_obj<O: StorableObject>(
+        &self,
+        key: &O::Key,
+    ) -> Result<(O, i64), SvcError> {
         let store = self.store.clone();
         match tokio::time::timeout(self.store_timeout, async move {
             let mut store = store.lock().await;
@@ -539,9 +567,9 @@ impl Registry {
             let Ok(mut info) = pstor_cache.get_obj::<NexusInfo>(&nexus_info_key).await else {
                 continue;
             };
-            info.uuid = nexus_info_key.nexus_id().clone();
-            info.volume_uuid = Some(volume.uuid().clone());
-            health.if_empty_insert(info);
+            info.0.uuid = nexus_info_key.nexus_id().clone();
+            info.0.volume_uuid = Some(volume.uuid().clone());
+            health.if_empty_insert(info.0);
         }
         Ok(())
     }

--- a/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/nexus.rs
@@ -114,7 +114,7 @@ impl GetPersistedNexusChildrenCtx {
         request: &GetPersistedNexusChildren,
     ) -> Result<Self, SvcError> {
         let nexus_info = registry
-            .nexus_info(request.volume_id(), request.nexus_info_id(), false)
+            .nexus_info(request.volume_id(), request.nexus_info_id(), false, None)
             .await?;
         let shutdown_pending_nexuses = match request.volume_id() {
             None => Vec::new(),

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
@@ -277,6 +277,7 @@ impl GetChildForRemovalContext {
                 Some(&request.spec.uuid),
                 request.spec.health_info_id(),
                 true,
+                None,
             )
             .await?;
 
@@ -519,7 +520,7 @@ impl VolumeReplicasForNexusCtx {
         nx_spec: &NexusSpec,
     ) -> Result<Self, SvcError> {
         let nexus_info = registry
-            .nexus_info(Some(&vol_spec.uuid), Some(&nx_spec.uuid), true)
+            .nexus_info(Some(&vol_spec.uuid), Some(&nx_spec.uuid), true, None)
             .await?;
 
         let shutdown_pending_nexuses = registry

--- a/control-plane/agents/src/bin/core/nexus/registry.rs
+++ b/control-plane/agents/src/bin/core/nexus/registry.rs
@@ -73,6 +73,7 @@ impl Registry {
         volume_uuid: Option<&VolumeId>,
         nexus_uuid: Option<&NexusId>,
         missing_key_is_error: bool,
+        get_mod_revision: Option<&mut i64>,
     ) -> Result<Option<NexusInfo>, SvcError> {
         match nexus_uuid {
             None => Ok(None),
@@ -100,8 +101,11 @@ impl Registry {
                 };
 
                 match result {
-                    Ok(mut info) => {
+                    Ok((mut info, mod_rev)) => {
                         info.uuid = nexus_uuid.clone();
+                        if let Some(mrev) = get_mod_revision {
+                            *mrev = mod_rev;
+                        }
                         Ok(Some(info))
                     }
                     Err(SvcError::StoreMissingEntry { .. }) if !missing_key_is_error => Ok(None),

--- a/control-plane/agents/src/bin/core/tests/controller/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/controller/mod.rs
@@ -105,7 +105,7 @@ async fn store_lease_lock() {
 
     let mut etcd = Etcd::new("0.0.0.0:2379").await.unwrap();
     let svc = ControlPlaneService::CoreAgent;
-    let obj: StoreLeaseOwner = etcd
+    let (obj, _mod_rev): (StoreLeaseOwner, i64) = etcd
         .get_obj(&StoreLeaseOwnerKey::new(&svc))
         .await
         .expect("Should exist!");
@@ -149,7 +149,7 @@ async fn core_agent_lease_lock() {
 
     let mut etcd = Etcd::new("0.0.0.0:2379").await.unwrap();
     let svc = ControlPlaneService::CoreAgent;
-    let obj: StoreLeaseOwner = etcd
+    let (obj, _mod_rev): (StoreLeaseOwner, i64) = etcd
         .get_obj(&StoreLeaseOwnerKey::new(&svc))
         .await
         .expect("Should exist!");

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -208,9 +208,10 @@ fn test_deserialization_v1_to_v2() {
             )),
         },
         TestEntry {
-            json_str: r#"{"children":[{"healthy":true,"uuid":"82779efa-a0c7-4652-a37b-83eefd894714"},{"healthy":true,"uuid":"2d98fa96-ac12-40be-acdc-e3559c0b1530"},{"healthy":true,"uuid":"620ff519-419a-48d6-97a8-c1ba3260d87e"}],"clean_shutdown":false}"#,
+            json_str: r#"{"children":[{"healthy":true,"uuid":"82779efa-a0c7-4652-a37b-83eefd894714"},{"healthy":true,"uuid":"2d98fa96-ac12-40be-acdc-e3559c0b1530"},{"healthy":true,"uuid":"620ff519-419a-48d6-97a8-c1ba3260d87e"}],"clean_shutdown":false, "do_self_shutdown":false}"#,
             expected: Expected::NexusInfo(NexusInfo {
                 clean_shutdown: false,
+                do_self_shutdown: false,
                 children: vec![
                     ChildInfo {
                         uuid: ReplicaId::try_from("82779efa-a0c7-4652-a37b-83eefd894714").unwrap(),

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -971,7 +971,7 @@ async fn test_disown_missing_replica_owners() {
     // Modify the replica spec in the store so that the replica has a volume and nexus owner;
     // neither of which exist.
     let mut etcd = Etcd::new("0.0.0.0:2379").await.unwrap();
-    let mut replica: ReplicaSpec = etcd
+    let (mut replica, _mod_rev): (ReplicaSpec, i64) = etcd
         .get_obj(&ReplicaSpecKey::from(&replica_id))
         .await
         .unwrap();

--- a/control-plane/agents/src/bin/core/tests/volume/hotspare.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/hotspare.rs
@@ -301,7 +301,8 @@ async fn hotspare_replica_count_spread(cluster: &Cluster) {
         .await
         .expect("Failed to connect to etcd.");
 
-    let mut volume_spec: VolumeSpec = store.get_obj(&volume.spec().key()).await.unwrap();
+    let (mut volume_spec, _mod_rev): (VolumeSpec, i64) =
+        store.get_obj(&volume.spec().key()).await.unwrap();
     volume_spec.num_replicas = replica_count as u8;
     tracing::info!("VolumeSpec: {:?}", volume_spec);
     store.put_obj(&volume_spec).await.unwrap();
@@ -468,7 +469,8 @@ async fn hotspare_nexus_replica_count(cluster: &Cluster) {
         .await
         .expect("Failed to connect to etcd.");
 
-    let mut volume_spec: VolumeSpec = store.get_obj(&volume.spec().key()).await.unwrap();
+    let (mut volume_spec, _mod_rev): (VolumeSpec, i64) =
+        store.get_obj(&volume.spec().key()).await.unwrap();
     volume_spec.num_replicas += 1;
     tracing::info!("VolumeSpec: {:?}", volume_spec);
     store.put_obj(&volume_spec).await.unwrap();
@@ -489,7 +491,8 @@ async fn hotspare_nexus_replica_count(cluster: &Cluster) {
     )
     .await;
 
-    let mut volume_spec: VolumeSpec = store.get_obj(&volume.spec().key()).await.unwrap();
+    let (mut volume_spec, _mod_rev): (VolumeSpec, i64) =
+        store.get_obj(&volume.spec().key()).await.unwrap();
     volume_spec.num_replicas -= 1;
     tracing::info!("VolumeSpec: {:?}", volume_spec);
     store.put_obj(&volume_spec).await.unwrap();

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -153,7 +153,7 @@ async fn nexus_persistence_test_iteration(
     let mut store = Etcd::new("0.0.0.0:2379")
         .await
         .expect("Failed to connect to etcd.");
-    let mut nexus_info: NexusInfo = store
+    let (mut nexus_info, _mod_rev): (NexusInfo, i64) = store
         .get_obj(&NexusInfoKey::new(&Some(volume_uuid.clone()), &nexus_uuid))
         .await
         .unwrap();
@@ -196,7 +196,7 @@ async fn nexus_persistence_test_iteration(
         }
     }
     store.put_obj(&nexus_info).await.unwrap();
-    nexus_info = store
+    let (mut nexus_info, _mod_rev): (NexusInfo, i64) = store
         .get_obj(&NexusInfoKey::new(&Some(volume_uuid.clone()), &nexus_uuid))
         .await
         .unwrap();

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -1,16 +1,23 @@
 #![cfg(test)]
 use crate::volume::helpers::wait_node_online;
-use deployer_cluster::{Cluster, ClusterBuilder};
-use grpc::operations::{
-    nexus::traits::NexusOperations, pool::traits::PoolOperations,
-    registry::traits::RegistryOperations, replica::traits::ReplicaOperations,
-    volume::traits::VolumeOperations,
+use deployer_cluster::{Cluster, ClusterBuilder, FindVolumeRequest};
+use grpc::{
+    csi_node_nvme::{nvme_operations_client, NvmeConnectRequest},
+    operations::{
+        nexus::traits::NexusOperations, pool::traits::PoolOperations,
+        registry::traits::RegistryOperations, replica::traits::ReplicaOperations,
+        volume::traits::VolumeOperations,
+    },
 };
+use http::Uri;
 use std::{collections::HashMap, time::Duration};
 use stor_port::{
     transport_api::{ReplyErrorKind, ResourceKind},
     types::v0::{
-        openapi::{apis::specs_api::tower::client::direct::Specs, models, models::SpecStatus},
+        openapi::{
+            apis::specs_api::tower::client::direct::Specs,
+            models::{self, SpecStatus},
+        },
         store::nexus::NexusSpec,
         transport::{
             CreateReplica, CreateVolume, DestroyReplica, DestroyShutdownTargets, DestroyVolume,
@@ -20,6 +27,7 @@ use stor_port::{
     },
 };
 use tokio::time::sleep;
+use tower::service_fn;
 
 // This test: Creates a three io engine cluster
 // Creates volume with 2 replicas and publishes it to create nexus
@@ -796,4 +804,388 @@ async fn reshutdown(cluster: &Cluster) {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
     assert!(result.is_ok(), "Volume republish should have succeeded");
+}
+
+/// ### Test details
+/// Avoid data corruption in a case when a new nexus picks up a replica deemed healthy(and is local to new nexus),
+/// while the same replica is being marked by an older nexus as unhealthy.
+/// 1. Create a 3-repl volume and publish it on a node.
+/// 2. Run IO to the volume.
+/// 3. Disconnect the io-engine that hosts volume target from the network. IO path loss.
+/// 4. Republish volume to a different node.
+/// 5. Find and nvme connect to new path. Frontend node remains as earlier.
+/// 6. Expect IO to finish without error.
+#[tokio::test]
+async fn republished_nexus_io_engine_txn_fail() {
+    let grpc_timeout = Duration::from_millis(512);
+
+    const POOL_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_csi(true, true)
+        .with_agents(vec!["core"])
+        .with_io_engines(3)
+        .with_tmpfs_pool(POOL_SIZE_BYTES)
+        .with_cache_period("1s")
+        .with_reconcile_period(Duration::from_secs(5), Duration::from_secs(5))
+        .with_node_deadline("2s")
+        .with_options(|o| {
+            o.with_io_engine_env("MAYASTOR_HB_INTERVAL_SEC", "1")
+                .with_isolated_io_engine(true)
+        })
+        .with_req_timeouts_min(true, grpc_timeout, grpc_timeout)
+        .build()
+        .await
+        .unwrap();
+
+    let node_idx0 = cluster.node(0);
+    let node_idx1 = cluster.node(1);
+    let vol_cli = cluster.grpc_client().volume();
+
+    let volume = vol_cli
+        .create(
+            &CreateVolume {
+                uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
+                size: 52428800,
+                replicas: 3,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let volume = vol_cli
+        .publish(
+            &PublishVolume {
+                uuid: volume.uuid().clone(),
+                share: Some(VolumeShareProtocol::Nvmf),
+                target_node: Some(node_idx0.clone()),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![node_idx0.to_string()],
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let api = cluster.rest_v00();
+    let rest_cli = api.volumes_api();
+    let volume_grpc = volume.clone();
+    let volume_models = rest_cli.get_volume(volume_grpc.uuid()).await.unwrap();
+
+    let (s, r) = tokio::sync::oneshot::channel::<()>();
+    let task = run_fio_vol(&cluster, volume_models.clone(), r).await;
+    drop(s);
+    println!("STEP: started fio...");
+
+    cluster.composer().pause(node_idx0.as_str()).await.unwrap();
+    println!("STEP: disconnected container from network...");
+
+    cluster
+        .wait_node_status(node_idx0.clone(), NodeStatus::Unknown)
+        .await
+        .unwrap();
+    println!("STEP: node now unknown...");
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let vol_republished = vol_cli
+        .republish(
+            &RepublishVolume {
+                uuid: volume.uuid().clone(),
+                target_node: Some(node_idx1),
+                share: VolumeShareProtocol::Nvmf,
+                reuse_existing: true,
+                frontend_node: node_idx0.clone(),
+                reuse_existing_fallback: false,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    println!("STEP: Republished volume to new node...");
+
+    let csi_node_ip = cluster.composer().container_ip("csi-node-1");
+    let socket_path_cp = std::path::PathBuf::from("/var/tmp/csi-app-node-1.sock");
+    let channel =
+        tonic::transport::channel::Endpoint::try_from(format!("http://{csi_node_ip}:50051"))
+            .expect("local endpoint should be valid")
+            .connect_with_connector_lazy(service_fn(move |_: Uri| {
+                let path = socket_path_cp.clone();
+                async {
+                    Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(
+                        tokio::net::UnixStream::connect(path).await?,
+                    ))
+                }
+            }));
+    let mut nvme_clnt = nvme_operations_client::NvmeOperationsClient::new(channel);
+    let new_path_uri = vol_republished.state().target.unwrap().device_uri;
+    let _ = nvme_clnt
+        .nvme_connect(NvmeConnectRequest {
+            uri: new_path_uri,
+            publish_context: None,
+        })
+        .await;
+
+    cluster.composer().thaw(node_idx0.as_str()).await.unwrap();
+    cluster
+        .wait_node_status(node_idx0.clone(), NodeStatus::Online)
+        .await
+        .unwrap();
+    println!("STEP: Reconnected older container back to network...");
+
+    let nexus_cli = cluster.grpc_client().nexus();
+    let nexuses = nexus_cli
+        .get(Filter::Node(node_idx0.clone()), None)
+        .await
+        .unwrap();
+    assert_eq!(nexuses.into_inner().len(), 1);
+
+    tracing::info!("STEP: wait for fio completion...");
+    let errcode = task.await.unwrap();
+    assert!(errcode.is_some_and(|s| s == 0));
+}
+
+async fn run_fio_vol(
+    cluster: &Cluster,
+    volume: models::Volume,
+    stop: tokio::sync::oneshot::Receiver<()>,
+) -> tokio::task::JoinHandle<Option<i64>> {
+    run_fio_vol_verify(cluster, volume, stop).await
+}
+async fn run_fio_vol_verify(
+    cluster: &Cluster,
+    volume: models::Volume,
+    mut stop: tokio::sync::oneshot::Receiver<()>,
+) -> tokio::task::JoinHandle<Option<i64>> {
+    let fio_builder = |device: &str| {
+        let filename = format!("--filename={device}");
+        vec![
+            "fio",
+            "--direct=1",
+            "--ioengine=libaio",
+            "--bs=4k",
+            "--iodepth=16",
+            "--loops=10",
+            "--numjobs=1",
+            "--name=fio",
+            "--readwrite=randwrite",
+            "--verify=crc32",
+            filename.as_str(),
+        ]
+        .into_iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+    };
+
+    println!("STEP: staging volume");
+    let mut node = cluster.csi_node_client(0).await.unwrap();
+    node.node_stage_volume(&volume, HashMap::new())
+        .await
+        .unwrap();
+
+    let response = node
+        .internal()
+        .find_volume(FindVolumeRequest {
+            volume_id: volume.spec.uuid.to_string(),
+        })
+        .await
+        .unwrap();
+
+    let device_path = response.into_inner().device_path;
+    let device_path = device_path.trim_end();
+    let fio_cmd = fio_builder(device_path);
+    let fio_cmdline = fio_cmd
+        .iter()
+        .fold(String::new(), |acc, next| format!("{acc} {next}"));
+    let composer = cluster.composer().clone();
+
+    println!("STEP: spawn fio in container");
+    tokio::spawn(async move {
+        use tokio::sync::oneshot::error::TryRecvError;
+        let code = loop {
+            let (code, out) = composer.exec("csi-node-1", fio_cmd.clone()).await.unwrap();
+            println!("{}: {}, code: {:?}", fio_cmdline, out, code);
+            if code != Some(0) {
+                return code;
+            }
+            assert_eq!(code, Some(0));
+
+            if stop.try_recv().is_ok() || matches!(stop.try_recv(), Err(TryRecvError::Closed)) {
+                break code;
+            }
+        };
+
+        node.node_unstage_volume(&volume).await.unwrap();
+        code
+    })
+}
+
+/// Similar to the test `republished_nexus_io_engine_txn_fail` but here the
+/// republish is spawned on a separate thread so most of the times old nexus thaws
+/// earlier than republish and it makes core-agent's txn fail during republish.
+#[tokio::test]
+async fn republished_nexus_core_agent_txn_fail() {
+    let grpc_timeout = Duration::from_millis(512);
+
+    const POOL_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_csi(true, true)
+        .with_agents(vec!["core"])
+        .with_io_engines(3)
+        .with_tmpfs_pool(POOL_SIZE_BYTES)
+        .with_cache_period("1s")
+        .with_reconcile_period(Duration::from_secs(5), Duration::from_secs(5))
+        .with_node_deadline("2s")
+        .with_options(|o| {
+            o.with_io_engine_env("MAYASTOR_HB_INTERVAL_SEC", "1")
+                .with_isolated_io_engine(true)
+        })
+        .with_req_timeouts_min(true, grpc_timeout, grpc_timeout)
+        .build()
+        .await
+        .unwrap();
+
+    let node_idx0 = cluster.node(0);
+    let node_idx1 = cluster.node(1);
+    let vol_cli = cluster.grpc_client().volume();
+
+    let volume = vol_cli
+        .create(
+            &CreateVolume {
+                uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
+                size: 52428800,
+                replicas: 3,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let volume = vol_cli
+        .publish(
+            &PublishVolume {
+                uuid: volume.uuid().clone(),
+                share: Some(VolumeShareProtocol::Nvmf),
+                target_node: Some(node_idx0.clone()),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![node_idx0.to_string()],
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let api = cluster.rest_v00();
+    let rest_cli = api.volumes_api();
+    let volume_grpc = volume.clone();
+    let volume_models = rest_cli.get_volume(volume_grpc.uuid()).await.unwrap();
+
+    let (s, r) = tokio::sync::oneshot::channel::<()>();
+    let task = run_fio_vol(&cluster, volume_models.clone(), r).await;
+    drop(s);
+    println!("STEP: started fio...");
+
+    cluster.composer().pause(node_idx0.as_str()).await.unwrap();
+    println!("STEP: disconnected container from network...");
+
+    cluster
+        .wait_node_status(node_idx0.clone(), NodeStatus::Unknown)
+        .await
+        .unwrap();
+    println!("STEP: node now unknown...");
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let csi_node_ip = cluster.composer().container_ip("csi-node-1");
+    let vol_clone = volume.clone();
+    let node_idx0_spawn = node_idx0.clone();
+    let node_idx1_spawn = node_idx1.clone();
+    let repub_task = tokio::spawn(async move {
+        let mut vol_republished = vol_cli
+            .republish(
+                &RepublishVolume {
+                    uuid: vol_clone.uuid().clone(),
+                    target_node: Some(node_idx1_spawn.clone()),
+                    share: VolumeShareProtocol::Nvmf,
+                    reuse_existing: true,
+                    frontend_node: node_idx0_spawn.clone(),
+                    reuse_existing_fallback: false,
+                },
+                None,
+            )
+            .await;
+
+        if let Err(ref e) = vol_republished {
+            match e.kind {
+                ReplyErrorKind::FailedPersist if e.source.contains("Etcd Txn Compare failed") => {
+                    // try few times so that path is recovered.
+                    for _ in 1..5 {
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                        vol_republished = vol_cli
+                            .republish(
+                                &RepublishVolume {
+                                    uuid: vol_clone.uuid().clone(),
+                                    target_node: Some(node_idx1_spawn.clone()),
+                                    share: VolumeShareProtocol::Nvmf,
+                                    reuse_existing: true,
+                                    frontend_node: node_idx0_spawn.clone(),
+                                    reuse_existing_fallback: false,
+                                },
+                                None,
+                            )
+                            .await;
+                        if vol_republished.is_ok() {
+                            break;
+                        }
+                    }
+                }
+                _ => panic!("{}", e.source),
+            }
+        }
+
+        let vol_republished = vol_republished.unwrap();
+
+        println!("STEP: Republished volume to new node...");
+
+        let socket_path_cp = std::path::PathBuf::from("/var/tmp/csi-app-node-1.sock");
+        let channel =
+            tonic::transport::channel::Endpoint::try_from(format!("http://{csi_node_ip}:50051"))
+                .expect("local endpoint should be valid")
+                .connect_with_connector_lazy(service_fn(move |_: Uri| {
+                    let path = socket_path_cp.clone();
+                    async {
+                        Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(
+                            tokio::net::UnixStream::connect(path).await?,
+                        ))
+                    }
+                }));
+        let mut nvme_clnt = nvme_operations_client::NvmeOperationsClient::new(channel);
+        let new_path_uri = vol_republished.state().target.unwrap().device_uri;
+        let _ = nvme_clnt
+            .nvme_connect(NvmeConnectRequest {
+                uri: new_path_uri,
+                publish_context: None,
+            })
+            .await;
+    });
+
+    cluster.composer().thaw(node_idx0.as_str()).await.unwrap();
+    cluster
+        .wait_node_status(node_idx0.clone(), NodeStatus::Online)
+        .await
+        .unwrap();
+    println!("STEP: Reconnected older container back to network...");
+
+    let nexus_cli = cluster.grpc_client().nexus();
+    let nexuses = nexus_cli
+        .get(Filter::Node(node_idx0.clone()), None)
+        .await
+        .unwrap();
+    assert_eq!(nexuses.into_inner().len(), 1);
+
+    repub_task.await.ok();
+
+    tracing::info!("STEP: wait for fio completion...");
+    let errcode = task.await.unwrap();
+    assert!(errcode.is_some_and(|s| s == 0));
 }

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -565,12 +565,50 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         self.validate_update_step(registry, result, &spec_clone)
             .await?;
 
+        let mut mod_rev: i64 = i64::MIN;
+        let old_nexus_info = match registry
+            .nexus_info(
+                Some(&request.uuid),
+                Some(older_nexus.uuid()),
+                false,
+                Some(&mut mod_rev),
+            )
+            .await
+        {
+            Ok(n) => n,
+            Err(e) => {
+                return self
+                    .validate_update_step(registry, Err(e), &spec_clone)
+                    .await;
+            }
+        };
         // Create a Nexus on the requested or auto-selected node.
         let result = self.create_nexus(registry, &target_cfg).await;
         let (mut nexus, nexus_state) = self
             .validate_update_step(registry, result, &spec_clone)
             .await?;
+
         let allowed_host = target_cfg.frontend().node_nqns();
+        if older_nexus.as_ref().status_info().shutdown_failed() {
+            // New nexus is created but not yet shared.
+            // At this point, mark the older nexus for a self shutdown in case io-engine is
+            // racing with this republish and doing some modifications to persistent nexus info.
+            if let Some(mut old_nexus_info) = old_nexus_info {
+                old_nexus_info.do_self_shutdown = true;
+                old_nexus_info.volume_uuid = Some(spec_clone.uuid.clone());
+                tracing::debug!(nexus.uuid=%older_nexus.as_ref().uuid, "Updated nexusinfo(mod_rev {mod_rev:?}) - {old_nexus_info:?}");
+                if let Err(e) = registry.store_obj_cas(&old_nexus_info, mod_rev).await {
+                    nexus
+                        .destroy(registry, &DestroyNexus::from(nexus_state).with_disown_all())
+                        .await
+                        .ok();
+                    return self
+                        .validate_update_step(registry, Err(e), &spec_clone)
+                        .await;
+                }
+            }
+        }
+
         // Share the Nexus.
         let result = match nexus
             .share(

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -142,7 +142,7 @@ impl OperationGuardArc<VolumeSpec> {
     ) -> Result<(), SvcError> {
         let health_info = self.lock().health_info_id().cloned();
         let nexus_info = registry
-            .nexus_info(Some(self.uuid()), health_info.as_ref(), true)
+            .nexus_info(Some(self.uuid()), health_info.as_ref(), true, None)
             .await?
             .ok_or(SvcError::Internal {
                 details: "No NexusInfo for a volume with allocated storage?".into(),

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -1118,7 +1118,7 @@ impl SpecOperationsHelper for VolumeSpec {
                     })
                 } else {
                     match registry
-                        .nexus_info(Some(&self.uuid), self.health_info_id(), true)
+                        .nexus_info(Some(&self.uuid), self.health_info_id(), true, None)
                         .await?
                     {
                         Some(info) => match info

--- a/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
@@ -20,6 +20,9 @@ pub struct NexusInfo {
     pub volume_uuid: Option<VolumeId>,
     /// Nexus destroyed successfully.
     pub clean_shutdown: bool,
+    /// Nexus need to be self shutdown by io-engine.
+    #[serde(default)]
+    pub do_self_shutdown: bool,
     /// Information about children.
     pub children: Vec<ChildInfo>,
 }

--- a/utils/pstor/src/api.rs
+++ b/utils/pstor/src/api.rs
@@ -60,8 +60,15 @@ pub trait StoreKv: Sync + Send + Clone {
 pub trait StoreObj: Sync + Send + Clone {
     /// Puts the given `O` object into the store.
     async fn put_obj<O: StorableObject>(&mut self, object: &O) -> Result<(), Error>;
+    /// Puts the given `O` object into the store as a compare and swap
+    /// transaction against expected value.
+    async fn put_obj_cas<O: StorableObject>(
+        &mut self,
+        object: &O,
+        expected_mod_rev: i64,
+    ) -> Result<(), Error>;
     /// Gets the object `O` through its `O::Key`.
-    async fn get_obj<O: StorableObject>(&mut self, _key: &O::Key) -> Result<O, Error>;
+    async fn get_obj<O: StorableObject>(&mut self, _key: &O::Key) -> Result<(O, i64), Error>;
     /// Watches for changes under the given `K` object key entry.
     /// Returns a channel which is signalled when an event occurs.
     /// # Warning: Events may be lost if we are restarted.

--- a/utils/pstor/src/etcd.rs
+++ b/utils/pstor/src/etcd.rs
@@ -14,9 +14,10 @@ use crate::{
 use async_trait::async_trait;
 use etcd_client::{
     Client, Compare, CompareOp, DeleteOptions, EventType, GetOptions, KeyValue, SortOrder,
-    SortTarget, Txn, TxnOp, WatchStream, Watcher,
+    SortTarget, Txn, TxnOp, TxnOpResponse, WatchStream, Watcher,
 };
 use serde_json::Value;
+
 use snafu::ResultExt;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
@@ -343,7 +344,6 @@ impl StoreObj for Etcd {
     async fn put_obj<O: StorableObject>(&mut self, object: &O) -> Result<(), Error> {
         let key = object.key().key();
         let vec_value = serde_json::to_vec(object).context(SerialiseValue)?;
-
         if let Some((lease_id, lock_key)) = self.lease_lock()? {
             let cmp = Compare::lease(lock_key.clone(), CompareOp::Equal, lease_id);
             let put = TxnOp::put(key.to_string(), vec_value, None);
@@ -372,21 +372,62 @@ impl StoreObj for Etcd {
         Ok(())
     }
 
-    async fn get_obj<O: StorableObject>(&mut self, key: &O::Key) -> Result<O, Error> {
+    /// Compare and swap the value as part of transaction.
+    async fn put_obj_cas<O: StorableObject>(
+        &mut self,
+        object: &O,
+        expected_mod_rev: i64,
+    ) -> Result<(), Error> {
+        let key = object.key().key();
+        let obj_value = serde_json::to_vec(object).context(SerialiseValue)?;
+        let cmp = Compare::mod_revision(key.to_string(), CompareOp::Equal, expected_mod_rev);
+        let put = TxnOp::put(key.to_string(), obj_value, None);
+        let get = TxnOp::get(key.to_string(), None);
+        let resp = self
+            .client
+            .txn(Txn::new().when([cmp]).and_then([put]).or_else([get]))
+            .await
+            .context(Put {
+                key: object.key().key(),
+                value: serde_json::to_string(object).context(SerialiseValue)?,
+            })?;
+        if !resp.succeeded() {
+            if let TxnOpResponse::Get(g) = &resp.op_responses()[0] {
+                if let Some(kv) = g.kvs().first() {
+                    let mod_rev_found = kv.mod_revision();
+                    tracing::error!("Expected mod_rev: {expected_mod_rev}, Found: {mod_rev_found}");
+                }
+            }
+            return Err(Error::Put {
+                key: object.key().key(),
+                value: serde_json::to_string(object).context(SerialiseValue)?,
+                source: etcd_client::Error::IoError(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Etcd Txn Compare failed".to_string(),
+                )),
+            });
+        }
+
+        Ok(())
+    }
+
+    async fn get_obj<O: StorableObject>(&mut self, key: &O::Key) -> Result<(O, i64), Error> {
         let resp = self
             .client
             .get(key.key(), None)
             .await
             .context(Get { key: key.key() })?;
         match resp.kvs().first() {
-            Some(kv) => Ok(
+            Some(kv) => Ok((
                 serde_json::from_slice(kv.value()).context(DeserialiseValue {
                     value: kv.value_str().context(ValueString {})?,
                 })?,
-            ),
+                kv.mod_revision(),
+            )),
             None => Err(Error::MissingEntry { key: key.key() }),
         }
     }
+
     async fn watch_obj<K: ObjectKey>(
         &mut self,
         key: &K,

--- a/utils/pstor/src/etcd_keep_alive.rs
+++ b/utils/pstor/src/etcd_keep_alive.rs
@@ -269,12 +269,12 @@ impl EtcdSingletonLock {
     }
     /// Get the current owner lease id, or None if it does not exist.
     async fn get_owner_lease_id(&mut self) -> Result<Option<String>, Error> {
-        let owner: Result<StoreLeaseOwner, Error> = Etcd::from(&self.client, None)
+        let owner: Result<(StoreLeaseOwner, i64), Error> = Etcd::from(&self.client, None)
             .get_obj(&StoreLeaseOwnerKey::new(&self.service_name))
             .await;
 
         match owner {
-            Ok(owner) => Ok(Some(owner.lease_id().to_string())),
+            Ok((owner, _mod_rev)) => Ok(Some(owner.lease_id().to_string())),
             Err(Error::MissingEntry { .. }) => Ok(None),
             Err(e) => Err(e),
         }


### PR DESCRIPTION
When a new nexus is created in republish path, it can pick up a healthy replica that is local to nexus node. But it is possible that the old nexus could momentarily come back and fails an IO to this replica and in turn marking it unhealthy in etcd. Since new nexus has already chosen this replica, it goes ahead using this as source of truth and hence compromising data integrity. This change lets core-agent indicate to old nexus that it should self shutdown now without modifying updating anything in etcd.