### PR TITLE
Cherry-Pick 1027 - don't delete pool on abort

### DIFF
--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -89,7 +89,7 @@ impl OnCreateFail {
             // 3. dataplane core is shared with other processes
             // TODO: use higher timeout on larger pool sizes or potentially make this
             //  an async operation.
-            tonic::Code::Cancelled => Self::LeaveAsIs,
+            tonic::Code::Cancelled | tonic::Code::Aborted => Self::LeaveAsIs,
             _ => Self::SetDeleting,
         }
     }

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -1087,6 +1087,16 @@ async fn slow_create() {
             }
         }
 
+        let result = client.pool().create(&create, None).await;
+        match result {
+            Err(error) => assert_eq!(error.kind, ReplyErrorKind::Aborted),
+            Ok(_) => {
+                let info = lvol.dm_info().unwrap();
+                tracing::error!("Log DMSetup info:\n{info}");
+                panic!("Should have failed!");
+            }
+        }
+
         lvol.resume().unwrap();
 
         let start = std::time::Instant::now();
@@ -1114,6 +1124,17 @@ async fn slow_create() {
             }
             break;
         }
+
+        let result = client.pool().create(&create, None).await;
+        match result {
+            Err(error) => assert_eq!(error.kind, ReplyErrorKind::AlreadyExists),
+            Ok(_) => {
+                let info = lvol.dm_info().unwrap();
+                tracing::error!("Log DMSetup info:\n{info}");
+                panic!("Should have failed!");
+            }
+        }
+
         let destroy = DestroyPool::from(create.clone());
         client.pool().destroy(&destroy, None).await.unwrap();
 


### PR DESCRIPTION
When creating pool, it may timeout. In this case we leave it as is, and allow the caller to retry.
But on the first retry, if the pool has not completed the create, then we see the abort error code instead, and in this case we should also leave as is, and allow caller to retry again.

Also update the existing test to do the retry.