### PR TITLE
feat(simulation): add simulator of cluster bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __pycache__
 /.tmp
 /ci-report/
 pytest.log
+/bundle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bundle-sim"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "composer",
+ "deployer",
+ "etcd-client",
+ "flate2",
+ "rpc",
+ "serde_json",
+ "stor-port",
+ "tar",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+ "utils",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1186,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 name = "deployer"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "clap",
  "composer",
@@ -1547,6 +1569,18 @@ dependencies = [
  "libc",
  "thiserror",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2719,7 +2753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2730,6 +2764,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -4493,6 +4528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5327,6 +5373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5384,6 +5436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5407,11 +5468,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5427,6 +5505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5437,6 +5521,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5451,10 +5541,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5469,6 +5571,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5479,6 +5587,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5493,6 +5607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5503,6 +5623,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winsafe"
@@ -5521,6 +5647,17 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xattr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ h2 = { path = "./utils/dependencies/h2" }
 
 [profile.dev]
 panic = "abort"
+debug = false
+
+[profile.dev.package.crc32fast]
+opt-level = 2
+[profile.dev.package.miniz_oxide]
+opt-level = 2
 
 [workspace]
 members = [
@@ -26,6 +32,7 @@ members = [
     "utils/deployer-cluster",
     "utils/hyper-body",
     "tests/io-engine",
+    "utils/bundle-sim",
 ]
 exclude = [
     "utils/dependencies/*",

--- a/control-plane/agents/src/bin/core/controller/io_engine/client.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/client.rs
@@ -28,6 +28,8 @@ pub(crate) struct GrpcContext {
     comms_timeouts: NodeCommsTimeout,
     /// The api version to be used for calls.
     api_version: ApiVersion,
+    /// Simulated io-engine node.
+    sim: bool,
 }
 
 impl GrpcContext {
@@ -39,6 +41,7 @@ impl GrpcContext {
         comms_timeouts: &NodeCommsTimeout,
         request: Option<MessageId>,
         api_version: ApiVersion,
+        sim: bool,
     ) -> Result<Self, SvcError> {
         let uri = http::uri::Uri::builder()
             .scheme("http")
@@ -66,6 +69,7 @@ impl GrpcContext {
             endpoint,
             comms_timeouts: comms_timeouts.clone(),
             api_version,
+            sim,
         })
     }
     /// Override the timeout config in the context for the given request.
@@ -98,7 +102,11 @@ impl GrpcContext {
     }
     /// Get the tonic endpoint.
     pub(crate) fn tonic_endpoint(&self) -> tonic::transport::Endpoint {
-        self.endpoint.clone()
+        let mut endpoint = self.endpoint.clone();
+        if self.sim {
+            endpoint = endpoint.user_agent(self.node().as_str()).unwrap();
+        }
+        endpoint
     }
     /// Get the node identifier.
     pub(crate) fn node(&self) -> &NodeId {

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/snap_rebuild.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/snap_rebuild.rs
@@ -134,6 +134,7 @@ mod test {
             &NodeCommsTimeout::new(one_s, one_s, false),
             None,
             ApiVersion::V1,
+            false,
         )
         .unwrap();
         let io_engine = GrpcClient::new(&ctx).await.unwrap();

--- a/control-plane/agents/src/bin/core/controller/reconciler/persistent_store.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/persistent_store.rs
@@ -1,4 +1,7 @@
-use crate::controller::task_poller::{PollContext, PollResult, PollerState, TaskPoller};
+use crate::controller::{
+    reconciler::PollTriggerEvent,
+    task_poller::{PollContext, PollEvent, PollResult, PollerState, TaskPoller},
+};
 
 /// Reconcile dirty specs in the persistent store.
 /// This happens when we fail to update the persistent store and we have a "live" spec that
@@ -32,5 +35,13 @@ impl TaskPoller for PersistentStoreReconciler {
         }
 
         PollResult::Ok(PollerState::Idle)
+    }
+    async fn poll_event(&mut self, context: &PollContext) -> bool {
+        match context.event() {
+            PollEvent::TimedRun => true,
+            PollEvent::Triggered(PollTriggerEvent::SimulStart) => true,
+            PollEvent::Triggered(_event) => true,
+            PollEvent::Shutdown => true,
+        }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/reconciler/poller.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/poller.rs
@@ -69,7 +69,7 @@ impl ReconcilerWorker {
     /// The polling will continue until we receive the shutdown signal
     pub(super) async fn poller(mut self, registry: Registry) {
         // kick-off the first run
-        let mut event = PollEvent::Triggered(PollTriggerEvent::Start);
+        let mut event = PollEvent::Triggered(self.start_trigger(&registry));
         loop {
             let result = match &event {
                 PollEvent::Shutdown => {
@@ -96,6 +96,16 @@ impl ReconcilerWorker {
                     PollEvent::TimedRun
                 }
             };
+        }
+    }
+    fn start_trigger(&self, registry: &Registry) -> PollTriggerEvent {
+        let Some(sim_args) = registry.sim_args() else {
+            return PollTriggerEvent::Start;
+        };
+        if sim_args.no_start_event {
+            PollTriggerEvent::SimulStart
+        } else {
+            PollTriggerEvent::Start
         }
     }
 

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -22,7 +22,7 @@ use crate::{
         task_poller::{PollEvent, PollTriggerEvent},
         wrapper::InternalOps,
     },
-    ThinArgs,
+    SimArgs, ThinArgs,
 };
 use agents::errors::SvcError;
 use std::{
@@ -122,6 +122,8 @@ pub(crate) struct RegistryInner<S: Store> {
     /// Blobstore cluster size(in bytes) required for pool creation and replica scheduling. This is
     /// not per-pool.
     pool_cluster_size: Option<u32>,
+    /// Running in simulation mode.
+    sim_args: Option<SimArgs>,
 }
 
 impl Registry {
@@ -151,6 +153,7 @@ impl Registry {
         allow_non_persistent_devlinks: bool,
         encrypted_pools_soft_scheduling: bool,
         pool_cluster_size: Option<u32>,
+        sim_args: Option<SimArgs>,
     ) -> Result<Self, SvcError> {
         let store_endpoint = Self::format_store_endpoint(&store_url);
         tracing::info!("Connecting to persistent store at {}", store_endpoint);
@@ -213,6 +216,7 @@ impl Registry {
                 allow_non_persistent_devlinks,
                 encrypted_pools_soft_scheduling,
                 pool_cluster_size: pool_cluster_size.or(Some(POOL_BS_CLUSTER_SIZE_DEFAULT)),
+                sim_args,
             }),
         };
         registry.init().await?;
@@ -262,6 +266,11 @@ impl Registry {
     /// Check if the target acc is disabled.
     pub(crate) fn target_acc_disabled(&self) -> bool {
         self.disable_target_acc
+    }
+
+    /// Get the simulation Args.
+    pub(crate) fn sim_args(&self) -> Option<&SimArgs> {
+        self.sim_args.as_ref()
     }
 
     /// Formats the store endpoint with a default port if one isn't supplied.

--- a/control-plane/agents/src/bin/core/controller/task_poller.rs
+++ b/control-plane/agents/src/bin/core/controller/task_poller.rs
@@ -24,6 +24,8 @@ pub(crate) enum PollTriggerEvent {
     VolumeDegraded,
     /// Resource Set to Deleting from Creating, garbage collection required.
     ResourceCreatingToDeleting,
+    /// The Agent is starting up in simulation mode.
+    SimulStart,
     /// The Agent is starting up.
     Start,
     /// A node needs to be drained.
@@ -150,6 +152,7 @@ pub(crate) trait TaskPoller: Send + Sync + std::fmt::Debug {
     async fn poll_event(&mut self, context: &PollContext) -> bool {
         match context.event() {
             PollEvent::TimedRun => true,
+            PollEvent::Triggered(PollTriggerEvent::SimulStart) => false,
             PollEvent::Triggered(_event) => true,
             PollEvent::Shutdown => true,
         }

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -162,6 +162,18 @@ pub(crate) struct CliArgs {
     /// to configure cluster size per-pool.
     #[clap(long)]
     pool_cluster_size: Option<u32>,
+
+    /// Running in simulation mode.
+    #[clap(long, env = "SIMULATION", requires = "bundle")]
+    simulation: bool,
+
+    /// Simulation bundle location.
+    #[clap(long = "sim-bundle", env = "SIM_BUNDLE")]
+    bundle: Option<std::path::PathBuf>,
+
+    /// Disable most start-time reconcilers (other than the pstor cleanup).
+    #[clap(long = "sim-no-start", env = "SIM_NO_START_EVENT")]
+    no_start: bool,
 }
 impl CliArgs {
     fn args() -> Self {
@@ -195,6 +207,32 @@ pub(crate) struct ThinArgs {
     volume_commitment_initial: u64,
 }
 
+/// Simulation related arguments.
+#[derive(Debug)]
+pub struct SimArgs {
+    /// Simulation bundle location.
+    bundle: std::path::PathBuf,
+    /// Disable most start-time reconcilers (other than the pstor cleanup).
+    no_start_event: bool,
+}
+impl TryFrom<&CliArgs> for Option<SimArgs> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &CliArgs) -> Result<Self, Self::Error> {
+        if !value.simulation {
+            return Ok(None);
+        }
+        let Some(bundle) = value.bundle.clone() else {
+            return Err(anyhow::anyhow!("Specify --sim-bundle"));
+        };
+        anyhow::ensure!(bundle.is_dir(), "Simulation Bundle must be extracted");
+        Ok(Some(SimArgs {
+            bundle,
+            no_start_event: value.no_start,
+        }))
+    }
+}
+
 fn value_parse_percent(value: &str) -> Result<u64, ParseIntError> {
     value.replace('%', "").parse()
 }
@@ -217,6 +255,7 @@ async fn main() -> anyhow::Result<()> {
 
 async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
     stor_port::platform::init_cluster_info_or_panic().await;
+    let sim_args: Option<SimArgs> = (&cli_args).try_into()?;
     let registry = controller::registry::Registry::new(
         cli_args.cache_period.into(),
         cli_args.store.clone(),
@@ -242,6 +281,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.allow_non_persistent_devlink,
         cli_args.encrypted_pools_soft_scheduling,
         cli_args.pool_cluster_size,
+        sim_args,
     )
     .await?;
 

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -13,8 +13,7 @@ use stor_port::types::v0::transport::{
     Deregister, Filter, Node, NodeId, NodeState, NodeStatus, Register,
 };
 
-use crate::controller::io_engine::HostApi;
-use crate::controller::wrapper::InternalOps;
+use crate::controller::{io_engine::HostApi, wrapper::InternalOps};
 use grpc::{
     context::Context,
     operations::{
@@ -32,6 +31,8 @@ pub(crate) struct Service {
     deadline: std::time::Duration,
     /// Node communication timeouts.
     comms_timeouts: NodeCommsTimeout,
+    /// Simulated node endpoint.
+    sim_socket: Option<std::net::SocketAddr>,
 }
 
 /// Node communication Timeouts for establishing the connection to a node and
@@ -165,19 +166,27 @@ impl RegistrationOperations for Service {
 }
 
 impl Service {
+    fn sim_socket(registry: &Registry) -> Option<std::net::SocketAddr> {
+        let sim_args = registry.sim_args()?;
+        let sim_socket = sim_args.bundle.join("sim_socket");
+        let sim_socket = std::fs::read_to_string(sim_socket).ok()?;
+        sim_socket.parse::<std::net::SocketAddr>().ok()
+    }
     /// New Node Service which uses the `registry` as its node cache and sets
     /// the `deadline` to each node's watchdog.
-    pub(super) async fn new(
+    pub(crate) async fn new(
         registry: Registry,
         deadline: std::time::Duration,
         request: std::time::Duration,
         connect: std::time::Duration,
         no_min: bool,
     ) -> Self {
+        let sim_socket = Self::sim_socket(&registry);
         let service = Self {
             registry,
             deadline,
             comms_timeouts: NodeCommsTimeout::new(connect, request, no_min),
+            sim_socket,
         };
         // attempt to reload the node state based on the specification
         for node in service.registry.specs().nodes() {
@@ -241,6 +250,7 @@ impl Service {
                     self.deadline,
                     self.comms_timeouts.clone(),
                     ha_disabled,
+                    self.sim_socket,
                 );
 
                 // On startup api version is not known, thus probe all apiversions

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -1,9 +1,8 @@
-use crate::controller::io_engine::HostApi;
 use crate::{
     controller::{
         io_engine::{
             types::{CreateNexusSnapshot, CreateNexusSnapshotResp},
-            GrpcClient, GrpcClientLocked, GrpcContext, NexusApi, NexusChildActionApi,
+            GrpcClient, GrpcClientLocked, GrpcContext, HostApi, NexusApi, NexusChildActionApi,
             NexusChildApi, NexusShareApi, NexusSnapshotApi, PoolApi, ReplicaApi,
             ReplicaSnapshotApi,
         },
@@ -19,23 +18,21 @@ use agents::{errors::SvcError, eventing::EventWithMeta};
 use async_trait::async_trait;
 use events_api::event::{EventAction, EventCategory, EventMessage, EventMeta, EventSource};
 use grpc::operations::snapshot::SnapshotInfo;
-use stor_port::transport_api::v0::BlockDevices;
-use stor_port::types::v0::transport::GetBlockDevices;
 use stor_port::{
-    transport_api::{Message, MessageId, ResourceKind},
+    transport_api::{v0::BlockDevices, Message, MessageId, ResourceKind},
     types::v0::{
         store,
         store::{nexus::NexusState, replica::ReplicaState},
         transport::{
             AddNexusChild, ApiVersion, Child, CreateNexus, CreatePool, CreateReplica,
             CreateReplicaSnapshot, DestroyNexus, DestroyPool, DestroyReplica,
-            DestroyReplicaSnapshot, FaultNexusChild, ImportPool, IoEngCreateSnapshotClone,
-            ListRebuildRecord, ListReplicaSnapshots, ListSnapshotClones, MessageIdVs, Nexus,
-            NexusChildAction, NexusChildActionContext, NexusChildActionKind, NexusId, NodeId,
-            NodeState, NodeStatus, PoolId, PoolState, RebuildHistory, Register, RemoveNexusChild,
-            Replica, ReplicaId, ReplicaName, ReplicaSnapshot, ResizeNexus, ResizeReplica,
-            SetReplicaEntityId, ShareNexus, ShareReplica, ShutdownNexus, SnapshotId, UnshareNexus,
-            UnshareReplica, VolumeId,
+            DestroyReplicaSnapshot, FaultNexusChild, GetBlockDevices, ImportPool,
+            IoEngCreateSnapshotClone, ListRebuildRecord, ListReplicaSnapshots, ListSnapshotClones,
+            MessageIdVs, Nexus, NexusChildAction, NexusChildActionContext, NexusChildActionKind,
+            NexusId, NodeId, NodeState, NodeStatus, PoolId, PoolState, RebuildHistory, Register,
+            RemoveNexusChild, Replica, ReplicaId, ReplicaName, ReplicaSnapshot, ResizeNexus,
+            ResizeReplica, SetReplicaEntityId, ShareNexus, ShareReplica, ShutdownNexus, SnapshotId,
+            UnshareNexus, UnshareReplica, VolumeId,
         },
     },
 };
@@ -104,6 +101,8 @@ pub(crate) struct NodeWrapper {
     num_rebuilds: Arc<RwLock<NumRebuilds>>,
     /// If HA is disabled, don't use reservations when creating nexuses.
     disable_ha: bool,
+    /// Simulated address for the node.
+    sim_socket: Option<std::net::SocketAddr>,
 }
 
 impl NodeWrapper {
@@ -113,6 +112,7 @@ impl NodeWrapper {
         deadline: std::time::Duration,
         comms_timeouts: NodeCommsTimeout,
         disable_ha: bool,
+        sim_socket: Option<std::net::SocketAddr>,
     ) -> Self {
         tracing::debug!("Creating new node {:?}", node);
         Self {
@@ -124,6 +124,7 @@ impl NodeWrapper {
             states: ResourceStatesLocked::new(),
             num_rebuilds: Arc::new(RwLock::new(0)),
             disable_ha,
+            sim_socket,
         }
     }
 
@@ -143,6 +144,7 @@ impl NodeWrapper {
             states: ResourceStatesLocked::new(),
             num_rebuilds: Arc::new(RwLock::new(0)),
             disable_ha: false,
+            sim_socket: None,
         }
     }
 
@@ -257,6 +259,13 @@ impl NodeWrapper {
         GrpcClient::new(&self.grpc_context_timeout(timeout)?).await
     }
 
+    fn node_endpoint(&self) -> std::net::SocketAddr {
+        match self.sim_socket {
+            Some(sim) => sim,
+            None => self.node_state().grpc_endpoint,
+        }
+    }
+
     /// Get `GrpcContext` for this node.
     /// It will be used to execute the `request` operation.
     pub(crate) fn grpc_context_ext(&self, request: MessageId) -> Result<GrpcContext, SvcError> {
@@ -264,10 +273,11 @@ impl NodeWrapper {
             Ok(GrpcContext::new(
                 self.lock.clone(),
                 self.id(),
-                self.node_state().grpc_endpoint,
+                self.node_endpoint(),
                 &self.comms_timeouts,
                 Some(request),
                 api_version,
+                self.sim_socket.is_some(),
             )?)
         } else {
             Err(SvcError::InvalidApiVersion { api_version: None })
@@ -283,10 +293,11 @@ impl NodeWrapper {
             Ok(GrpcContext::new(
                 self.lock.clone(),
                 self.id(),
-                self.node_state().grpc_endpoint,
+                self.node_endpoint(),
                 &timeout,
                 None,
                 api_version,
+                self.sim_socket.is_some(),
             )?)
         } else {
             Err(SvcError::InvalidApiVersion { api_version: None })
@@ -299,10 +310,11 @@ impl NodeWrapper {
             Ok(GrpcContext::new(
                 self.lock.clone(),
                 self.id(),
-                self.node_state().grpc_endpoint,
+                self.node_endpoint(),
                 &self.comms_timeouts,
                 None,
                 api_version,
+                self.sim_socket.is_some(),
             )?)
         } else {
             Err(SvcError::InvalidApiVersion { api_version: None })

--- a/control-plane/stor-port/src/types/v0/transport/child.rs
+++ b/control-plane/stor-port/src/types/v0/transport/child.rs
@@ -15,6 +15,7 @@ pub struct Child {
     /// Current rebuild progress (%).
     pub rebuild_progress: Option<u8>,
     /// Reason for the child state.
+    #[serde(default)]
     pub state_reason: ChildStateReason,
     /// Last faulted timestamp of this child.
     pub faulted_at: Option<SystemTime>,

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -99,8 +99,10 @@ pub struct PoolState {
     /// Total pool commitment (in bytes) which is basically the accrued size of pool replicas.
     pub committed: Option<u64>,
     /// Is the pool encrypted.
+    #[serde(default)]
     pub encrypted: bool,
     /// Blobstore cluster size used for this pool.
+    #[serde(default = "crate::types::v0::store::pool::default_pool_cluster_size")]
     pub cluster_size: u32,
 }
 

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -35,3 +35,4 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tower = { version = "0.5.1", features = ["timeout", "util"] }
 events-api = { path = "../utils/dependencies/apis/events" }
+anyhow = "1.0.92"

--- a/deployer/bin/src/deployer.rs
+++ b/deployer/bin/src/deployer.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use deployer_lib::CliArgs;
+use deployer_lib::{ListOptions, StartOptions, StopOptions};
 
 const RUST_LOG_SILENCE_DEFAULTS: &str =
     "h2=info,hyper=info,tower_buffer=info,tower=info,rustls=info,reqwest=info,mio=info,tokio_util=info,async_io=info,polling=info,tonic=info,want=info,bollard=info,stor_port=warn";
@@ -26,11 +26,36 @@ fn init_tracing() {
     tracing_subscriber::fmt().with_env_filter(filter).init();
 }
 
+#[derive(Debug, Parser)]
+#[clap(name = utils::package_description!(), version = utils::version_info_str!())]
+struct CliArgs {
+    #[clap(subcommand)]
+    action: Action,
+}
+#[derive(Debug, Parser)]
+#[clap(about = "Deployment actions")]
+enum Action {
+    Start(Box<StartOptions>),
+    Stop(StopOptions),
+    List(ListOptions),
+}
+
+impl Action {
+    async fn execute(&mut self) -> anyhow::Result<()> {
+        match self {
+            Action::Start(options) => options.start().await.map(|_| ()),
+            Action::Stop(options) => options.stop().await,
+            Action::List(options) => options.list().await,
+        }
+        .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+}
+
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     init_tracing();
 
-    let cli_args = CliArgs::parse();
+    let mut cli_args = CliArgs::parse();
     tracing::info!("Using options: {:?}", &cli_args);
 
     composer::initialize(
@@ -40,5 +65,7 @@ async fn main() {
             .to_str()
             .unwrap(),
     );
-    cli_args.execute().await.unwrap();
+    cli_args.action.execute().await?;
+
+    Ok(())
 }

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -339,8 +339,13 @@ impl BuilderConfigure for Components {
                 .with_direct_bind("/etc/machine-id")
                 .with_direct_bind("/sys/class/dmi/id/product_uuid")
                 .with_env("PLATFORM_TYPE", "deployer");
-            if let Some(uid) = &self.1.cluster_uid {
+            let spec = if let Some(uid) = &self.1.cluster_uid {
                 spec.with_env("NOPLATFORM_UUID", uid)
+            } else {
+                spec
+            };
+            if let Some(ns) = &self.1.cluster_ns {
+                spec.with_env("NOPLATFORM_NS", ns)
             } else {
                 spec
             }

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -10,21 +10,6 @@ pub(crate) use utils::tracing_telemetry::KeyValue;
 
 const TEST_LABEL_PREFIX: &str = "io.composer.test";
 
-#[derive(Debug, Parser)]
-#[clap(name = utils::package_description!(), version = utils::version_info_str!())]
-pub struct CliArgs {
-    #[clap(subcommand)]
-    action: Action,
-}
-
-#[derive(Debug, Parser)]
-#[clap(about = "Deployment actions")]
-pub(crate) enum Action {
-    Start(Box<StartOptions>),
-    Stop(StopOptions),
-    List(ListOptions),
-}
-
 /// docker network label:
 /// $prefix.name = $name
 const DEFAULT_CLUSTER_LABEL: &str = ".cluster";
@@ -256,6 +241,11 @@ pub struct StartOptions {
     /// By default the agents will determine this value themselves.
     #[clap(long)]
     pub cluster_uid: Option<ClusterUid>,
+
+    /// Namespace of the cluster.
+    /// By default the agents will determine this value themselves.
+    #[clap(long)]
+    pub cluster_ns: Option<String>,
 
     /// Disable the etcd service.
     #[clap(long)]
@@ -647,25 +637,8 @@ impl StartOptions {
     }
 }
 
-impl CliArgs {
-    /// Act upon the requested action
-    pub async fn execute(&self) -> Result<(), Error> {
-        self.action.execute().await
-    }
-}
-
-impl Action {
-    async fn execute(&self) -> Result<(), Error> {
-        match self {
-            Action::Start(options) => options.start(self).await,
-            Action::Stop(options) => options.stop(self).await,
-            Action::List(options) => options.list(self).await,
-        }
-    }
-}
-
 impl StartOptions {
-    async fn start(&self, _action: &Action) -> Result<(), Error> {
+    pub async fn start(&self) -> Result<composer::ComposeTest, Error> {
         let components = Components::new(self.clone());
         let composer = Builder::new()
             .name(&self.cluster_label.name())
@@ -698,11 +671,11 @@ impl StartOptions {
             };
             lister.list_simple().await?;
         }
-        Ok(())
+        Ok(composer)
     }
 }
 impl StopOptions {
-    async fn stop(&self, _action: &Action) -> Result<(), Error> {
+    pub async fn stop(&self) -> Result<(), Error> {
         let composer = Builder::new()
             .name(&self.cluster_label.name())
             .label_prefix(&self.cluster_label.prefix())
@@ -769,7 +742,7 @@ impl ListOptions {
         }
         Ok(())
     }
-    async fn list(&self, _action: &Action) -> Result<(), Error> {
+    pub async fn list(&self) -> Result<(), Error> {
         match self.no_docker {
             true => self.list_simple().await,
             false => self.list_docker(),

--- a/shell.nix
+++ b/shell.nix
@@ -103,5 +103,6 @@ mkShellNoCC {
       export DOCKER_PASS=$(echo $DOCKER_TOKEN | cut -d':' -f2)
     fi
     unset CC
+    unset AR
   '';
 }

--- a/tests/bdd/features/snapshot/create/test_feature.py
+++ b/tests/bdd/features/snapshot/create/test_feature.py
@@ -511,13 +511,13 @@ def snapshot_node(snapshot):
     return NODE_NAME
 
 
-@retry(wait_fixed=100, stop_max_attempt_number=20)
+@retry(wait_fixed=100, stop_max_attempt_number=40)
 def wait_snapshot_deleted():
     with pytest.raises(NotFoundException) as e:
         ApiClient.snapshots_api().get_volumes_snapshot(SNAP_UUID)
 
 
-@retry(wait_fixed=100, stop_max_attempt_number=20)
+@retry(wait_fixed=100, stop_max_attempt_number=40)
 def wait_snapshot_state(snapshot, state):
     snapshot = ApiClient.snapshots_api().get_volumes_snapshot(snapshot.state.uuid)
     assert len(snapshot.state.replica_snapshots) == 1

--- a/utils/bundle-sim/Cargo.toml
+++ b/utils/bundle-sim/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bundle-sim"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+composer = { path = "../dependencies/composer", default-features = false }
+deployer = { path = "../../deployer" }
+stor-port = { path = "../../control-plane/stor-port" }
+rpc = { path = "../../rpc" }
+utils = { path = "../utils-lib" }
+clap = { version = "4.5.20", features = ["color", "derive", "env", "string"] }
+tokio = { version = "1.43.1", features = ["full"] }
+tonic = "0.12.3"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+anyhow = "1.0.92"
+flate2 = "1.0"
+tar = "0.4"
+etcd-client = "0.14.0"
+serde_json = { version = "1.0.132" }

--- a/utils/bundle-sim/src/bin/bundle-sim.rs
+++ b/utils/bundle-sim/src/bin/bundle-sim.rs
@@ -1,0 +1,241 @@
+use clap::Parser;
+use deployer_lib::{ListOptions, StartOptions, StopOptions};
+use std::{collections::HashSet, io::Seek, os::unix::fs::MetadataExt, time::Duration};
+use utils::tracing_telemetry::KeyValue;
+
+const RUST_LOG_SILENCE_DEFAULTS: &str = "h2=info,hyper=info,tower_buffer=info,tower=info,rustls=info,reqwest=info,mio=info,tokio_util=info,async_io=info,polling=info,tonic=info,want=info,bollard=info,stor_port=warn";
+
+fn rust_log_add_quiet_defaults(
+    current: Option<tracing_subscriber::EnvFilter>,
+) -> tracing_subscriber::EnvFilter {
+    let main = match current {
+        None => {
+            format!("info,{RUST_LOG_SILENCE_DEFAULTS}")
+        }
+        Some(level) => match level.to_string().as_str() {
+            "debug" | "trace" => {
+                format!("{level},{RUST_LOG_SILENCE_DEFAULTS}")
+            }
+            _ => return level,
+        },
+    };
+    tracing_subscriber::EnvFilter::try_new(main).unwrap()
+}
+fn init_tracing() {
+    let filter =
+        rust_log_add_quiet_defaults(tracing_subscriber::EnvFilter::try_from_default_env().ok());
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+}
+
+#[derive(Debug, Parser)]
+#[clap(name = utils::package_description!(), version = utils::version_info_str!())]
+struct CliArgs {
+    #[clap(subcommand)]
+    action: Action,
+}
+
+#[derive(Debug, Parser)]
+#[clap(about = "Deployment actions")]
+enum Action {
+    Start(Box<SimulateOptions>),
+    Stop(StopOptions),
+    List(ListOptions),
+}
+
+#[derive(Debug, Default, Clone, Parser)]
+#[clap(about = "Simulate a cluster from a support bundle")]
+struct SimulateOptions {
+    /// The generic start options, though be careful not to set anything which conflicts with the
+    /// support bundle dump.
+    #[clap(flatten)]
+    opts: StartOptions,
+    /// This can either be the support bundle's tar.gz file or the extracted content.
+    /// If it's a tar.gz we'll extract to --untar-path.
+    #[clap(long)]
+    bundle: std::path::PathBuf,
+    /// If `--bundle` is a tar.gz file, then you may override the untar location.
+    #[clap(long, default_value = "./bundle")]
+    untar_path: std::path::PathBuf,
+    /// Disable most start-time reconcilers (other than the pstor cleanup).
+    #[clap(long)]
+    no_start_event: bool,
+}
+
+impl SimulateOptions {
+    async fn simulate(&mut self, root: &std::path::Path) -> anyhow::Result<()> {
+        self.extract()?;
+
+        let etcd_dump_path = self.untar_path.join("etcd_dump");
+        let etcd_dump = std::fs::File::open(&etcd_dump_path)?;
+        anyhow::ensure!(
+            etcd_dump.metadata()?.size() > 0,
+            "Unable to simulate cluster with an empty etcd dump at '{}'",
+            etcd_dump_path.display()
+        );
+
+        // Set the cluster id to match the dump, otherwise the core agent will not pick it up
+        let (uid, ns) = self.cluster_info(&etcd_dump)?;
+        self.opts.cluster_uid = Some(uid);
+        self.opts.cluster_ns = Some(ns);
+        // We're going to fake the nodes
+        self.opts.io_engines = 0;
+        self.opts.idle_io_engines = 1;
+        self.opts.idle_io_engine_bin =
+            Some(root.join("target/debug/io-engine").display().to_string());
+        let full = self.bundle.canonicalize()?;
+        self.opts.io_engine_devices = vec![full.display().to_string()];
+        self.opts.io_engine_env = Some(vec![KeyValue::new(
+            "SIM_BUNDLE",
+            self.bundle.display().to_string(),
+        )]);
+        self.opts.agents_env = Some(vec![
+            KeyValue::new("SIM_BUNDLE", self.bundle.display().to_string()),
+            KeyValue::new("SIMULATION", "true"),
+            KeyValue::new("SIM_NO_START_EVENT", self.no_start_event.to_string()),
+        ]);
+        // todo: we could fake the app nodes in future improvements
+        self.opts.app_nodes = None;
+        self.opts.csi_node = false;
+        // disable core agent timed reconcilers
+        self.opts.reconcile_period = Some(Duration::from_secs(u64::MAX).into());
+        self.opts.reconcile_idle_period = Some(Duration::from_secs(u64::MAX).into());
+        self.opts.wait_timeout = Some(Duration::from_secs(10).into());
+        self.opts.node_deadline = Some(Duration::from_secs(u64::MAX).into());
+        // disable etcd-health feature? in case nexus entries are missing
+        // Start the deployer
+        let composer = self
+            .opts
+            .start()
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        composer.stop("core").await?;
+        let sim_socket = composer.container_ip("io-engine-1");
+        let sim_socket_p = self.bundle.join("sim_socket");
+        std::fs::write(sim_socket_p, format!("{sim_socket}:10124"))?;
+        composer.start("io-engine-1").await?;
+        // Load the fake etcd data
+        self.load_etcd_dump(&etcd_dump).await?;
+        // Restart core agent, so it will reload its etcd data
+        composer.start("core").await?;
+
+        Ok(())
+    }
+    async fn load_etcd_dump(&self, mut etcd_dump: &std::fs::File) -> anyhow::Result<()> {
+        use etcd_client::Client;
+        use std::io::{BufRead, BufReader};
+
+        let mut etcd = Client::connect(["0.0.0.0:2379"], None).await?;
+        etcd_dump.rewind()?;
+        let reader = BufReader::new(etcd_dump);
+
+        let mut lines = reader.lines();
+        // Ignore old nexus health entries, from mayastor v0
+        let ignore = "ffd20a56-8d97-4f68-8049-1cae2294a690".len();
+        while let (Some(Ok(key)), Some(Ok(value))) = (lines.next(), lines.next()) {
+            if key.len() == ignore {
+                break;
+            }
+            if key.contains("/AppNodeSpec/") || key.contains("StoreLeaseLock/CoreAgent") {
+                continue;
+            }
+            etcd.put(key.clone(), value, None).await?;
+        }
+        Ok(())
+    }
+    fn cluster_info(&self, etcd_dump: &std::fs::File) -> anyhow::Result<(String, String)> {
+        use std::io::{BufRead, BufReader};
+        let mut reader = BufReader::new(etcd_dump);
+        let mut first_line = String::new();
+        reader.read_line(&mut first_line)?;
+
+        let parts: Vec<&str> = first_line.split('/').collect();
+        let cluster_id = parts
+            .iter()
+            .position(|&x| x == "clusters")
+            .and_then(|i| parts.get(i + 1))
+            .ok_or(anyhow::anyhow!(
+                "No cluster id in the first etcd_dump line: {first_line}"
+            ))?;
+        let cluster_ns = parts
+            .iter()
+            .position(|&x| x == "namespaces")
+            .and_then(|i| parts.get(i + 1))
+            .ok_or(anyhow::anyhow!(
+                "No cluster namespace in the first etcd_dump line: {first_line}"
+            ))?;
+        Ok((cluster_id.to_string(), cluster_ns.to_string()))
+    }
+    fn extract(&mut self) -> anyhow::Result<()> {
+        println!();
+        anyhow::ensure!(
+            self.bundle.exists() && (self.bundle.is_dir() || self.bundle.is_file()),
+            "--bundle argument must specify an existing file or directory"
+        );
+        if self.bundle.is_file() {
+            let file = std::fs::File::open(&self.bundle)?;
+            std::fs::create_dir_all(&self.untar_path)?;
+
+            let gz_decoder = flate2::read::GzDecoder::new(file);
+            let mut archive = tar::Archive::new(gz_decoder);
+
+            // Define the directories you want to extract
+            let target_dirs = vec![
+                "topology/node",
+                "topology/pool",
+                "topology/volume",
+                "etcd_dump",
+            ];
+            let mut unpacked_dirs = HashSet::<&str>::new();
+
+            for entry in archive.entries()? {
+                let mut entry = entry?;
+                let path = entry.path()?;
+
+                // Check if the path starts with any of the target directories
+                if let Some(target_dir) = target_dirs.iter().find(|dir| path.starts_with(dir)) {
+                    tracing::trace!("Extracting {}", path.display());
+                    if !unpacked_dirs.contains(target_dir) {
+                        tracing::info!("Extracting {target_dir}");
+                    }
+                    entry.unpack_in(&self.untar_path)?;
+
+                    unpacked_dirs.insert(target_dir);
+                }
+            }
+
+            if unpacked_dirs.len() != target_dirs.len() {
+                let mut target_dirs = target_dirs;
+                target_dirs.retain(|t| !unpacked_dirs.contains(t));
+                anyhow::bail!("{target_dirs:?} were not found in the bundle file")
+            }
+            self.bundle = self.untar_path.clone();
+        }
+        Ok(())
+    }
+}
+
+impl Action {
+    async fn execute(&mut self, root: &std::path::Path) -> anyhow::Result<()> {
+        match self {
+            Action::Start(options) => options.simulate(root).await,
+            Action::Stop(options) => options.stop().await.map_err(|e| anyhow::anyhow!("{e}")),
+            Action::List(options) => options.list().await.map_err(|e| anyhow::anyhow!("{e}")),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    init_tracing();
+
+    let mut cli_args = CliArgs::parse();
+    tracing::info!("Using options: {:?}", &cli_args);
+
+    let manifest = std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
+    let root = manifest.parent().and_then(|p| p.parent()).unwrap();
+
+    composer::initialize(root.display().to_string());
+    cli_args.action.execute(root).await?;
+
+    Ok(())
+}

--- a/utils/bundle-sim/src/bin/io-engine.rs
+++ b/utils/bundle-sim/src/bin/io-engine.rs
@@ -1,0 +1,537 @@
+use rpc::v1::pb::{
+    host_rpc_server::HostRpcServer, nexus_rpc_server::NexusRpcServer,
+    pool_rpc_server::PoolRpcServer, replica_rpc_server::ReplicaRpcServer, *,
+};
+use std::{
+    collections::HashMap,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+};
+use stor_port::types::v0::{
+    openapi::apis::Uuid, store::node::NodeSpec, transport, transport::PoolState,
+};
+use tonic::metadata::MetadataMap;
+use tracing_subscriber::{FmtSubscriber, fmt::format::FmtSpan};
+
+#[derive(Debug, Default, Clone)]
+struct IoEngine {
+    sims: HashMap<String, IoEngineCfg>,
+}
+#[derive(Debug, Clone)]
+struct IoEngineCfg {
+    version: String,
+    id: String,
+    endpoint: SocketAddr,
+    pools: Vec<Pool>,
+    replicas: Vec<Replica>,
+    nexuses: Vec<Nexus>,
+}
+
+impl IoEngine {
+    fn new() -> anyhow::Result<IoEngine> {
+        use std::io::{BufRead, BufReader};
+
+        let bundle = std::path::PathBuf::from(std::env::var("SIM_BUNDLE")?);
+        let etcd_dump = std::fs::File::open(bundle.join("etcd_dump"))?;
+        let mut io_engine = IoEngine::default();
+
+        let reader = BufReader::new(etcd_dump);
+        let mut lines = reader.lines();
+        let mut node_section = false;
+        while let (Some(Ok(key)), Some(Ok(value))) = (lines.next(), lines.next()) {
+            if !key.contains("/NodeSpec/") {
+                if node_section {
+                    break;
+                }
+                continue;
+            }
+            node_section = true;
+            let node = serde_json::from_str::<NodeSpec>(&value)?;
+            io_engine.sims.insert(
+                node.id().to_string(),
+                IoEngineCfg {
+                    version: node.version().clone().unwrap(),
+                    id: node.id().to_string(),
+                    endpoint: node.endpoint(),
+                    pools: vec![],
+                    replicas: vec![],
+                    nexuses: vec![],
+                },
+            );
+        }
+
+        let path = bundle.join("topology/pool/");
+        for entry in std::fs::read_dir(path)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            let content = std::fs::read_to_string(&path)?;
+            let value: serde_json::Value = serde_json::from_str(&content)?;
+            let state = &value["pool"]["state"];
+            if state.is_null() {
+                continue;
+            }
+            let state = serde_json::from_value::<PoolState>(state.clone())?;
+            let pool = Pool {
+                uuid: Uuid::new_v4().to_string(),
+                name: state.id.to_string(),
+                disks: state.disks.into_iter().map(Into::into).collect(),
+                state: state.status as i32,
+                capacity: state.capacity,
+                used: state.used,
+                pooltype: PoolType::Lvs as i32,
+                committed: state.committed.unwrap_or_default(),
+                cluster_size: state.cluster_size,
+                page_size: None,
+                disk_capacity: state.capacity,
+                md_info: None,
+                encrypted: Some(state.encrypted),
+            };
+            if let Some(node) = io_engine.sims.get_mut(state.node.as_str()) {
+                node.pools.push(pool);
+            }
+        }
+
+        let path = bundle.join("topology/volume/");
+        for entry in std::fs::read_dir(path)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            let content = match std::fs::read_to_string(&path) {
+                Ok(content) => content,
+                Err(error) => {
+                    tracing::error!("Failed to load content for {}: {error}", path.display());
+                    continue;
+                }
+            };
+            let value: serde_json::Value = serde_json::from_str(&content)?;
+            if let Some(replicas) = value.get("replicas_topology").and_then(|v| v.as_array()) {
+                for item in replicas {
+                    let Some(mut replicav) = item.get("replica").cloned() else {
+                        continue;
+                    };
+                    let to_lower = |v: serde_json::Value| v.as_str().unwrap().to_lowercase();
+                    // Since we're dumping the REST and not the transport, there are some nuances...
+                    replicav["name"] = replicav["uuid"].clone();
+                    replicav["status"] = to_lower(replicav["state"].take()).into();
+                    replicav["poolId"] = replicav["pool"].take();
+                    replicav["kind"] = to_lower(replicav["kind"].take()).into();
+                    replicav["allowedHosts"] = serde_json::Value::Array(vec![]);
+                    replicav["space"]["allocated_clusters_snapshots"] = 0.into();
+                    let mut replica: transport::Replica = serde_json::from_value(replicav.clone())?;
+                    replica.status = transport::ReplicaStatus::Online;
+                    let replicaf = Replica {
+                        name: replica.name.to_string(),
+                        uuid: replica.uuid.to_string(),
+                        pooluuid: replica.pool_uuid.unwrap_or_default().to_string(),
+                        size: replica.size,
+                        thin: replica.thin,
+                        share: replica.share as i32,
+                        uri: replica.uri,
+                        poolname: replica.pool_id.to_string(),
+                        usage: None,
+                        allowed_hosts: replica.allowed_hosts.into_iter().map(Into::into).collect(),
+                        is_snapshot: replica.kind == transport::ReplicaKind::Snapshot,
+                        is_clone: replica.kind == transport::ReplicaKind::SnapshotClone,
+                        snapshot_uuid: None,
+                        entity_id: replica.entity_id.map(Into::into),
+                        pooltype: PoolType::Lvs as i32,
+                        encrypted: replica.encrypted,
+                    };
+                    if let Some(node) = io_engine.sims.get_mut(replica.node.as_str()) {
+                        node.replicas.push(replicaf);
+                    }
+                }
+            }
+            let state = &value["volume"]["state"];
+            if let Some(mut target) = state.get("target").cloned() {
+                // Since we're dumping the REST and not the transport, there are some nuances...
+                target["name"] = target["uuid"].clone();
+                target["status"] = target["state"].take();
+                target["share"] = "nvmf".into();
+                target["allowedHosts"] = serde_json::Value::Array(vec![]);
+                let mut state: transport::Nexus = serde_json::from_value(target.clone()).unwrap();
+                state.status = transport::NexusStatus::Online;
+                let nexus = Nexus {
+                    name: state.name,
+                    uuid: state.uuid.into(),
+                    size: state.size,
+                    state: state.status as i32,
+                    children: state
+                        .children
+                        .into_iter()
+                        .map(|c| Child {
+                            uri: c.uri.to_string(),
+                            state: c.state as i32,
+                            state_reason: c.state_reason as i32,
+                            rebuild_progress: c.rebuild_progress.unwrap_or_default() as i32,
+                            device_name: None,
+                            fault_timestamp: c.faulted_at.map(Into::into),
+                            has_io_log: c.has_io_log.unwrap_or_default(),
+                        })
+                        .collect(),
+                    device_uri: state.device_uri,
+                    rebuilds: state.rebuilds,
+                    ana_state: 0,
+                    allowed_hosts: state.allowed_hosts.into_iter().map(Into::into).collect(),
+                };
+                if let Some(node) = io_engine.sims.get_mut(state.node.as_str()) {
+                    node.nexuses.push(nexus);
+                }
+            }
+        }
+
+        Ok(io_engine)
+    }
+    fn request_node(&self, metadata: &MetadataMap) -> Result<&IoEngineCfg, tonic::Status> {
+        let Some(agent) = metadata.get("user-agent") else {
+            return Err(tonic::Status::internal("no user-agent"));
+        };
+        let agent = agent.to_str().unwrap();
+        let mut parts = agent.split_whitespace();
+        let id = parts.next().unwrap_or_default();
+        let Some(node) = self.sims.get(id) else {
+            return Err(tonic::Status::internal(format!("node {id} not found")));
+        };
+        Ok(node)
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let subscriber = FmtSubscriber::builder()
+        .with_span_events(FmtSpan::ENTER | FmtSpan::EXIT)
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    let io_engine = IoEngine::new()?;
+    tonic::transport::Server::builder()
+        .add_service(PoolRpcServer::new(io_engine.clone()))
+        .add_service(ReplicaRpcServer::new(io_engine.clone()))
+        .add_service(NexusRpcServer::new(io_engine.clone()))
+        .add_service(HostRpcServer::new(io_engine))
+        .serve(SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(0, 0, 0, 0),
+            10124,
+        )))
+        .await?;
+    Ok(())
+}
+
+#[tonic::async_trait]
+impl rpc::v1::pb::host_rpc_server::HostRpc for IoEngine {
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn get_mayastor_info(
+        &self,
+        request: tonic::Request<()>,
+    ) -> Result<tonic::Response<MayastorInfoResponse>, tonic::Status> {
+        let node = self.request_node(request.metadata())?;
+
+        let info = MayastorInfoResponse {
+            version: node.version.clone(),
+            previous_features: None,
+            registration_info: Some(RegisterRequest {
+                id: node.id.clone(),
+                grpc_endpoint: node.endpoint.to_string(),
+                instance_uuid: None,
+                api_version: vec![1],
+                hostnqn: None,
+                features: None,
+                bugfixes: None,
+                version: Some(node.version.clone()),
+            }),
+        };
+        Ok(tonic::Response::new(info))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn list_block_devices(
+        &self,
+        _request: tonic::Request<ListBlockDevicesRequest>,
+    ) -> Result<tonic::Response<ListBlockDevicesResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn get_mayastor_resource_usage(
+        &self,
+        _request: tonic::Request<()>,
+    ) -> Result<tonic::Response<GetMayastorResourceUsageResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn list_nvme_controllers(
+        &self,
+        _request: tonic::Request<()>,
+    ) -> Result<tonic::Response<ListNvmeControllersResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn stat_nvme_controller(
+        &self,
+        _request: tonic::Request<StatNvmeControllerRequest>,
+    ) -> Result<tonic::Response<StatNvmeControllerResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+}
+
+#[tonic::async_trait]
+impl rpc::v1::pb::pool_rpc_server::PoolRpc for IoEngine {
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn create_pool(
+        &self,
+        _request: tonic::Request<CreatePoolRequest>,
+    ) -> Result<tonic::Response<Pool>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn destroy_pool(
+        &self,
+        _request: tonic::Request<DestroyPoolRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn export_pool(
+        &self,
+        _request: tonic::Request<ExportPoolRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn import_pool(
+        &self,
+        _request: tonic::Request<ImportPoolRequest>,
+    ) -> Result<tonic::Response<Pool>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn list_pools(
+        &self,
+        request: tonic::Request<ListPoolOptions>,
+    ) -> Result<tonic::Response<ListPoolsResponse>, tonic::Status> {
+        let node = self.request_node(request.metadata())?;
+        Ok(tonic::Response::new(ListPoolsResponse {
+            pools: node.pools.clone(),
+        }))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn grow_pool(
+        &self,
+        _request: tonic::Request<GrowPoolRequest>,
+    ) -> Result<tonic::Response<GrowPoolResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+}
+
+#[tonic::async_trait]
+impl rpc::v1::pb::nexus_rpc_server::NexusRpc for IoEngine {
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn create_nexus(
+        &self,
+        _request: tonic::Request<CreateNexusRequest>,
+    ) -> Result<tonic::Response<CreateNexusResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn destroy_nexus(
+        &self,
+        _request: tonic::Request<DestroyNexusRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn resize_nexus(
+        &self,
+        _request: tonic::Request<ResizeNexusRequest>,
+    ) -> Result<tonic::Response<ResizeNexusResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn list_nexus(
+        &self,
+        request: tonic::Request<ListNexusOptions>,
+    ) -> Result<tonic::Response<ListNexusResponse>, tonic::Status> {
+        let node = self.request_node(request.metadata())?;
+        Ok(tonic::Response::new(ListNexusResponse {
+            nexus_list: node.nexuses.clone(),
+        }))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn add_child_nexus(
+        &self,
+        _request: tonic::Request<AddChildNexusRequest>,
+    ) -> Result<tonic::Response<AddChildNexusResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn remove_child_nexus(
+        &self,
+        _request: tonic::Request<RemoveChildNexusRequest>,
+    ) -> Result<tonic::Response<RemoveChildNexusResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn fault_nexus_child(
+        &self,
+        _request: tonic::Request<FaultNexusChildRequest>,
+    ) -> Result<tonic::Response<FaultNexusChildResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn shutdown_nexus(
+        &self,
+        _request: tonic::Request<ShutdownNexusRequest>,
+    ) -> Result<tonic::Response<ShutdownNexusResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn publish_nexus(
+        &self,
+        _request: tonic::Request<PublishNexusRequest>,
+    ) -> Result<tonic::Response<PublishNexusResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn unpublish_nexus(
+        &self,
+        _request: tonic::Request<UnpublishNexusRequest>,
+    ) -> Result<tonic::Response<UnpublishNexusResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn get_nvme_ana_state(
+        &self,
+        _request: tonic::Request<GetNvmeAnaStateRequest>,
+    ) -> Result<tonic::Response<GetNvmeAnaStateResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn set_nvme_ana_state(
+        &self,
+        _request: tonic::Request<SetNvmeAnaStateRequest>,
+    ) -> Result<tonic::Response<SetNvmeAnaStateResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn child_operation(
+        &self,
+        _request: tonic::Request<ChildOperationRequest>,
+    ) -> Result<tonic::Response<ChildOperationResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn start_rebuild(
+        &self,
+        _request: tonic::Request<StartRebuildRequest>,
+    ) -> Result<tonic::Response<StartRebuildResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn stop_rebuild(
+        &self,
+        _request: tonic::Request<StopRebuildRequest>,
+    ) -> Result<tonic::Response<StopRebuildResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn pause_rebuild(
+        &self,
+        _request: tonic::Request<PauseRebuildRequest>,
+    ) -> Result<tonic::Response<PauseRebuildResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn resume_rebuild(
+        &self,
+        _request: tonic::Request<ResumeRebuildRequest>,
+    ) -> Result<tonic::Response<ResumeRebuildResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn get_rebuild_state(
+        &self,
+        _request: tonic::Request<RebuildStateRequest>,
+    ) -> Result<tonic::Response<RebuildStateResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn get_rebuild_stats(
+        &self,
+        _request: tonic::Request<RebuildStatsRequest>,
+    ) -> Result<tonic::Response<RebuildStatsResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn get_rebuild_history(
+        &self,
+        _request: tonic::Request<RebuildHistoryRequest>,
+    ) -> Result<tonic::Response<RebuildHistoryResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn list_rebuild_history(
+        &self,
+        _request: tonic::Request<ListRebuildHistoryRequest>,
+    ) -> Result<tonic::Response<ListRebuildHistoryResponse>, tonic::Status> {
+        Ok(tonic::Response::new(ListRebuildHistoryResponse {
+            histories: Default::default(),
+            end_time: None,
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl rpc::v1::pb::replica_rpc_server::ReplicaRpc for IoEngine {
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn create_replica(
+        &self,
+        _request: tonic::Request<CreateReplicaRequest>,
+    ) -> Result<tonic::Response<Replica>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn destroy_replica(
+        &self,
+        _request: tonic::Request<DestroyReplicaRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn list_replicas(
+        &self,
+        request: tonic::Request<ListReplicaOptions>,
+    ) -> Result<tonic::Response<ListReplicasResponse>, tonic::Status> {
+        let node = self.request_node(request.metadata())?;
+        Ok(tonic::Response::new(ListReplicasResponse {
+            replicas: node.replicas.clone(),
+        }))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn share_replica(
+        &self,
+        _request: tonic::Request<ShareReplicaRequest>,
+    ) -> Result<tonic::Response<Replica>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn unshare_replica(
+        &self,
+        _request: tonic::Request<UnshareReplicaRequest>,
+    ) -> Result<tonic::Response<Replica>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn resize_replica(
+        &self,
+        _request: tonic::Request<ResizeReplicaRequest>,
+    ) -> Result<tonic::Response<Replica>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn set_replica_entity_id(
+        &self,
+        _request: tonic::Request<SetReplicaEntityIdRequest>,
+    ) -> Result<tonic::Response<Replica>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+}


### PR DESCRIPTION
The kubectl-mayastor plugin takes a support bundle which includes various resources, such as pools and volumes.
Sometimes it's helpful to not only visualize but also run commands against a similar configured cluster.
In order to aid this, we add a simulation tool here, which is able to load a bundle and attempts to re-create similar spec and state. The process is not entirely accurate because the bundle is taken using the public api, and here we are using the internal types.