### PR TITLE
feat(affinity-group): support scale down to 1 replica

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,13 @@
+pull_request_rules:
+  - name: auto-label and approve backport PRs
+    conditions:
+      - author=mergify[bot]
+      - title~=\(backport \#[0-9]+\)$
+    actions:
+      label:
+        add:
+          - kind/backport
+      review:
+        type: APPROVE
+        message: "Automatically approved backport PR"
+        bot_account: openebs-ci

--- a/control-plane/agents/src/bin/core/controller/scheduling/affinity_group.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/affinity_group.rs
@@ -1,5 +1,5 @@
 use crate::controller::{registry::Registry, resources::ResourceUid};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use stor_port::types::v0::{
     store::volume::{AffinityGroupSpec, VolumeOperation, VolumeSpec},
     transport::{NodeId, PoolId},
@@ -59,6 +59,27 @@ pub(crate) async fn get_pool_ag_replica_count(
         }
     }
     pool_ag_replica_count
+}
+
+/// Get a set of nodes which contain the replica of a single-replica volume, part of the affinity group.
+pub(crate) async fn ag_restricted_nodes(
+    affinity_group_spec: &AffinityGroupSpec,
+    registry: &Registry,
+) -> HashSet<NodeId> {
+    let mut nodes = HashSet::<NodeId>::new();
+    let specs = registry.specs();
+    for volume_id in affinity_group_spec.volumes() {
+        let Some(volume) = registry.specs().volume_rsc(volume_id) else {
+            // should not really happen
+            continue;
+        };
+        if volume.lock().num_replicas != 1 {
+            continue;
+        }
+
+        nodes.extend(specs.volume_replica_nodes(volume_id));
+    }
+    nodes
 }
 
 /// Get the map of node to the number of the Affinity Group nexuses on the node.

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -332,13 +332,23 @@ impl ChildSorters {
     /// Sort replicas by their nexus child (state and rebuild progress)
     /// todo: should we use weights instead (like moac)?
     pub(crate) fn sort(
-        _request: &GetChildForRemovalContext,
+        request: &GetChildForRemovalContext,
         a: &ReplicaItem,
         b: &ReplicaItem,
     ) -> std::cmp::Ordering {
         match Self::sort_by_health(a, b) {
             Ordering::Equal => match Self::sort_by_child(a, b) {
                 Ordering::Equal => {
+                    if let Some(ag) = request.affinity_group() {
+                        match (
+                            a.ag_restricted_node(ag.restricted_nodes()),
+                            b.ag_restricted_node(ag.restricted_nodes()),
+                        ) {
+                            (Some(a), Some(b)) if a != b => return b.cmp(&a),
+                            _ => {}
+                        }
+                    }
+
                     // Remove replicas from nodes which are cordoned with most priority.
                     // remove mismatched topology replicas first
                     if let (Some(a), Some(b)) = (a.valid_node_topology(), b.valid_node_topology()) {
@@ -377,6 +387,7 @@ impl ChildSorters {
                     let childb_is_local = !b.spec().share.shared();
                     match (childa_is_local, childb_is_local) {
                         (true, true) | (false, false) => {
+                            // todo: this should probably be done regardless of child locality
                             b.ag_replicas_on_pool().cmp(&a.ag_replicas_on_pool())
                         }
                         (true, false) => Ordering::Greater,

--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -16,7 +16,11 @@ use stor_port::types::v0::{
     transport::{Child, ChildUri, NodeId, PoolId, Replica},
 };
 
-use std::{cmp::Ordering, collections::HashMap, ops::Deref};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    ops::Deref,
+};
 
 /// Item for pool scheduling logic.
 #[derive(Debug, Clone)]
@@ -293,6 +297,10 @@ impl ReplicaItem {
         self.valid_pool_topology = valid_pool_topology;
         self
     }
+    /// Check all topological information is valid!
+    pub(crate) fn valid_topology(&self) -> bool {
+        self.valid_pool_topology() == &Some(true) && self.valid_node_topology() == Some(true)
+    }
     /// Get a reference to the node topology validity information.
     pub(crate) fn node_topology_info(&self) -> &Option<TopologyRmInfo> {
         &self.node_topology_info
@@ -337,6 +345,13 @@ impl ReplicaItem {
     /// Count of ag replicas on the replica's pool.
     pub(crate) fn ag_replicas_on_pool(&self) -> u64 {
         self.ag_replicas_on_pool.unwrap_or(u64::MIN)
+    }
+    /// Check if this replica is in an Affinity Group restricted node.
+    /// A restricted node is a node where another single-replica volume (from the same AG) already
+    /// resides in.
+    pub(crate) fn ag_restricted_node(&self, restricted_nodes: &HashSet<NodeId>) -> Option<bool> {
+        let node_spec = self.node_spec.as_ref()?;
+        Some(restricted_nodes.get(node_spec.id()).is_some())
     }
 }
 

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume.rs
@@ -22,11 +22,12 @@ use stor_port::types::v0::{
     transport::{NodeId, PoolId, VolumeState},
 };
 
-use crate::controller::scheduling::ResourceExcReason;
+use crate::controller::scheduling::{affinity_group::ag_restricted_nodes, ResourceExcReason};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::Deref,
 };
+use stor_port::types::v0::store::volume::AffinityGroupSpec;
 
 /// Move replica to another pool.
 #[derive(Default, Clone)]
@@ -273,6 +274,20 @@ impl GetChildForRemoval {
     }
 }
 
+/// Affinity Group useful information when scaling down.
+#[derive(Clone)]
+pub(crate) struct AffinityGroupRmCtx {
+    _group: AffinityGroupSpec,
+    pool_repl_cnt: HashMap<PoolId, u64>,
+    restricted_nodes: HashSet<NodeId>,
+}
+impl AffinityGroupRmCtx {
+    /// Get the Affinity Group restricted nodes.
+    pub(crate) fn restricted_nodes(&self) -> &HashSet<NodeId> {
+        &self.restricted_nodes
+    }
+}
+
 /// Used to filter nexus children in order to choose the best candidates for removal
 /// when the volume's replica count is being reduced.
 #[derive(Clone)]
@@ -282,6 +297,7 @@ pub(crate) struct GetChildForRemovalContext {
     state: VolumeState,
     nexus_info: Option<NexusInfo>,
     unused_only: bool,
+    affinity_group: Option<AffinityGroupRmCtx>,
 }
 impl std::fmt::Debug for GetChildForRemovalContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -295,7 +311,11 @@ impl std::fmt::Debug for GetChildForRemovalContext {
 }
 
 impl GetChildForRemovalContext {
-    async fn new(registry: &Registry, request: &GetChildForRemoval) -> Result<Self, SvcError> {
+    async fn new(
+        registry: &Registry,
+        request: &GetChildForRemoval,
+        affinity_group: Option<AffinityGroupSpec>,
+    ) -> Result<Self, SvcError> {
         let nexus_info = registry
             .nexus_info(
                 Some(&request.spec.uuid),
@@ -311,10 +331,19 @@ impl GetChildForRemovalContext {
             state: request.state.clone(),
             nexus_info,
             unused_only: request.unused_only,
+            affinity_group: match affinity_group {
+                None => None,
+                Some(group) => Some(AffinityGroupRmCtx {
+                    pool_repl_cnt: get_pool_ag_replica_count(&group, registry).await,
+                    restricted_nodes: ag_restricted_nodes(&group, registry).await,
+                    _group: group,
+                }),
+            },
         })
     }
 
-    async fn list(&self, pool_ag_rep: &Option<HashMap<PoolId, u64>>) -> Vec<ReplicaItem> {
+    async fn list(&self) -> Vec<ReplicaItem> {
+        let pool_ag_rep = self.affinity_group.as_ref().map(|g| &g.pool_repl_cnt);
         let replicas = self.registry.specs().volume_replicas_cln(&self.spec.uuid);
         let nexus = self.registry.specs().volume_target_nexus_rsc(&self.spec);
         let used_node_spread =
@@ -386,19 +415,22 @@ impl GetChildForRemovalContext {
             })
             .collect::<Vec<_>>()
     }
+
+    /// Get the volume's affinity group.
+    pub(crate) fn affinity_group(&self) -> Option<&AffinityGroupRmCtx> {
+        self.affinity_group.as_ref()
+    }
 }
 
 impl DecreaseVolumeReplica {
     async fn builder(request: &GetChildForRemoval, registry: &Registry) -> Result<Self, SvcError> {
-        let mut pool_ag_replica_count_map: Option<HashMap<PoolId, u64>> = None;
-        if let Some(affinity_group) = &request.spec.affinity_group {
-            let affinity_group_spec = registry.specs().affinity_group_spec(affinity_group.id())?;
-            pool_ag_replica_count_map =
-                Some(get_pool_ag_replica_count(&affinity_group_spec, registry).await);
-        }
+        let affinity_group = request.spec.affinity_group.as_ref();
+        let affinity_group = affinity_group
+            .map(|g| registry.specs().affinity_group_spec(g.id()))
+            .transpose()?;
 
-        let context = GetChildForRemovalContext::new(registry, request).await?;
-        let list = context.list(&pool_ag_replica_count_map).await;
+        let context = GetChildForRemovalContext::new(registry, request, affinity_group).await?;
+        let list = context.list().await;
         Ok(Self {
             data: ResourceData::new(context, list),
         })
@@ -448,6 +480,24 @@ impl ReplicaRemovalCandidates {
             None
         }
     }
+    fn ag_restricted_nodes(&self) -> Option<&HashSet<NodeId>> {
+        let ag = self.context.affinity_group.as_ref()?;
+        if ag.restricted_nodes.is_empty() {
+            return None;
+        }
+        //     N
+        // R 1 2 3
+        // 1 x x
+        // 2 x x
+        // 3 x x x
+        // todo: In this case, shouldn't we block removal or r3n3 ?
+        if self.context.spec.num_replicas > 2 {
+            // for now, we only restrict from 2->1
+            return None;
+        }
+        Some(&ag.restricted_nodes)
+    }
+
     /// Get the next unhealthy candidates (any is a good fit).
     fn next_unhealthy(&mut self) -> Option<ReplicaItem> {
         self.unhealthy.pop()
@@ -456,6 +506,46 @@ impl ReplicaRemovalCandidates {
     /// Unhealthy replicas are removed before healthy replicas.
     pub(crate) fn next(&mut self) -> Option<ReplicaItem> {
         self.next_unhealthy().or_else(|| self.next_healthy())
+    }
+    /// Get the next removal candidate.
+    /// Unhealthy replicas are removed before healthy replicas.
+    /// Use when scaling down the volume where we need to guard against restricted node usage.
+    pub(crate) fn next_down(&mut self) -> Option<Option<ReplicaItem>> {
+        // we don't want to leave place 1-r affinity volumes in the same node (potentially),
+        // so we should check whether we have other replicas available
+        let mut replicas_in_unrestricted_nodes = false;
+
+        let candidate = self.next_unhealthy().or_else(|| self.next_healthy())?;
+
+        let Some(restricted_nodes) = self.ag_restricted_nodes() else {
+            // no affinity groups, just remove the best candidate
+            return Some(Some(candidate));
+        };
+        // todo: still need a better way of controlling the priority of candidates when
+        //  scaling from X -> X-1, where X > 2
+        //  also we can block scale down to 1, if we don't have sufficient distinct nodes
+        //  to place all the other volume replicas
+
+        tracing::debug!("Restricted Affinity Group Nodes: {restricted_nodes:?}");
+        tracing::debug!("Candidate for removal: {}", candidate.spec().uuid);
+
+        for repl in &self.healthy {
+            let Some(node) = repl.node_spec() else {
+                continue;
+            };
+            if restricted_nodes.get(node.id()).is_none()
+                && (repl.valid_topology() || !candidate.valid_topology())
+            {
+                replicas_in_unrestricted_nodes = true;
+                break;
+            }
+        }
+
+        if replicas_in_unrestricted_nodes {
+            Some(Some(candidate))
+        } else {
+            Some(None)
+        }
     }
 
     fn new(context: GetChildForRemovalContext, items: Vec<ReplicaItem>) -> Self {

--- a/control-plane/agents/src/bin/core/tests/volume/affinity_group.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/affinity_group.rs
@@ -1,7 +1,15 @@
 use deployer_cluster::{Cluster, ClusterBuilder};
 use grpc::operations::{registry::traits::RegistryOperations, volume::traits::VolumeOperations};
-use stor_port::types::v0::transport::{
-    AffinityGroup, CreateVolume, DestroyVolume, GetSpecs, SetVolumeReplica, VolumeId,
+use std::collections::{HashMap, HashSet};
+use stor_port::{
+    transport_api::ReplyErrorKind,
+    types::v0::{
+        transport,
+        transport::{
+            AffinityGroup, CreateVolume, DestroyVolume, Filter, GetSpecs, NodeId, SetVolumeReplica,
+            VolumeId,
+        },
+    },
 };
 use tracing::info;
 
@@ -18,7 +26,7 @@ async fn affinity_group() {
         .unwrap();
 
     startup_test(&cluster).await;
-    scale_up_test(&cluster).await;
+    scale_up_down_test(&cluster).await;
 }
 
 async fn startup_test(cluster: &Cluster) {
@@ -105,14 +113,25 @@ async fn startup_test(cluster: &Cluster) {
     }
 }
 
-async fn scale_up_test(cluster: &Cluster) {
+async fn scale_up_down_test(cluster: &Cluster) {
     let vols = vec![
         (Some("ag1"), "eba487d9-0b57-407b-8b48-0b631a372183"),
         (Some("ag1"), "359b7e1a-b724-443b-98b4-e6d97fabbb60"),
         (Some("ag1"), "f2296d6a-77a6-401d-aad3-ccdc247b0a56"),
     ];
 
+    use grpc::operations::node::traits::NodeOperations;
     let registry_client = cluster.grpc_client().registry();
+
+    let mut affinity_labels = std::collections::HashMap::new();
+    affinity_labels.insert("r".to_string(), "r".to_string());
+
+    let noder = cluster.grpc_client().node();
+    for node in 0..cluster.nodes() {
+        let node = cluster.node(node);
+        let label = affinity_labels.clone();
+        noder.label(node, label, false).await.unwrap();
+    }
 
     // The Affinity Group specs should now have been loaded in memory.
     // Fetch the specs.
@@ -134,6 +153,15 @@ async fn scale_up_test(cluster: &Cluster) {
                     size: 5242880,
                     replicas: 1,
                     affinity_group: item.0.map(|val| AffinityGroup::new(val.to_string())),
+                    topology: Some(transport::Topology {
+                        pool: None,
+                        node: Some(transport::NodeTopology::Labelled(
+                            transport::LabelledTopology {
+                                inclusion: affinity_labels.clone(),
+                                ..Default::default()
+                            },
+                        )),
+                    }),
                     ..Default::default()
                 },
                 None,
@@ -181,7 +209,8 @@ async fn scale_up_test(cluster: &Cluster) {
             .expect("Scale down should not fail");
     }
 
-    for &item in &vols {
+    // Scale down 2 of the volumes
+    for &item in vols.iter().take(2) {
         volume_client
             .set_replica(
                 &SetVolumeReplica {
@@ -191,6 +220,72 @@ async fn scale_up_test(cluster: &Cluster) {
                 None,
             )
             .await
-            .expect_err("Scale down should fail");
+            .expect("Scale down should fail");
     }
+
+    // Replica location now looks like this:
+    // 1 2 3
+    // x
+    //   x
+    // x   x
+    let volumes = volume_client
+        .get(Filter::None, false, None, None)
+        .await
+        .unwrap();
+    let last_vol = volumes.entries.last().unwrap();
+    let mut node_replicas = HashMap::<NodeId, u32>::new();
+    let last_vol_nodes = last_vol
+        .state()
+        .replica_topology
+        .values()
+        .map(|topology| topology.node().as_ref().unwrap().clone())
+        .collect::<HashSet<_>>();
+    for volume in &volumes.entries {
+        for topology in volume.state().replica_topology.values() {
+            let node = topology.node().as_ref().unwrap();
+            *node_replicas.entry(node.clone()).or_default() += 1;
+        }
+    }
+    let node = node_replicas
+        .iter()
+        .filter(|(_, r)| **r == 1)
+        .map(|(n, _)| n)
+        .find(|n| last_vol_nodes.contains(n))
+        .unwrap();
+
+    let mut bad_labels = HashMap::new();
+    bad_labels.insert("r".to_string(), "x".to_string());
+
+    // Invalidate topology from the "good" removal candidate (with not conflict on restricted nodes)
+    noder.label(node.clone(), bad_labels, true).await.unwrap();
+
+    let error = volume_client
+        .set_replica(
+            &SetVolumeReplica {
+                uuid: last_vol.uuid().clone(),
+                replicas: 1,
+            },
+            None,
+        )
+        .await
+        .expect_err("Scale down should fail");
+    assert_eq!(error.kind, ReplyErrorKind::FailedPrecondition);
+    assert!(error.source.contains("RestrictedReplicaCount"));
+
+    // Revalidate topology
+    noder
+        .label(node.clone(), affinity_labels, true)
+        .await
+        .unwrap();
+
+    volume_client
+        .set_replica(
+            &SetVolumeReplica {
+                uuid: last_vol.uuid().clone(),
+                replicas: 1,
+            },
+            None,
+        )
+        .await
+        .expect("Scale down should succeed");
 }

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -20,12 +20,9 @@ use crate::{
     },
     volume::{operations::CreateVolumeSource, scheduling},
 };
-use agents::{
-    errors,
-    errors::{
-        NotEnough, SvcError,
-        SvcError::{VolSnapshotNotFound, VolumeNotFound},
-    },
+use agents::errors::{
+    NotEnough, SvcError,
+    SvcError::{VolSnapshotNotFound, VolumeNotFound},
 };
 use grpc::operations::{PaginatedResult, Pagination};
 use stor_port::{
@@ -48,7 +45,6 @@ use stor_port::{
     },
 };
 
-use snafu::OptionExt;
 use std::convert::From;
 
 /// CreateReplicaCandidate for volume and Affinity Group.
@@ -112,11 +108,13 @@ pub(crate) async fn volume_replica_remove_candidate(
 
     spec.trace_span(|| tracing::trace!("Volume Replica removal candidates: {:?}", candidates));
 
-    candidates
-        .next()
-        .context(errors::ReplicaRemovalNoCandidates {
+    match candidates.next_down() {
+        None => Err(SvcError::ReplicaRemovalNoCandidates {
             id: spec.uuid_str(),
-        })
+        }),
+        Some(None) => Err(SvcError::RestrictedReplicaCount {}),
+        Some(Some(candidate)) => Ok(candidate),
+    }
 }
 
 /// Get replica candidates to be removed from the volume.
@@ -1087,19 +1085,11 @@ impl SpecOperationsHelper for VolumeSpec {
                         volume_id: self.uuid_str(),
                         volume_state: state.status.to_string(),
                     })
+                } else if *replica_count > self.num_replicas && self.has_snapshots() {
+                    let fix = NodeBugFix::NexusRebuildReplicaAncestry;
+                    registry.volume_replica_nodes_fix(self, &fix)
                 } else {
-                    // Validation for Affinity Group volume's replica count cannot go below 2.
-                    if self.affinity_group.is_some() && *replica_count < 2 {
-                        Err(SvcError::RestrictedReplicaCount {
-                            resource: ResourceKind::AffinityGroup,
-                            count: *replica_count,
-                        })
-                    } else if *replica_count > self.num_replicas && self.has_snapshots() {
-                        let fix = NodeBugFix::NexusRebuildReplicaAncestry;
-                        registry.volume_replica_nodes_fix(self, &fix)
-                    } else {
-                        Ok(())
-                    }
+                    Ok(())
                 }
             }
             VolumeOperation::RemoveUnusedReplica(uuid) => {

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -304,12 +304,8 @@ pub enum SvcError {
     NoHealthyReplicas { id: String },
     #[snafu(display("Pool not ready to take clone of snapshot '{}'", id))]
     NoSnapshotPools { id: String },
-    #[snafu(display(
-        "Replica Count of {} is not attainable for {}",
-        count,
-        resource.to_string()
-    ))]
-    RestrictedReplicaCount { resource: ResourceKind, count: u8 },
+    #[snafu(display("Cannot scale down volume due to affinity group restrictions"))]
+    RestrictedReplicaCount {},
     #[snafu(display("Entry with key '{}' not found in the persistent store.", key))]
     StoreMissingEntry { key: String },
     #[snafu(display("The uuid '{}' for kind '{}' is not valid.", uuid, kind.to_string()))]
@@ -1026,9 +1022,9 @@ impl From<SvcError> for ReplyError {
                 source,
                 extra,
             },
-            SvcError::RestrictedReplicaCount { resource, .. } => ReplyError {
+            SvcError::RestrictedReplicaCount { .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPrecondition,
-                resource,
+                resource: ResourceKind::Volume,
                 source,
                 extra,
             },

--- a/tests/bdd/features/volume-group/set-replica/feature.feature
+++ b/tests/bdd/features/volume-group/set-replica/feature.feature
@@ -28,8 +28,24 @@ Feature: Anti-Affinity for Affinity Group
     Given 3 pools, 1 on node A, 1 on node B, 1 on node C
     And 3 volumes belonging to an affinity group with <replicas> each and <thin>
     When the 3 volumes are scaled down to 1
+    Then the scale down operation should not fail
+    And all volumes should have exactly 1 replica
+    Examples:
+      | replicas | thin  |
+      | 2        | True  |
+      | 2        | False |
+
+  Scenario Outline: affinity group volumes are scaled down below 2 replicas with insufficient nodes
+    Given 2 pools, 1 on node A, 1 on node B
+    And 3 volumes belonging to an affinity group with <replicas> each and <thin>
+    When the 3 volumes are scaled down to 1
     Then the scale down operation should fail
-    And no volume should have less than 2 replicas
+    And exactly 2 volumes should have 1 replica, and 1 volume 2 replicas
+    Then we create another pool on node C
+    And we scale the remaining 2-replica volume to 3 and then back to 2
+    When we scale down the volume to 1 replica
+    Then the scale down operation should not fail
+    And all volumes should have exactly 1 replica
     Examples:
       | replicas | thin  |
       | 2        | True  |

--- a/tests/bdd/features/volume-group/set-replica/test_set-replica.py
+++ b/tests/bdd/features/volume-group/set-replica/test_set-replica.py
@@ -56,6 +56,14 @@ def test_affinity_group_volumes_are_scaled_down_below_2_replicas():
     """affinity group volumes are scaled down below 2 replicas."""
 
 
+@scenario(
+    "feature.feature",
+    "affinity group volumes are scaled down below 2 replicas with insufficient nodes",
+)
+def test_affinity_group_volumes_are_scaled_down_below_2_replicas_with_insufficient_nodes():
+    """affinity group volumes are scaled down below 2 replicas with insufficient nodes."""
+
+
 @scenario("feature.feature", "affinity group volumes are scaled up")
 def test_affinity_group_volumes_are_scaled_up():
     """affinity group volumes are scaled up."""
@@ -72,6 +80,13 @@ def pools_1_on_node_a_0_on_node_b_1_on_node_c():
 def pools_1_on_node_a_1_on_node_b_1_on_node_c():
     """3 pools, 1 on node A, 1 on node B, 1 on node C."""
     node_pool_map = {NODE_NAME_1: 1, NODE_NAME_2: 1, NODE_NAME_3: 1}
+    create_node_pools(node_pool_map)
+
+
+@given("2 pools, 1 on node A, 1 on node B")
+def pools_1_on_node_a_1_on_node_b():
+    """2 pools, 1 on node A, 1 on node B."""
+    node_pool_map = {NODE_NAME_1: 1, NODE_NAME_2: 1}
     create_node_pools(node_pool_map)
 
 
@@ -109,6 +124,7 @@ def the_3_volumes_are_scaled_down_to_1():
     """the 3 volumes are scaled down to 1."""
     try:
         scale_affinity_group(1)
+        pytest.error_body = None
     except openapi.exceptions.ApiException as e:
         pytest.error_body = json.loads(e.body)
 
@@ -169,6 +185,33 @@ def the_volume_is_scaled_up_by_one():
     ApiClient.volumes_api().put_volume_replica_count(AG_VOLUME_UUID_1, 2)
 
 
+@when("we scale down the volume to 1 replica")
+def _():
+    """we scale down the volume to 1 replica."""
+    try:
+        ApiClient.volumes_api().put_volume_replica_count(AG_VOLUME_UUID_3, 1)
+        pytest.error_body = None
+    except openapi.exceptions.ApiException as e:
+        pytest.error_body = json.loads(e.body)
+
+
+@then("we create another pool on node C")
+def _():
+    """we create another pool on node C."""
+    ApiClient.pools_api().put_node_pool(
+        NODE_NAME_3,
+        "new_pool",
+        CreatePoolBody(disks=["malloc:///new_disk?size_mb=200"]),
+    )
+
+
+@then("we scale the remaining 2-replica volume to 3 and then back to 2")
+def _():
+    """we scale the remaining 2-replica volume to 3 and then back to 2."""
+    ApiClient.volumes_api().put_volume_replica_count(AG_VOLUME_UUID_3, 3)
+    ApiClient.volumes_api().put_volume_replica_count(AG_VOLUME_UUID_3, 2)
+
+
 @then("3 new replicas should be created")
 def new_replicas_should_be_created():
     """3 new replicas should be created."""
@@ -210,6 +253,27 @@ def no_volume_should_have_less_than_2_replicas():
         assert vol.spec.num_replicas == 2
 
 
+@then("exactly 2 volumes should have 1 replica, and 1 volume 2 replicas")
+def _():
+    """exactly 2 volumes should have 1 replica, and 1 volume 2 replicas."""
+    ag_vols = get_affinity_group_volumes()
+    repl_counts = {1: 0, 2: 0}
+    for vol in ag_vols:
+        assert vol.spec.num_replicas in [1, 2]
+        repl_counts[vol.spec.num_replicas] += 1
+
+    assert repl_counts[1] == 2
+    assert repl_counts[2] == 1
+
+
+@then("all volumes should have exactly 1 replica")
+def all_volumes_should_have_exactly_1_replica():
+    """all volumes should have exactly 1 replica."""
+    ag_vols = get_affinity_group_volumes()
+    for vol in ag_vols:
+        assert vol.spec.num_replicas == 1
+
+
 @then("the creation should fail")
 def the_creation_should_fail():
     """the creation should fail."""
@@ -227,6 +291,12 @@ def the_scale_down_operation_should_fail():
     """the scale down operation should fail."""
     assert pytest.error_body["message"].startswith("SvcError :: RestrictedReplicaCount")
     assert pytest.error_body["kind"] == "FailedPrecondition"
+
+
+@then("the scale down operation should not fail")
+def the_scale_down_operation_should_not_fail():
+    """the scale down operation should not fail."""
+    assert pytest.error_body is None
 
 
 # HELPER METHODS

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -438,6 +438,10 @@ impl Cluster {
     pub fn node(&self, index: u32) -> transport::NodeId {
         IoEngine::name(index, &self.builder.opts).into()
     }
+    /// How many io-engine nodes deployed.
+    pub fn nodes(&self) -> u32 {
+        self.builder.opts.io_engines
+    }
 
     /// The io-engine node nqn for `index`.
     pub fn node_nqn(&self, index: u32) -> transport::HostNqn {


### PR DESCRIPTION
Scaling down affinity groups to 1 replica was previously blocked because we didn't want to get into a situation where replicas would end up sharing the same node, defeating the purpose of Affinity Groups!

We now loosen this restriction by allowing the scale down if we don't get into that scenario :)

This is done by creating a list of restricted nodes which are nodes where a 1-replica volume part of the same affinity group places its replica. In such case, we don't want to scale down in such a way that the last remaining replica would be placed in restricted nodes!

This isn't the full monty as replicas may be sharing nodes when Scaling back from 3 to 2, which would end up impeding further scaling down to 1! For this we'd have to implement some logic to improve the sorting. This limitation is fine for now, we can document scaling up and down as a way of moving replicas around!