### PR TITLE
adding crd changes and grow api call on annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__
 !/openapi/build.rs
 !/openapi/src/lib.rs
 /tests/bdd/autogen/
+/k8s/crd_test/crds/diskpools.crd.yaml
 /terraform/cluster/ansible-hosts
 /terraform/cluster/current_user.txt
 /rust-toolchain.toml

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
@@ -93,16 +93,24 @@ impl crate::controller::io_engine::PoolApi for super::RpcClient {
                 self.context.node(),
             )),
             Err(error) if error.code() == tonic::Code::OutOfRange => {
-                Err(SvcError::PoolDeviceBeyondMaxSize {
-                    name: request.id.clone().into(),
+                Err(SvcError::DiskBeyondMaxSize {
+                    name: request.id.clone(),
                 })
             }
             Err(error)
                 if (error.code() == tonic::Code::FailedPrecondition
                     && error.metadata().contains_key("bdev_not_extended")) =>
             {
-                Err(SvcError::PoolDeviceNotExtended {
-                    name: request.id.clone().into(),
+                Err(SvcError::DiskNotExtended {
+                    name: request.id.clone(),
+                })
+            }
+            Err(error)
+                if (error.code() == tonic::Code::FailedPrecondition
+                    && error.metadata().contains_key("bdev_rescan_failed")) =>
+            {
+                Err(SvcError::DiskRescanFailed {
+                    name: request.id.clone(),
                 })
             }
             Err(error) => Err(error).context(GrpcRequestError {

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -178,7 +178,10 @@ impl ResourceResize for OperationGuardArc<PoolSpec> {
         let pool = registry.ctrl_pool(&request.id).await?;
         let node = registry.node_wrapper(&pool.node()).await?;
         if !node.read().await.is_online() {
-            return Err(SvcError::NodeNotOnline { node: pool.node() });
+            return Err(SvcError::PoolNodeNotOnline {
+                node: pool.node(),
+                pool: pool.id().clone(),
+            });
         }
         let pool_state = node.expand_pool(request).await?;
         let pool_spec = registry.specs().pool(&request.id)?;

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -178,10 +178,7 @@ impl ResourceResize for OperationGuardArc<PoolSpec> {
         let pool = registry.ctrl_pool(&request.id).await?;
         let node = registry.node_wrapper(&pool.node()).await?;
         if !node.read().await.is_online() {
-            return Err(SvcError::PoolNodeNotOnline {
-                node: pool.node(),
-                pool: pool.id().clone(),
-            });
+            return Err(SvcError::NodeNotOnline { node: pool.node() });
         }
         let pool_state = node.expand_pool(request).await?;
         let pool_spec = registry.specs().pool(&request.id)?;

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -362,10 +362,10 @@ async fn pool_expansion() {
     // Attempt expand without extending the underlying device.
     // Should result in FailedPrecondition.
     if let Err(e) = pool_client.expand(&expand_request_one).await {
-        assert_eq!(e.kind, ReplyErrorKind::FailedPrecondition);
+        assert_eq!(e.kind, ReplyErrorKind::DiskNotExtended);
     }
     if let Err(e) = pool_client.expand(&expand_request_two).await {
-        assert_eq!(e.kind, ReplyErrorKind::FailedPrecondition);
+        assert_eq!(e.kind, ReplyErrorKind::DiskNotExtended);
     }
     // Attempt expand after extending the device 1 cluster more then max_expandable_size.
     // Should result in OutOfRange. max_expandable_size is absolute limit.

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -21,8 +21,6 @@ pub enum SvcError {
     GetNodes { source: ReplyError },
     #[snafu(display("Node '{}' is not online", node))]
     NodeNotOnline { node: NodeId },
-    #[snafu(display("Node: '{node}' hosting Pool: '{pool}' is not online"))]
-    PoolNodeNotOnline { node: NodeId, pool: PoolId },
     #[snafu(display("Node {} has invalid socket address {}", node, socket))]
     NodeGrpcEndpoint {
         node: NodeId,
@@ -436,10 +434,12 @@ pub enum SvcError {
     },
     #[snafu(display("Invalid devlink, use a persistent devlink for pool creation"))]
     InvalidDevlink {},
-    #[snafu(display("Pool {name} underlying device exceeds max expandable size"))]
-    PoolDeviceBeyondMaxSize { name: String },
-    #[snafu(display("Pool {name} underlying device has not been extended"))]
-    PoolDeviceNotExtended { name: String },
+    #[snafu(display("Pool {name} underlying disk exceeded max expandable size"))]
+    DiskBeyondMaxSize { name: PoolId },
+    #[snafu(display("Pool {name} underlying disk has not been extended"))]
+    DiskNotExtended { name: PoolId },
+    #[snafu(display("Pool {name} underlying disk rescan failed"))]
+    DiskRescanFailed { name: PoolId },
 }
 
 impl SvcError {
@@ -600,12 +600,6 @@ impl From<SvcError> for ReplyError {
 
             SvcError::NodeNotOnline { .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPrecondition,
-                resource: ResourceKind::Node,
-                source,
-                extra,
-            },
-            SvcError::PoolNodeNotOnline { .. } => ReplyError {
-                kind: ReplyErrorKind::Unavailable,
                 resource: ResourceKind::Node,
                 source,
                 extra,
@@ -1091,14 +1085,20 @@ impl From<SvcError> for ReplyError {
                 source,
                 extra,
             },
-            SvcError::PoolDeviceBeyondMaxSize { .. } => ReplyError {
+            SvcError::DiskBeyondMaxSize { .. } => ReplyError {
                 kind: ReplyErrorKind::OutOfRange,
                 resource: ResourceKind::Pool,
                 source,
                 extra,
             },
-            SvcError::PoolDeviceNotExtended { .. } => ReplyError {
-                kind: ReplyErrorKind::FailedPrecondition,
+            SvcError::DiskNotExtended { .. } => ReplyError {
+                kind: ReplyErrorKind::DiskNotExtended,
+                resource: ResourceKind::Pool,
+                source,
+                extra,
+            },
+            SvcError::DiskRescanFailed { .. } => ReplyError {
+                kind: ReplyErrorKind::DiskRescanFailed,
                 resource: ResourceKind::Pool,
                 source,
                 extra,

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -21,6 +21,8 @@ pub enum SvcError {
     GetNodes { source: ReplyError },
     #[snafu(display("Node '{}' is not online", node))]
     NodeNotOnline { node: NodeId },
+    #[snafu(display("Node: '{node}' hosting Pool: '{pool}' is not online"))]
+    PoolNodeNotOnline { node: NodeId, pool: PoolId },
     #[snafu(display("Node {} has invalid socket address {}", node, socket))]
     NodeGrpcEndpoint {
         node: NodeId,
@@ -598,6 +600,12 @@ impl From<SvcError> for ReplyError {
 
             SvcError::NodeNotOnline { .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPrecondition,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::PoolNodeNotOnline { .. } => ReplyError {
+                kind: ReplyErrorKind::Unavailable,
                 resource: ResourceKind::Node,
                 source,
                 extra,

--- a/control-plane/grpc/proto/v1/misc/common.proto
+++ b/control-plane/grpc/proto/v1/misc/common.proto
@@ -70,6 +70,8 @@ enum ReplyErrorKind {
   CapacityLimitExceeded = 30;
   NotAcceptable = 31;
   Cancelled = 32;
+  DiskNotExtended = 33;
+  DiskRescanFailed = 34;
 }
 
 // ResourceKind for the resource which has undergone this error

--- a/control-plane/grpc/src/misc/traits.rs
+++ b/control-plane/grpc/src/misc/traits.rs
@@ -103,6 +103,8 @@ impl From<ReplyErrorKind> for common::ReplyErrorKind {
             ReplyErrorKind::CapacityLimitExceeded => Self::CapacityLimitExceeded,
             ReplyErrorKind::NotAcceptable => Self::NotAcceptable,
             ReplyErrorKind::Cancelled => Self::Cancelled,
+            ReplyErrorKind::DiskNotExtended => Self::DiskNotExtended,
+            ReplyErrorKind::DiskRescanFailed => Self::DiskRescanFailed,
         }
     }
 }
@@ -143,6 +145,8 @@ impl From<common::ReplyErrorKind> for ReplyErrorKind {
             common::ReplyErrorKind::CapacityLimitExceeded => Self::CapacityLimitExceeded,
             common::ReplyErrorKind::NotAcceptable => Self::NotAcceptable,
             common::ReplyErrorKind::Cancelled => Self::Cancelled,
+            common::ReplyErrorKind::DiskNotExtended => Self::DiskNotExtended,
+            common::ReplyErrorKind::DiskRescanFailed => Self::DiskRescanFailed,
         }
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3231,17 +3231,17 @@ components:
         encrypted:
           description: Is the pool encrypted
           type: boolean
-        cluster_size:
+        clusterSize:
           description: Blobstore cluster size for this pool, in bytes
           type: integer
           format: int64
           example: 4194304
           minimum: 4194304
-        disk_capacity:
+        diskCapacity:
           description: Size of the underlying disk, in bytes
           type: integer
           format: uint64
-        max_expandable_size:
+        maxExpandableSize:
           description: Maximum size upto which this pool can be grown, in bytes
           type: integer
           format: uint64
@@ -3593,7 +3593,9 @@ components:
           type: integer
           format: int64
         maxExpansion:
-          description: The maximum size the pool disk may be expanded to.
+          description: |-
+            Maximum expected expansion for the pool. It can be a factor or an absolute size,
+            Example: 5x, 10x, 6x, 200GiB, 2TiB, 536870912000B
           type: string
       required:
         - disks

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2561,9 +2561,6 @@ components:
       example:
         disks:
           - "malloc:///disk?size_mb=100"
-        encryption:
-          secret:
-            name: pool-secret-encr
       description: Create Pool Body
       type: object
       properties:
@@ -3242,7 +3239,7 @@ components:
           type: integer
           format: uint64
         maxExpandableSize:
-          description: Maximum size upto which this pool can be grown, in bytes
+          description: Maximum size underlying disk can be grown to, in bytes
           type: integer
           format: uint64
       required:
@@ -3427,6 +3424,8 @@ components:
             - CapacityLimitExceeded
             - NotAcceptable
             - Cancelled
+            - DiskNotExtended
+            - DiskRescanFailed
       required:
         - details
         - kind
@@ -3595,7 +3594,7 @@ components:
         maxExpansion:
           description: |-
             Maximum expected expansion for the pool. It can be a factor or an absolute size,
-            Example: 5x, 10x, 6x, 200GiB, 2TiB, 536870912000B
+            Example: 5x, 10x, 6x, 200GiB, 2TiB or 536870912000B.
           type: string
       required:
         - disks

--- a/control-plane/stor-port/src/transport_api/mod.rs
+++ b/control-plane/stor-port/src/transport_api/mod.rs
@@ -445,6 +445,8 @@ pub enum ReplyErrorKind {
     CapacityLimitExceeded,
     NotAcceptable,
     Cancelled,
+    DiskNotExtended,
+    DiskRescanFailed,
 }
 
 impl From<tonic::Code> for ReplyErrorKind {

--- a/control-plane/stor-port/src/types/mod.rs
+++ b/control-plane/stor-port/src/types/mod.rs
@@ -146,6 +146,14 @@ impl From<ReplyError> for RestError<RestJsonError> {
                 let error = RestJsonError::new(details, message, Kind::Cancelled);
                 (StatusCode::GATEWAY_TIMEOUT, error)
             }
+            ReplyErrorKind::DiskNotExtended => {
+                let error = RestJsonError::new(details, message, Kind::DiskNotExtended);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::DiskRescanFailed => {
+                let error = RestJsonError::new(details, message, Kind::DiskRescanFailed);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
         };
 
         RestError::new(status, error)

--- a/k8s/crd_test/__snapshot__/diskpools.crd-v1beta3.yaml
+++ b/k8s/crd_test/__snapshot__/diskpools.crd-v1beta3.yaml
@@ -1,12 +1,13 @@
 apiVersion: openebs.io/v1beta3
 kind: DiskPool
 spec:
-  cluster_size: string
+  clusterSize: string
   disks: [] # minItems 0 of type string
   encryptionConfig:
     source:
       secret:
         name: string
+  maxExpansion: string
   node: string
   topology:
     labelled: {}
@@ -15,9 +16,11 @@ status:
   available_q: "100 GiB"
   capacity: 0
   capacity_q: "100 GiB"
-  cluster_size: "100 GiB"
+  clusterSize: "100 GiB"
   cr_state: "Creating"
+  diskCapacity: "100 GiB"
   encrypted: true
+  maxExpandableSize: "100 GiB"
   pool_status: "Unknown" # "Unknown", "Online", "Degraded", "Faulted"
   used: 0
   used_q: "100 GiB"

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -4,6 +4,7 @@ use super::{
     error::Error,
 };
 use crate::diskpool::crd::v1beta3::{EncryptionSecretConfig, EncryptionSource};
+use openapi::models::rest_json_error::Kind;
 use openapi::models::{Encryption, EncryptionSecret};
 use openapi::{
     apis::StatusCode,
@@ -238,6 +239,24 @@ impl ResourceContext {
         Ok(Action::requeue(Duration::from_secs(30)))
     }
 
+    /// Removes pool expand annotation from the CR.
+    async fn patch_metadata(&self) -> Result<(), Error> {
+        let patch = Patch::Merge(json!({
+            "metadata": {
+                "annotations": {
+                    "openebs.io/expand": null
+                }
+            }
+        }));
+        let ps = PatchParams::apply(WHO_AM_I);
+        let _o: kube::api::PartialObjectMeta<DiskPool> = self
+            .api()
+            .patch_metadata(&self.name_any(), &ps, &patch)
+            .await
+            .map_err(|source| Error::Kube { source })?;
+        Ok(())
+    }
+
     /// Patch the resource state to creating.
     async fn is_missing(&self) -> Result<Action, Error> {
         self.patch_status(DiskPoolStatus::default()).await?;
@@ -287,8 +306,13 @@ impl ResourceContext {
             None => None,
         };
 
-        let body =
-            CreatePoolBody::new_all(self.spec.disks(), labels, encryption, cluster_size, None);
+        let body = CreatePoolBody::new_all(
+            self.spec.disks(),
+            labels,
+            encryption,
+            cluster_size,
+            self.spec.max_expansion(),
+        );
         match self
             .pools_api()
             .put_node_pool(&self.spec.node(), &self.name_any(), body)
@@ -445,12 +469,47 @@ impl ResourceContext {
 
     /// Check the state of the pool.
     ///
+    /// If "openebs.io/expand" is set, then attempt the pool expansion by invoking put_pool_expand.
+    /// Removes annotation in 3 failure cases:
+    /// 1. If pool device is extended beyond max_expandable_size, expansion fails with OutOfRange.
+    /// 2. If device is not resized before adding expand annotation.
+    /// 3. Device rescan fails if Pool device is detached from the node. It fails even if it comes back.
+    /// We need to handle that scenario. Until then, we will not retry this operation.
+    ///
     /// Get the pool information from the control plane and use this to set the state of the CRD
     /// accordingly. If the control plane returns a pool state, set the CRD to 'Online'. If the
     /// control plane does not return a pool state (occurs when a node is missing), set the CRD to
     /// 'Unknown' and let the reconciler retry later.
     #[tracing::instrument(fields(name = ?self.name_any(), status = ?self.status) skip(self))]
     pub(crate) async fn pool_check(&self) -> Result<Action, Error> {
+        if let Some(annotation) = self.metadata.annotations.clone() {
+            if let Some(value) = annotation.get("openebs.io/expand") {
+                if value == "true" {
+                    info!("Attempting to expand {}", self.name_any());
+                    match self.pools_api().put_pool_expand(&self.name_any()).await {
+                        Err(e) => {
+                            if matches!(
+                            e.error_body(),
+                            Some(body) if matches!(body.kind, Kind::OutOfRange | Kind::FailedPrecondition)
+                            ) {
+                                error!(
+                                    "DiskPool expansion failed, Stopping reconciliation err: {:?}",
+                                    e
+                                );
+                                let _ = self.patch_metadata().await;
+                            } else {
+                                error!("DiskPool expansion failed, {:?}", e);
+                            }
+                        }
+                        Ok(_) => {
+                            info!("DiskPool {} expanded successfully", self.name_any());
+                            let _ = self.patch_metadata().await;
+                        }
+                    }
+                }
+            }
+        }
+
         let pool = match self
             .pools_api()
             .get_node_pool(&self.spec.node(), &self.name_any())

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -240,7 +240,7 @@ impl ResourceContext {
     }
 
     /// Removes pool expand annotation from the CR.
-    async fn patch_metadata(&self) -> Result<(), Error> {
+    async fn remove_expand_annotation(&self) -> Result<(), Error> {
         let patch = Patch::Merge(json!({
             "metadata": {
                 "annotations": {
@@ -248,7 +248,7 @@ impl ResourceContext {
                 }
             }
         }));
-        let ps = PatchParams::apply(WHO_AM_I);
+        let ps = PatchParams::default();
         let _o: kube::api::PartialObjectMeta<DiskPool> = self
             .api()
             .patch_metadata(&self.name_any(), &ps, &patch)
@@ -490,20 +490,20 @@ impl ResourceContext {
                         Err(e) => {
                             if matches!(
                             e.error_body(),
-                            Some(body) if matches!(body.kind, Kind::OutOfRange | Kind::FailedPrecondition)
+                            Some(body) if matches!(body.kind, Kind::OutOfRange | Kind::DiskNotExtended | Kind::DiskRescanFailed )
                             ) {
                                 error!(
                                     "DiskPool expansion failed, Stopping reconciliation err: {:?}",
                                     e
                                 );
-                                let _ = self.patch_metadata().await;
+                                let _ = self.remove_expand_annotation().await;
                             } else {
                                 error!("DiskPool expansion failed, {:?}", e);
                             }
                         }
                         Ok(_) => {
                             info!("DiskPool {} expanded successfully", self.name_any());
-                            let _ = self.patch_metadata().await;
+                            let _ = self.remove_expand_annotation().await;
                         }
                     }
                 }

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -107,6 +107,7 @@ pub(crate) async fn create_missing_cr(
                             encryption,
                             spec.cluster_size
                                 .map(|c| utils::bytes::into_human(c as u64)),
+                            spec.max_expansion.clone(),
                         );
                         let new_disk_pool: DiskPool = DiskPool::new(&pool.id, cr_spec);
                         if let Err(error) = pools_api.create(&param, &new_disk_pool).await {

--- a/k8s/operators/src/pool/diskpool/crd/migration.rs
+++ b/k8s/operators/src/pool/diskpool/crd/migration.rs
@@ -135,7 +135,7 @@ pub(crate) async fn migrate_to_v1beta3(
                     &name,
                     ns,
                     Some(res_ver.clone()),
-                    DiskPoolSpec::new(node, disk, topology, None, None),
+                    DiskPoolSpec::new(node, disk, topology, None, None, None),
                 )
                 .await?;
                 info!(crd = ?dsp.name_any(), "CR creation successful");

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -24,13 +24,13 @@ use super::quantity::Quantity;
     shortname = "dsp",
     printcolumn = r#"{ "name":"node", "type":"string", "description":"node the pool is on", "jsonPath":".spec.node"}"#,
     printcolumn = r#"{ "name":"state", "type":"string", "description":"dsp cr state", "jsonPath":".status.cr_state"}"#,
-    printcolumn = r#"{ "name":"pool_status", "type":"string", "description":"Control plane pool status", "jsonPath":".status.pool_status"}"#,
+    printcolumn = r#"{ "name":"pool-status", "type":"string", "description":"Control plane pool status", "jsonPath":".status.pool_status"}"#,
     printcolumn = r#"{ "name":"encrypted", "type":"boolean", "description":"encryption enabled", "jsonPath":".status.encrypted"}"#,
     printcolumn = r#"{ "name":"capacity", "type":"string", "nullable": "true", "description":"total bytes", "jsonPath":".status.capacity_q"}"#,
     printcolumn = r#"{ "name":"used", "type":"string", "nullable": "true", "description":"used bytes", "jsonPath":".status.used_q"}"#,
     printcolumn = r#"{ "name":"available", "type":"string", "nullable": "true", "description":"available bytes", "jsonPath":".status.available_q"}"#,
-    printcolumn = r#"{ "name":"disk_capacity", "type":"string", "nullable": "true", "description":"underlying disk capacity", "jsonPath":".status.disk_capacity"}"#,
-    printcolumn = r#"{ "name":"max_expandable_size", "type":"string", "nullable": "true", "description":"max expandable size", "jsonPath":".status.max_expandable_size"}"#
+    printcolumn = r#"{ "name":"disk-capacity", "type":"string", "nullable": "true", "description":"underlying disk capacity", "jsonPath":".status.diskCapacity"}"#,
+    printcolumn = r#"{ "name":"max-expandable-size", "type":"string", "nullable": "true", "description":"max expandable size", "jsonPath":".status.maxExpandableSize"}"#
 )]
 /// The pool spec which contains the parameters we use when creating the pool
 pub struct DiskPoolSpec {
@@ -179,11 +179,12 @@ pub struct DiskPoolStatus {
     /// Blobstore cluster size of this pool.
     #[serde(rename = "clusterSize")]
     pub cluster_size: Option<Quantity>,
-    /// Size of the underlying disk, in quantity.
+    /// Current size of the underlying disk. in quantity.
     #[serde(rename = "diskCapacity")]
     pub disk_capacity: Option<Quantity>,
-    /// Size upto which disk_capacity_q can grow upto, in quantity.
-    #[serde(rename = "maxExpansionSize")]
+    /// Maximum capacity the disk can be expanded to.
+    /// This is an absolute max. No expansion is allowed beyond this size.
+    #[serde(rename = "maxExpandableSize")]
     pub max_expandable_size: Option<Quantity>,
 }
 

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -28,7 +28,9 @@ use super::quantity::Quantity;
     printcolumn = r#"{ "name":"encrypted", "type":"boolean", "description":"encryption enabled", "jsonPath":".status.encrypted"}"#,
     printcolumn = r#"{ "name":"capacity", "type":"string", "nullable": "true", "description":"total bytes", "jsonPath":".status.capacity_q"}"#,
     printcolumn = r#"{ "name":"used", "type":"string", "nullable": "true", "description":"used bytes", "jsonPath":".status.used_q"}"#,
-    printcolumn = r#"{ "name":"available", "type":"string", "nullable": "true", "description":"available bytes", "jsonPath":".status.available_q"}"#
+    printcolumn = r#"{ "name":"available", "type":"string", "nullable": "true", "description":"available bytes", "jsonPath":".status.available_q"}"#,
+    printcolumn = r#"{ "name":"disk_capacity", "type":"string", "nullable": "true", "description":"underlying disk capacity", "jsonPath":".status.disk_capacity"}"#,
+    printcolumn = r#"{ "name":"max_expandable_size", "type":"string", "nullable": "true", "description":"max expandable size", "jsonPath":".status.max_expandable_size"}"#
 )]
 /// The pool spec which contains the parameters we use when creating the pool
 pub struct DiskPoolSpec {
@@ -43,7 +45,12 @@ pub struct DiskPoolSpec {
     pub encryption_config: Option<EncryptionConfig>,
     /// Blobstore cluster size required for this pool. This is an advanced option,
     /// please refer documentation to understand this configuration and its implications.
+    #[serde(rename = "clusterSize")]
     pub cluster_size: Option<String>,
+    /// Maximum expected expansion for the pool. It can be a factor or an absolute size,
+    /// Example: 5x, 10x, 6x, 200GiB, 2TiB or 536870912000B.
+    #[serde(rename = "maxExpansion")]
+    pub max_expansion: Option<String>,
 }
 
 /// Placement pool topology used by volume operations.
@@ -81,6 +88,7 @@ impl DiskPoolSpec {
         topology: Option<Topology>,
         encryption_config: Option<EncryptionConfig>,
         cluster_size: Option<String>,
+        max_expansion: Option<String>,
     ) -> Self {
         Self {
             node,
@@ -88,6 +96,7 @@ impl DiskPoolSpec {
             topology,
             encryption_config,
             cluster_size,
+            max_expansion,
         }
     }
     /// The node the pool is placed on.
@@ -110,6 +119,11 @@ impl DiskPoolSpec {
     /// Blobstore cluster size for this pool.
     pub fn cluster_size(&self) -> Option<String> {
         self.cluster_size.clone()
+    }
+
+    /// Maximum expected expansion for the pool.
+    pub fn max_expansion(&self) -> Option<String> {
+        self.max_expansion.clone()
     }
 }
 
@@ -163,7 +177,14 @@ pub struct DiskPoolStatus {
     /// Encryption enabled.
     pub encrypted: Option<bool>,
     /// Blobstore cluster size of this pool.
+    #[serde(rename = "clusterSize")]
     pub cluster_size: Option<Quantity>,
+    /// Size of the underlying disk, in quantity.
+    #[serde(rename = "diskCapacity")]
+    pub disk_capacity: Option<Quantity>,
+    /// Size upto which disk_capacity_q can grow upto, in quantity.
+    #[serde(rename = "maxExpansionSize")]
+    pub max_expandable_size: Option<Quantity>,
 }
 
 impl Default for DiskPoolStatus {
@@ -179,6 +200,8 @@ impl Default for DiskPoolStatus {
             available_q: None,
             encrypted: None,
             cluster_size: None,
+            disk_capacity: None,
+            max_expandable_size: None,
         }
     }
 }
@@ -209,6 +232,8 @@ impl DiskPoolStatus {
             used_q: Some(Quantity::from_bytes(state.used)),
             available_q: Some(Quantity::from_bytes(free)),
             cluster_size: state.cluster_size.map(Quantity::from_bytes),
+            disk_capacity: state.disk_capacity.map(Quantity::from_bytes),
+            max_expandable_size: state.max_expandable_size.map(Quantity::from_bytes),
         }
     }
 
@@ -259,6 +284,8 @@ impl From<Pool> for DiskPoolStatus {
                 used_q: Some(Quantity::from_bytes(state.used)),
                 available_q: Some(Quantity::from_bytes(free)),
                 cluster_size: Some(Quantity::from_bytes(state.cluster_size.unwrap_or(0))),
+                disk_capacity: state.disk_capacity.map(Quantity::from_bytes),
+                max_expandable_size: state.max_expandable_size.map(Quantity::from_bytes),
             }
         } else {
             Self {

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -375,7 +375,7 @@ pub(crate) async fn migrate_and_clean_msps(k8s: &Client, namespace: &str) -> Res
                         k8s,
                         namespace,
                         &name,
-                        DiskPoolSpec::new(node, disks, None, None, None),
+                        DiskPoolSpec::new(node, disks, None, None, None, None),
                     )
                     .await
                     {


### PR DESCRIPTION
This PR: 

1. adds required changes in `v1beta3` crd for pool expansion.
2. adds support to pass `max_expansion` in `put_node_pool`
3. adds change to act on `"openebs.io/expand": true` annotation. Calls `put_pool_expand` api, removes annotation on success and irrecoverable errors.
4. Adds `SvcError::PoolNodeNotOnline` . We will not remove annotation if `put_pool_expand` fails with this.

