### PR TITLE
fix(pool): don't delete pool on abort

### DIFF
--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -89,7 +89,7 @@ impl OnCreateFail {
             // 3. dataplane core is shared with other processes
             // TODO: use higher timeout on larger pool sizes or potentially make this
             //  an async operation.
-            tonic::Code::Cancelled => Self::LeaveAsIs,
+            tonic::Code::Cancelled | tonic::Code::Aborted => Self::LeaveAsIs,
             _ => Self::SetDeleting,
         }
     }

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -1380,6 +1380,16 @@ async fn slow_create() {
             }
         }
 
+        let result = client.pool().create(&create, None).await;
+        match result {
+            Err(error) => assert_eq!(error.kind, ReplyErrorKind::Aborted),
+            Ok(_) => {
+                let info = lvol.dm_info().unwrap();
+                tracing::error!("Log DMSetup info:\n{info}");
+                panic!("Should have failed!");
+            }
+        }
+
         lvol.resume().unwrap();
 
         let start = std::time::Instant::now();
@@ -1407,6 +1417,17 @@ async fn slow_create() {
             }
             break;
         }
+
+        let result = client.pool().create(&create, None).await;
+        match result {
+            Err(error) => assert_eq!(error.kind, ReplyErrorKind::AlreadyExists),
+            Ok(_) => {
+                let info = lvol.dm_info().unwrap();
+                tracing::error!("Log DMSetup info:\n{info}");
+                panic!("Should have failed!");
+            }
+        }
+
         let destroy = DestroyPool::from(create.clone());
         client.pool().destroy(&destroy, None).await.unwrap();
 

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -930,7 +930,11 @@ async fn republished_nexus_io_engine_txn_fail() {
 
     cluster.composer().thaw(node_idx0.as_str()).await.unwrap();
     cluster
-        .wait_node_status(node_idx0.clone(), NodeStatus::Online)
+        .wait_node_status_tmo(
+            node_idx0.clone(),
+            NodeStatus::Online,
+            Duration::from_secs(4),
+        )
         .await
         .unwrap();
     println!("STEP: Reconnected older container back to network...");

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -40,9 +40,9 @@ impl CreateRow for openapi::models::Pool {
         // spec data and mark the status as Unknown.
         let state = self.state.clone().unwrap_or(openapi::models::PoolState {
             capacity: 0,
-            disks: spec.disks.clone(),
-            id: spec.id.clone(),
-            node: spec.node.clone(),
+            disks: spec.disks,
+            id: spec.id,
+            node: spec.node,
             status: openapi::models::PoolStatus::Unknown,
             used: 0,
             committed: None,

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -260,11 +260,21 @@ impl Cluster {
         &self,
         node_id: I,
         status: NodeStatus,
-    ) -> Result<(), ()> {
+    ) -> Result<(), String> {
+        self.wait_node_status_tmo(node_id, status, Duration::from_secs(2))
+            .await
+    }
+    /// Wait till the node is in the given status.
+    pub async fn wait_node_status_tmo<I: AsRef<NodeId>>(
+        &self,
+        node_id: I,
+        status: NodeStatus,
+        timeout: Duration,
+    ) -> Result<(), String> {
         let node_id = node_id.as_ref();
-        let timeout = Duration::from_secs(2);
         let node_cli = self.grpc_client().node();
         let start = std::time::Instant::now();
+        let mut seen_status = None;
         loop {
             let node = node_cli
                 .get(Filter::Node(node_id.clone()), true, None)
@@ -274,13 +284,16 @@ impl Cluster {
                 if node.state().map(|n| &n.status) == Some(&status) {
                     return Ok(());
                 }
+                seen_status = node.state().map(|n| n.status.clone());
             }
             if std::time::Instant::now() > (start + timeout) {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
-        Err(())
+        Err(format!(
+            "Node {node_id} not {status} within {timeout:?}, currently: {seen_status:?}"
+        ))
     }
     /// Wait till the pool is online.
     pub async fn wait_pool_online(&self, pool_id: PoolId) -> Result<(), ()> {


### PR DESCRIPTION
When creating pool, it may timeout. In this case we leave it as is, and allow the caller to retry.
But on the first retry, if the pool has not completed the create, then we see the abort error code instead, and in this case we should also leave as is, and allow caller to retry again.

Also update the existing test to do the retry.