### PR TITLE
feat(restore): use cluster size of pool from replica snapshots

### DIFF
--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -424,7 +424,7 @@ async fn volume_repl_placement_with_cluster_size() {
         .unwrap();
 }
 
-async fn validate_vol_repl_cluster_size(
+pub(crate) async fn validate_vol_repl_cluster_size(
     cluster: &Cluster,
     volume: &Volume,
     expected_cluster_size: u64,

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot_clone.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot_clone.rs
@@ -1,9 +1,16 @@
+use crate::pool::validate_vol_repl_cluster_size;
 use deployer_cluster::ClusterBuilder;
-use grpc::operations::volume::traits::{CreateVolumeSnapshot, VolumeOperations};
+use grpc::operations::{
+    pool::traits::PoolOperations,
+    volume::traits::{CreateVolumeSnapshot, DestroyVolumeSnapshot, VolumeOperations},
+};
 use std::time::Duration;
 use stor_port::{
     transport_api::ReplyErrorKind,
-    types::v0::transport::{CreateSnapshotVolume, CreateVolume, Filter, SnapshotId},
+    types::v0::{
+        store::pool::POOL_BS_CLUSTER_SIZE_DEFAULT,
+        transport::{CreatePool, CreateSnapshotVolume, CreateVolume, Filter, SnapshotId},
+    },
 };
 
 #[tokio::test]
@@ -120,4 +127,172 @@ async fn snapshot_clone() {
         )
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn snapshot_clone_pool_cluster_size_constraint() {
+    let cluster = ClusterBuilder::builder()
+        .with_io_engines(3)
+        .with_reconcile_period(Duration::from_secs(10), Duration::from_secs(10))
+        .build()
+        .await
+        .unwrap();
+
+    let client = cluster.grpc_client();
+
+    let vol_cli = cluster.grpc_client().volume();
+
+    let pool_4m_1 = CreatePool {
+        node: cluster.node(0),
+        id: "pool_cs_4m_1".into(),
+        disks: vec!["malloc:///disk0?size_mb=200".into()],
+        labels: None,
+        encryption: None,
+        cluster_size: None,
+    };
+
+    let pool_32m_1 = CreatePool {
+        node: cluster.node(1),
+        id: "pool_cs_32m_1".into(),
+        disks: vec!["malloc:///disk1?size_mb=200".into()],
+        labels: None,
+        encryption: None,
+        cluster_size: Some(33554432),
+    };
+
+    let pool_32m_2 = CreatePool {
+        node: cluster.node(2),
+        id: "pool_cs_32m_2".into(),
+        disks: vec!["malloc:///disk2?size_mb=200".into()],
+        labels: None,
+        encryption: None,
+        cluster_size: Some(33554432),
+    };
+
+    let _ = client.pool().create(&pool_4m_1, None).await.unwrap();
+    let _ = client.pool().create(&pool_32m_1, None).await.unwrap();
+    let _ = client.pool().create(&pool_32m_2, None).await.unwrap();
+
+    // Craete a 1-repl volume. Should succeed on default cluster size pool.
+    let volume_1 = vol_cli
+        .create(
+            &CreateVolume {
+                uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
+                size: 20 * 1024 * 1024,
+                replicas: 1,
+                thin: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let vol_snapshot_1 = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume_1.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let clone_1 = vol_cli
+        .create_snapshot_volume(
+            &CreateSnapshotVolume::new(
+                vol_snapshot_1.spec().snap_id().clone(),
+                CreateVolume {
+                    uuid: "2e3cf927-80c2-47a8-adf0-95c486bdd7b8".try_into().unwrap(),
+                    size: 20 * 1024 * 1024,
+                    replicas: 1,
+                    thin: true,
+                    ..Default::default()
+                },
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(volume_1.spec().cluster_size, POOL_BS_CLUSTER_SIZE_DEFAULT);
+    assert_eq!(clone_1.spec().cluster_size, volume_1.spec().cluster_size);
+    validate_vol_repl_cluster_size(&cluster, &volume_1, POOL_BS_CLUSTER_SIZE_DEFAULT.into())
+        .await
+        .unwrap();
+    validate_vol_repl_cluster_size(&cluster, &clone_1, POOL_BS_CLUSTER_SIZE_DEFAULT.into())
+        .await
+        .unwrap();
+
+    // Now create a 2-repl volume with 32MiB requested pool cluster size, take a snapshot
+    // and restore into a 2-repl clone. Clone volume also must have replicas on 32MiB cluster
+    // size pools.
+    let volume_2 = vol_cli
+        .create(
+            &CreateVolume {
+                uuid: "3e3cf927-80c2-47a8-adf0-95c486bdd7b7".try_into().unwrap(),
+                size: 20 * 1024 * 1024,
+                replicas: 2,
+                thin: false,
+                cluster_size: Some(33554432),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let vol_snapshot_2 = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume_2.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let clone_2 = vol_cli
+        .create_snapshot_volume(
+            &CreateSnapshotVolume::new(
+                vol_snapshot_2.spec().snap_id().clone(),
+                CreateVolume {
+                    uuid: "4e3cf927-80c2-47a8-adf0-95c486bdd7b8".try_into().unwrap(),
+                    size: 20 * 1024 * 1024,
+                    replicas: 2,
+                    thin: true,
+                    ..Default::default()
+                },
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(volume_2.spec().cluster_size, 33554432);
+    assert_eq!(clone_2.spec().cluster_size, volume_2.spec().cluster_size);
+    validate_vol_repl_cluster_size(&cluster, &volume_2, 33554432)
+        .await
+        .unwrap();
+    validate_vol_repl_cluster_size(&cluster, &clone_2, 33554432)
+        .await
+        .unwrap();
+
+    // And scaling the volume should fail, even though there is a third pool available,
+    // because that pool won't fit cluster size constraints for the volume.
+    let rest_client = cluster.rest_v00();
+    rest_client
+        .volumes_api()
+        .put_volume_replica_count(clone_2.uuid(), 3)
+        .await
+        .expect_err("volume replica count scale-up must fail");
+
+    vol_cli.destroy(&clone_1, None).await.unwrap();
+    vol_cli.destroy(&clone_2, None).await.unwrap();
+    vol_cli
+        .destroy_snapshot(&DestroyVolumeSnapshot::from(&vol_snapshot_1), None)
+        .await
+        .unwrap();
+    vol_cli
+        .destroy_snapshot(&DestroyVolumeSnapshot::from(&vol_snapshot_2), None)
+        .await
+        .unwrap();
+    vol_cli.destroy(&volume_1, None).await.unwrap();
+    vol_cli.destroy(&volume_2, None).await.unwrap();
 }

--- a/control-plane/agents/src/bin/core/volume/service.rs
+++ b/control-plane/agents/src/bin/core/volume/service.rs
@@ -232,10 +232,11 @@ impl VolumeOperations for Service {
         req: &dyn CreateSnapshotVolumeInfo,
         _ctx: Option<Context>,
     ) -> Result<Volume, ReplyError> {
-        let request = req.into();
+        let mut request = req.into();
         let service = self.clone();
         let volume =
-            Context::spawn(async move { service.create_snapshot_volume(&request).await }).await??;
+            Context::spawn(async move { service.create_snapshot_volume(&mut request).await })
+                .await??;
         Ok(volume)
     }
 
@@ -590,11 +591,14 @@ impl Service {
     #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.params().uuid))]
     pub(super) async fn create_snapshot_volume(
         &self,
-        request: &CreateSnapshotVolume,
+        request: &mut CreateSnapshotVolume,
     ) -> Result<Volume, SvcError> {
         let _permit = self.create_volume_permit().await?;
         let snap_uuid = request.snapshot_uuid();
         let mut snapshot = self.specs().volume_snapshot(snap_uuid).await?;
+        let cluster_size_for_clone_vol =
+            snapshot.pool_cluster_size_for_clone(&self.registry).await?;
+        request.params_mut().cluster_size = Some(cluster_size_for_clone_vol);
         snapshot.create_clone(&self.registry, request).await?;
         self.registry.volume(&request.params().uuid).await
     }

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -553,4 +553,41 @@ impl OperationGuardArc<VolumeSnapshot> {
         }
         failed
     }
+
+    /// Get the pool cluster size from one of the replica snapshot. This gets set as the cluster size
+    /// constraint in the new restore/clone volume. Once the correct cluster size constraint is set on the
+    /// volume, the further replica scheduling work as expected in terms of cluster size constraint, for
+    /// the clone volume.
+    pub(crate) async fn pool_cluster_size_for_clone(
+        &self,
+        registry: &Registry,
+    ) -> Result<u32, SvcError> {
+        let repl_snap = self
+            .as_ref()
+            .metadata()
+            .replica_snapshots()
+            .ok_or(SvcError::NoHealthyReplicas {
+                id: self.as_ref().uid_str().clone(),
+            })?
+            .first()
+            .ok_or(SvcError::NoHealthyReplicas {
+                id: self.as_ref().uid_str().clone(),
+            })?;
+
+        let snapshot_replica = registry
+            .snapshot_replica(repl_snap.spec())
+            .await
+            .map_err(|_| SvcError::ReplicaSnapMiss {
+                replica: repl_snap.spec().source_id().replica_id().to_string(),
+            })?;
+
+        Ok(registry
+            .ctrl_pool(snapshot_replica.pool_id())
+            .await?
+            .spec()
+            .ok_or(SvcError::PoolNotFound {
+                pool_id: snapshot_replica.pool_id().clone(),
+            })?
+            .cluster_size)
+    }
 }

--- a/control-plane/csi-driver/src/context.rs
+++ b/control-plane/csi-driver/src/context.rs
@@ -80,8 +80,8 @@ pub enum Parameters {
     FormatOptions,
     #[strum(serialize = "overrideGlobalFormatOpts")]
     OverrideGlobalFormatOpts,
-    #[strum(serialize = "pool_cluster_size")]
-    PoolAllocationUnitSize,
+    #[strum(serialize = "poolClusterSize")]
+    PoolClusterSize,
 }
 impl Parameters {
     fn parse_human_time(
@@ -264,7 +264,7 @@ impl Parameters {
     ) -> Result<Option<bool>, ParseBoolError> {
         Self::parse_bool(value)
     }
-    /// Parse the value for `Self::PoolAllocationUnitSize`
+    /// Parse the value for `Self::PoolClusterSize`
     pub fn pool_cluster_size(value: Option<&String>) -> Result<Option<u64>, tonic::Status> {
         if let Some(value) = value {
             let alloc_unit_bytes = parse_size(value).ok();
@@ -534,7 +534,7 @@ impl CreateParams {
     pub fn encrypted(&self) -> Option<bool> {
         self.encrypted
     }
-    /// Get the `Parameters::PoolAllocationUnitSize` value.
+    /// Get the `Parameters::PoolClusterSize` value.
     pub fn pool_cluster_size(&self) -> Option<u64> {
         self.pool_cluster_size
     }
@@ -713,7 +713,7 @@ impl TryFrom<&HashMap<String, String>> for CreateParams {
             })?;
 
         let pool_cluster_size =
-            Parameters::pool_cluster_size(args.get(Parameters::PoolAllocationUnitSize.as_ref()))?;
+            Parameters::pool_cluster_size(args.get(Parameters::PoolClusterSize.as_ref()))?;
 
         Ok(Self {
             publish_params,

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -1025,4 +1025,8 @@ impl CreateSnapshotVolume {
     pub fn params(&self) -> &CreateVolume {
         &self.volume_params
     }
+    /// Get a mutable reference to the generic volume parameters.
+    pub fn params_mut(&mut self) -> &mut CreateVolume {
+        &mut self.volume_params
+    }
 }


### PR DESCRIPTION
While creating a clone volume with snapshot as source, get the pool cluster size from one of the replica snapshot. This gets set as the cluster size constraint in the new restore/clone volume.