### PR TITLE
adding changes in create_pool and list_pool service for pool expansion

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -93,6 +93,8 @@ impl IoEngineToAgent for v0::Pool {
             committed: None,
             encrypted: false,
             cluster_size: POOL_BS_CLUSTER_SIZE_DEFAULT,
+            disk_capacity: None,
+            max_expandable_size: None,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -660,6 +660,8 @@ impl IoEngineToAgent for v1::pool::Pool {
             },
             encrypted: self.encrypted.unwrap_or_default(),
             cluster_size: self.cluster_size,
+            disk_capacity: Some(self.disk_capacity),
+            max_expandable_size: self.max_expandable_size,
         }
     }
 }
@@ -674,7 +676,10 @@ impl AgentToIoEngine for transport::CreatePool {
             uuid: None,
             pooltype: v1::pool::PoolType::Lvs as i32,
             cluster_size: self.cluster_size,
-            md_args: None,
+            md_args: Some(v1::pool::PoolMetadataArgs {
+                md_resv_ratio: None,
+                max_expansion: self.max_expansion.clone(),
+            }),
             encryption: self
                 .encryption
                 .clone()

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -303,6 +303,8 @@ mod tests {
             committed: None,
             encrypted: false,
             cluster_size: POOL_BS_CLUSTER_SIZE_DEFAULT,
+            disk_capacity: None,
+            max_expandable_size: None,
         };
         let replica = Replica::default();
         let pool = PoolWrapper::new(

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -157,6 +157,7 @@ fn test_deserialization_v1_to_v2() {
                 encryption: None,
                 cordon_drain: None,
                 cluster_size: 4194304,
+                max_expansion: None,
             }),
         },
         TestEntry {

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -61,6 +61,7 @@ async fn pool() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )
@@ -75,6 +76,7 @@ async fn pool() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )
@@ -274,6 +276,64 @@ async fn pool() {
         .is_empty());
 }
 
+/// Creates two pool on a temps fs files using max_expansion arg.
+/// Validates that disk_capacity is equal to the underlying disk capacity.
+/// TODO: Add logic to assert max_expandable_size and grow functionality once changes are in.
+#[tokio::test]
+async fn pool_expansion() {
+    let pool_disk_one = deployer_cluster::TmpDiskFile::new(POOL_FILE_NAME, TEN_GIB_BYTES);
+    let pool_disk_two = deployer_cluster::TmpDiskFile::new(POOL_FILE_NAME_2, TEN_GIB_BYTES);
+    let cluster = ClusterBuilder::builder()
+        .with_rest(false)
+        .with_options(|p| {
+            p.with_io_engine_devices(vec![pool_disk_one.path(), pool_disk_two.path()])
+        })
+        .build()
+        .await
+        .unwrap();
+    let pool_client = cluster.grpc_client().pool();
+    let pool_one = pool_client
+        .create(
+            &CreatePool {
+                node: cluster.node(0),
+                id: "pool-1".into(),
+                disks: vec![pool_disk_one.path().into()],
+                labels: None,
+                encryption: None,
+                cluster_size: None,
+                max_expansion: Some("30x".to_string()),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let disk_capacity_one = pool_one.state().unwrap().disk_capacity.unwrap();
+    let pool_two = pool_client
+        .create(
+            &CreatePool {
+                node: cluster.node(0),
+                id: "pool-2".into(),
+                disks: vec![pool_disk_two.path().into()],
+                labels: None,
+                encryption: None,
+                cluster_size: None,
+                max_expansion: Some("300GiB".to_string()),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let disk_capacity_two = pool_two.state().unwrap().disk_capacity.unwrap();
+    assert_eq!(
+        TEN_GIB_BYTES, disk_capacity_one,
+        "disk capacity doesnt match with underlying disk capacity"
+    );
+    assert_eq!(
+        TEN_GIB_BYTES, disk_capacity_two,
+        "disk capacity doesnt match with underlying disk capacity"
+    );
+}
+
 // Tests creation and import of pool with larger blobstore cluster size.
 // Create a few replicas, restart the node. Pool should import again without issue.
 #[tokio::test]
@@ -355,6 +415,7 @@ async fn volume_repl_placement_with_cluster_size() {
         labels: None,
         encryption: None,
         cluster_size: None,
+        max_expansion: None,
     };
 
     let pool_32m_1 = CreatePool {
@@ -364,6 +425,7 @@ async fn volume_repl_placement_with_cluster_size() {
         labels: None,
         encryption: None,
         cluster_size: Some(33554432),
+        max_expansion: None,
     };
 
     let pool_32m_2 = CreatePool {
@@ -373,6 +435,7 @@ async fn volume_repl_placement_with_cluster_size() {
         labels: None,
         encryption: None,
         cluster_size: Some(33554432),
+        max_expansion: None,
     };
 
     let _ = client.pool().create(&pool_4m_1, None).await.unwrap();
@@ -723,6 +786,7 @@ const POOL_FILE_NAME: &str = "disk1.img";
 const POOL_FILE_NAME_2: &str = "disk2.img";
 const POOL_SIZE_BYTES: u64 = 200 * 1024 * 1024;
 const POOL_BS_CLUSTER_SIZE: u64 = 33554432;
+const TEN_GIB_BYTES: u64 = 10737418240;
 
 /// Creates a pool on a io_engine instance, which will have both spec and state.
 /// Stops/Kills the io_engine container. At some point we will have no pool state, because the node
@@ -1221,6 +1285,7 @@ async fn destroy_after_restart() {
         labels: None,
         encryption: None,
         cluster_size: None,
+        max_expansion: None,
     };
 
     client.pool().destroy(&destroy, None).await.unwrap();
@@ -1257,6 +1322,7 @@ async fn slow_create() {
             labels: Some(PoolLabel::from([("a".into(), "b".into())])),
             encryption: None,
             cluster_size: None,
+            max_expansion: None,
         };
 
         let result = client.pool().create(&create, None).await;
@@ -1408,6 +1474,7 @@ async fn reject_devlink_reuse() {
                 name: SECRETFILE.to_string(),
             })),
             cluster_size: None,
+            max_expansion: None,
         };
 
         client
@@ -1429,6 +1496,7 @@ async fn reject_devlink_reuse() {
                 name: SECRETFILE.to_string(),
             })),
             cluster_size: None,
+            max_expansion: None,
         };
 
         client
@@ -1480,6 +1548,7 @@ async fn reject_devlink_reuse() {
             labels: None,
             encryption: None,
             cluster_size: None,
+            max_expansion: None,
         };
 
         client

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot_clone.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot_clone.rs
@@ -149,6 +149,7 @@ async fn snapshot_clone_pool_cluster_size_constraint() {
         labels: None,
         encryption: None,
         cluster_size: None,
+        max_expansion: None,
     };
 
     let pool_32m_1 = CreatePool {
@@ -158,6 +159,7 @@ async fn snapshot_clone_pool_cluster_size_constraint() {
         labels: None,
         encryption: None,
         cluster_size: Some(33554432),
+        max_expansion: None,
     };
 
     let pool_32m_2 = CreatePool {
@@ -167,6 +169,7 @@ async fn snapshot_clone_pool_cluster_size_constraint() {
         labels: None,
         encryption: None,
         cluster_size: Some(33554432),
+        max_expansion: None,
     };
 
     let _ = client.pool().create(&pool_4m_1, None).await.unwrap();

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -76,6 +76,10 @@ message PoolState {
   optional bool encrypted = 8;
   // Blobstore cluster size required for this pool
   optional uint32 cluster_size = 9;
+  // Size of the underlying disk, in bytes
+  optional uint64 disk_capacity = 10;
+  // Maximum disk_capacity this pool can be expanded to, in bytes
+  optional uint64 max_expandable_size = 11;
 }
 
 // status of the pool
@@ -117,6 +121,8 @@ message CreatePoolRequest {
   }
   // Blobstore cluster size required for this pool
   optional uint32 cluster_size = 7;
+  // Maximum expansion size for this pool
+  optional string max_expansion = 8;
 }
 
 // Destroy Pool Request

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -123,6 +123,7 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
             cluster_size: pool_spec
                 .cluster_size
                 .unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
+            max_expansion: None,
         })
     }
 }
@@ -152,6 +153,8 @@ impl TryFrom<pool::PoolState> for PoolState {
             cluster_size: pool_state
                 .cluster_size
                 .unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
+            disk_capacity: pool_state.disk_capacity,
+            max_expandable_size: pool_state.max_expandable_size,
         })
     }
 }
@@ -236,6 +239,8 @@ impl From<PoolState> for pool::PoolState {
             committed: pool_state.committed,
             encrypted: Some(pool_state.encrypted),
             cluster_size: Some(pool_state.cluster_size),
+            disk_capacity: pool_state.disk_capacity,
+            max_expandable_size: pool_state.max_expandable_size,
         }
     }
 }
@@ -310,6 +315,8 @@ pub trait CreatePoolInfo: Send + Sync + std::fmt::Debug {
     fn encryption(&self) -> Option<Encryption>;
     /// Requested cluster size for blobstore.
     fn cluster_size(&self) -> Option<u32>;
+    /// Maximum expansion size for this pool.
+    fn max_expansion(&self) -> Option<String>;
 }
 
 /// DestroyPoolInfo trait for the pool deletion to be implemented by entities which want to avail
@@ -344,6 +351,10 @@ impl CreatePoolInfo for CreatePool {
 
     fn cluster_size(&self) -> Option<u32> {
         self.cluster_size
+    }
+
+    fn max_expansion(&self) -> Option<String> {
+        self.max_expansion.clone()
     }
 }
 
@@ -381,6 +392,10 @@ impl CreatePoolInfo for ValidatedCreatePoolRequest {
     fn cluster_size(&self) -> Option<u32> {
         self.inner.cluster_size
     }
+
+    fn max_expansion(&self) -> Option<String> {
+        self.inner.max_expansion.clone()
+    }
 }
 
 impl ValidateRequestTypes for CreatePoolRequest {
@@ -411,6 +426,7 @@ impl From<&dyn CreatePoolInfo> for CreatePoolRequest {
                 .map(|labels| crate::common::StringMapValue { value: labels }),
             encryption: data.encryption().into_opt(),
             cluster_size: data.cluster_size(),
+            max_expansion: data.max_expansion(),
         }
     }
 }
@@ -424,6 +440,7 @@ impl From<&dyn CreatePoolInfo> for CreatePool {
             labels: data.labels(),
             encryption: data.encryption(),
             cluster_size: data.cluster_size(),
+            max_expansion: data.max_expansion(),
         }
     }
 }

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -49,6 +49,8 @@ impl CreateRow for openapi::models::Pool {
             committed: None,
             encrypted: spec.encryption.is_some(),
             cluster_size: Some(0),
+            disk_capacity: None,
+            max_expandable_size: None,
         });
         let free = state.capacity.saturating_sub(state.used);
         let disks = state.disks.join(", ");

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2567,6 +2567,11 @@ components:
            Blobstore cluster size for the pool, in bytes. Must be >= 4 MiB and in multiples of 4MiB.
            This is an advanced option. Please refer documentation to understand the implications
            of changing this.
+        max_expansion:
+          type: string
+          description: |-
+            Sets the maximum allowed growth for the pool disk. Can be passed as absolute size or a
+            factor of the original size.
       required:
         - disks
     HostNqn:
@@ -3206,6 +3211,14 @@ components:
           format: int64
           example: 4194304
           minimum: 4194304
+        disk_capacity:
+          description: Size of the underlying disk, in bytes
+          type: integer
+          format: uint64
+        max_expandable_size:
+          description: Maximum size upto which this pool can be grown, in bytes
+          type: integer
+          format: uint64
       required:
         - capacity
         - disks

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -80,6 +80,8 @@ pub struct CreatePoolBody {
     pub encryption: Option<Encryption>,
     /// Blobstore cluster size for the pool
     pub cluster_size: Option<u32>,
+    /// Maximum expansion size for this pool.
+    pub max_expansion: Option<String>,
 }
 impl From<models::CreatePoolBody> for CreatePoolBody {
     fn from(src: models::CreatePoolBody) -> Self {
@@ -88,6 +90,7 @@ impl From<models::CreatePoolBody> for CreatePoolBody {
             labels: src.labels,
             encryption: src.encryption.into_opt(),
             cluster_size: src.cluster_size.map(|v| v as u32),
+            max_expansion: src.max_expansion,
         }
     }
 }
@@ -100,6 +103,7 @@ impl TryFrom<CreatePool> for CreatePoolBody {
             labels: create.labels,
             encryption: create.encryption.try_into_opt()?,
             cluster_size: create.cluster_size,
+            max_expansion: create.max_expansion,
         })
     }
 }
@@ -113,6 +117,7 @@ impl CreatePoolBody {
             labels: self.labels.clone(),
             encryption: self.encryption.clone().into_opt(),
             cluster_size: self.cluster_size,
+            max_expansion: self.max_expansion.clone(),
         }
     }
 }

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -145,7 +145,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
         models::Pool::new_all(
             "pooloop",
             models::PoolSpec::new_all(vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", None, &io_engine1, models::SpecStatus::Created, None, None, 4194304),
-            models::PoolState::new_all(100663296u64, vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::PoolStatus::Online, 0u64, 0, false, 4194304u64)
+            models::PoolState::new_all(100663296u64, vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::PoolStatus::Online, 0u64, 0, false, 4194304u64, 104857600u64 , Some(0))
         )
     );
 

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -64,6 +64,7 @@ impl From<&CreatePool> for PoolSpec {
             cordon_drain: None,
             // Default is 4MiB today.
             cluster_size: request.cluster_size.unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
+            max_expansion: request.max_expansion.clone(),
         }
     }
 }
@@ -76,6 +77,7 @@ impl From<&PoolSpec> for CreatePool {
             labels: pool.labels.clone(),
             encryption: pool.encryption.clone(),
             cluster_size: Some(pool.cluster_size),
+            max_expansion: pool.max_expansion.clone(),
         }
     }
 }
@@ -136,6 +138,9 @@ pub struct PoolSpec {
     /// Blobstore cluster size used for this pool.
     #[serde(default = "default_pool_cluster_size")]
     pub cluster_size: u32,
+    /// Maximum expansion size for this pool.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_expansion: Option<String>,
 }
 
 impl PoolSpec {
@@ -495,6 +500,8 @@ impl From<&PoolSpec> for transport::PoolState {
             committed: None,
             encrypted: pool.encryption.is_some(),
             cluster_size: pool.cluster_size,
+            disk_capacity: None,
+            max_expandable_size: None,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -104,6 +104,10 @@ pub struct PoolState {
     /// Blobstore cluster size used for this pool.
     #[serde(default = "crate::types::v0::store::pool::default_pool_cluster_size")]
     pub cluster_size: u32,
+    /// Size of the underlying disk, in bytes.
+    pub disk_capacity: Option<u64>,
+    /// Maximum disk_capacity this pool can be expanded to, in bytes.
+    pub max_expandable_size: Option<u64>,
 }
 
 impl From<CtrlPoolState> for models::PoolState {
@@ -119,6 +123,8 @@ impl From<CtrlPoolState> for models::PoolState {
             src.committed,
             src.encrypted,
             Some(src.cluster_size as u64),
+            src.disk_capacity,
+            src.max_expandable_size,
         )
     }
 }
@@ -298,6 +304,8 @@ pub struct CreatePool {
     pub encryption: Option<Encryption>,
     /// Blobstore cluster size in bytes.
     pub cluster_size: Option<u32>,
+    /// Maximum expansion size for this pool.
+    pub max_expansion: Option<String>,
 }
 
 impl CreatePool {
@@ -309,6 +317,7 @@ impl CreatePool {
         labels: &Option<PoolLabel>,
         encryption: &Option<Encryption>,
         cluster_size: &Option<u32>,
+        max_expansion: &Option<String>,
     ) -> Self {
         Self {
             node: node.clone(),
@@ -317,6 +326,7 @@ impl CreatePool {
             labels: labels.clone(),
             encryption: encryption.clone(),
             cluster_size: *cluster_size,
+            max_expansion: max_expansion.clone(),
         }
     }
 }

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -287,7 +287,8 @@ impl ResourceContext {
             None => None,
         };
 
-        let body = CreatePoolBody::new_all(self.spec.disks(), labels, encryption, cluster_size);
+        let body =
+            CreatePoolBody::new_all(self.spec.disks(), labels, encryption, cluster_size, None);
         match self
             .pools_api()
             .put_node_pool(&self.spec.node(), &self.name_any(), body)

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -675,7 +675,7 @@ pub mod v1 {
     pub mod pool {
         pub use super::pb::{
             pool_rpc_client, CreatePoolRequest, DestroyPoolRequest, ImportPoolRequest,
-            ListPoolOptions, ListPoolsResponse, Pool, PoolType,
+            ListPoolOptions, ListPoolsResponse, Pool, PoolMetadataArgs, PoolType,
         };
     }
 

--- a/tests/io-engine/tests/pools.rs
+++ b/tests/io-engine/tests/pools.rs
@@ -93,6 +93,7 @@ async fn create_pool_idempotent() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )
@@ -108,6 +109,7 @@ async fn create_pool_idempotent() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )
@@ -129,6 +131,7 @@ async fn create_pool_idempotent_same_disk_different_query() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )
@@ -144,6 +147,7 @@ async fn create_pool_idempotent_same_disk_different_query() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )
@@ -168,6 +172,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )
@@ -183,6 +188,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )
@@ -198,6 +204,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )
@@ -213,6 +220,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
                 labels: None,
                 encryption: None,
                 cluster_size: None,
+                max_expansion: None,
             },
             None,
         )

--- a/utils/bundle-sim/src/bin/io-engine.rs
+++ b/utils/bundle-sim/src/bin/io-engine.rs
@@ -82,9 +82,10 @@ impl IoEngine {
                 committed: state.committed.unwrap_or_default(),
                 cluster_size: state.cluster_size,
                 page_size: None,
-                disk_capacity: state.capacity,
+                disk_capacity: state.disk_capacity.unwrap_or_default(),
                 md_info: None,
                 encrypted: Some(state.encrypted),
+                max_expandable_size: state.max_expandable_size,
             };
             if let Some(node) = io_engine.sims.get_mut(state.node.as_str()) {
                 node.pools.push(pool);
@@ -319,6 +320,13 @@ impl rpc::v1::pb::pool_rpc_server::PoolRpc for IoEngine {
         &self,
         _request: tonic::Request<GrowPoolRequest>,
     ) -> Result<tonic::Response<GrowPoolResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
+    #[tracing::instrument(skip(self), err, level = "info")]
+    async fn grow_pool_v2(
+        &self,
+        _request: tonic::Request<GrowPoolRequest>,
+    ) -> Result<tonic::Response<Pool>, tonic::Status> {
         Err(tonic::Status::unimplemented(""))
     }
 }

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -645,6 +645,14 @@ impl TmpDiskFile {
         &self.inner.path
     }
 
+    /// Resizes the disk by `expand_by`.
+    pub fn expand(self, expand_by: u64) -> std::io::Result<()> {
+        let file: std::fs::File = std::fs::OpenOptions::new().write(true).open(self.path())?;
+        let new_size = file.metadata()?.len().saturating_add(expand_by);
+        file.set_len(new_size)?;
+        Ok(())
+    }
+
     /// Get the inner disk if there are no other references to it.
     pub fn into_inner(self) -> Result<TmpDiskFileInner, Arc<TmpDiskFileInner>> {
         Arc::try_unwrap(self.inner)
@@ -1132,6 +1140,7 @@ impl ClusterBuilder {
                         labels: None,
                         encryption: None,
                         cluster_size: None,
+                        max_expansion: None,
                     },
                     None,
                 )


### PR DESCRIPTION
This PR introduces the control plane changes required to support pool expansion:

`max_expansion` in CreatePool allows stating limit for pool expansion via factor or absolute size. 

`disk_capacity` in the Pool state shows the current size of the disk backing the Pool.

`max_expandable_size` in the Pool state shows the max capacity by which underlying disk can be grown from the pool expansion perspective.