### PR TITLE
Bugfixes for spread, snapshot restore and plugin sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,6 +3802,7 @@ dependencies = [
  "gag",
  "humantime",
  "inquire",
+ "itertools 0.13.0",
  "lazy_static",
  "once_cell",
  "openapi",

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -8,7 +8,7 @@ mod volume_policy;
 use crate::controller::scheduling::{
     nexus::GetPersistedNexusChildrenCtx,
     resources::{ChildItem, PoolItem, ReplicaItem},
-    volume::{ReplicaResizePoolsContext, VolumeReplicasForNexusCtx},
+    volume::{GetChildForRemovalContext, ReplicaResizePoolsContext, VolumeReplicasForNexusCtx},
 };
 use std::{cmp::Ordering, collections::HashMap, future::Future};
 use weighted_scoring::{Criteria, Value, ValueGrading, WeightedScore};
@@ -164,20 +164,33 @@ pub(crate) struct ChildSorters {}
 impl ChildSorters {
     /// Sort replicas by their nexus child (state and rebuild progress)
     /// todo: should we use weights instead (like moac)?
-    pub(crate) fn sort(a: &ReplicaItem, b: &ReplicaItem) -> std::cmp::Ordering {
+    pub(crate) fn sort(
+        _request: &GetChildForRemovalContext,
+        a: &ReplicaItem,
+        b: &ReplicaItem,
+    ) -> std::cmp::Ordering {
         match Self::sort_by_health(a, b) {
             Ordering::Equal => match Self::sort_by_child(a, b) {
                 Ordering::Equal => {
                     // Remove replicas from nodes which are cordoned with most priority.
                     // remove mismatched topology replicas first
                     if let (Some(a), Some(b)) = (a.valid_node_topology(), b.valid_node_topology()) {
-                        match a.cmp(b) {
+                        match a.cmp(&b) {
                             Ordering::Equal => {}
                             // todo: what if the pool and node topology are at odds with each other?
                             _else => return _else,
                         }
                     }
+
                     if let (Some(a), Some(b)) = (a.valid_pool_topology(), b.valid_pool_topology()) {
+                        match a.cmp(b) {
+                            Ordering::Equal => {}
+                            _else => return _else,
+                        }
+                    }
+
+                    // in case node topology is valid but there are clashes, allow the pool topology first...
+                    if let (Some(a), Some(b)) = (a.node_topology_info(), b.node_topology_info()) {
                         match a.cmp(b) {
                             Ordering::Equal => {}
                             _else => return _else,

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -16,7 +16,7 @@ use stor_port::types::v0::{
     transport::{Child, ChildUri, NodeId, PoolId, Replica},
 };
 
-use std::{collections::HashMap, ops::Deref};
+use std::{cmp::Ordering, collections::HashMap, ops::Deref};
 
 /// Item for pool scheduling logic.
 #[derive(Debug, Clone)]
@@ -94,9 +94,7 @@ impl PoolItemLister {
                 n.pool_wrappers()
                     .into_iter()
                     .filter_map(|p| {
-                        let cordoned = registry
-                            .specs()
-                            .pool_with(&p.id, |p| p.lock().cordoned().cloned());
+                        let cordoned = registry.specs().pool_with(&p.id, |p| p.cordoned().cloned());
                         let cordoned = cordoned.ok()?;
                         let ag_rep_count =
                             pool_ag_rep.as_ref().and_then(|map| map.get(&p.id).cloned());
@@ -119,7 +117,7 @@ impl PoolItemLister {
                     .and_then(|node| {
                         let cordoned = registry
                             .specs()
-                            .pool_with(&item.pool().id, |p| p.lock().cordoned().cloned());
+                            .pool_with(&item.pool().id, |p| p.cordoned().cloned());
                         let pool =
                             PoolItem::new(node.clone(), item.pool().clone(), None, cordoned.ok()?);
                         Some(pool)
@@ -188,6 +186,49 @@ impl PoolItemLister {
     }
 }
 
+/// Topology information to aid in selecting the "worst" replica which is the "best" removal.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct TopologyRmInfo {
+    /// The topology is valid (ie has required labels).
+    valid: bool,
+    /// In case of exclusion, track how many others this replica clashes with.
+    clashes: u64,
+}
+impl PartialOrd for TopologyRmInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for TopologyRmInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Best removal candidate should be lesser as the list is reversed later on.
+        match (self.valid, other.valid) {
+            (true, true) => other.clashes.cmp(&self.clashes),
+            (false, false) => Ordering::Equal,
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+        }
+    }
+}
+
+impl TopologyRmInfo {
+    /// There's no topology involved.
+    pub(crate) fn new_no_topology() -> Option<Self> {
+        None
+    }
+    /// This resource has an invalid topology.
+    pub(crate) fn new_invalid() -> Option<Self> {
+        Some(Self::new(false, 0))
+    }
+    /// A valid topology, but with clashes.
+    pub(crate) fn new_clashes(clashes: u64) -> Option<Self> {
+        Some(Self::new(true, clashes))
+    }
+    fn new(valid: bool, clashes: u64) -> Self {
+        Self { valid, clashes }
+    }
+}
+
 /// A replica item used for scheduling.
 #[derive(Debug, Clone)]
 pub(crate) struct ReplicaItem {
@@ -203,7 +244,7 @@ pub(crate) struct ReplicaItem {
     /// on this pool.
     ag_replicas_on_pool: Option<u64>,
     valid_pool_topology: Option<bool>,
-    valid_node_topology: Option<bool>,
+    node_topology_info: Option<TopologyRmInfo>,
     node_spec: Option<NodeSpec>,
 }
 
@@ -229,15 +270,20 @@ impl ReplicaItem {
             child_info,
             ag_replicas_on_pool,
             valid_pool_topology: None,
-            valid_node_topology: None,
+            node_topology_info: None,
             node_spec,
         }
     }
     /// Set the validity of the replica's node topology.
     /// If set to false, this means the replica is not in sync with the volume topology and
     /// therefore should be replaced by another replica which is in sync.
-    pub(crate) fn with_node_topology(mut self, valid_node_topology: Option<bool>) -> ReplicaItem {
-        self.valid_node_topology = valid_node_topology;
+    pub(crate) fn with_node_topology<F: Fn(&NodeSpec) -> Option<TopologyRmInfo>>(
+        mut self,
+        f: F,
+    ) -> ReplicaItem {
+        if let Some(node_spec) = &self.node_spec {
+            self.node_topology_info = f(node_spec);
+        }
         self
     }
     /// Set the validity of the replica's pool topology.
@@ -247,9 +293,13 @@ impl ReplicaItem {
         self.valid_pool_topology = valid_pool_topology;
         self
     }
+    /// Get a reference to the node topology validity information.
+    pub(crate) fn node_topology_info(&self) -> &Option<TopologyRmInfo> {
+        &self.node_topology_info
+    }
     /// Get a reference to the node topology validity flag.
-    pub(crate) fn valid_node_topology(&self) -> &Option<bool> {
-        &self.valid_node_topology
+    pub(crate) fn valid_node_topology(&self) -> Option<bool> {
+        self.node_topology_info.as_ref().map(|t| t.valid)
     }
     /// Get a reference to the node topology validity flag.
     pub(crate) fn node_spec(&self) -> &Option<NodeSpec> {

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
@@ -5,7 +5,10 @@ use crate::controller::{
         affinity_group::{get_pool_ag_replica_count, get_restricted_nodes},
         pool::replica_rebuildable,
         resources::{ChildItem, PoolItem, PoolItemLister, ReplicaItem},
-        volume_policy::{node::NodeFilters, SimplePolicy, ThickPolicy},
+        volume_policy::{
+            node::{volume_node_spread_labels, volume_node_spread_labels_x, NodeFilters},
+            SimplePolicy, ThickPolicy,
+        },
         AddReplicaFilters, AddReplicaSorters, ChildSorters, ResourceData, ResourceFilter,
     },
     wrapper::PoolWrapper,
@@ -13,8 +16,8 @@ use crate::controller::{
 use agents::errors::SvcError;
 use stor_port::types::v0::{
     store::{
-        nexus::NexusSpec, nexus_persistence::NexusInfo, snapshots::replica::ReplicaSnapshot,
-        volume::VolumeSpec,
+        nexus::NexusSpec, nexus_persistence::NexusInfo, replica::ReplicaSpec,
+        snapshots::replica::ReplicaSnapshot, volume::VolumeSpec,
     },
     transport::{NodeId, PoolId, VolumeState},
 };
@@ -73,6 +76,7 @@ pub(crate) struct GetSuitablePoolsContext {
     move_repl: Option<MoveReplica>,
     snap_repl: bool,
     ag_restricted_nodes: Option<Vec<NodeId>>,
+    used_spread_labels: std::collections::HashMap<String, Vec<String>>,
 }
 impl GetSuitablePoolsContext {
     /// Get the registry.
@@ -106,6 +110,9 @@ impl GetSuitablePoolsContext {
         let max_cap_allowed = allowed_commit_percent * pool.capacity;
         (self.size + pool.commitment()) * 100 < max_cap_allowed
     }
+    pub(crate) fn spread_labels(&self) -> &std::collections::HashMap<String, Vec<String>> {
+        &self.used_spread_labels
+    }
 }
 
 impl Deref for GetSuitablePoolsContext {
@@ -135,6 +142,14 @@ impl AddVolumeReplica {
     // May return None if the replica nodes are offline.
     async fn allocated_bytes(registry: &Registry, volume: &VolumeSpec) -> Option<u64> {
         let replicas = registry.specs().volume_replicas(&volume.uuid);
+        Self::allocated_bytes_repl(registry, &replicas).await
+    }
+    // Return max allocated bytes from volume replicas.
+    // May return None if the replica nodes are offline.
+    async fn allocated_bytes_repl(
+        registry: &Registry,
+        replicas: &Vec<ResourceMutex<ReplicaSpec>>,
+    ) -> Option<u64> {
         if replicas.is_empty() {
             return Some(0);
         }
@@ -147,12 +162,16 @@ impl AddVolumeReplica {
                 }
             }
         }
-        used_bytes.iter().max().cloned()
+        used_bytes.into_iter().max()
     }
     async fn builder(request: GetSuitablePools, registry: &Registry) -> Self {
         let volume_spec = request.spec;
 
-        let allocated_bytes = Self::allocated_bytes(registry, &volume_spec).await;
+        let replicas = registry.specs().volume_replicas(&volume_spec.uuid);
+        // the spread keys and the currently used values which cannot be reused by new replicas
+        let exclude_labels = volume_node_spread_labels(&volume_spec, registry, &replicas);
+
+        let allocated_bytes = Self::allocated_bytes_repl(registry, &replicas).await;
 
         let mut ag_restricted_nodes: Option<Vec<NodeId>> = None;
         let mut pool_ag_replica_count_map: Option<HashMap<PoolId, u64>> = None;
@@ -180,6 +199,7 @@ impl AddVolumeReplica {
                     move_repl: request.move_repl,
                     snap_repl: false,
                     ag_restricted_nodes,
+                    used_spread_labels: exclude_labels,
                 },
                 PoolItemLister::list(registry, &pool_ag_replica_count_map).await,
             ),
@@ -291,53 +311,50 @@ impl GetChildForRemovalContext {
     }
 
     async fn list(&self, pool_ag_rep: &Option<HashMap<PoolId, u64>>) -> Vec<ReplicaItem> {
-        let replicas = self.registry.specs().volume_replicas(&self.spec.uuid);
+        let replicas = self.registry.specs().volume_replicas_cln(&self.spec.uuid);
         let nexus = self.registry.specs().volume_target_nexus_rsc(&self.spec);
-        let replicas = replicas.iter().map(|r| r.lock().clone());
+        let used_node_spread =
+            volume_node_spread_labels_x(&self.spec, &self.registry, replicas.iter());
 
         let replica_states = self.registry.replicas().await;
         replicas
+            .into_iter()
             .map(|replica_spec| {
                 let replica_node_spec = self.registry.specs().replica_node_spec(&replica_spec.uuid);
                 let ag_rep_count = pool_ag_rep
                     .as_ref()
                     .and_then(|map| map.get(replica_spec.pool_name()).cloned());
+                let replica_state = replica_states.iter().find(|r| r.uuid == replica_spec.uuid);
                 ReplicaItem::new(
                     replica_spec.clone(),
-                    replica_states.iter().find(|r| r.uuid == replica_spec.uuid),
-                    replica_states
-                        .iter()
-                        .find(|replica_state| replica_state.uuid == replica_spec.uuid)
-                        .and_then(|replica_state| {
-                            nexus.as_ref().and_then(|nexus_spec| {
-                                nexus_spec
-                                    .lock()
-                                    .children
-                                    .iter()
-                                    .find(|child| child.uri() == replica_state.uri)
-                                    .map(|child| child.uri())
-                            })
-                        }),
-                    replica_states
-                        .iter()
-                        .find(|replica_state| replica_state.uuid == replica_spec.uuid)
-                        .and_then(|replica_state| {
-                            self.state.target.as_ref().and_then(|nexus_state| {
-                                nexus_state
-                                    .children
-                                    .iter()
-                                    .find(|child| child.uri.as_str() == replica_state.uri)
-                                    .cloned()
-                            })
-                        }),
+                    replica_state,
+                    replica_state.and_then(|replica_state| {
+                        nexus.as_ref().and_then(|nexus_spec| {
+                            nexus_spec
+                                .lock()
+                                .children
+                                .iter()
+                                .find(|child| child.uri() == replica_state.uri)
+                                .map(|child| child.uri())
+                        })
+                    }),
+                    replica_state.and_then(|replica_state| {
+                        self.state.target.as_ref().and_then(|nexus_state| {
+                            nexus_state
+                                .children
+                                .iter()
+                                .find(|child| child.uri.as_str() == replica_state.uri)
+                                .cloned()
+                        })
+                    }),
                     nexus.as_ref().and_then(|nexus_spec| {
                         nexus_spec
                             .lock()
                             .children
                             .iter()
                             .find(|child| {
-                                child.as_replica().map(|uri| uri.uuid().clone())
-                                    == Some(replica_spec.uuid.clone())
+                                child.as_replica().as_ref().map(|uri| uri.uuid())
+                                    == Some(&replica_spec.uuid)
                             })
                             .cloned()
                     }),
@@ -351,12 +368,8 @@ impl GetChildForRemovalContext {
                     ag_rep_count,
                     replica_node_spec,
                 )
-                .with_node_topology({
-                    Some(NodeFilters::topology_replica(
-                        &self.spec,
-                        &self.registry,
-                        replica_spec.pool_name(),
-                    ))
+                .with_node_topology(|node_spec| {
+                    NodeFilters::topology_replica_removal(&self.spec, node_spec, &used_node_spread)
                 })
                 .with_pool_topology({
                     use crate::controller::scheduling::volume_policy::pool::PoolBaseFilters;
@@ -391,9 +404,8 @@ impl DecreaseVolumeReplica {
         request: &GetChildForRemoval,
         registry: &Registry,
     ) -> Result<Self, SvcError> {
-        Ok(Self::builder(request, registry)
-            .await?
-            .sort(ChildSorters::sort))
+        let remover = Self::builder(request, registry).await?;
+        Ok(remover.sort_ctx(ChildSorters::sort))
     }
     /// Get the `ReplicaRemovalCandidates` for this request, which splits the candidates into
     /// healthy and unhealthy candidates.
@@ -672,6 +684,7 @@ impl SnapshotVolumeReplica {
                     move_repl: None,
                     snap_repl: true,
                     ag_restricted_nodes: None,
+                    used_spread_labels: Default::default(),
                 },
                 PoolItemLister::list_for_snaps(registry, items).await,
             ),
@@ -737,6 +750,7 @@ impl CloneVolumeSnapshot {
                     move_repl: None,
                     snap_repl: false,
                     ag_restricted_nodes: None,
+                    used_spread_labels: Default::default(),
                 },
                 PoolItemLister::list_for_clones(registry, snapshots).await,
             ),

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/mod.rs
@@ -74,16 +74,16 @@ impl DefaultBasePolicy {
 /// Return true if all the keys present in volume's pool/node inclusion matches with the pool/node
 /// labels otherwise returns false.
 pub(crate) fn qualifies_label_criteria(
-    vol_pool_inc_labels: HashMap<String, String>,
-    pool_labels: &HashMap<String, String>,
+    vol_labels: &HashMap<String, String>,
+    labels: &HashMap<String, String>,
 ) -> bool {
-    for (vol_inc_key, vol_inc_value) in vol_pool_inc_labels.iter() {
-        match pool_labels.get(vol_inc_key) {
+    for (vol_key, vol_value) in vol_labels.iter() {
+        match labels.get(vol_key) {
             Some(pool_val) => {
-                if vol_inc_value.is_empty() {
+                if vol_value.is_empty() {
                     continue;
                 }
-                if pool_val != vol_inc_value {
+                if pool_val != vol_value {
                     return false;
                 }
             }

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/node.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/node.rs
@@ -1,15 +1,16 @@
 use crate::controller::{
     registry::Registry,
+    resources::ResourceMutex,
     scheduling::{
         nexus::GetSuitableNodesContext,
-        resources::{NodeItem, PoolItem},
+        resources::{NodeItem, PoolItem, TopologyRmInfo},
         volume::GetSuitablePoolsContext,
         volume_policy::qualifies_label_criteria,
     },
 };
 use stor_port::types::v0::{
-    store::volume::VolumeSpec,
-    transport::{NodeId, NodeTopology, PoolId},
+    store::{node::NodeSpec, replica::ReplicaSpec, volume::VolumeSpec},
+    transport::{LabelledTopology, NodeId, NodeTopology},
 };
 
 use std::collections::HashMap;
@@ -79,55 +80,61 @@ impl NodeFilters {
     }
     /// Should only attempt to use nodes having specific creation label if topology has it.
     pub(crate) fn topology(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
-        Self::topology_(request, request.registry(), &item.pool.node)
+        Self::topology_(
+            request,
+            request.registry(),
+            &item.pool.node,
+            request.spread_labels(),
+        )
+    }
+    /// Get topology remove information used to help determine which replica should be removed first.
+    pub(crate) fn topology_replica_removal(
+        volume: &VolumeSpec,
+        node: &NodeSpec,
+        used_node_spread: &HashMap<String, Vec<String>>,
+    ) -> Option<TopologyRmInfo> {
+        let Some(topology) = volume_labels_any(volume) else {
+            return TopologyRmInfo::new_no_topology();
+        };
+
+        if !qualifies_label_criteria(&topology.inclusion, node.labels())
+            || !qualifies_label_criteria(&topology.exclusion, node.labels())
+        {
+            return TopologyRmInfo::new_invalid();
+        }
+
+        let mut conflicts = 0;
+        for (used_key, used_values) in used_node_spread {
+            let Some(node_value) = node.labels().get(used_key) else {
+                // we'd have been excluded anyway
+                continue;
+            };
+            if used_values.contains(node_value) {
+                // we conflict with another
+                conflicts += 1;
+            }
+        }
+
+        TopologyRmInfo::new_clashes(conflicts)
     }
     /// Should only attempt to use nodes having specific creation label if topology has it.
-    pub(crate) fn topology_replica(
+    pub(crate) fn topology_(
         volume: &VolumeSpec,
         registry: &Registry,
-        pool_id: &PoolId,
+        node_id: &NodeId,
+        used_node_spread: &HashMap<String, Vec<String>>,
     ) -> bool {
-        let Ok(pool) = registry.specs().pool(pool_id) else {
-            return false;
-        };
-        Self::topology_(volume, registry, &pool.node)
-    }
-    /// Should only attempt to use nodes having specific creation label if topology has it.
-    pub(crate) fn topology_(volume: &VolumeSpec, registry: &Registry, node_id: &NodeId) -> bool {
-        let volume_node_topology_inclusion_labels: HashMap<String, String>;
-        let volume_node_topology_exclusion_labels: HashMap<String, String>;
-        match &volume.topology {
-            None => return true,
-            Some(topology) => match &topology.node {
-                None => return true,
-                Some(node_topology) => match node_topology {
-                    NodeTopology::Labelled(labelled_topology) => {
-                        // The labels in Volume Node Topology should match the node labels if
-                        // present, otherwise selection of any pool is allowed.
-                        if !labelled_topology.inclusion.is_empty()
-                            || !labelled_topology.exclusion.is_empty()
-                        {
-                            volume_node_topology_inclusion_labels =
-                                labelled_topology.inclusion.clone();
-                            volume_node_topology_exclusion_labels =
-                                labelled_topology.exclusion.clone();
-                        } else {
-                            return true;
-                        }
-                    }
-                    NodeTopology::Explicit(_) => return true,
-                },
-            },
+        let Some(topology) = volume_labels_any(volume) else {
+            return true;
         };
 
         // We will reach this part of code only if the volume has inclusion/exclusion labels.
-        match registry.specs().node(node_id) {
+        match registry.specs().node_rsc(node_id) {
             Ok(spec) => {
-                qualifies_label_criteria(volume_node_topology_inclusion_labels, spec.labels())
-                    && qualifies_label_criteria(
-                        volume_node_topology_exclusion_labels,
-                        spec.labels(),
-                    )
+                let spec = spec.lock();
+                qualifies_label_criteria(&topology.inclusion, spec.labels())
+                    && qualifies_label_criteria(&topology.exclusion, spec.labels())
+                    && qualifies_spread_criteria(used_node_spread, spec.labels())
             }
             Err(_) => false,
         }
@@ -150,5 +157,140 @@ impl NodeSorters {
                     .nexus_count()
                     .cmp(&b.node_wrapper().nexus_count())
             })
+    }
+}
+
+/// Get volume labelled topology, if any is set.
+pub(crate) fn volume_labels_any(volume: &VolumeSpec) -> Option<&LabelledTopology> {
+    match volume_labels(volume) {
+        Some(labelled_topology)
+            if !labelled_topology.exclusion.is_empty()
+                || !labelled_topology.inclusion.is_empty() =>
+        {
+            Some(labelled_topology)
+        }
+        _ => None,
+    }
+}
+/// Get node exclusion labels, if any is present.
+pub(crate) fn node_exclusion(volume: &VolumeSpec) -> Option<&HashMap<String, String>> {
+    match volume_labels(volume) {
+        Some(labelled_topology) if !labelled_topology.exclusion.is_empty() => {
+            Some(&labelled_topology.exclusion)
+        }
+        _ => None,
+    }
+}
+
+/// Get the currently used volume spread labels.
+/// # NOTE
+/// Only nodes which are respecting the current exclusion policy are used to populate these labels.
+/// This ensures we start working towards the correct topology at the price of limiting the list
+/// to the would-be correct nodes only!
+pub(crate) fn volume_node_spread_labels(
+    volume_spec: &VolumeSpec,
+    registry: &Registry,
+    replicas: &[ResourceMutex<ReplicaSpec>],
+) -> HashMap<String, Vec<String>> {
+    volume_node_spread_label_impl(
+        volume_spec,
+        replicas.iter().flat_map(|replica| {
+            let replica = replica.lock();
+            registry
+                .specs()
+                .pool_with(replica.pool_name(), |p| p.node.clone())
+                .and_then(|n| registry.specs().node_rsc(&n))
+        }),
+    )
+}
+/// Similar to [`volume_node_spread_labels`] but accepting an iteration over [`ReplicaSpec`].
+pub(crate) fn volume_node_spread_labels_x<'a>(
+    volume_spec: &VolumeSpec,
+    registry: &Registry,
+    replicas: impl Iterator<Item = &'a ReplicaSpec>,
+) -> HashMap<String, Vec<String>> {
+    volume_node_spread_label_impl(
+        volume_spec,
+        replicas.into_iter().flat_map(|replica| {
+            registry
+                .specs()
+                .pool_with(replica.pool_name(), |p| p.node.clone())
+                .and_then(|n| registry.specs().node_rsc(&n))
+        }),
+    )
+}
+
+fn volume_node_spread_label_impl(
+    volume_spec: &VolumeSpec,
+    replica_nodes: impl Iterator<Item = ResourceMutex<NodeSpec>>,
+) -> HashMap<String, Vec<String>> {
+    let Some(volume_exc_labels) = node_exclusion(volume_spec) else {
+        return Default::default();
+    };
+    if volume_exc_labels.is_empty() {
+        return Default::default();
+    }
+
+    // the spread keys and the currently used values which cannot be reused by new replicas
+    let mut exclude_labels = HashMap::<String, Vec<String>>::new();
+    for node in replica_nodes {
+        let node = node.lock();
+        let labels = node.labels();
+
+        node_spread_labels(volume_exc_labels, labels, &mut exclude_labels);
+    }
+    exclude_labels
+}
+fn node_spread_labels(
+    volume_labels: &HashMap<String, String>,
+    node_labels: &HashMap<String, String>,
+    accrued_exclusions: &mut HashMap<String, Vec<String>>,
+) {
+    // first we need to ensure the node is respecting the volume's current spread policy
+    // if not, then there's no point including this node in the log, since we'll have to remove it
+    // sometime later anyway!
+    let mut node_exclusions = HashMap::<&String, &String>::new();
+
+    for vol_key in volume_labels.keys() {
+        let Some(value) = node_labels.get(vol_key) else {
+            // we're missing a key, so don't accrue this node!
+            return;
+        };
+        node_exclusions.insert(vol_key, value);
+    }
+
+    // node is compliant with spread labels, so we can accrue with its labels
+    for (key, value) in node_exclusions {
+        accrued_exclusions
+            .entry(key.clone())
+            .or_default()
+            .push(value.clone());
+    }
+}
+
+fn qualifies_spread_criteria(
+    used_labels: &HashMap<String, Vec<String>>,
+    node_labels: &HashMap<String, String>,
+) -> bool {
+    for (used_key, used_values) in used_labels {
+        let Some(node_values) = node_labels.get(used_key) else {
+            // exclusion key must exist in order for spread to be valid
+            return false;
+        };
+        if used_values.contains(node_values) {
+            // we want to spread across different values
+            return false;
+        }
+    }
+    true
+}
+
+fn volume_labels(volume: &VolumeSpec) -> Option<&LabelledTopology> {
+    let topology = volume.topology.as_ref();
+    let node_topology = topology.and_then(|topology| topology.node.as_ref());
+
+    match node_topology {
+        Some(NodeTopology::Labelled(labelled_topology)) => Some(labelled_topology),
+        _ => None,
     }
 }

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
@@ -79,7 +79,7 @@ impl PoolBaseFilters {
         }
     }
     /// Should only attempt to use pools with sufficient free space for a full rebuild.
-    /// Currently the data-plane fully rebuilds a volume, meaning a thin provisioned volume
+    /// Currently, the data-plane fully rebuilds a volume, meaning a thin provisioned volume
     /// becomes fully allocated.
     pub(crate) fn min_free_space_full_rebuild(
         request: &GetSuitablePoolsContext,
@@ -115,7 +115,7 @@ impl PoolBaseFilters {
 
     /// Should only attempt to use pools having specific creation label if topology has it.
     pub(crate) fn topology_(volume: &VolumeSpec, registry: &Registry, pool_id: &PoolId) -> bool {
-        let volume_pool_topology_inclusion_labels: HashMap<String, String>;
+        let inclusion_labels: &HashMap<String, String>;
         match &volume.topology {
             None => return true,
             Some(topology) => match &topology.pool {
@@ -128,21 +128,19 @@ impl PoolBaseFilters {
                             // todo: missing exclusion check?
                             return true;
                         }
-                        volume_pool_topology_inclusion_labels = labelled_topology.inclusion.clone()
+                        inclusion_labels = &labelled_topology.inclusion
                     }
                 },
             },
         };
 
         // We will reach this part of code only if the volume has inclusion/exclusion labels.
-        match registry.specs().pool(pool_id) {
-            Ok(spec) => match spec.labels {
+        match registry.specs().pool_rsc(pool_id) {
+            Some(spec) => match &spec.lock().labels {
                 None => false,
-                Some(pool_labels) => {
-                    qualifies_label_criteria(volume_pool_topology_inclusion_labels, &pool_labels)
-                }
+                Some(pool_labels) => qualifies_label_criteria(inclusion_labels, pool_labels),
             },
-            Err(_) => false,
+            None => false,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/pool/specs.rs
+++ b/control-plane/agents/src/bin/core/pool/specs.rs
@@ -408,13 +408,13 @@ impl ResourceSpecsLocked {
     pub(crate) fn pool_with<R>(
         &self,
         id: &PoolId,
-        run: impl Fn(&ResourceMutex<PoolSpec>) -> R,
+        run: impl Fn(parking_lot::MutexGuard<PoolSpec>) -> R,
     ) -> Result<R, SvcError> {
         let specs = self.read();
         let pool = specs.pools.get(id).ok_or(PoolNotFound {
             pool_id: id.to_owned(),
         })?;
-        Ok(run(pool))
+        Ok(run(pool.lock()))
     }
     /// Get a pools's node from its spec for the given pool `id`, if it exists.
     pub(crate) fn spec_pool_node(&self, id: &PoolId) -> Option<NodeId> {

--- a/control-plane/agents/src/bin/core/volume/clone_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/clone_operations.rs
@@ -121,6 +121,7 @@ impl CreateVolumeExe for SnapshotCloneOp<'_> {
     type Candidates = Vec<SnapshotCloneSpecParams>;
 
     async fn setup<'a>(&'a self, context: &mut Context<'a>) -> Result<Self::Candidates, SvcError> {
+        // todo: topology is not being used here at all
         let clonable_snapshots = self.cloneable_snapshot(context).await?;
         let volume = context.volume.as_ref();
         if volume.num_replicas > clonable_snapshots.len() as u8 {
@@ -142,20 +143,19 @@ impl CreateVolumeExe for SnapshotCloneOp<'_> {
         let volume_replicas = context.volume.as_ref().num_replicas as usize;
         // todo: need to add new replica and do full rebuild, if clonable snapshots
         // count is less than volume replicas count.
-        for (idx, clone_replica) in clone_replicas.iter().enumerate() {
-            match OperationGuardArc::<ReplicaSpec>::create_ext(context.registry, clone_replica)
+        for clone_replica in clone_replicas {
+            match OperationGuardArc::<ReplicaSpec>::create_ext(context.registry, &clone_replica)
                 .await
             {
                 Ok(replica) => {
                     replicas.push(replica);
-                    if idx + 1 == volume_replicas {
+                    if replicas.len() == volume_replicas {
                         break;
                     }
                 }
                 Err(error) => {
                     context.volume.error(&format!(
-                        "Failed to create replica {:?} for volume, error: {}",
-                        clone_replica,
+                        "Failed to create replica {clone_replica:?} for volume, error: {}",
                         error.full_string()
                     ));
                 }
@@ -166,6 +166,7 @@ impl CreateVolumeExe for SnapshotCloneOp<'_> {
 
     async fn undo<'a>(&'a self, _context: &mut Context<'a>, _replicas: Vec<Replica>) {
         // nothing to undo since we only support 1-replica snapshot
+        // todo: we do support multi-replica snapshots, this should have been tweaked :(
     }
 }
 
@@ -186,22 +187,29 @@ impl SnapshotCloneOp<'_> {
             }),
         }?;
 
-        let mut pools = CloneVolumeSnapshot::builder_with_defaults(registry, new_volume, snapshots)
+        let pools = CloneVolumeSnapshot::builder_with_defaults(registry, new_volume, snapshots)
             .await
             .collect();
-        if pools.len() != snapshots.len() || pools.is_empty() {
+        if pools.len() < new_volume.num_replicas as usize || pools.is_empty() {
             return Err(SvcError::NoSnapshotPools {
                 id: snapshot.spec().uuid().to_string(),
             });
         }
 
-        let mut clone_spec_params = vec![];
+        let mut clone_spec_params = Vec::with_capacity(pools.len());
         for snapshot in snapshots {
+            let Some(pool) = pools
+                .iter()
+                .find(|p| &p.pool().id == snapshot.spec().source_id().pool_id())
+            else {
+                continue;
+            };
+
             let clone_id = SnapshotCloneId::new();
             let clone_name = clone_id.to_string();
             let repl_params =
                 SnapshotCloneParameters::new(snapshot.spec().uuid().clone(), clone_name, clone_id);
-            let pool = pools.remove(0);
+
             let clone_spec_param = SnapshotCloneSpecParams::new(
                 repl_params,
                 snapshot.meta().source_spec_size(),

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -827,97 +827,6 @@ impl ResourceShutdownOperations for OperationGuardArc<VolumeSpec> {
 }
 
 #[async_trait::async_trait]
-impl ResourceLifecycleExt<CreateVolume> for OperationGuardArc<VolumeSpec> {
-    type CreateOutput = Self;
-
-    async fn create_ext(
-        registry: &Registry,
-        request: &CreateVolume,
-    ) -> Result<Self::CreateOutput, SvcError> {
-        let specs = registry.specs();
-        let mut volume = specs
-            .get_or_create_volume(&CreateVolumeSource::None(request))?
-            .operation_guard_wait()
-            .await?;
-        let volume_clone = volume.start_create(registry, request).await?;
-
-        // If the volume is a part of the ag, create or update accordingly.
-        registry.specs().get_or_create_affinity_group(&volume_clone);
-
-        // todo: pick nodes and pools using the Node&Pool Topology
-        // todo: virtually increase the pool usage to avoid a race for space with concurrent calls
-        let result = create_volume_replicas(registry, request, &volume_clone).await;
-        let create_replica_candidate = volume
-            .validate_create_step_ext(registry, result, OnCreateFail::Delete)
-            .await?;
-
-        let mut replicas = Vec::<Replica>::new();
-        for replica in create_replica_candidate.candidates() {
-            if replicas.len() >= request.replicas as usize {
-                break;
-            } else if replicas.iter().any(|r| r.node == replica.node) {
-                // don't reuse the same node
-                continue;
-            }
-            let replica = if replicas.is_empty() {
-                let mut replica = replica.clone();
-                // the local replica needs to be connected via "bdev:///"
-                replica.share = Protocol::None;
-                replica
-            } else {
-                replica.clone()
-            };
-            match OperationGuardArc::<ReplicaSpec>::create(registry, &replica).await {
-                Ok(replica) => {
-                    replicas.push(replica);
-                }
-                Err(error) => {
-                    volume_clone.error(&format!(
-                        "Failed to create replica {:?} for volume, error: {}",
-                        replica,
-                        error.full_string()
-                    ));
-                    // continue trying...
-                }
-            };
-        }
-
-        // we can't fulfil the required replication factor, so let the caller
-        // decide what to do next
-        let result = if replicas.len() < request.replicas as usize {
-            for replica_state in replicas {
-                let result = match specs.replica(&replica_state.uuid).await {
-                    Ok(mut replica) => {
-                        let request = DestroyReplica::from(replica_state.clone());
-                        replica.destroy(registry, &request.with_disown_all()).await
-                    }
-                    Err(error) => Err(error),
-                };
-                if let Err(error) = result {
-                    volume_clone.error(&format!(
-                        "Failed to delete replica {:?} from volume, error: {}",
-                        replica_state,
-                        error.full_string()
-                    ));
-                }
-            }
-            Err(SvcError::ReplicaCreateNumber {
-                id: request.uuid.to_string(),
-            })
-        } else {
-            Ok(())
-        };
-
-        // we can destroy volume on error because there's no volume resource created on the nodes,
-        // only sub-resources (such as nexuses/replicas which will be garbage-collected later).
-        volume
-            .complete_create(result, registry, OnCreateFail::Delete)
-            .await?;
-        Ok(volume)
-    }
-}
-
-#[async_trait::async_trait]
 impl ResourceLifecycleExt<CreateVolumeSource<'_>> for OperationGuardArc<VolumeSpec> {
     type CreateOutput = Self;
 
@@ -1080,7 +989,7 @@ impl CreateVolumeExe for CreateVolume {
 
                 replicas
             }
-            _ => create(candidates, context).await,
+            None => create(candidates, context).await,
         }
     }
 

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -44,6 +44,7 @@ use stor_port::{
     },
 };
 
+use itertools::Itertools;
 use std::{fmt::Debug, ops::Deref};
 
 #[async_trait::async_trait]
@@ -978,6 +979,24 @@ pub(super) struct Context<'a> {
     pub(super) registry: &'a Registry,
     pub(super) volume: &'a mut OperationGuardArc<VolumeSpec>,
 }
+impl<'a> Context<'a> {
+    fn is_node_spread(&self) -> bool {
+        self.node_exclusion().is_some()
+    }
+    fn node_exclusion(&self) -> Option<&std::collections::HashMap<String, String>> {
+        let topology = self.volume.as_ref().topology.as_ref();
+        let node_topology = topology.and_then(|topology| topology.node.as_ref());
+
+        match node_topology {
+            Some(NodeTopology::Labelled(labelled_topology))
+                if !labelled_topology.exclusion.is_empty() =>
+            {
+                Some(&labelled_topology.exclusion)
+            }
+            _ => None,
+        }
+    }
+}
 
 /// Trait that abstracts away the pre-flight validation checks when creating a volume.
 pub(super) trait CreateVolumeExeVal: Sync + Send {
@@ -991,6 +1010,7 @@ pub(super) trait CreateVolumeExe: CreateVolumeExeVal {
 
     async fn run<'a>(&'a self, mut context: Context<'a>) -> Result<Vec<Replica>, SvcError> {
         let result = self.setup(&mut context).await;
+
         let candidates = context
             .volume
             .validate_create_step_ext(context.registry, result, OnCreateFail::Delete)
@@ -1035,6 +1055,13 @@ impl CreateVolumeExe for CreateVolume {
         &'a self,
         context: &mut Context<'a>,
     ) -> Result<CreateReplicaCandidate, SvcError> {
+        if context.is_node_spread() {
+            // clean up any previous leftover attempts
+            // this is required because with spread and delayed affinity, the creation of replicas may
+            // depend on the previous ones due to the exclusion requirements
+            undo_previous(context).await?;
+        }
+
         // todo: pick nodes and pools using the Node&Pool Topology
         // todo: virtually increase the pool usage to avoid a race for space with concurrent calls
         create_volume_replicas(context.registry, self, context.volume.as_ref()).await
@@ -1045,47 +1072,16 @@ impl CreateVolumeExe for CreateVolume {
         context: &mut Context<'a>,
         candidates: CreateReplicaCandidate,
     ) -> Vec<Replica> {
-        let mut replicas = Vec::<Replica>::with_capacity(candidates.candidates().len());
-        for replica in candidates.candidates() {
-            if replicas.len() >= self.replicas as usize {
-                break;
-            } else if replicas.iter().any(|r| {
-                r.node == replica.node
-                    || spread_label_is_same(r, replica, context).unwrap_or_else(|error| {
-                        context.volume.error(&format!(
-                            "Failed to create replica {:?} for volume, error: {}",
-                            replica,
-                            error.full_string()
-                        ));
-                        false
-                    })
-            }) {
-                // don't re-use the same node or same exclusion labels
-                continue;
+        match context.node_exclusion() {
+            Some(keys) => {
+                let CreateVolumeResult { replicas, undo } =
+                    create_spread(candidates, keys, context).await;
+                self.undo(context, undo).await;
+
+                replicas
             }
-            let replica = if replicas.is_empty() {
-                let mut replica = replica.clone();
-                // the local replica needs to be connected via "bdev:///"
-                replica.share = Protocol::None;
-                replica
-            } else {
-                replica.clone()
-            };
-            match OperationGuardArc::<ReplicaSpec>::create(context.registry, &replica).await {
-                Ok(replica) => {
-                    replicas.push(replica);
-                }
-                Err(error) => {
-                    context.volume.error(&format!(
-                        "Failed to create replica {:?} for volume, error: {}",
-                        replica,
-                        error.full_string()
-                    ));
-                    // continue trying...
-                }
-            };
+            _ => create(candidates, context).await,
         }
-        replicas
     }
 
     async fn undo<'a>(&'a self, context: &mut Context<'a>, replicas: Vec<Replica>) {
@@ -1119,35 +1115,173 @@ impl CreateVolumeExeVal for CreateVolumeSource<'_> {
     }
 }
 
-// spread_label_is_same checks if the node labels is same as that of all existing replicas.
-fn spread_label_is_same(
-    replica: &Replica,
-    replica_candidate: &CreateReplica,
+async fn create(candidates: CreateReplicaCandidate, context: &Context<'_>) -> Vec<Replica> {
+    let num_replicas = context.volume.as_ref().num_replicas as usize;
+    let mut replicas = Vec::<Replica>::with_capacity(candidates.candidates().len());
+    for replica in candidates.candidates() {
+        if replicas.len() >= num_replicas {
+            break;
+        } else if replicas.iter().any(|r| r.node == replica.node) {
+            // don't re-use the same node or same exclusion labels
+            continue;
+        }
+        let replica = if replicas.is_empty() {
+            let mut replica = replica.clone();
+            // the local replica needs to be connected via "bdev:///"
+            replica.share = Protocol::None;
+            replica
+        } else {
+            replica.clone()
+        };
+        match OperationGuardArc::<ReplicaSpec>::create(context.registry, &replica).await {
+            Ok(replica) => {
+                replicas.push(replica);
+            }
+            Err(error) => {
+                context.volume.error(&format!(
+                    "Failed to create replica {:?} for volume, error: {}",
+                    replica,
+                    error.full_string()
+                ));
+                // continue trying...
+            }
+        };
+    }
+    replicas
+}
+
+struct CreateVolumeResult {
+    replicas: Vec<Replica>,
+    undo: Vec<Replica>,
+}
+async fn create_spread(
+    candidates: CreateReplicaCandidate,
+    keys: &std::collections::HashMap<String, String>,
     context: &Context<'_>,
-) -> Result<bool, SvcError> {
-    let topology = context.volume.as_ref().topology.as_ref();
-    let node_topology = topology.and_then(|topology| topology.node.as_ref());
+) -> CreateVolumeResult {
+    let num_replicas = context.volume.as_ref().num_replicas;
+    let mut created = Vec::<Replica>::with_capacity(candidates.candidates().len());
+    let mut failed = Vec::<&CreateReplica>::with_capacity(candidates.candidates().len());
 
-    match node_topology {
-        Some(NodeTopology::Explicit(_)) => Ok(false),
-        Some(NodeTopology::Labelled(labelled_topology)) => {
-            if !labelled_topology.exclusion.is_empty() {
-                let candidate_node = context.registry.specs().node(&replica_candidate.node)?;
-                let replica_node = context.registry.specs().node(&replica.node)?;
+    let candidates = candidates.candidates();
+    for candidates in node_spread_combinations(candidates, keys, context) {
+        let mut replicas = Vec::<Replica>::with_capacity(num_replicas as usize);
 
-                for key in labelled_topology.exclusion.keys() {
-                    if let (Some(candidate_value), Some(replica_value)) = (
-                        candidate_node.labels().get(key),
-                        replica_node.labels().get(key),
-                    ) {
-                        if candidate_value == replica_value {
-                            return Ok(true);
+        for replica in candidates {
+            if let Some(replica) = created.iter().find(|r| r.uuid == replica.uuid) {
+                replicas.push(replica.clone());
+                continue; // we've already created this replica...
+            }
+            if failed.iter().any(|r| r.uuid == replica.uuid) {
+                break; // we've tried and failed already...
+            }
+
+            match OperationGuardArc::<ReplicaSpec>::create(context.registry, replica).await {
+                Ok(replica) => {
+                    created.push(replica.clone());
+                    replicas.push(replica);
+                }
+                Err(error) => {
+                    failed.push(replica);
+                    context.volume.error(&format!(
+                        "Failed to create replica {:?} for volume, error: {}",
+                        replica,
+                        error.full_string()
+                    ));
+                    // this combination has failed, try the next set
+                    break;
+                }
+            };
+
+            if replicas.len() >= num_replicas as usize {
+                break;
+            }
+        }
+
+        if replicas.len() >= num_replicas as usize {
+            created.retain(|s| replicas.iter().all(|r| r.uuid != s.uuid));
+            return CreateVolumeResult {
+                replicas,
+                undo: created,
+            };
+        }
+    }
+    CreateVolumeResult {
+        replicas: vec![],
+        undo: created,
+    }
+}
+
+/// Returns a list of all combinations of `CreateReplica` requests based on the exclusion labels.
+fn node_spread_combinations<'a>(
+    candidates: &'a [CreateReplica],
+    keys: &'a std::collections::HashMap<String, String>,
+    context: &Context<'a>,
+) -> impl Iterator<Item = Vec<&'a CreateReplica>> {
+    let num_replicas = context.volume.as_ref().num_replicas as usize;
+
+    candidates
+        .iter()
+        // order is deterministic so we keep the list in the same priority order as it were
+        .combinations(num_replicas)
+        .filter(|combi| {
+            let mut seen =
+                std::collections::HashMap::<&String, std::collections::HashSet<String>>::new();
+            let mut nodes = std::collections::HashSet::new();
+
+            let specs = context.registry.specs().read();
+
+            for candidate in combi {
+                if !nodes.insert(&candidate.node) {
+                    return false; // anti-affinity for the replica nodes
+                }
+
+                let Some(node) = specs.nodes.get(&candidate.node).map(|n| n.lock()) else {
+                    return false; // should not happen, but just in case
+                };
+                for key in keys.keys() {
+                    if let Some(value) = node.labels().get(key) {
+                        let entry = seen.entry(key).or_default();
+                        if entry.contains(value) {
+                            return false;
                         }
+                        entry.insert(value.clone());
                     }
                 }
             }
-            Ok(false)
+            true
+        })
+}
+
+/// Undoes a previous failed attempt, when the volume has a node spread topology.
+async fn undo_previous(context: &Context<'_>) -> Result<(), SvcError> {
+    let mut result = Ok(());
+
+    let replicas = context
+        .registry
+        .specs()
+        .volume_replicas(context.volume.uuid());
+
+    for replica in replicas {
+        let mut replica = replica.operation_guard()?;
+        if match context.registry.replica(replica.uuid()).await {
+            Ok(replica_state) => {
+                let request = DestroyReplica::from(replica_state);
+                replica
+                    .destroy(context.registry, &request.with_disown_all())
+                    .await
+                    .is_err()
+            }
+            Err(_) => true,
+        } {
+            if let Err(error) = replica
+                .remove_owners(context.registry, &ReplicaOwners::new_disown_all(), true)
+                .await
+            {
+                result = Err(error);
+            }
         }
-        _ => Ok(false),
     }
+
+    result
 }

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -326,6 +326,7 @@ impl OperationGuardArc<VolumeSpec> {
     /// (that is, replicas which are not used by a nexus).
     /// It must not be the last replica of the volume
     /// (an error will be returned in such case).
+    /// todo: this is succeeding without acomplishing...
     pub(crate) async fn remove_unused_volume_replica(
         &mut self,
         registry: &Registry,

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -191,7 +191,7 @@ pub(crate) async fn volume_replica_candidates(
 
     volume_spec.trace(&format!(
         "Creation pool candidates for volume: {:?}",
-        pools.iter().map(|p| p.state()).collect::<Vec<_>>()
+        pools.iter().take(10).map(|p| p.state()).collect::<Vec<_>>()
     ));
 
     Ok(pools

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -191,7 +191,11 @@ pub(crate) async fn volume_replica_candidates(
 
     volume_spec.trace(&format!(
         "Creation pool candidates for volume: {:?}",
-        pools.iter().take(10).map(|p| p.state()).collect::<Vec<_>>()
+        pools
+            .iter()
+            .take(50)
+            .map(|p| &p.state().id)
+            .collect::<Vec<_>>()
     ));
 
     Ok(pools

--- a/control-plane/grpc/src/context.rs
+++ b/control-plane/grpc/src/context.rs
@@ -48,7 +48,9 @@ pub fn timeout_grpc(op_id: MessageId, timeout_opts: TimeoutOptions) -> Duration 
     if let Some(min_timeouts) = timeout_opts.request_min_timeout() {
         let op_timeout = match op_id {
             MessageId::v0(op_id) => match op_id {
-                MessageIdVs::CreateVolume => min_timeouts.replica() * 3 + min_timeouts.nexus(),
+                MessageIdVs::CreateSnapshotVolume | MessageIdVs::CreateVolume => {
+                    min_timeouts.replica() * 3 + min_timeouts.nexus()
+                }
                 MessageIdVs::DestroyVolume => min_timeouts.replica() * 3 + min_timeouts.nexus(),
                 MessageIdVs::PublishVolume => min_timeouts.nexus(),
                 MessageIdVs::UnpublishVolume => min_timeouts.nexus(),

--- a/control-plane/plugin/Cargo.toml
+++ b/control-plane/plugin/Cargo.toml
@@ -38,6 +38,7 @@ humantime = "2.1.0"
 chrono = "0.4.38"
 snafu = "0.8.5"
 inquire = { version = "0.7.5", default-features = false, features = ["crossterm"] }
+itertools = "0.13.0"
 
 [dev-dependencies]
 # Test dependencies

--- a/control-plane/plugin/src/lib.rs
+++ b/control-plane/plugin/src/lib.rs
@@ -15,9 +15,10 @@ use crate::{
         ReplicaTopology, Scale,
     },
     resources::{
-        blockdevice, cordon, drain, node, pool, snapshot, volume, CordonResources, DeleteArgs,
-        DeleteResources, DrainResources, ExpandResources, GetCordonArgs, GetDrainArgs,
-        GetResources, ScaleResources, SetPropertyResources, SetVolumeProperties, UnCordonResources,
+        blockdevice, cordon, drain, node, pool, snapshot, volume, volume::VolumeTopologiesArgs,
+        CordonResources, DeleteArgs, DeleteResources, DrainResources, ExpandResources,
+        GetCordonArgs, GetDrainArgs, GetResources, ScaleResources, SetPropertyResources,
+        SetVolumeProperties, UnCordonResources,
     },
 };
 
@@ -172,8 +173,9 @@ impl ExecuteOperation for GetResources {
             GetResources::VolumeReplicaTopologies(vol_args) => {
                 volume::Volume::topologies(&cli_args.output, vol_args).await
             }
-            GetResources::VolumeReplicaTopology { id } => {
-                volume::Volume::topology(id, &cli_args.output).await
+            GetResources::VolumeReplicaTopology { id, args } => {
+                volume::Volume::topology(id, &cli_args.output, &VolumeTopologiesArgs::from(args))
+                    .await
             }
             GetResources::Pools(args) => pool::Pools::list(args, &cli_args.output).await,
             GetResources::Pool(args) => {

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -145,7 +145,11 @@ pub trait ReplicaTopology {
     type ID;
     type Context;
     async fn topologies(output: &utils::OutputFormat, context: &Self::Context) -> PluginResult;
-    async fn topology(id: &Self::ID, output: &utils::OutputFormat) -> PluginResult;
+    async fn topology(
+        id: &Self::ID,
+        output: &utils::OutputFormat,
+        context: &Self::Context,
+    ) -> PluginResult;
 }
 
 /// Rebuild trait.

--- a/control-plane/plugin/src/resources/blockdevice.rs
+++ b/control-plane/plugin/src/resources/blockdevice.rs
@@ -11,6 +11,7 @@ use crate::{
     rest_wrapper::RestClient,
 };
 use async_trait::async_trait;
+use itertools::Itertools;
 use openapi::apis::Url;
 use prettytable::Row;
 use serde::Serialize;
@@ -68,6 +69,7 @@ impl CreateRow for BlockDeviceAll {
             device
                 .devlinks
                 .iter()
+                .sorted()
                 .map(|s| format!("\"{s}\""))
                 .collect::<Vec<String>>()
                 .join(", "),

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -3,7 +3,7 @@ use crate::resources::{
     node::{DrainNodeArgs, GetNodeArgs, GetNodesArgs},
     pool::{GetPoolArgs, GetPoolsArgs},
     snapshot::VolumeSnapshotArgs,
-    volume::VolumesArgs,
+    volume::{VolumeTopologiesArgs, VolumeTopologyArgs, VolumesArgs},
 };
 
 pub mod blockdevice;
@@ -40,9 +40,13 @@ pub enum GetResources {
     /// Get Rebuild history for the volume with the given ID.
     RebuildHistory { id: VolumeId },
     /// Get the replica topology for all volumes.
-    VolumeReplicaTopologies(VolumesArgs),
+    VolumeReplicaTopologies(VolumeTopologiesArgs),
     /// Get the replica topology for the volume with the given ID.
-    VolumeReplicaTopology { id: VolumeId },
+    VolumeReplicaTopology {
+        id: VolumeId,
+        #[clap(flatten)]
+        args: VolumeTopologyArgs,
+    },
     /// Get volume snapshots based on input args.
     VolumeSnapshots(VolumeSnapshotArgs),
 
@@ -57,7 +61,7 @@ pub enum GetResources {
     /// Get node with the given ID.
     Node(GetNodeArgs),
     /// Get BlockDevices present on the Node. Lists usable devices by default.
-    /// Currently disks having blobstore pools not created by control-plane are also shown as
+    /// Currently, disks having blobstore pools not created by control-plane are also shown as
     /// usable.
     BlockDevices(BlockDeviceArgs),
 }

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -184,6 +184,7 @@ impl NodeDisplayLabels {
                     .collect();
             }
         }
+        node_labels.sort_unstable();
         node_labels
     }
 }

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -414,6 +414,7 @@ impl PoolDisplay {
                     .collect();
             }
         }
+        pools_labels.sort_unstable();
         pools_labels
     }
 }

--- a/control-plane/plugin/src/resources/snapshot.rs
+++ b/control-plane/plugin/src/resources/snapshot.rs
@@ -230,8 +230,8 @@ impl CreateRows for Vec<openapi::models::ReplicaSnapshotState> {
                         s.uuid,
                         s.pool_id,
                         "Online",
-                        s.size,
-                        s.allocated_size,
+                        ::utils::bytes::into_human(s.size),
+                        ::utils::bytes::into_human(s.allocated_size),
                         s.source_id
                     ]
                 }

--- a/control-plane/plugin/src/resources/snapshot.rs
+++ b/control-plane/plugin/src/resources/snapshot.rs
@@ -217,6 +217,9 @@ impl CreateRows for VolumeSnapshotTopology {
             })
             .collect()
     }
+    fn sort_rows(&self) -> bool {
+        false
+    }
 }
 impl CreateRows for Vec<openapi::models::ReplicaSnapshotState> {
     fn create_rows(&self) -> Vec<Row> {

--- a/control-plane/plugin/src/resources/tests.rs
+++ b/control-plane/plugin/src/resources/tests.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 use crate::resources::utils::{print_table, CreateRows, GetHeaderRow, OutputFormat};
-use crate::{rest_wrapper::RestClient, ExecuteOperation};
+use crate::{
+    resources::volume::VolumeReplicaTopologies, rest_wrapper::RestClient, ExecuteOperation,
+};
 
 use deployer_cluster::{Cluster, ClusterBuilder};
 use gag::BufferRedirect;
@@ -361,7 +363,7 @@ async fn get_replica_topology() {
             replica.pool.as_ref().unwrap(),
             replica.state.to_string()
         ),
-        replica_topo,
+        VolumeReplicaTopologies::from(replica_topo),
     );
 }
 

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -135,10 +135,16 @@ pub fn table_printer(titles: Row, rows: Vec<Row>) {
 /// CreateRows trait to be implemented by Vec<`resource`> to create the rows.
 pub trait CreateRows {
     fn create_rows(&self) -> Vec<Row>;
+    fn sort_rows(&self) -> bool {
+        true
+    }
 }
 /// CreateRows trait to be implemented by `resource` to create a row.
 pub trait CreateRow {
     fn row(&self) -> Row;
+    fn sort_rows(&self) -> bool {
+        true
+    }
 }
 
 /// GetHeaderRow trait to be implemented by Vec<`resource`> to fetch the corresponding headers.
@@ -168,6 +174,9 @@ where
     fn create_rows(&self) -> Vec<Row> {
         self.iter().map(|i| i.row()).collect()
     }
+    fn sort_rows(&self) -> bool {
+        self.first().map(T::sort_rows).unwrap_or_default()
+    }
 }
 impl<T> CreateRows for T
 where
@@ -175,6 +184,9 @@ where
 {
     fn create_rows(&self) -> Vec<Row> {
         vec![self.row()]
+    }
+    fn sort_rows(&self) -> bool {
+        T::sort_rows(self)
     }
 }
 
@@ -208,7 +220,11 @@ where
         }
         OutputFormat::None => {
             // Show the tabular form if output format is not specified.
-            let rows: Vec<Row> = obj.create_rows();
+            let mut rows: Vec<Row> = obj.create_rows();
+            if obj.sort_rows() {
+                // not the most optimal way to do it at this stage but at least will work for all by default
+                rows.sort_by_key(|r| r.get_cell(0).map(|r| r.get_content()).unwrap_or_default());
+            }
             let header: Row = obj.get_header_row();
             table_printer(header, rows);
         }

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -39,7 +39,7 @@ lazy_static! {
         "TOTAL-ALLOCATED-SIZE",
         "SOURCE-VOL",
         "RESTORES",
-        "SNAPSHOT_REPLICAS"
+        "REPLICAS"
     ];
     pub static ref POOLS_HEADERS: Row = row![
         "ID",
@@ -73,12 +73,12 @@ lazy_static! {
     ];
     pub static ref SNAPSHOT_TOPOLOGY_PREFIX: Row = row!["SNAPSHOT-ID"];
     pub static ref SNAPSHOT_TOPOLOGY_HEADERS: Row = row![
-        "ID",
+        "SNAPSHOT-REPLICA-ID",
         "POOL",
-        "SNAPSHOT_STATUS",
+        "STATUS",
         "SIZE",
-        "ALLOCATED_SIZE",
-        "SOURCE"
+        "ALLOCATED-SIZE",
+        "SOURCE-REPLICA-ID"
     ];
     pub static ref REBUILD_HISTORY_HEADER: Row = row![
         "DST",
@@ -201,6 +201,7 @@ where
     }
 }
 
+/// Output the object in json,yaml or non/tabled format.
 pub fn print_table<T>(output: &OutputFormat, obj: T)
 where
     T: ser::Serialize,
@@ -209,14 +210,10 @@ where
 {
     match output {
         OutputFormat::Yaml => {
-            // Show the YAML form output if output format is YAML.
-            let s = serde_yaml::to_string(&obj).unwrap();
-            println!("{s}");
+            println!("{s}", s = serde_yaml::to_string(&obj).unwrap());
         }
         OutputFormat::Json => {
-            // Show the JSON form output if output format is JSON.
-            let s = serde_json::to_string(&obj).unwrap();
-            println!("{s}");
+            println!("{s}", s = serde_json::to_string(&obj).unwrap());
         }
         OutputFormat::None => {
             // Show the tabular form if output format is not specified.
@@ -242,7 +239,7 @@ where
 /// # Parameters
 /// - `key`: A `char` representing the character to check.
 ///
-/// # Returns
+/// # Output
 /// Returns `true` if the character is allowed in topology keys; otherwise, returns `false`.
 ///
 /// # Examples

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -58,7 +58,7 @@ lazy_static! {
     pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS", "VERSION"];
     pub static ref REPLICA_TOPOLOGIES_PREFIX: Row = row!["VOLUME-ID"];
     pub static ref REPLICA_TOPOLOGY_HEADERS: Row = row![
-        "ID",
+        "REPLICA-ID",
         "NODE",
         "POOL",
         "STATUS",

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -4,6 +4,7 @@ use crate::{
     },
     resources::{
         error::Error,
+        node::NodeDisplayLabels,
         utils::{self, optional_cell, CreateRow, CreateRows, GetHeaderRow, OutputFormat},
         VolumeId,
     },
@@ -38,6 +39,9 @@ pub struct VolumesArgs {
     #[clap(long)]
     /// Shows only volumes created from specific source, viz none, snapshot
     source: Option<VolumeSource>,
+    /// Show the node labels for each replica (tabled output only).
+    #[clap(long)]
+    show_node_labels: bool,
 }
 
 impl CreateRow for openapi::models::Volume {
@@ -318,7 +322,7 @@ impl ReplicaTopology for Volume {
     type ID = VolumeId;
     type Context = VolumesArgs;
     async fn topologies(output: &OutputFormat, context: &Self::Context) -> PluginResult {
-        let volumes = VolumeTopologies(get_paginated_volumes(context).await.unwrap_or_default());
+        let volumes = VolumesTopologies::new(context).await?;
         utils::print_table(output, volumes);
         Ok(())
     }
@@ -326,7 +330,10 @@ impl ReplicaTopology for Volume {
         match RestClient::client().volumes_api().get_volume(id).await {
             Ok(volume) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table(output, volume.into_body().state.replica_topology);
+                utils::print_table(
+                    output,
+                    VolumeReplicaTopologies::new(volume.into_body()).await?,
+                );
             }
             Err(e) => {
                 return Err(Error::GetVolumeError {
@@ -362,31 +369,57 @@ impl RebuildHistory for Volume {
     }
 }
 
-#[derive(Default, Debug, serde::Serialize, serde::Deserialize)]
-struct VolumeTopologies(Vec<openapi::models::Volume>);
+#[derive(Default, Debug)]
+struct VolumesTopologies {
+    volumes: Vec<openapi::models::Volume>,
+    nodes: Vec<openapi::models::Node>,
+    show_node_labels: bool,
+}
+impl VolumesTopologies {
+    async fn new(context: &VolumesArgs) -> Result<Self, Error> {
+        Ok(Self {
+            volumes: get_paginated_volumes(context).await.unwrap_or_default(),
+            nodes: list_nodes(context.show_node_labels).await?,
+            show_node_labels: context.show_node_labels,
+        })
+    }
+}
 
-impl GetHeaderRow for VolumeTopologies {
+impl serde::Serialize for VolumesTopologies {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.volumes.serialize(serializer)
+    }
+}
+
+impl GetHeaderRow for VolumesTopologies {
     fn get_header_row(&self) -> Row {
-        utils::REPLICA_TOPOLOGIES_PREFIX
+        let mut row: Row = utils::REPLICA_TOPOLOGIES_PREFIX
             .iter()
             .chain(utils::REPLICA_TOPOLOGY_HEADERS.iter())
             .cloned()
-            .collect()
+            .collect();
+        if self.show_node_labels {
+            row.extend(vec!["NODE-LABELS"]);
+        }
+        row
     }
 }
-impl CreateRows for VolumeTopologies {
+impl CreateRows for VolumesTopologies {
     fn create_rows(&self) -> Vec<Row> {
-        self.0
+        self.volumes
             .iter()
             .flat_map(|volume| {
                 let mut rows = Vec::new();
                 volume
                     .state
                     .replica_topology
-                    .create_rows()
-                    .into_iter()
+                    .iter()
+                    .sorted_by(|(a, _), (b, _)| a.cmp(b))
                     .enumerate()
-                    .for_each(|(i, mut r)| {
+                    .for_each(|(i, r)| {
                         let mut row = if i == 0 {
                             row![volume.spec.uuid]
                         } else if i < volume.state.replica_topology.len() - 1 {
@@ -394,7 +427,8 @@ impl CreateRows for VolumeTopologies {
                         } else {
                             row!["└─"]
                         };
-                        for cell in r.iter_mut() {
+
+                        for cell in VolumeReplicaTopology::new(r, &self.nodes).row().iter_mut() {
                             row.add_cell(cell.clone());
                         }
                         rows.push(row);
@@ -408,34 +442,94 @@ impl CreateRows for VolumeTopologies {
     }
 }
 
-impl GetHeaderRow for HashMap<String, openapi::models::ReplicaTopology> {
+#[derive(Default, Debug, serde::Serialize)]
+pub(crate) struct VolumeReplicaTopologies {
+    #[serde(flatten)]
+    replicas: HashMap<String, openapi::models::ReplicaTopology>,
+    #[serde(skip)]
+    nodes: Vec<openapi::models::Node>,
+}
+impl VolumeReplicaTopologies {
+    async fn new(volume: openapi::models::Volume) -> Result<Self, Error> {
+        Ok(Self {
+            replicas: volume.state.replica_topology,
+            nodes: list_nodes(false).await?,
+        })
+    }
+}
+impl From<HashMap<String, openapi::models::ReplicaTopology>> for VolumeReplicaTopologies {
+    fn from(replicas: HashMap<String, openapi::models::ReplicaTopology>) -> Self {
+        Self {
+            replicas,
+            nodes: vec![],
+        }
+    }
+}
+
+impl GetHeaderRow for VolumeReplicaTopologies {
     fn get_header_row(&self) -> Row {
         (*utils::REPLICA_TOPOLOGY_HEADERS).clone()
     }
 }
 
-impl CreateRows for HashMap<String, openapi::models::ReplicaTopology> {
+impl CreateRows for VolumeReplicaTopologies {
     fn create_rows(&self) -> Vec<Row> {
-        self.iter()
+        self.replicas
+            .iter()
             .sorted_by(|(a, _), (b, _)| a.cmp(b))
-            .map(|(id, topology)| {
-                let usage = topology.usage.as_ref();
-                row![
-                    id,
-                    optional_cell(topology.node.as_ref()),
-                    optional_cell(topology.pool.as_ref()),
-                    topology.state,
-                    optional_cell(topology.encrypted),
-                    optional_cell(usage.map(|u| ::utils::bytes::into_human(u.capacity))),
-                    optional_cell(usage.map(|u| ::utils::bytes::into_human(u.allocated))),
-                    optional_cell(usage.map(|u| ::utils::bytes::into_human(u.allocated_snapshots))),
-                    optional_cell(topology.child_status.as_ref().map(|s| s.to_string())),
-                    optional_cell(topology.child_status_reason.as_ref().map(|s| s.to_string())),
-                    optional_cell(topology.rebuild_progress.map(|p| format!("{p}%"))),
-                    optional_cell(topology.healthy)
-                ]
-            })
+            .map(|s| VolumeReplicaTopology::new(s, &self.nodes).row())
             .collect()
+    }
+    fn sort_rows(&self) -> bool {
+        false
+    }
+}
+
+struct VolumeReplicaTopology<'a> {
+    id: &'a String,
+    topology: &'a openapi::models::ReplicaTopology,
+    nodes: &'a Vec<openapi::models::Node>,
+}
+impl<'a> VolumeReplicaTopology<'a> {
+    fn new(
+        (id, topology): (&'a String, &'a openapi::models::ReplicaTopology),
+        nodes: &'a Vec<openapi::models::Node>,
+    ) -> Self {
+        Self {
+            id,
+            topology,
+            nodes,
+        }
+    }
+}
+
+impl<'a> CreateRow for VolumeReplicaTopology<'a> {
+    fn row(&self) -> Row {
+        let topology = &self.topology;
+        let usage = topology.usage.as_ref();
+        let labels = self
+            .nodes
+            .iter()
+            .find(|n| Some(&n.id) == topology.node.as_ref())
+            .map(|n| NodeDisplayLabels::get_node_label_list(n).join(", "));
+        let mut row = row![
+            self.id,
+            optional_cell(topology.node.as_ref()),
+            optional_cell(topology.pool.as_ref()),
+            topology.state,
+            optional_cell(topology.encrypted),
+            optional_cell(usage.map(|u| ::utils::bytes::into_human(u.capacity))),
+            optional_cell(usage.map(|u| ::utils::bytes::into_human(u.allocated))),
+            optional_cell(usage.map(|u| ::utils::bytes::into_human(u.allocated_snapshots))),
+            optional_cell(topology.child_status.as_ref().map(|s| s.to_string())),
+            optional_cell(topology.child_status_reason.as_ref().map(|s| s.to_string())),
+            optional_cell(topology.rebuild_progress.map(|p| format!("{p}%"))),
+            optional_cell(topology.healthy),
+        ];
+        if !self.nodes.is_empty() {
+            row.add_cell(prettytable::Cell::new(&optional_cell(labels)));
+        }
+        row
     }
     fn sort_rows(&self) -> bool {
         false
@@ -491,4 +585,16 @@ fn child_uuid(uri: &str) -> String {
 
 fn to_human_readable(val: u64) -> String {
     ::utils::bytes::into_human(val)
+}
+
+async fn list_nodes(labels: bool) -> Result<Vec<openapi::models::Node>, Error> {
+    if !labels {
+        return Ok(vec![]);
+    }
+    Ok(RestClient::client()
+        .nodes_api()
+        .get_nodes(None)
+        .await
+        .map_err(|source| Error::ListNodesError { source })?
+        .into_body())
 }

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -5,6 +5,7 @@ use crate::{
     resources::{
         error::Error,
         node::NodeDisplayLabels,
+        pool::PoolDisplay,
         utils::{self, optional_cell, CreateRow, CreateRows, GetHeaderRow, OutputFormat},
         VolumeId,
     },
@@ -33,15 +34,42 @@ enum VolumeSource {
     Snapshot,
 }
 
-#[derive(Debug, Clone, clap::Args)]
+/// Volume topology args.
+#[derive(Debug, Default, Clone, clap::Args)]
+pub struct VolumeTopologyArgs {
+    /// Show the node labels for each replica (tabled output only).
+    #[clap(long)]
+    show_node_labels: bool,
+    /// Show the pool labels for each replica (tabled output only).
+    #[clap(long)]
+    show_pool_labels: bool,
+    /// Show both the pool and node labels for each replica (tabled output only).
+    #[clap(long)]
+    show_labels: bool,
+}
+/// Volume topologies args.
+#[derive(Debug, Default, Clone, clap::Args)]
+pub struct VolumeTopologiesArgs {
+    #[clap(flatten)]
+    args: VolumesArgs,
+    #[clap(flatten)]
+    labels: VolumeTopologyArgs,
+}
+impl From<&VolumeTopologyArgs> for VolumeTopologiesArgs {
+    fn from(labels: &VolumeTopologyArgs) -> Self {
+        Self {
+            labels: labels.clone(),
+            ..Default::default()
+        }
+    }
+}
+
 /// Volume args.
+#[derive(Debug, Default, Clone, clap::Args)]
 pub struct VolumesArgs {
     #[clap(long)]
     /// Shows only volumes created from specific source, viz none, snapshot
     source: Option<VolumeSource>,
-    /// Show the node labels for each replica (tabled output only).
-    #[clap(long)]
-    show_node_labels: bool,
 }
 
 impl CreateRow for openapi::models::Volume {
@@ -320,19 +348,23 @@ impl SetProperty for Volume {
 #[async_trait(?Send)]
 impl ReplicaTopology for Volume {
     type ID = VolumeId;
-    type Context = VolumesArgs;
+    type Context = VolumeTopologiesArgs;
     async fn topologies(output: &OutputFormat, context: &Self::Context) -> PluginResult {
         let volumes = VolumesTopologies::new(context).await?;
         utils::print_table(output, volumes);
         Ok(())
     }
-    async fn topology(id: &Self::ID, output: &OutputFormat) -> PluginResult {
+    async fn topology(
+        id: &Self::ID,
+        output: &OutputFormat,
+        context: &Self::Context,
+    ) -> PluginResult {
         match RestClient::client().volumes_api().get_volume(id).await {
             Ok(volume) => {
                 // Print table, json or yaml based on output format.
                 utils::print_table(
                     output,
-                    VolumeReplicaTopologies::new(volume.into_body()).await?,
+                    VolumeReplicaTopologies::new(&context.labels, volume.into_body()).await?,
                 );
             }
             Err(e) => {
@@ -372,15 +404,19 @@ impl RebuildHistory for Volume {
 #[derive(Default, Debug)]
 struct VolumesTopologies {
     volumes: Vec<openapi::models::Volume>,
-    nodes: Vec<openapi::models::Node>,
-    show_node_labels: bool,
+    nodes: Option<Vec<openapi::models::Node>>,
+    pools: Option<Vec<openapi::models::Pool>>,
 }
 impl VolumesTopologies {
-    async fn new(context: &VolumesArgs) -> Result<Self, Error> {
+    async fn new(context: &VolumeTopologiesArgs) -> Result<Self, Error> {
+        let show_node = context.labels.show_node_labels || context.labels.show_labels;
+        let show_pool = context.labels.show_pool_labels || context.labels.show_labels;
         Ok(Self {
-            volumes: get_paginated_volumes(context).await.unwrap_or_default(),
-            nodes: list_nodes(context.show_node_labels).await?,
-            show_node_labels: context.show_node_labels,
+            volumes: get_paginated_volumes(&context.args)
+                .await
+                .unwrap_or_default(),
+            nodes: list_nodes(show_node).await?,
+            pools: list_pools(show_pool).await?,
         })
     }
 }
@@ -401,8 +437,11 @@ impl GetHeaderRow for VolumesTopologies {
             .chain(utils::REPLICA_TOPOLOGY_HEADERS.iter())
             .cloned()
             .collect();
-        if self.show_node_labels {
+        if self.nodes.is_some() {
             row.extend(vec!["NODE-LABELS"]);
+        }
+        if self.pools.is_some() {
+            row.extend(vec!["POOL-LABELS"]);
         }
         row
     }
@@ -428,7 +467,10 @@ impl CreateRows for VolumesTopologies {
                             row!["└─"]
                         };
 
-                        for cell in VolumeReplicaTopology::new(r, &self.nodes).row().iter_mut() {
+                        for cell in VolumeReplicaTopology::new(r, &self.nodes, &self.pools)
+                            .row()
+                            .iter_mut()
+                        {
                             row.add_cell(cell.clone());
                         }
                         rows.push(row);
@@ -447,13 +489,21 @@ pub(crate) struct VolumeReplicaTopologies {
     #[serde(flatten)]
     replicas: HashMap<String, openapi::models::ReplicaTopology>,
     #[serde(skip)]
-    nodes: Vec<openapi::models::Node>,
+    nodes: Option<Vec<openapi::models::Node>>,
+    #[serde(skip)]
+    pools: Option<Vec<openapi::models::Pool>>,
 }
 impl VolumeReplicaTopologies {
-    async fn new(volume: openapi::models::Volume) -> Result<Self, Error> {
+    async fn new(
+        context: &VolumeTopologyArgs,
+        volume: openapi::models::Volume,
+    ) -> Result<Self, Error> {
+        let show_node = context.show_node_labels || context.show_labels;
+        let show_pool = context.show_pool_labels || context.show_labels;
         Ok(Self {
             replicas: volume.state.replica_topology,
-            nodes: list_nodes(false).await?,
+            nodes: list_nodes(show_node).await?,
+            pools: list_pools(show_pool).await?,
         })
     }
 }
@@ -461,14 +511,22 @@ impl From<HashMap<String, openapi::models::ReplicaTopology>> for VolumeReplicaTo
     fn from(replicas: HashMap<String, openapi::models::ReplicaTopology>) -> Self {
         Self {
             replicas,
-            nodes: vec![],
+            nodes: None,
+            pools: None,
         }
     }
 }
 
 impl GetHeaderRow for VolumeReplicaTopologies {
     fn get_header_row(&self) -> Row {
-        (*utils::REPLICA_TOPOLOGY_HEADERS).clone()
+        let mut headers = (*utils::REPLICA_TOPOLOGY_HEADERS).clone();
+        if self.nodes.is_some() {
+            headers.extend(vec!["NODE-LABELS"]);
+        }
+        if self.pools.is_some() {
+            headers.extend(vec!["POOL-LABELS"]);
+        }
+        headers
     }
 }
 
@@ -477,7 +535,7 @@ impl CreateRows for VolumeReplicaTopologies {
         self.replicas
             .iter()
             .sorted_by(|(a, _), (b, _)| a.cmp(b))
-            .map(|s| VolumeReplicaTopology::new(s, &self.nodes).row())
+            .map(|s| VolumeReplicaTopology::new(s, &self.nodes, &self.pools).row())
             .collect()
     }
     fn sort_rows(&self) -> bool {
@@ -488,17 +546,20 @@ impl CreateRows for VolumeReplicaTopologies {
 struct VolumeReplicaTopology<'a> {
     id: &'a String,
     topology: &'a openapi::models::ReplicaTopology,
-    nodes: &'a Vec<openapi::models::Node>,
+    nodes: &'a Option<Vec<openapi::models::Node>>,
+    pools: &'a Option<Vec<openapi::models::Pool>>,
 }
 impl<'a> VolumeReplicaTopology<'a> {
     fn new(
         (id, topology): (&'a String, &'a openapi::models::ReplicaTopology),
-        nodes: &'a Vec<openapi::models::Node>,
+        nodes: &'a Option<Vec<openapi::models::Node>>,
+        pools: &'a Option<Vec<openapi::models::Pool>>,
     ) -> Self {
         Self {
             id,
             topology,
             nodes,
+            pools,
         }
     }
 }
@@ -507,11 +568,18 @@ impl<'a> CreateRow for VolumeReplicaTopology<'a> {
     fn row(&self) -> Row {
         let topology = &self.topology;
         let usage = topology.usage.as_ref();
-        let labels = self
-            .nodes
-            .iter()
-            .find(|n| Some(&n.id) == topology.node.as_ref())
-            .map(|n| NodeDisplayLabels::get_node_label_list(n).join(", "));
+        let node_labels = self.nodes.as_ref().map(|nodes| {
+            nodes
+                .iter()
+                .find(|n| Some(&n.id) == topology.node.as_ref())
+                .map(|n| NodeDisplayLabels::get_node_label_list(n).join(", "))
+        });
+        let pool_labels = self.pools.as_ref().map(|pools| {
+            pools
+                .iter()
+                .find(|p| Some(&p.id) == topology.pool.as_ref())
+                .map(|p| PoolDisplay::pool_label_list(p).join(", "))
+        });
         let mut row = row![
             self.id,
             optional_cell(topology.node.as_ref()),
@@ -526,7 +594,10 @@ impl<'a> CreateRow for VolumeReplicaTopology<'a> {
             optional_cell(topology.rebuild_progress.map(|p| format!("{p}%"))),
             optional_cell(topology.healthy),
         ];
-        if !self.nodes.is_empty() {
+        if let Some(labels) = node_labels {
+            row.add_cell(prettytable::Cell::new(&optional_cell(labels)));
+        }
+        if let Some(labels) = pool_labels {
             row.add_cell(prettytable::Cell::new(&optional_cell(labels)));
         }
         row
@@ -587,14 +658,26 @@ fn to_human_readable(val: u64) -> String {
     ::utils::bytes::into_human(val)
 }
 
-async fn list_nodes(labels: bool) -> Result<Vec<openapi::models::Node>, Error> {
+async fn list_nodes(labels: bool) -> Result<Option<Vec<openapi::models::Node>>, Error> {
     if !labels {
-        return Ok(vec![]);
+        return Ok(None);
     }
-    Ok(RestClient::client()
+    let nodes = RestClient::client()
         .nodes_api()
         .get_nodes(None)
         .await
-        .map_err(|source| Error::ListNodesError { source })?
-        .into_body())
+        .map_err(|source| Error::ListNodesError { source })?;
+    Ok(Some(nodes.into_body()))
+}
+
+async fn list_pools(labels: bool) -> Result<Option<Vec<openapi::models::Pool>>, Error> {
+    if !labels {
+        return Ok(None);
+    }
+    let pools = RestClient::client()
+        .pools_api()
+        .get_pools(None)
+        .await
+        .map_err(|source| Error::ListPoolsError { source })?;
+    Ok(Some(pools.into_body()))
 }

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::prelude::*;
+use itertools::Itertools;
 use openapi::{
     apis::StatusCode,
     models::{ReplicaState, SetVolumePropertyBody, VolumeContentSource},
@@ -134,7 +135,7 @@ async fn get_paginated_volumes(volume_args: &VolumesArgs) -> Option<Vec<openapi:
                 starting_token = v.next_token;
             }
             Err(e) => {
-                println!("Failed to list volumes. Error {e}");
+                eprintln!("Failed to list volumes. Error {e}");
                 return None;
             }
         }
@@ -402,6 +403,9 @@ impl CreateRows for VolumeTopologies {
             })
             .collect()
     }
+    fn sort_rows(&self) -> bool {
+        false
+    }
 }
 
 impl GetHeaderRow for HashMap<String, openapi::models::ReplicaTopology> {
@@ -413,6 +417,7 @@ impl GetHeaderRow for HashMap<String, openapi::models::ReplicaTopology> {
 impl CreateRows for HashMap<String, openapi::models::ReplicaTopology> {
     fn create_rows(&self) -> Vec<Row> {
         self.iter()
+            .sorted_by(|(a, _), (b, _)| a.cmp(b))
             .map(|(id, topology)| {
                 let usage = topology.usage.as_ref();
                 row![
@@ -432,6 +437,9 @@ impl CreateRows for HashMap<String, openapi::models::ReplicaTopology> {
             })
             .collect()
     }
+    fn sort_rows(&self) -> bool {
+        false
+    }
 }
 
 impl GetHeaderRow for openapi::models::RebuildHistory {
@@ -444,6 +452,7 @@ impl CreateRows for openapi::models::RebuildHistory {
     fn create_rows(&self) -> Vec<Row> {
         self.records
             .iter()
+            .sorted_by_key(|rec| &rec.start_time)
             .map(|rec| {
                 let start: DateTime<Utc> = DateTime::from_str(rec.start_time.as_str())
                     .expect("Cant map time to required format");
@@ -464,6 +473,9 @@ impl CreateRows for openapi::models::RebuildHistory {
                 ]
             })
             .collect()
+    }
+    fn sort_rows(&self) -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
    fix(node-spread): use spread policy on replica add/remove
    
    Use node-spread policy when adding new replicas to a volume.
    This is done by updating the existing filtering logic, ensuring that
    new replicas are created on nodes which contain the spread keys and
    also ensuring that the new values are different from existing replicas.
    
    Also when removing replicas we now use the spread, preferring to remove
    replicas which don't contain the spreads keys (all else being equal).
    If more than 1 replicas don't contain the spread keys, the deadlock is
    broken by picking the one with more spread value collisions.
    
---

    feat(plugin): add --show-labels to volume replica topologies

---

    fix(snapshot): candidates may be less than the snapshots
    
    This is however fine, because user may want to create lesser replicas
    on the cloned volume.
    
    Also fixes a bug whereas the index of the snapshot was used to check
    for completion which is not true when one of the requests fails.
    
---

    fix(snapshot): specify timeout for create volume from snapshot
    
---

    fix(spread): use combinations fine tune candidates
    
    Using the given list directly may not work correctly if the first element
    of the list ends up not being valid for use with the remaining ones.
    
    Instead, we now create all usable combinations and ensure that only valid
    ones are considered before completing the volume creation.
    
    Another bug was found which may leave replicas around until nexus creation.
    This may again lead into using replicas which don't obey the topology. We
    now clean up previous attempts before starting volume creation.
    
---

    fix(plugin): sort node,pool labels and block devlinks
    
---

    fix(plugin): sort tabled output on first column
    
    Add sort_rows method to CreateRows and CreateRow traits.
    The first column is typically the identifier of something so default
    to sorting by row. This may be opted out ofcourse.
    
    Certain outputs such as the topologies are a bit complicated so have
    to be sorted manually prior.
    
    This approach has the downside that the json/yaml output is not sorted,
    but that's probably fine for now.