### PR TITLE
Add pool cordoned import

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
@@ -114,10 +114,14 @@ async fn missing_pool_state_reconciler(
         // nothing to do here
         return PollResult::Ok(PollerState::Idle);
     }
-    let pool_id = pool.id();
 
-    if !context.registry().has_pool_state(pool_id).await {
+    if !context.registry().has_pool_state(pool.id()).await {
         let pool_spec = pool.lock().clone();
+
+        if pool_spec.cordoned().map(|s| s.import).unwrap_or_default() {
+            tracing::trace!("Not allowed to import because the pool is cordoned for imports");
+            return PollResult::Ok(PollerState::Idle);
+        }
 
         let warn_missing = |pool_spec: &PoolSpec, node_status: NodeStatus| {
             let node_id = &pool_spec.node;
@@ -125,7 +129,7 @@ async fn missing_pool_state_reconciler(
                 tracing::trace!(
                     node.id = %node_id,
                     node.status = %node_status.to_string(),
-                    "Attempted to recreate missing pool state, but the node is not online"
+                    "Attempted to import the pool, but the node is not online"
                 )
             });
         };
@@ -143,17 +147,17 @@ async fn missing_pool_state_reconciler(
         };
 
         async {
-            pool_spec.warn_span(|| tracing::warn!("Attempting to recreate missing pool"));
+            pool_spec.warn_span(|| tracing::warn!("Attempting to import the pool"));
 
             let request = ImportPool::new(&pool_spec.node, &pool_spec.id, &pool_spec.disks, &pool_spec.encryption);
             match node.import_pool(&request).await {
                 Ok(_) => {
-                    pool_spec.info_span(|| tracing::info!("Pool successfully recreated"));
+                    pool_spec.info_span(|| tracing::info!("Pool successfully imported"));
                     PollResult::Ok(PollerState::Idle)
                 }
                 Err(error) => {
                     pool_spec.error_span(
-                        || tracing::error!(error=%error, "Failed to recreate the pool"),
+                        || tracing::error!(error=%error, "Failed to import the pool")
                     );
                     Err(error)
                 }

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -213,6 +213,7 @@ impl ResourceCordon for OperationGuardArc<PoolSpec> {
             replicas: request.replicas,
             snapshots: request.snapshots,
             restores: request.restores,
+            import: request.import,
         };
         let spec_clone = self.lock().clone();
         let spec_clone = self
@@ -232,6 +233,7 @@ impl ResourceCordon for OperationGuardArc<PoolSpec> {
             replicas: request.replicas,
             snapshots: request.snapshots,
             restores: request.restores,
+            import: request.import,
         };
         let spec_clone = self.lock().clone();
         let spec_clone = self

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -180,6 +180,7 @@ message CordonPoolRequest {
   bool replicas = 3;
   bool snapshots = 4;
   bool restores = 5;
+  bool import = 6;
 }
 message CordonPoolReply {
   oneof reply {
@@ -195,6 +196,8 @@ message CordonedState {
   bool snapshots = 2;
   // New restores can't be created
   bool restores = 3;
+  // Pool cannot be imported
+  bool import = 4;
 }
 
 // Service for managing storage pools

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -114,6 +114,7 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
                             replicas: state.replicas,
                             snapshots: state.snapshots,
                             restores: state.restores,
+                            import: state.import,
                         }))
                     }
                 },
@@ -200,6 +201,7 @@ impl From<PoolSpec> for pool::PoolDefinition {
                                 replicas: state.replicas,
                                 snapshots: state.snapshots,
                                 restores: state.restores,
+                                import: state.import,
                             },
                         };
                         Some(pool::pool_spec::CordonDrain::Cordoned(co))
@@ -628,6 +630,8 @@ pub struct PoolCordonRequest {
     pub snapshots: bool,
     /// Cordon or uncordon restores.
     pub restores: bool,
+    /// Importing the pool after node/engine restart.
+    pub import: bool,
 }
 
 impl From<CordonPoolRequest> for PoolCordonRequest {
@@ -638,6 +642,7 @@ impl From<CordonPoolRequest> for PoolCordonRequest {
             replicas: value.replicas,
             snapshots: value.snapshots,
             restores: value.restores,
+            import: value.import,
         }
     }
 }
@@ -649,6 +654,7 @@ impl From<PoolCordonRequest> for CordonPoolRequest {
             replicas: value.replicas,
             snapshots: value.snapshots,
             restores: value.restores,
+            import: value.import,
         }
     }
 }

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -106,7 +106,8 @@ pub enum CordonResources {
     /// Cordon the node with the given ID by applying the cordon label to that node.
     Node { id: NodeId, label: String },
     /// Cordon the pool with the given ID by applying the cordon constraints to that pool{n}
-    /// By default all resources are cordoned. Otherwise you may individually select specific constraints.
+    /// By default only replicas and restores are constrained. Otherwise, you may individually
+    /// select specific constraints.
     Pool {
         /// Id of the pool to cordon.
         id: PoolId,
@@ -122,8 +123,8 @@ pub enum UnCordonResources {
     /// When the node has no more cordon labels, it is effectively uncordoned.
     Node { id: NodeId, label: String },
     /// Removes the cordon constraints from the pool.
-    /// When the pool has no more cordon labels, it is effectively uncordoned{n}
-    /// By default all resources are cordoned. Otherwise you may individually select specific constraints removal.
+    /// When the pool has no more cordon constraints, it is effectively uncordoned{n}
+    /// By default all constraints are removed. Otherwise, you may individually select specific constraints' removal.
     Pool {
         /// Id of the pool to uncordon.
         id: PoolId,

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -462,6 +462,47 @@ pub struct CordonReq {
     /// No new restores can be created on the pool.
     #[clap(long)]
     pub restores: bool,
+    /// Pool will not be imported on node/io-engine restart.{n}
+    /// Warning: this may impact existing volume I/O{n}
+    /// This may be useful when repairing the pool metadata.
+    #[clap(long)]
+    pub import: bool,
+    /// Apply all cordon sub-resource scheduling constraints.
+    /// Note: you must selectively enable the import constraint.
+    #[clap(long)]
+    pub all_sub: bool,
+    /// Apply *ALL* cordon constraints.
+    /// Warning: This enables import constraint, which may impact existing volume I/O
+    #[clap(long)]
+    pub all: bool,
+}
+impl Default for CordonReq {
+    fn default() -> Self {
+        Self {
+            replicas: true,
+            snapshots: false,
+            restores: true,
+            import: false,
+            all_sub: false,
+            all: false,
+        }
+    }
+}
+impl From<CordonReq> for models::PoolCordonReq {
+    fn from(value: CordonReq) -> Self {
+        if value.all {
+            models::PoolCordonReq::new_all(true, true, true, false)
+        } else if value.all_sub {
+            models::PoolCordonReq::new_all(true, true, true, value.import)
+        } else {
+            models::PoolCordonReq::new_all(
+                value.replicas,
+                value.snapshots,
+                value.restores,
+                value.import,
+            )
+        }
+    }
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -475,6 +516,37 @@ pub struct UncordonReq {
     /// New restores can be created on the pool.
     #[clap(long)]
     pub restores: bool,
+    /// Pool may be imported again.
+    #[clap(long)]
+    pub import: bool,
+    /// Remove all cordon constraints (default).
+    #[clap(long)]
+    pub all: bool,
+}
+impl Default for UncordonReq {
+    fn default() -> Self {
+        Self {
+            replicas: true,
+            snapshots: true,
+            restores: true,
+            import: true,
+            all: true,
+        }
+    }
+}
+impl From<UncordonReq> for models::PoolCordonReq {
+    fn from(value: UncordonReq) -> Self {
+        if value.all {
+            models::PoolCordonReq::new_all(true, true, true, true)
+        } else {
+            models::PoolCordonReq::new_all(
+                value.replicas,
+                value.snapshots,
+                value.restores,
+                value.import,
+            )
+        }
+    }
 }
 
 #[async_trait(?Send)]
@@ -484,36 +556,37 @@ impl Cordoning for Pool {
     type UREQ = Option<UncordonReq>;
 
     async fn cordon(id: &Self::ID, resources: &Self::CREQ, output: &OutputFormat) -> PluginResult {
-        let resources = resources.clone().unwrap_or(CordonReq {
-            replicas: true,
-            snapshots: false,
-            restores: true,
-        });
-        let body = models::PoolCordonReq::new_all(
-            resources.replicas,
-            resources.snapshots,
-            resources.restores,
-        );
+        let body = models::PoolCordonReq::from(resources.clone().unwrap_or_default());
         match RestClient::client()
             .pools_api()
             .put_pool_cordon(id, body)
             .await
         {
-            Ok(node) => match output {
+            Ok(pool) => match output {
                 OutputFormat::Yaml | OutputFormat::Json => {
                     // Print json or yaml based on output format.
-                    utils::print_table(output, node.into_body());
+                    utils::print_table(output, pool.into_body());
                 }
                 OutputFormat::None => {
                     // In case the output format is not specified, show a success message.
-                    println!("Pool {id} cordoned successfully")
+                    let constraints = pool_cordon_resources(&pool.into_body());
+                    println!("Pool {id} cordoned successfully. Current constraints: {constraints}");
                 }
             },
             Err(source) => {
                 if source.error_body().map(|b| b.kind)
                     == Some(models::rest_json_error::Kind::AlreadyExists)
                 {
-                    println!("Pool {id} already cordoned");
+                    let pool = RestClient::client()
+                        .pools_api()
+                        .get_pool(id)
+                        .await
+                        .map_err(|source| Error::GetPoolError {
+                            id: id.to_string(),
+                            source,
+                        })?;
+                    let constraints = pool_cordon_resources(&pool.into_body());
+                    println!("Pool {id} is already cordoned. Current constraints: {constraints}");
                 } else {
                     return Err(Error::PoolCordonError {
                         id: id.to_string(),
@@ -530,16 +603,7 @@ impl Cordoning for Pool {
         resources: &Self::UREQ,
         output: &OutputFormat,
     ) -> PluginResult {
-        let resources = resources.clone().unwrap_or(UncordonReq {
-            replicas: true,
-            snapshots: true,
-            restores: true,
-        });
-        let body = models::PoolCordonReq::new_all(
-            resources.replicas,
-            resources.snapshots,
-            resources.restores,
-        );
+        let body = models::PoolCordonReq::from(resources.clone().unwrap_or_default());
         let (failed, pool) = match RestClient::client()
             .pools_api()
             .del_pool_cordon(id, body)
@@ -575,14 +639,14 @@ impl Cordoning for Pool {
                 let resources = pool_cordon_resources(&pool.into_body());
                 if failed {
                     if resources.is_empty() {
-                        println!("Pool {id} already uncordoned");
+                        println!("Pool {id} is already uncordoned");
                     } else {
-                        println!("Pool {id} already partially uncordoned. Remaining cordoned resources: {resources:?}");
+                        println!("Pool {id} is already partially uncordoned. Remaining constraints: {resources}");
                     }
                 } else if resources.is_empty() {
                     println!("Pool {id} successfully uncordoned");
                 } else {
-                    println!("Pool {id} partially uncordoned. Remaining cordoned resources: {resources:?}");
+                    println!("Pool {id} partially uncordoned. Remaining constraints: {resources}");
                 }
             }
         }
@@ -598,15 +662,20 @@ fn resource(yes: bool, name: &str) -> &str {
     }
 }
 fn cordon_resources(rsc: &models::PoolCordon) -> String {
-    [
+    let cordon = [
         resource(rsc.replicas, "replicas"),
         resource(rsc.snapshots, "snapshots"),
         resource(rsc.restores, "restores"),
+        resource(rsc.import, "import"),
     ]
     .into_iter()
     .filter(|s| !s.is_empty())
     .collect::<Vec<&str>>()
-    .join(",")
+    .join(",");
+    if cordon.is_empty() {
+        return "Unknown".to_string();
+    }
+    cordon
 }
 fn pool_cordon_resources(pool: &models::Pool) -> String {
     match &pool.spec {

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -4338,10 +4338,13 @@ components:
           type: boolean
         restores:
           type: boolean
+        import:
+          type: bool
       required:
         - replicas
         - snapshots
         - restores
+        - import
     PoolCordon:
       description: The pool is cordoned with the following resource constraints
       type: object
@@ -4355,10 +4358,14 @@ components:
         restores:
           description: No new restores can be created on this pool
           type: boolean
+        import:
+          description: Pool cannot be imported in case of node/engine restart.
+          type: boolean
       required:
         - replicas
         - snapshots
         - restores
+        - import
     CordonDrainState:
       description: The cordon and drain state
       type: object

--- a/control-plane/rest/service/src/v0/pools.rs
+++ b/control-plane/rest/service/src/v0/pools.rs
@@ -144,6 +144,7 @@ impl apis::actix_server::Pools for RestApi {
             replicas: body.replicas,
             snapshots: body.snapshots,
             restores: body.restores,
+            import: body.import,
         };
         let pool = client().cordon(request).await?;
         Ok(pool.into())
@@ -159,6 +160,7 @@ impl apis::actix_server::Pools for RestApi {
             replicas: body.replicas,
             snapshots: body.snapshots,
             restores: body.restores,
+            import: body.import,
         };
         let pool = client().uncordon(request).await?;
         Ok(pool.into())

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -222,6 +222,11 @@ impl PoolSpec {
         })
     }
 
+    /// Check if the pool is cordoned for imports.
+    pub fn cordoned_imports(&self) -> bool {
+        self.cordoned().map(|s| s.import).unwrap_or_default()
+    }
+
     /// Returns true if all labels are already present.
     pub fn cordon_would_modify(&self, op: &PoolCordonOp) -> bool {
         match &self.cordon_drain {
@@ -378,6 +383,8 @@ pub struct PoolCordonOp {
     pub snapshots: bool,
     /// No new restores can be created on this pool
     pub restores: bool,
+    /// Pool cannot be imported after node/engine restart.
+    pub import: bool,
 }
 impl PoolCordonOp {
     fn resource(yes: bool, name: &str) -> &str {
@@ -393,6 +400,7 @@ impl PoolCordonOp {
             Self::resource(self.replicas, "replicas"),
             Self::resource(self.snapshots, "snapshots"),
             Self::resource(self.restores, "restores"),
+            Self::resource(self.import, "import"),
         ]
         .into_iter()
         .filter(|s| !s.is_empty())
@@ -495,16 +503,18 @@ impl From<models::Encryption> for Encryption {
 #[derive(Clone, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CordonedState {
     // todo: or should these be negated, ie: by default all blocked?
-    /// No new replicas can be created on this pool
+    /// No new replicas can be created on this pool.
     pub replicas: bool,
-    /// No new snapshots can be created on this pool
+    /// No new snapshots can be created on this pool.
     pub snapshots: bool,
-    /// No new restores can be created on this pool
+    /// No new restores can be created on this pool.
     pub restores: bool,
+    /// Pool cannot be imported after node/engine restart.
+    pub import: bool,
 }
 impl CordonedState {
     fn cordoned(&self) -> bool {
-        self.replicas || self.snapshots || self.restores
+        self.replicas || self.snapshots || self.restores || self.import
     }
 }
 
@@ -514,6 +524,7 @@ impl From<PoolCordonOp> for CordonedState {
             replicas: value.replicas,
             snapshots: value.snapshots,
             restores: value.restores,
+            import: value.import,
         }
     }
 }
@@ -526,15 +537,17 @@ impl CordonedState {
     }
     /// Add cordon resources.
     pub fn add_cordon(&mut self, op: PoolCordonOp) {
-        Self::set_if(op.replicas, &mut self.replicas, true);
-        Self::set_if(op.snapshots, &mut self.snapshots, true);
-        Self::set_if(op.restores, &mut self.restores, true);
+        self.op_cordon(op, true);
     }
     /// Remove cordon resources.
     pub fn rm_cordon(&mut self, op: PoolCordonOp) {
-        Self::set_if(op.replicas, &mut self.replicas, false);
-        Self::set_if(op.snapshots, &mut self.snapshots, false);
-        Self::set_if(op.restores, &mut self.restores, false);
+        self.op_cordon(op, false);
+    }
+    fn op_cordon(&mut self, op: PoolCordonOp, cordon: bool) {
+        Self::set_if(op.replicas, &mut self.replicas, cordon);
+        Self::set_if(op.snapshots, &mut self.snapshots, cordon);
+        Self::set_if(op.restores, &mut self.restores, cordon);
+        Self::set_if(op.import, &mut self.import, cordon);
     }
     fn if_modify(current: bool, op: bool, cordon: bool) -> bool {
         if cordon {
@@ -548,6 +561,7 @@ impl CordonedState {
         Self::if_modify(self.replicas, op.replicas, cordon)
             || Self::if_modify(self.snapshots, op.snapshots, cordon)
             || Self::if_modify(self.restores, op.restores, cordon)
+            || Self::if_modify(self.import, op.import, cordon)
     }
 }
 
@@ -591,6 +605,7 @@ impl From<CordonDrainState> for models::PoolCordonDrain {
                     replicas: state.replicas,
                     snapshots: state.snapshots,
                     restores: state.restores,
+                    import: state.import,
                 };
                 Self::cordoned(cs)
             }

--- a/tests/bdd/common/operations.py
+++ b/tests/bdd/common/operations.py
@@ -66,13 +66,13 @@ class Pool(object):
             return label, ""
 
     @staticmethod
-    def cordon(pool, replicas=True, snapshots=False, restores=True):
-        rsc = PoolCordon(replicas, snapshots, restores)
+    def cordon(pool, replicas=True, snapshots=False, restores=True, imports=False):
+        rsc = PoolCordon(replicas, snapshots, restores, imports)
         return Pool.__pools_api().put_pool_cordon(pool.id, pool_cordon_req=rsc)
 
     @staticmethod
-    def uncordon(pool, replicas=True, snapshots=True, restores=True):
-        rsc = PoolCordon(replicas, snapshots, restores)
+    def uncordon(pool, replicas=True, snapshots=True, restores=True, imports=True):
+        rsc = PoolCordon(replicas, snapshots, restores, imports)
         return Pool.__pools_api().del_pool_cordon(pool.id, pool_cordon_req=rsc)
 
     @staticmethod

--- a/tests/bdd/features/pool/cordon/feature.feature
+++ b/tests/bdd/features/pool/cordon/feature.feature
@@ -45,6 +45,11 @@ Feature: Pool Cordoning
     Then the pool should be imported successfully
     And all pool resources should be Online
 
+  Scenario: Restarting a cordoned pool with import constraint
+    Given a cordoned pool with import constraint
+    When the cordoned pool is restarted
+    Then the pool should be not be imported
+
   Scenario: No replica rebuild due to pool cordon
     Given a published volume with multiple replicas
     And a cordoned pool, otherwise schedulable for the volume

--- a/tests/bdd/features/pool/cordon/test_feature.py
+++ b/tests/bdd/features/pool/cordon/test_feature.py
@@ -6,6 +6,7 @@ import pytest
 import uuid
 import http
 import openapi.exceptions
+from common import human_sleep
 from common.apiclient import ApiClient
 from common.operations import wait_pool_online, wait_volume_status, wait_node_status
 from common.operations import Cluster
@@ -28,12 +29,16 @@ from openapi.model.volume import Volume
 
 
 VOLUME_SIZE = 10 * 1024 * 1024
+RECONCILE_PERIOD = "80ms"
 
 
 @pytest.fixture(scope="module")
 def init():
     Deployer.start(
-        3, cache_period="50ms", reconcile_period="80ms", faulted_child_wait_period="0ms"
+        3,
+        cache_period="50ms",
+        reconcile_period=RECONCILE_PERIOD,
+        faulted_child_wait_period="0ms",
     )
     yield
     Deployer.stop()
@@ -85,6 +90,11 @@ def test_restarting_a_cordoned_pool():
     """Restarting a cordoned pool."""
 
 
+@scenario("feature.feature", "Restarting a cordoned pool with import constraint")
+def test_restarting_a_cordoned_pool_with_import_constraint():
+    """Restarting a cordoned pool with import constraint."""
+
+
 @scenario("feature.feature", "Uncordoning a pool")
 def test_uncordoning_a_pool():
     """Uncordoning a pool."""
@@ -107,6 +117,17 @@ def _(disks):
         Deployer.node_name(0), Deployer.pool_name(), CreatePoolBody([f"{disks[0]}"])
     )
     pool = PoolOps.cordon(pool)
+    yield pool
+    PoolOps.cleanup(pool)
+
+
+@given("a cordoned pool with import constraint", target_fixture="pool")
+def _(disks):
+    """a cordoned pool with import constraint."""
+    pool = ApiClient.pools_api().put_node_pool(
+        Deployer.node_name(0), Deployer.pool_name(), CreatePoolBody([f"{disks[0]}"])
+    )
+    pool = PoolOps.cordon(pool, imports=True)
     yield pool
     PoolOps.cleanup(pool)
 
@@ -269,7 +290,7 @@ def _(pool):
 @when("we issue a cordon command with additional constraints")
 def _(pool):
     """we issue a cordon command with additional constraints."""
-    PoolOps.cordon(pool, True, True, True)
+    PoolOps.cordon(pool, True, True, True, False)
 
 
 @when("we issue an uncordon command with all resources")
@@ -292,7 +313,8 @@ def _(pool):
     assert resources["replicas"] == True
     assert resources["snapshots"] == False
     assert resources["restores"] == True
-    PoolOps.uncordon(pool, True, False, False)
+    assert resources["import"] == False
+    PoolOps.uncordon(pool, True, False, False, False)
 
 
 @when("we attempt to increase the replica count", target_fixture="set_repl_request")
@@ -325,6 +347,7 @@ def _(pool, resource):
         "replicas": resource == "replicas",
         "snapshots": resource == "snapshots",
         "restores": resource == "restores",
+        "import": resource == "import",
     }
     PoolOps.cordon(pool, cordon["replicas"], cordon["snapshots"], cordon["restores"])
     yield cordon
@@ -340,6 +363,7 @@ def _(pool, resource, resources):
     assert pool_rsc["replicas"] == resources["replicas"]
     assert pool_rsc["snapshots"] == resources["snapshots"]
     assert pool_rsc["restores"] == resources["restores"]
+    assert pool_rsc["import"] == resources["import"]
     assert pool_rsc[resource] == True
 
     if resource == "replicas":
@@ -348,6 +372,8 @@ def _(pool, resource, resources):
         schedule_snap(pool, True)
     elif resource == "restores":
         schedule_restore(pool, True)
+    else:
+        assert False, "Unexpected!"
 
 
 @then("other resources can")
@@ -378,11 +404,20 @@ def _(volume, set_repl_request):
     assert ApiClient.exception_to_error(response).kind == "ResourceExhausted"
 
 
+@then("the pool should be not be imported")
+def _(pool):
+    """the pool should be not be imported."""
+    for i in range(2):
+        human_sleep(RECONCILE_PERIOD)
+    pool = PoolOps.update(pool)
+    assert not hasattr(pool, "state")
+
+
 @then("all pool resources should be Online")
 def _(pool):
     """all pool resources should be Online."""
     pool = PoolOps.update(pool, False)
-    assert pool.state is not None
+    assert hasattr(pool, "state")
     assert pool.state.status == PoolStatus("Online")
 
 


### PR DESCRIPTION
    test(pool/cordon): add import test scenario
    
---

    feat(pool/cordon): add imports as cordon constraint
    
    A new constraint is added to the transport apis and to the plugin which allow
    you to block pool imports.
    This is useful for when you're modifying/repairing the pool disk and therefore
    we can't let the control-plane import the pool at the same time.
    
---

    docs(rest-plugin): fix subcommand help
    
    Help was incorrectly claiming we cordon all aspects by default.
