### PR TITLE
refactor: allow zfs volume paths

### DIFF
--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -186,5 +186,4 @@ pub fn nvme_controller_model_id() -> String {
 pub const ETCD_MAX_PAGE_LIMIT: &str = "500";
 
 /// Regex to match persistent disks.
-pub const DEVLINK_REGEX: &str =
-    r"^(/dev/(disk/by-(id|uuid|label|path|partuuid|partlabel)/[^/\s]+|mapper/[^/\s]+))$";
+pub const DEVLINK_REGEX: &str = r"^(/dev/(disk/by-(id|uuid|label|path|partuuid|partlabel)/[^/\s]+|mapper/[^/\s]+|zvol/[^/\s]+(/[^/\s]+)*))$";

--- a/utils/utils-lib/src/disk.rs
+++ b/utils/utils-lib/src/disk.rs
@@ -63,6 +63,11 @@ mod tests {
             ("/dev/disk/by-partuuid/somepath", true),
             ("/dev/disk/by-partlabel/somepath", true),
             ("/dev/mapper/dm0", true),
+            ("/dev/mapper/zvol", true),
+            ("/dev/disk/zvol", false),
+            ("/dev/disk/by-zvol/zpool/somevolume", false),
+            ("/dev/zvol/zpool/somevolume", true),
+            ("/dev/zvol/zpool/somevolume/somevolume", true),
         ];
 
         for test in test_suite {


### PR DESCRIPTION
- Allow /dev/zvol paths to be a valid devlink as they are also persistent.