### PR TITLE
Use PreCondition Errors when appropriate

### DIFF
--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -10,8 +10,16 @@ use crate::controller::scheduling::{
     resources::{ChildItem, PoolItem, ReplicaItem},
     volume::{ReplicaResizePoolsContext, VolumeReplicasForNexusCtx},
 };
-use std::{cmp::Ordering, collections::HashMap, future::Future};
+
+use stor_port::transport_api::ResourceKind;
 use weighted_scoring::{Criteria, Value, ValueGrading, WeightedScore};
+
+use snafu::Snafu;
+use std::{
+    cmp::Ordering,
+    collections::{btree_map::Entry, BTreeMap, HashMap},
+    future::Future,
+};
 
 #[async_trait::async_trait(?Send)]
 pub(crate) trait ResourcePolicy<Request: ResourceFilter>: Sized {
@@ -22,11 +30,111 @@ pub(crate) trait ResourcePolicy<Request: ResourceFilter>: Sized {
     }
 }
 
+/// Failed precondition errors.
+#[derive(Clone, Debug, Snafu, Eq, Hash, PartialEq)]
+#[allow(missing_docs)]
+pub(crate) enum FailedPredicate {
+    #[snafu(display("Pool is not online"))]
+    PoolNotOnline,
+    #[snafu(display("Pool is cordoned for snapshots"))]
+    PoolSnapshotCordon,
+    #[snafu(display("Pool's capacity is not sufficient"))]
+    PoolTooSmall,
+    #[snafu(display("Node where pool/replica resides is not online"))]
+    NodeNotOnline,
+    #[snafu(display("Node where pool/replica is cordoned"))]
+    NodeCordoned,
+}
+impl From<&FailedPredicate> for ResourceKind {
+    fn from(value: &FailedPredicate) -> Self {
+        match value {
+            FailedPredicate::PoolNotOnline => Self::Pool,
+            FailedPredicate::PoolSnapshotCordon => Self::Pool,
+            FailedPredicate::PoolTooSmall => Self::Pool,
+            FailedPredicate::NodeNotOnline => Self::Node,
+            FailedPredicate::NodeCordoned => Self::Node,
+        }
+    }
+}
+
+/// Resource Exhausted errors.
+#[derive(Clone, Debug, Snafu, Eq, Hash, PartialEq)]
+#[allow(missing_docs)]
+pub(crate) enum ResourceExhausted {
+    #[snafu(display("Pool doesn't have sufficient free space"))]
+    PoolNoSpace,
+    #[snafu(display("Pool is already overcommitted"))]
+    PoolOverCommit,
+}
+impl From<&ResourceExhausted> for ResourceKind {
+    fn from(value: &ResourceExhausted) -> Self {
+        match value {
+            ResourceExhausted::PoolNoSpace => Self::Pool,
+            ResourceExhausted::PoolOverCommit => Self::Pool,
+        }
+    }
+}
+
+/// Reason for excluding or filtering out items as part of the scheduling.
+#[derive(Clone, Debug, Snafu, Eq, Hash, PartialEq)]
+#[allow(missing_docs)]
+pub(crate) enum ResourceExcReason {
+    #[snafu(display("{source}"))]
+    PreCondition { source: FailedPredicate },
+    #[snafu(display("{source}"))]
+    RscExhausted { source: ResourceExhausted },
+}
+impl PartialOrd for ResourceExcReason {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.order_weight().cmp(&other.order_weight()))
+    }
+}
+impl Ord for ResourceExcReason {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.order_weight().cmp(&other.order_weight())
+    }
+}
+impl From<&ResourceExcReason> for ResourceKind {
+    fn from(value: &ResourceExcReason) -> Self {
+        match value {
+            ResourceExcReason::PreCondition { source } => source.into(),
+            ResourceExcReason::RscExhausted { source } => source.into(),
+        }
+    }
+}
+
+impl ResourceExcReason {
+    fn order_weight(&self) -> u8 {
+        match self {
+            Self::PreCondition { .. } => 0,
+            Self::RscExhausted { .. } => 1,
+        }
+    }
+    /// Get the equivalent `tonic::Code`.
+    pub(crate) fn tonic_code(&self) -> tonic::Code {
+        match self {
+            ResourceExcReason::PreCondition { .. } => tonic::Code::FailedPrecondition,
+            ResourceExcReason::RscExhausted { .. } => tonic::Code::ResourceExhausted,
+        }
+    }
+}
+impl From<FailedPredicate> for ResourceExcReason {
+    fn from(source: FailedPredicate) -> Self {
+        Self::PreCondition { source }
+    }
+}
+impl From<ResourceExhausted> for ResourceExcReason {
+    fn from(source: ResourceExhausted) -> Self {
+        Self::RscExhausted { source }
+    }
+}
+
 /// Default container of context and a list of items which must be filtered down and sorted.
 #[derive(Clone)]
 pub(crate) struct ResourceData<C, I: std::fmt::Debug> {
     context: C,
     list: Vec<I>,
+    out: BTreeMap<ResourceExcReason, Vec<I>>,
 }
 impl<C, I: std::fmt::Debug> ResourceData<C, I> {
     /// Create a new `Self`.
@@ -34,6 +142,7 @@ impl<C, I: std::fmt::Debug> ResourceData<C, I> {
         Self {
             context: request,
             list,
+            out: Default::default(),
         }
     }
     pub(crate) fn context(&self) -> &C {
@@ -63,6 +172,33 @@ pub(crate) trait ResourceFilter: Sized {
         data.list.retain(|v| filter(param, &data.context, v));
         self
     }
+    fn filter_param_expl<P, F>(
+        mut self,
+        param: &P,
+        filter: F,
+        reason: impl Into<ResourceExcReason>,
+    ) -> Self
+    where
+        F: Fn(&P, &Self::Request, &Self::Item) -> bool,
+    {
+        let data = self.data();
+        data.list.retain(|v| filter(param, &data.context, v));
+        let removed = data
+            .list
+            .extract_if(.., |v| !filter(param, &data.context, v))
+            .collect::<Vec<_>>();
+        if !removed.is_empty() {
+            match data.out.entry(reason.into()) {
+                Entry::Occupied(mut o) => {
+                    o.get_mut().extend(removed);
+                }
+                Entry::Vacant(v) => {
+                    v.insert(removed);
+                }
+            }
+        }
+        self
+    }
     #[allow(dead_code)]
     fn filter_iter(self, filter: fn(Self) -> Self) -> Self {
         filter(self)
@@ -80,6 +216,28 @@ pub(crate) trait ResourceFilter: Sized {
         data.list.retain(|v| filter(&data.context, v));
         self
     }
+    fn filter_expl<F: FnMut(&Self::Request, &Self::Item) -> bool>(
+        mut self,
+        mut filter: F,
+        reason: impl Into<ResourceExcReason>,
+    ) -> Self {
+        let data = self.data();
+        let removed = data
+            .list
+            .extract_if(.., |v| !filter(&data.context, v))
+            .collect::<Vec<_>>();
+        if !removed.is_empty() {
+            match data.out.entry(reason.into()) {
+                Entry::Occupied(mut o) => {
+                    o.get_mut().extend(removed);
+                }
+                Entry::Vacant(v) => {
+                    v.insert(removed);
+                }
+            }
+        }
+        self
+    }
     fn sort<F: FnMut(&Self::Item, &Self::Item) -> std::cmp::Ordering>(mut self, sort: F) -> Self {
         let data = self.data();
         data.list.sort_unstable_by(sort);
@@ -94,6 +252,15 @@ pub(crate) trait ResourceFilter: Sized {
         self
     }
     fn collect(self) -> Vec<Self::Item>;
+    #[allow(clippy::type_complexity)]
+    fn collect_ext(
+        self,
+    ) -> (
+        Vec<Self::Item>,
+        BTreeMap<ResourceExcReason, Vec<Self::Item>>,
+    ) {
+        (self.collect(), Default::default())
+    }
     #[allow(dead_code)]
     fn group_by<K, V, F: Fn(&Self::Request, &Vec<Self::Item>) -> HashMap<K, V>>(
         mut self,

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
@@ -19,7 +19,11 @@ use stor_port::types::v0::{
     transport::{NodeId, PoolId, VolumeState},
 };
 
-use std::{collections::HashMap, ops::Deref};
+use crate::controller::scheduling::ResourceExcReason;
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Deref,
+};
 
 /// Move replica to another pool.
 #[derive(Default, Clone)]
@@ -713,6 +717,14 @@ impl ResourceFilter for SnapshotVolumeReplica {
 
     fn collect(self) -> Vec<Self::Item> {
         self.data.list
+    }
+    fn collect_ext(
+        self,
+    ) -> (
+        Vec<Self::Item>,
+        BTreeMap<ResourceExcReason, Vec<Self::Item>>,
+    ) {
+        (self.data.list, self.data.out)
     }
 }
 

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
@@ -1,4 +1,7 @@
-use super::{volume::ResizeVolumeReplicas, ReplicaFilters, ResourceFilter};
+use super::{
+    volume::ResizeVolumeReplicas, FailedPredicate, ReplicaFilters, ResourceExhausted,
+    ResourceFilter,
+};
 use crate::controller::scheduling::volume::{
     AddVolumeReplica, CloneVolumeSnapshot, SnapshotVolumeReplica,
 };
@@ -39,15 +42,33 @@ impl DefaultBasePolicy {
     }
     fn filter_snapshot_nodes(request: SnapshotVolumeReplica) -> SnapshotVolumeReplica {
         request
-            .filter(node::NodeFilters::cordoned_for_pool)
-            .filter(node::NodeFilters::online_for_pool)
+            .filter_expl(
+                node::NodeFilters::cordoned_for_pool,
+                FailedPredicate::NodeCordoned,
+            )
+            .filter_expl(
+                node::NodeFilters::online_for_pool,
+                FailedPredicate::NodeNotOnline,
+            )
     }
     fn filter_snapshot_pools(request: SnapshotVolumeReplica) -> SnapshotVolumeReplica {
         request
-            .filter(pool::PoolBaseFilters::usable)
-            .filter(pool::PoolBaseFilters::uncordoned_snaps)
-            .filter(pool::PoolBaseFilters::capacity)
-            .filter(pool::PoolBaseFilters::min_free_space)
+            .filter_expl(
+                pool::PoolBaseFilters::usable,
+                FailedPredicate::PoolNotOnline,
+            )
+            .filter_expl(
+                pool::PoolBaseFilters::uncordoned_snaps,
+                FailedPredicate::PoolSnapshotCordon,
+            )
+            .filter_expl(
+                pool::PoolBaseFilters::capacity,
+                FailedPredicate::PoolTooSmall,
+            )
+            .filter_expl(
+                pool::PoolBaseFilters::min_free_space,
+                ResourceExhausted::PoolNoSpace,
+            )
     }
     fn filter_clone(request: CloneVolumeSnapshot) -> CloneVolumeSnapshot {
         Self::filter_clone_pools(Self::filter_clone_nodes(request))

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -8,7 +8,7 @@ use crate::{
                 ReplicaResizePoolsContext, ResizeVolumeReplicas, SnapshotVolumeReplica,
             },
             volume_policy::{affinity_group, pool::PoolBaseFilters, DefaultBasePolicy},
-            ResourceFilter, ResourcePolicy, SortBuilder, SortCriteria,
+            ResourceExhausted, ResourceFilter, ResourcePolicy, SortBuilder, SortCriteria,
         },
     },
     ThinArgs,
@@ -53,9 +53,16 @@ impl ResourcePolicy<AddVolumeReplica> for SimplePolicy {
 impl ResourcePolicy<SnapshotVolumeReplica> for SimplePolicy {
     fn apply(self, to: SnapshotVolumeReplica) -> SnapshotVolumeReplica {
         DefaultBasePolicy::filter_snapshot(to)
-            .filter(PoolBaseFilters::min_free_space)
-            .filter_param(&self, SimplePolicy::min_free_space)
-            .filter_param(&self, SimplePolicy::pool_overcommit)
+            .filter_param_expl(
+                &self,
+                SimplePolicy::min_free_space,
+                ResourceExhausted::PoolNoSpace,
+            )
+            .filter_param_expl(
+                &self,
+                SimplePolicy::pool_overcommit,
+                ResourceExhausted::PoolOverCommit,
+            )
     }
 }
 

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -24,7 +24,7 @@ use grpc::{
 use std::{collections::HashMap, sync::Arc};
 
 /// Node's Service
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct Service {
     registry: Registry,
     /// Deadline for receiving keepalive/Register messages.
@@ -33,6 +33,15 @@ pub(crate) struct Service {
     comms_timeouts: NodeCommsTimeout,
     /// Simulated node endpoint.
     sim_socket: Option<std::net::SocketAddr>,
+}
+impl std::fmt::Debug for Service {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Service")
+            .field("deadline", &self.deadline)
+            .field("comms_timeouts", &self.comms_timeouts)
+            .field("sim_socket", &self.sim_socket)
+            .finish()
+    }
 }
 
 /// Node communication Timeouts for establishing the connection to a node and

--- a/control-plane/agents/src/bin/core/node/watchdog.rs
+++ b/control-plane/agents/src/bin/core/node/watchdog.rs
@@ -3,13 +3,22 @@ use stor_port::types::v0::transport::NodeId;
 
 /// Watchdog which must be pet within the deadline, otherwise
 /// it triggers the `on_timeout` callback from the node `Service`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct Watchdog {
     node_id: NodeId,
     deadline: std::time::Duration,
     timestamp: std::time::Instant,
     pet_chan: Option<tokio::sync::mpsc::Sender<()>>,
     service: Option<Service>,
+}
+impl std::fmt::Debug for Watchdog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Watchdog")
+            .field("node_id", &self.node_id)
+            .field("deadline", &self.deadline)
+            .field("timestamp", &self.timestamp)
+            .finish()
+    }
 }
 
 impl Watchdog {

--- a/control-plane/agents/src/bin/core/volume/service.rs
+++ b/control-plane/agents/src/bin/core/volume/service.rs
@@ -325,7 +325,7 @@ impl Service {
     }
 
     /// Destroy a volume using the given parameters.
-    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
+    #[tracing::instrument(level = "info", skip(self, request), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn destroy_volume(&self, request: &DestroyVolume) -> Result<(), SvcError> {
         let mut volume = self.specs().volume(&request.uuid).await?;
         let content_source = volume.as_ref().content_source.as_ref();
@@ -370,7 +370,7 @@ impl Service {
     }
 
     /// Unshare a volume using the given parameters.
-    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
+    #[tracing::instrument(level = "info", skip(self, request), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn unshare_volume(&self, request: &UnshareVolume) -> Result<(), SvcError> {
         let mut volume = self.specs().volume(&request.uuid).await?;
         volume.unshare(&self.registry, request).await
@@ -409,7 +409,7 @@ impl Service {
     }
 
     /// Set volume replica.
-    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
+    #[tracing::instrument(level = "info", skip(self, request), err, fields(volume.uuid = %request.uuid, request.replicas = request.replicas))]
     pub(super) async fn set_volume_replica(
         &self,
         request: &SetVolumeReplica,
@@ -419,7 +419,7 @@ impl Service {
         self.registry.volume(&request.uuid).await
     }
     /// Set volume property.
-    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
+    #[tracing::instrument(level = "info", skip(self, request), err, fields(volume.uuid = %request.uuid, request.property = ?request.property))]
     pub(super) async fn set_volume_property(
         &self,
         request: &SetVolumeProperty,
@@ -429,7 +429,7 @@ impl Service {
         self.registry.volume(&request.uuid).await
     }
     /// Create a volume snapshot.
-    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.source_id, snapshot.source_uuid = %request.source_id, snapshot.uuid = %request.snap_id))]
+    #[tracing::instrument(level = "info", skip(self, request), err, fields(volume.uuid = %request.source_id, snapshot.source_uuid = %request.source_id, snapshot.uuid = %request.snap_id))]
     async fn create_snapshot(
         &self,
         request: CreateVolumeSnapshot,
@@ -471,7 +471,7 @@ impl Service {
     }
 
     /// Delete a volume snapshot.
-    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = ?request.source_id, snapshot.source_uuid = ?request.source_id, snapshot.uuid = %request.snap_id))]
+    #[tracing::instrument(level = "info", skip(self, request), err, fields(volume.uuid = ?request.source_id, snapshot.source_uuid = ?request.source_id, snapshot.uuid = %request.snap_id))]
     async fn destroy_snapshot(&self, request: DestroyVolumeSnapshot) -> Result<(), SvcError> {
         // Fetch the snapshot spec.
         let snapshot = self.specs().volume_snapshot_rsc(request.snap_id()).ok_or(

--- a/control-plane/agents/src/bin/core/volume/snapshot_helpers.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_helpers.rs
@@ -25,8 +25,6 @@ use stor_port::{
     },
 };
 
-use std::collections::HashSet;
-
 /// A request type for creating snapshot of a volume, which essentially
 /// means a snapshot of all(or selected) healthy replicas associated with that volume.
 pub(super) struct PrepareVolumeSnapshot {
@@ -116,14 +114,33 @@ pub(crate) async fn snapshoteable_replica(
 
     //todo: check for snapshot chain for all the replicas.
 
-    let pools =
+    let (pools, out) =
         SnapshotVolumeReplica::builder_with_defaults(registry, volume, children.candidates())
             .await
-            .collect();
-    let pools: HashSet<_> = pools.iter().map(|item| item.pool.id.clone()).collect();
+            .collect_ext();
+
+    // all healthy replicas must be snapshotted, so any excluded pools is a failure
+    // build a nice error message
+    // note that pools may be excluded due to different reasons, example, 1 pool may not be
+    // online and another may not have sufficient free space, or be cordoned
+    // there's no right answer in this case, but we know that ResourceExhausted has some unresolved
+    // issues in the csi snapshotter, so let's prefer pre-condition failed..
+
+    for (reason, pools) in out.iter() {
+        if !pools.is_empty() {
+            let ids = pools.iter().map(|item| item.pool.id.as_str());
+            return Err(SvcError::VolSnapshotPools {
+                reason: reason.to_string(),
+                pools: format!("{:?}", ids.collect::<Vec<_>>()),
+                code: reason.tonic_code(),
+                kind: reason.into(),
+            });
+        }
+    }
 
     for item in children.candidates() {
-        if !pools.contains(&item.pool().id) {
+        if !pools.iter().any(|p| p.pool.id == item.pool().id) {
+            // this should not happen since we excluded above, but just in case...
             return Err(SvcError::NotEnoughResources {
                 source: NotEnough::PoolFree {},
             });

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -136,6 +136,13 @@ pub enum SvcError {
         invalid_source_id: String,
         correct_source_id: String,
     },
+    #[snafu(display("Failed to take snapshot on pools {pools}: {reason}"))]
+    VolSnapshotPools {
+        pools: String,
+        reason: String,
+        kind: ResourceKind,
+        code: Code,
+    },
     #[snafu(display("{} '{}' not found", kind.to_string(), id))]
     NotFound { kind: ResourceKind, id: String },
     #[snafu(display("{} '{}' is still being created..", kind.to_string(), id))]
@@ -913,6 +920,12 @@ impl From<SvcError> for ReplyError {
             SvcError::NoSnapshotPools { .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPrecondition,
                 resource: ResourceKind::VolumeSnapshotClone,
+                source,
+                extra,
+            },
+            SvcError::VolSnapshotPools { code, kind, .. } => ReplyError {
+                kind: code.into(),
+                resource: kind,
                 source,
                 extra,
             },

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -951,7 +951,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                             Status::resource_exhausted(reason)
                         }
                         ApiClientError::PreconditionFailed(reason) => {
-                            Status::resource_exhausted(reason)
+                            Status::failed_precondition(reason)
                         }
                         error => error.into(),
                     })

--- a/control-plane/stor-port/src/types/v0/transport/misc.rs
+++ b/control-plane/stor-port/src/types/v0/transport/misc.rs
@@ -149,7 +149,7 @@ macro_rules! rpc_impl_string_id {
 macro_rules! rpc_impl_string_uuid_inner {
     ($Name:ident, $Doc:literal) => {
         #[doc = $Doc]
-        #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+        #[derive(Clone, Eq, PartialEq, Hash)]
         pub struct $Name(uuid::Uuid, String);
 
         impl Serialize for $Name {
@@ -182,6 +182,11 @@ macro_rules! rpc_impl_string_uuid_inner {
         impl std::fmt::Display for $Name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{}", self.0)
+            }
+        }
+        impl std::fmt::Debug for $Name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}({})", stringify!($Name), self.1)
             }
         }
 

--- a/tests/bdd/features/pool/cordon/test_feature.py
+++ b/tests/bdd/features/pool/cordon/test_feature.py
@@ -578,8 +578,8 @@ def schedule_snap(pool, cordoned):
 
     except openapi.exceptions.ApiException as exception:
         assert cordoned
-        assert exception.status == http.HTTPStatus.INSUFFICIENT_STORAGE
-        assert ApiClient.exception_to_error(exception).kind == "ResourceExhausted"
+        assert exception.status == http.HTTPStatus.PRECONDITION_FAILED
+        assert ApiClient.exception_to_error(exception).kind == "FailedPrecondition"
 
 
 def schedule_restore(pool, cordoned):


### PR DESCRIPTION

    fix(csi): use correct precondition error
    
    In previous side car versions, non final errors used to lead into a burst
    of retries. Because of this we had "massaged" the returned error codes.
    Now the issue has been fixed upstream, so we can return the appropriate
    error code.
    
---

    refactor(pool/scheduling): use more precise snapshot errors
    
    When a pool is cordoned the returned error should be failed precondition.
    When pools are filtered out, we end up with no choices, and return a
    hardcoded generic error of resource exhausted.
    
    In order to achieve this, we have to remember what reasons were used to
    exclude a pool.
    This changes introduces a list of excluded resources when they are filtered
    out.
    For the moment, this has just been done for the pools, though it could be
    extended to other schedulers.
    
---

    refactor: format debug for stringified id's
    
    Makes debug display properly, example from
    VolumeId("xxxx", "xxxx)
    to
    VolumeId("xxxx")
    
    Implements debug for Service and Watchdog to avoid printing infinite
    loop though these aren't used in practice, it may be useful to print
    while debugging something.
    
    Also remove redundant requests from service handlers.
