### PR TITLE
ha/node: use kernel event monitor

### DIFF
--- a/.github/workflows/mod-update.yml
+++ b/.github/workflows/mod-update.yml
@@ -1,0 +1,43 @@
+name: Submodule Update
+on:
+  workflow_dispatch:
+    inputs:
+      submodules:
+        description: 'Override modules to update via comma-separated list of names'
+        required: false
+        default: ''
+
+jobs:
+  submodule:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Update submodules
+        run: ./utils/dependencies/scripts/git/submodule-branches.sh -u -m "${{ github.event.inputs.submodules }}"
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(ci): update git submodules"
+          committer: GitHub <noreply@github.com>
+          title: "[CI] Update git submodules"
+          draft: false
+          signoff: true
+          delete-branch: true
+          branch: update-submodules/${{ github.ref_name }}
+          token: ${{ secrets.ORG_CI_GITHUB }}
+
+      - name: Approve Pull Request by CI Bot 1
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr review ${{ steps.cpr.outputs.pull-request-number }} --approve
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,7 +1087,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
- "udev 0.9.1",
+ "udev",
  "url",
  "utils",
  "uuid",
@@ -1322,7 +1322,7 @@ dependencies = [
  "nix",
  "semver",
  "snafu",
- "udev 0.9.1",
+ "udev",
  "url",
  "uuid",
 ]
@@ -4718,13 +4718,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-udev"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25418da261774ef3dcae985951bc138cf5fd49b3f4bd7450124ca75af8ed142"
+checksum = "d239a184f334141ead9fce462203705d199d053a63d00e25c8caf4e717149233"
 dependencies = [
  "futures-core",
  "tokio",
- "udev 0.7.0",
+ "udev",
 ]
 
 [[package]]
@@ -5032,17 +5032,6 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "udev"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a"
-dependencies = [
- "libc",
- "libudev-sys",
- "pkg-config",
-]
 
 [[package]]
 name = "udev"

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -70,7 +70,7 @@ weighted-scoring = { path = "../../utils/weighted-scoring" }
 events-api = { path = "../../utils/dependencies/apis/events" }
 
 [target.'cfg(target_os="linux")'.dependencies]
-tokio-udev = { version = "0.9.1" }
+tokio-udev = { version = "0.10.0" }
 
 [dev-dependencies]
 deployer-cluster = { path = "../../utils/deployer-cluster" }

--- a/control-plane/agents/src/bin/ha/cluster/switchover.rs
+++ b/control-plane/agents/src/bin/ha/cluster/switchover.rs
@@ -591,14 +591,14 @@ impl SwitchOverEngine {
             let errored_request = req.retry_count > 0;
             let retry_delay = if req.retry_count < ReQueue::NumFast as u64 {
                 match fast_requeue {
-                    None => ReQueue::Fast as u64,
-                    Some(duration) => duration.as_secs(),
+                    None => Duration::from_secs(ReQueue::Fast as u64),
+                    Some(duration) => duration.into(),
                 }
             } else {
-                ReQueue::Slow as u64
+                Duration::from_secs(ReQueue::Slow as u64)
             };
             if errored_request {
-                tokio::time::sleep(Duration::from_secs(retry_delay)).await;
+                tokio::time::sleep(retry_delay).await;
             }
             tx_clone.send(req)
         });

--- a/control-plane/agents/src/bin/ha/node/detector.rs
+++ b/control-plane/agents/src/bin/ha/node/detector.rs
@@ -1,5 +1,5 @@
 use crate::{
-    path_provider::{CachedNvmePathProvider, NvmePath, NvmePathNameCollection},
+    path_provider::{CachedNvmePathProvider, NvmePath, NvmePathNameCollection, UdevMonitor},
     reporter::PathReporter,
     Cli,
 };
@@ -247,6 +247,7 @@ pub struct PathFailureDetector {
     reporter: Rc<PathReporter>,
     cache_channel_rx: Receiver<NvmeCacheMessage>,
     cache_channel_tx: Arc<Sender<NvmeCacheMessage>>,
+    monitor: UdevMonitor,
 }
 
 impl PathFailureDetector {
@@ -268,6 +269,7 @@ impl PathFailureDetector {
             reporter: Rc::new(reporter),
             cache_channel_tx: Arc::new(tx),
             cache_channel_rx: rx,
+            monitor: args.udev_monitor,
         }
     }
 
@@ -351,7 +353,7 @@ impl PathFailureDetector {
 
     /// Start NVMe path error detection loop.
     pub async fn start(mut self) -> anyhow::Result<()> {
-        let mut path_provider = CachedNvmePathProvider::new();
+        let mut path_provider = CachedNvmePathProvider::new(self.monitor);
         let mut path_collection = path_provider.get_path_collection().unwrap();
         let start = path_provider.start()?;
         tokio::pin!(start);

--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -27,6 +27,7 @@ mod path_provider;
 mod reporter;
 mod server;
 
+use crate::path_provider::UdevMonitor;
 use detector::PathFailureDetector;
 use server::NodeAgentApiServer;
 use utils::tracing_telemetry::{FmtLayer, FmtStyle};
@@ -76,6 +77,10 @@ struct Cli {
     /// NVMe subsystem refresh period when monitoring its state.
     #[clap(short, long, env = "SUBSYS_REFRESH_PERIOD", default_value = NVME_SUBSYS_REFRESH_PERIOD)]
     subsys_refresh_period: humantime::Duration,
+
+    /// Udev monitor with udev or kernel events.
+    #[arg(long, value_enum, default_value_t = UdevMonitor::default())]
+    udev_monitor: UdevMonitor,
 
     /// Sends opentelemetry spans to the Jaeger endpoint agent.
     #[clap(long, short)]

--- a/control-plane/agents/src/bin/ha/node/path_provider.rs
+++ b/control-plane/agents/src/bin/ha/node/path_provider.rs
@@ -73,6 +73,15 @@ enum CacheOp {
     InvalidateCache,
 }
 
+/// Monitor kernel or udev events.
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub(crate) enum UdevMonitor {
+    Udev,
+    #[default]
+    Kernel,
+}
+
 /// UDEV-based NVMe path provider that uses cache to keep all known NVMe targets
 /// in memory and avoid wildcard Sysfs enumeration when there is a need to get
 /// a list of all existing NVMe path in the system.
@@ -90,6 +99,7 @@ pub struct CachedNvmePathProvider {
     #[cfg(target_os = "linux")]
     udev_queue: Arc<SegQueue<CacheOp>>,
     frontend: Option<NvmePathNameCollection>,
+    monitor: UdevMonitor,
 }
 
 impl CachedNvmePathProvider {
@@ -135,7 +145,11 @@ impl CachedNvmePathProvider {
             self.spawn_nvmeadm_syncer();
         }
 
-        let builder = MonitorBuilder::new()?.match_subsystem("nvme")?;
+        let builder = match self.monitor {
+            UdevMonitor::Udev => MonitorBuilder::new()?,
+            UdevMonitor::Kernel => MonitorBuilder::new_kernel()?,
+        }
+        .match_subsystem("nvme")?;
 
         let monitor: AsyncMonitorSocket = builder.listen()?.try_into()?;
 
@@ -197,13 +211,14 @@ impl CachedNvmePathProvider {
     }
 
     /// Create a new cached name provider.
-    pub fn new() -> Self {
+    pub fn new(monitor: UdevMonitor) -> Self {
         let q = Arc::new(SegQueue::new());
 
         Self {
             frontend: Some(NvmePathNameCollection::new(Arc::clone(&q))),
             #[cfg(target_os = "linux")]
             udev_queue: q,
+            monitor,
         }
     }
 }

--- a/control-plane/agents/src/bin/ha/node/path_provider.rs
+++ b/control-plane/agents/src/bin/ha/node/path_provider.rs
@@ -2,18 +2,17 @@ use nvmeadm::nvmf_subsystem::{NvmeSubsystems, Subsystem};
 use stor_port::platform::{current_platform_type, PlatformType};
 use utils::nvme_target_nqn_prefix;
 
-#[cfg(target_os = "linux")]
-use std::convert::TryInto;
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
-
 use crossbeam_queue::SegQueue;
 use futures_util::future::ready;
 #[cfg(target_os = "linux")]
 use futures_util::stream::StreamExt;
+#[cfg(target_os = "linux")]
+use std::convert::TryInto;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 #[cfg(target_os = "linux")]
 use tokio_udev::{AsyncMonitorSocket, EventType, MonitorBuilder};
 
@@ -22,7 +21,7 @@ const SYSFS_PREFIX: &str = "/sys/devices/virtual/nvme-fabrics/ctl/";
 const CACHE_EVENTS_BATCH_SIZE: usize = 128;
 
 /// Object that represents a path to sysfs NVMe object.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NvmePath {
     path_buffer: PathBuf,
     nqn: String,
@@ -56,6 +55,11 @@ pub fn get_nvme_path_entry(path: &String) -> Option<NvmePath> {
             if s.nqn.starts_with(&nvme_target_nqn_prefix()) {
                 Some(NvmePath::new(pb, s.nqn))
             } else {
+                // todo: right after being added a path may not yet be fully init
+                // in the sysfs, example: nqn: "(efault)", state: "connecting"
+                // address: SubsystemAddr("traddr=10.1.0.8,trsvcid=8420"), serial: "(efault)"
+                // we could sleep for a bit and retry but since we get the [`EventType::Change`]
+                // event, this is probably fine as is
                 None
             }
         })
@@ -67,6 +71,7 @@ pub fn get_nvme_path_entry(path: &String) -> Option<NvmePath> {
 #[allow(dead_code)]
 enum CacheOp {
     Add(String),
+    Change(String),
     Remove(String),
     /// Sync up subsystems for platforms where udev is not supported.
     SubsystemsSync(Vec<String>),
@@ -185,6 +190,10 @@ impl CachedNvmePathProvider {
                                 tracing::debug!(path, "NVMe path removed");
                                 Some(CacheOp::Remove(path.to_owned()))
                             }
+                            EventType::Change => {
+                                tracing::debug!(path, "NVMe path changed");
+                                Some(CacheOp::Change(path.to_owned()))
+                            }
                             _ => None,
                         };
 
@@ -245,6 +254,23 @@ impl NvmePathNameCollection {
         }
     }
 
+    fn update_cache_entry(&mut self, path: String) {
+        if let Some(pb) = get_nvme_path_entry(&path) {
+            match self.entries.entry(path.clone()) {
+                Entry::Occupied(mut existing) => {
+                    if existing.get() != &pb {
+                        tracing::warn!(path, nqn = pb.nqn, "Updating NVMe path entry in cache");
+                        *existing.get_mut() = pb;
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    tracing::warn!(path, nqn = pb.nqn, "Adding new NVMe path entry to cache");
+                    entry.insert(pb);
+                }
+            }
+        }
+    }
+
     /// Fully rebuild the NVMe path cache.
     fn invalidate_cache(&mut self) {
         self.entries.clear();
@@ -273,6 +299,9 @@ impl NvmePathNameCollection {
                 match e {
                     CacheOp::Add(p) => {
                         self.add_cache_entry(p);
+                    }
+                    CacheOp::Change(p) => {
+                        self.update_cache_entry(p);
                     }
                     CacheOp::Remove(path) => match self.entries.remove(&path) {
                         Some(_) => tracing::info!(path, "NVMe path removed from the cache"),

--- a/control-plane/agents/src/bin/ha/node/path_provider.rs
+++ b/control-plane/agents/src/bin/ha/node/path_provider.rs
@@ -131,17 +131,17 @@ impl CachedNvmePathProvider {
         });
     }
     #[cfg(target_os = "linux")]
-    fn udev_supported() -> bool {
+    fn udev_supported(&self) -> bool {
         match current_platform_type() {
             PlatformType::K8s => true,
             PlatformType::None => true,
-            PlatformType::Deployer => false,
+            PlatformType::Deployer => matches!(self.monitor, UdevMonitor::Kernel),
         }
     }
     /// Start UDEV monitoring loop.
     #[cfg(target_os = "linux")]
     pub fn start(&mut self) -> anyhow::Result<impl std::future::Future<Output = ()> + '_> {
-        if !Self::udev_supported() {
+        if !self.udev_supported() {
             self.spawn_nvmeadm_syncer();
         }
 


### PR DESCRIPTION
Switches to latest tokio-udev which has the kernel udev monitor.
Use the kernel monitor which allows the ha node to function in more
environments, such as the deployer where we had to fake it.
