### PR TITLE
build: use shared workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,12 +113,11 @@ dependencies = [
 
 [[package]]
 name = "actix-service"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
 dependencies = [
  "futures-core",
- "paste",
  "pin-project-lite",
 ]
 
@@ -527,7 +526,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -648,26 +647,6 @@ dependencies = [
  "shlex",
  "syn 2.0.98",
  "which 4.4.2",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.6.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -1318,7 +1297,7 @@ dependencies = [
 name = "devinfo"
 version = "1.0.0"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen",
  "nix",
  "semver",
  "snafu",
@@ -1535,7 +1514,6 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "once_cell",
  "prost",
  "prost-extend",
  "serde",
@@ -1805,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grpc"
@@ -1982,12 +1960,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.1.0",
  "http-body",
  "pin-project-lite",
@@ -2623,7 +2601,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tower 0.4.13",
- "tower-http 0.5.2",
+ "tower-http",
  "tracing",
 ]
 
@@ -3120,7 +3098,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower 0.5.1",
- "tower-http 0.6.1",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3333,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -3722,34 +3700,26 @@ checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
  "http 1.1.0",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4508,27 +4478,6 @@ name = "sysfs"
 version = "1.0.0"
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4843,24 +4792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
-dependencies = [
- "base64 0.22.1",
- "bitflags 2.6.0",
- "bytes",
- "http 1.1.0",
- "http-body",
- "mime",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4874,9 +4805,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4901,9 +4832,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4912,9 +4843,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,126 @@ exclude = [
     "utils/dependencies/*",
 ]
 resolver = "1"
+
+[workspace.dependencies]
+stor-port = { path = "./control-plane/stor-port" }
+grpc = { path = "./control-plane/grpc" }
+openapi = { path = "./openapi", default-features = false, features = ["tower-trace"] }
+rpc = { path = "./rpc" }
+deployer = { path = "./deployer" }
+utils = { path = "./utils/utils-lib" }
+pstor = { path = "./utils/pstor" }
+shutdown = { path = "./utils/shutdown" }
+weighted-scoring = { path = "./utils/weighted-scoring" }
+deployer-cluster = { path = "./utils/deployer-cluster" }
+platform = { path = "./utils/dependencies/platform" }
+events-api = { path = "./utils/dependencies/apis/events" }
+devinfo = { path = "./utils/dependencies/devinfo" }
+nvmeadm = { path = "./utils/dependencies/nvmeadm" }
+sysfs = { path = "./utils/dependencies/sysfs" }
+composer = { path = "./utils/dependencies/composer", default-features = false }
+
+rustls = { version = "0.23.19", default-features = false }
+rustls-pemfile = "2.2.0"
+webpki = "0.22.4"
+tokio-native-tls = "0.3.1"
+
+actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
+actix-service = "2.0.3"
+awc = { version = "3.5.1" }
+tinytemplate = "1.2.1"
+jsonwebtoken = "9.3.0"
+
+tokio = { version = "1.45.1", features = ["sync"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+futures = { version = "0.3.31", default-features = false }
+futures-util = { version = "0.3.31" }
+pin-project = "1.1.7"
+tokio-udev = { version = "0.10.0" }
+
+# tracing and telemetry
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-actix-web = { version = "0.7.14", features = ["opentelemetry_0_26"] }
+tracing-opentelemetry = { version = "0.27.0" }
+opentelemetry = { version = "0.26.0" }
+opentelemetry-otlp = { version = "0.26.0" }
+opentelemetry_sdk = { version = "0.26.0" }
+opentelemetry-http = { version = "0.26.0" }
+opentelemetry-semantic-conventions = "0.26.0"
+
+paste = "1.0.15"
+once_cell = "1.20.2"
+async-trait = "0.1.73"
+dyn-clonable = "0.9.0"
+lazy_static = "1.5.0"
+itertools = "0.13.0"
+parking_lot = "0.12.3"
+indexmap = "2.6.0"
+crossbeam-queue = "0.3.11"
+
+serde = { version = "1.0.214", features = ["derive"] }
+serde_derive = "1.0.214"
+serde_json = { version = "1.0.132", features = ["preserve_order"] }
+serde_yaml = "0.9.34"
+serde_tuple = "1.0.0"
+serde_urlencoded = "0.7.1"
+
+anyhow = "1.0.92"
+snafu = "0.8.5"
+thiserror = "1.0.68"
+url = "2.5.4"
+http = "1.1.0"
+http-body = { version = "1.0.1" }
+percent-encoding = "2.3.2"
+reqwest = { version = "0.12.9", default-features = false }
+state = "0.6.0"
+clap = { version = "4.5.20", features = ["color", "derive", "env", "string"] }
+humantime = "2.1.0"
+num_cpus = "1.16.0"
+rand = "0.8.5"
+uuid = { version = "1.4.1", features = ["v4"] }
+chrono = { version = "0.4.38", features = ["serde"] }
+parse-size = "1.1.0"
+shutdown_hooks = "0.1.0"
+gag = "1.0.0"
+regex = "1.11.1"
+glob = "0.3.1"
+which = "7.0.1"
+prettytable-rs = "0.10.0"
+inquire = { version = "0.7.5", default-features = false, features = ["crossterm"] }
+
+strum = "0.26.3"
+strum_macros = "0.26.4"
+heck = "0.5.0"
+
+tonic = "0.12.3"
+tonic-build = "0.12.3"
+prost-types = "0.13.3"
+prost = "0.13.2"
+prost-derive = "0.13.3"
+bytes = "1.8.0"
+tower = { version = "=0.5.1", default-features = false, features = ["timeout", "util"] }
+tower-http = { version = "0.5.2", features = ["trace", "map-response-body", "auth"] }
+hyper-util = "0.1.10"
+hyper = { version = "1.5.0", default-features = false, features = ["client", "http1", "http2"] }
+hyper-body = { path = "./utils/hyper-body" }
+http-body-util = { version = "0.1.3", default-features = false }
+hyper-rustls = { version = "0.27.3", default-features = false }
+hyper-tls = { version = "0.6.0" }
+
+udev = "0.9.1"
+sys-mount = { version = "3.0.1", default-features = false }
+nix = { version = "0.29.0", default-features = false, features = ["ioctl", "fs"] }
+ipnetwork = "0.20.0"
+bollard = "0.17.1"
+semver = "1.0.23"
+bindgen = "0.69.5"
+flate2 = "1.0"
+tar = "0.4"
+
+k8s-openapi = { version = "0.22.0", default-features = false, features = ["v1_24"] }
+kube = { version = "0.94.2", features = ["runtime", "derive"] }
+schemars = { version = "0.8.21" }
+async-nats = { version = "0.37.0", default-features = false }
+etcd-client = "0.14.0"

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -29,55 +29,52 @@ name = "agent-ha-cluster"
 path = "src/bin/ha/cluster/main.rs"
 
 [dependencies]
-anyhow = "1.0.92"
-uuid = { version = "1.11.0", features = ["serde", "v4"] }
-chrono = "0.4.38"
-clap = { version = "4.5.20", features = ["color", "derive", "env", "string"] }
-tokio = { version = "1.43.1", features = ["full"] }
-tonic = "0.12.3"
-futures = "0.3.31"
-serde_json = "1.0.132"
-async-trait = "0.1.83"
-dyn-clonable = "0.9.0"
-snafu = "0.8.5"
-humantime = "2.1.0"
-state = "0.6.0"
-reqwest = "0.12.9"
-parking_lot = "0.12.3"
-itertools = "0.13.0"
-once_cell = "1.20.2"
-indexmap = "2.6.0"
-futures-util = { version = "0.3.31" }
-crossbeam-queue = "0.3.11"
-tower = { version = "0.5.1", features = ["timeout", "util"] }
-http = "1.1.0"
-hyper-util = "0.1.10"
-hyper = { version = "1.5.0", features = ["client", "http1", "http2"] }
-opentelemetry = { version = "0.26.0" }
-tracing = "0.1.40"
-nix = { version = "0.29.0", default-features = false }
-prost-types = "0.13.3"
-url = "2.5.4"
-regex = "1.11.1"
+anyhow = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
+chrono = { workspace = true }
+clap = { workspace = true, features = ["color", "derive", "env", "string"] }
+tokio = { workspace = true, features = ["full"] }
+tonic = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+dyn-clonable = { workspace = true }
+snafu = { workspace = true }
+humantime = { workspace = true }
+state = { workspace = true }
+reqwest = { workspace = true }
+parking_lot = { workspace = true }
+itertools = { workspace = true }
+once_cell = { workspace = true }
+indexmap = { workspace = true }
+futures-util = { workspace = true }
+crossbeam-queue = { workspace = true }
+tower = { workspace = true, features = ["timeout", "util"] }
+http = { workspace = true }
+hyper-util = { workspace = true }
+hyper = { workspace = true, features = ["client", "http1", "http2"] }
+opentelemetry = { workspace = true }
+tracing = { workspace = true }
+nix = { workspace = true, default-features = false }
+prost-types = { workspace = true }
+url = { workspace = true }
+regex = { workspace = true }
 
-grpc = { path = "../grpc" }
-shutdown = { path = "../../utils/shutdown" }
-rpc = { path = "../../rpc" }
-stor-port = { path = "../stor-port" }
-utils = { path = "../../utils/utils-lib" }
-nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
-weighted-scoring = { path = "../../utils/weighted-scoring" }
-events-api = { path = "../../utils/dependencies/apis/events" }
+grpc = { workspace = true }
+shutdown = { workspace = true }
+rpc = { workspace = true }
+stor-port = { workspace = true }
+utils = { workspace = true }
+nvmeadm = { workspace = true }
+weighted-scoring = { workspace = true }
+events-api = { workspace = true }
 
 [target.'cfg(target_os="linux")'.dependencies]
-tokio-udev = { version = "0.10.0" }
+tokio-udev = { workspace = true }
 
 [dev-dependencies]
-deployer-cluster = { path = "../../utils/deployer-cluster" }
-events-api = { path = "../../utils/dependencies/apis/events" }
-url = "2.5.4"
-once_cell = "1.20.2"
-
-[dependencies.serde]
-features = ["derive"]
-version = "1.0.214"
+deployer-cluster = { workspace = true }
+events-api = { workspace = true }
+url = { workspace = true }
+once_cell = { workspace = true }

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -15,47 +15,47 @@ name = "csi-node"
 path = "src/bin/node/main.rs"
 
 [build-dependencies]
-tonic-build = "0.12.3"
+tonic-build = { workspace = true }
 
 [dependencies]
-prost = "0.13.3"
-prost-types = "0.13.3"
-tonic = "0.12.3"
+prost = { workspace = true }
+prost-types = { workspace = true }
+tonic = { workspace = true }
 
-tokio-stream = { version = "0.1", features = ["net"] }
+tokio-stream = { workspace = true, features = ["net"] }
 
-anyhow = "1.0.92"
-futures = { version = "0.3.31", default-features = false }
-humantime = "2.1.0"
-once_cell = "1.20.2"
-regex = "1.11.1"
-rpc = { path = "../../rpc" }
-grpc = { path = "../grpc" }
-tokio = { version = "1.43.1", features = ["full"] }
-clap = { version = "4.5.20", features = ["color", "env", "string"] }
-nix = { version = "0.29.0", default-features = false, features = ["ioctl", "fs"] }
-strum = "0.26.3"
-strum_macros = "0.26.4"
-heck = "0.5.0"
-tracing = "0.1.40"
-glob = "0.3.1"
-lazy_static = "1.5.0"
-serde_json = "1.0.132"
-snafu = "0.8.5"
-url = "2.5.4"
-uuid = { version = "1.11.0", features = ["v4"] }
-which = "7.0.0"
-k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
-kube = { version = "0.94.2", features = ["runtime", "derive"] }
-nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
-sysfs = { path = "../../utils/dependencies/sysfs" }
-stor-port = { path = "../stor-port" }
-utils = { path = "../../utils/utils-lib" }
-shutdown = { path = "../../utils/shutdown" }
-serde = { version = "1.0.214", features = ["derive"] }
-parse-size = "1.1.0"
+anyhow = { workspace = true }
+futures = { workspace = true, default-features = false }
+humantime = { workspace = true }
+once_cell = { workspace = true }
+regex = { workspace = true }
+rpc = { workspace = true }
+grpc = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+clap = { workspace = true, features = ["color", "env", "string"] }
+nix = { workspace = true, default-features = false, features = ["ioctl", "fs"] }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+heck = { workspace = true }
+tracing = { workspace = true }
+glob = { workspace = true }
+lazy_static = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+which = { workspace = true }
+k8s-openapi = { workspace = true }
+kube = { workspace = true, features = ["runtime", "derive"] }
+nvmeadm = { workspace = true }
+sysfs = { workspace = true }
+stor-port = { workspace = true }
+utils = { workspace = true }
+shutdown = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+parse-size = { workspace = true }
 
 [target.'cfg(target_os="linux")'.dependencies]
-udev = "0.9.1"
-devinfo = { path = "../../utils/dependencies/devinfo" }
-sys-mount = { version = "3.0.1", default-features = false }
+udev = { workspace = true }
+devinfo = { workspace = true }
+sys-mount = { workspace = true, default-features = false }

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -10,26 +10,26 @@ name = "grpc"
 path = "src/lib.rs"
 
 [build-dependencies]
-tonic-build = "0.12.3"
+tonic-build = { workspace = true }
 
 [dependencies]
-tonic = "0.12.3"
-prost = "0.13.3"
-prost-types = "0.13.3"
+tonic = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
 
-tokio = { version = "1.43.1", features = ["full"] }
-stor-port = { path = "../stor-port" }
-humantime = "2.1.0"
-utils = { path = "../../utils/utils-lib" }
-rpc = { path = "../../rpc" }
-uuid = { version = "1.11.0", features = ["v4"] }
-tracing-opentelemetry = "0.27.0"
-opentelemetry = { version = "0.26.0" }
-opentelemetry-http = { version = "0.26.0" }
-tracing = "0.1.40"
-tower = { version = "0.5.1", features = ["timeout", "util"] }
-serde_json = "1.0.132"
-events-api = { path = "../../utils/dependencies/apis/events" }
+tokio = { workspace = true, features = ["full"] }
+stor-port = { workspace = true }
+humantime = { workspace = true }
+utils = { workspace = true }
+rpc = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+tracing-opentelemetry = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry-http = { workspace = true }
+tracing = { workspace = true }
+tower = { workspace = true, features = ["timeout", "util"] }
+serde_json = { workspace = true }
+events-api = { workspace = true }
 
 [dev-dependencies]
-once_cell = "1.20.2"
+once_cell = { workspace = true }

--- a/control-plane/plugin/Cargo.toml
+++ b/control-plane/plugin/Cargo.toml
@@ -19,29 +19,28 @@ rls = ["openapi/tower-client-rls"]
 tls = ["openapi/tower-client-tls"]
 
 [dependencies]
-tracing = "0.1.40"
-openapi = { path = "../../openapi", default-features = false, features = ["tower-trace"] }
-utils = { path = "../../utils/utils-lib" }
-strum = "0.26.3"
-strum_macros = "0.26.4"
-tokio = { version = "1.43.1" }
-anyhow = "1.0.92"
-async-trait = "0.1.83"
-once_cell = "1.20.2"
-clap = { version = "4.5.20", features = ["color", "derive", "string"] }
-prettytable-rs = "0.10.0"
-lazy_static = "1.5.0"
-serde = "1.0.214"
-serde_json = "1.0.132"
-serde_yaml = "0.9.34"
-humantime = "2.1.0"
-chrono = "0.4.38"
-snafu = "0.8.5"
-inquire = { version = "0.7.5", default-features = false, features = ["crossterm"] }
-itertools = "0.13.0"
+tracing = { workspace = true }
+openapi = { workspace = true, default-features = false, features = ["tower-trace"] }
+utils = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+once_cell = { workspace = true }
+clap = { workspace = true, features = ["color", "derive", "string"] }
+prettytable-rs = { workspace = true }
+lazy_static = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+humantime = { workspace = true }
+chrono = { workspace = true }
+snafu = { workspace = true }
+inquire = { workspace = true, default-features = false, features = ["crossterm"] }
+itertools = { workspace = true }
 
 [dev-dependencies]
-# Test dependencies
-shutdown_hooks = "0.1.0"
-deployer-cluster = { path = "../../utils/deployer-cluster" }
-gag = "1.0.0"
+shutdown_hooks = { workspace = true }
+deployer-cluster = { workspace = true }
+gag = { workspace = true }

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -16,35 +16,32 @@ path = "./src/lib.rs"
 
 [dependencies]
 # Actix Server, telemetry
-rustls = { version = "0.23.19", default-features = false }
-rustls-pemfile = "2.2.0"
-actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
-actix-service = "2.0.2"
-tokio = { version = "1.43.1", features = ["sync"] }
-tracing-actix-web = { version = "0.7.14", features = ["opentelemetry_0_26"] }
-tracing = "0.1.40"
-once_cell = "1.20.2"
-async-trait = "0.1.83"
-serde_json = { version = "1.0.132", features = ["preserve_order"] }
-serde_yaml = "0.9.34"
-clap = { version = "4.5.20", features = ["color", "derive", "env", "string"] }
-futures = "0.3.31"
-anyhow = "1.0.92"
-snafu = "0.8.5"
-url = "2.5.4"
-http = "1.1.0"
-tinytemplate = "1.2.1"
-jsonwebtoken = "9.3.0"
+rustls = { workspace = true, default-features = false }
+rustls-pemfile = { workspace = true }
+actix-web = { workspace = true }
+actix-service = { workspace = true }
+tracing-actix-web = { workspace = true, features = ["opentelemetry_0_26"] }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
+once_cell = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
+serde_yaml = { workspace = true }
+clap = { workspace = true, features = ["color", "derive", "env", "string"] }
+futures = { workspace = true }
+anyhow = { workspace = true }
+snafu = { workspace = true }
+url = { workspace = true }
+http = { workspace = true }
+tinytemplate = { workspace = true }
+jsonwebtoken = { workspace = true }
 stor-port = { path = "../stor-port" }
 utils = { path = "../../utils/utils-lib" }
-humantime = "2.1.0"
+humantime = { workspace = true }
 grpc = { path = "../grpc" }
-num_cpus = "1.16.0"
+num_cpus = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.43.1", features = ["full"] }
-deployer-cluster = { path = "../../utils/deployer-cluster" }
-
-[dependencies.serde]
-features = ["derive"]
-version = "1.0.214"
+tokio = { workspace = true, features = ["full"] }
+deployer-cluster = { workspace = true }

--- a/control-plane/stor-port/Cargo.toml
+++ b/control-plane/stor-port/Cargo.toml
@@ -7,24 +7,24 @@ description = "Persistent store and transport associated information for the con
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-url = "2.5.4"
-uuid = { version = "1.11.0", features = ["v4"] }
-strum = "0.26.3"
-strum_macros = "0.26.4"
-serde_json = "1.0.132"
-percent-encoding = "2.3.1"
-tokio = { version = "1.43.1", features = ["full"] }
-serde = { version = "1.0.214", features = ["derive"] }
-serde_tuple = "1.0.0"
-async-trait = "0.1.83"
-dyn-clonable = "0.9.0"
-rand = "0.8.5"
-tonic = "0.12.3"
-chrono = { version = "0.4.38", features = ["serde"] }
-tracing = "0.1.40"
-prost-types = "0.13.3"
+url = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+serde_json = { workspace = true }
+percent-encoding = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_tuple = { workspace = true }
+async-trait = { workspace = true }
+dyn-clonable = { workspace = true }
+rand = { workspace = true }
+tonic = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+tracing = { workspace = true }
+prost-types = { workspace = true }
 
-openapi = { path = "../../openapi", features = [ "actix-server", "tower-client", "tower-trace" ] }
-platform = { path = "../../utils/dependencies/platform" }
-pstor = { path = "../../utils/pstor" }
-utils = { path = "../../utils/utils-lib" }
+openapi = { workspace = true, features = [ "actix-server", "tower-client", "tower-trace", "tower-client-rls" ] }
+platform = { workspace = true }
+pstor = { workspace = true }
+utils = { workspace = true }

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -15,24 +15,25 @@ name = "deployer_lib"
 path = "src/lib.rs"
 
 [dependencies]
-composer = { path = "../utils/dependencies/composer", default-features = false }
-stor-port = { path = "../control-plane/stor-port" }
-rpc = { path = "../rpc" }
-utils = { path = "../utils/utils-lib" }
-grpc = { path = "../control-plane/grpc" }
-clap = { version = "4.5.20", features = ["color", "derive", "env", "string"] }
-tokio = { version = "1.43.1", features = ["full"] }
-tonic = "0.12.3"
-async-trait = "0.1.83"
-hyper-util = "0.1.10"
-strum = "0.26.3"
-strum_macros = "0.26.4"
-paste = "1.0.15"
-humantime = "2.1.0"
-reqwest = { version = "0.12.9", default-features = false, features = ["multipart"] }
-futures = "0.3.31"
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tower = { version = "0.5.1", features = ["timeout", "util"] }
-events-api = { path = "../utils/dependencies/apis/events" }
-anyhow = "1.0.92"
+composer = { workspace = true, default-features = false }
+stor-port = { workspace = true }
+rpc = { workspace = true }
+utils = { workspace = true }
+grpc = { workspace = true }
+
+clap = { workspace = true, features = ["color", "derive", "env", "string"] }
+tokio = { workspace = true, features = ["full"] }
+tonic = { workspace = true }
+async-trait = { workspace = true }
+hyper-util = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+paste = { workspace = true }
+humantime = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["multipart"] }
+futures = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tower = { workspace = true, features = ["timeout", "util"] }
+events-api = { workspace = true }
+anyhow = { workspace = true }

--- a/k8s/forward/Cargo.toml
+++ b/k8s/forward/Cargo.toml
@@ -7,18 +7,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kube = { version = "0.94.2", features = ["ws"] }
-k8s-openapi = { version = "0.22.0", default-features = false, features = ["v1_24"] }
-tokio = { version = "1.43.1", features = ["full"] }
-tokio-stream = { version = "0.1.16", features = ["net"] }
-futures = "0.3.31"
-anyhow = "1.0.92"
-tracing = "0.1.40"
-shutdown = { path = "../../utils/shutdown" }
-tower = "0.5.1"
-hyper = { version = "1.5.0", features = ["client", "http1", "http2"] }
-hyper-body = { path = "../../utils/hyper-body" }
-thiserror = "1.0.68"
+kube = { workspace = true, features = ["ws"] }
+k8s-openapi = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true, features = ["net"] }
+futures = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+shutdown = { workspace = true }
+tower = { workspace = true }
+hyper = { workspace = true, features = ["client", "http1", "http2"] }
+hyper-body = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/k8s/operators/Cargo.toml
+++ b/k8s/operators/Cargo.toml
@@ -21,21 +21,21 @@ tls = ["openapi/tower-client-tls"]
 
 [dependencies]
 # CRD
-k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
-kube = { version = "0.94.2", features = ["derive", "runtime"] }
-schemars = { version = "0.8.21" }
-serde = { version = "1.0.214" }
-serde_json = { version = "1.0.132" }
+k8s-openapi = { workspace = true }
+kube = { workspace = true, features = ["derive", "runtime"] }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Binary
-openapi = { path = "../../openapi", default-features = false, features = ["tower-client", "tower-trace"], optional = true }
-utils = { path = "../../utils/utils-lib", optional = true }
-anyhow = { version = "1.0.92", optional = true }
-chrono = { version = "0.4.38", optional = true }
-clap = { version = "4.5.20", features = ["color", "env", "string"], optional = true }
-futures = { version = "0.3.31", optional = true }
-snafu = { version = "0.8.5", optional = true }
-tokio = { version = "1.43.1", features = ["full"], optional = true }
-humantime = { version = "2.1.0", optional = true }
-tracing = { version = "0.1.40", optional = true }
-parse-size = "1.1.0"
+openapi = { workspace = true, default-features = false, features = ["tower-client", "tower-trace"], optional = true }
+utils = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+clap = { workspace = true, features = ["color", "env", "string"], optional = true }
+futures = { workspace = true, optional = true }
+snafu = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
+humantime = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+parse-size = { workspace = true }

--- a/k8s/proxy/Cargo.toml
+++ b/k8s/proxy/Cargo.toml
@@ -13,15 +13,15 @@ tls = ["openapi/tower-client-tls"]
 
 [dependencies]
 kube-forward = { path = "../forward" }
-openapi = { path = "../../openapi", default-features = false, features = ["tower-trace"] }
-utils = { path = "../../utils/utils-lib" }
+openapi = { workspace = true, default-features = false, features = ["tower-trace"] }
+utils = { workspace = true }
 
-kube = { version = "0.94.2", features = ["derive"] }
-tower = { version = "0.5.1", features = ["timeout", "util"] }
-hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1", "http2", "tokio", "service"] }
-hyper = { version = "1.5.0", features = ["client", "http1", "http2"] }
-hyper-body = { path = "../../utils/hyper-body" }
+kube = { workspace = true, features = ["derive"] }
+tower = { workspace = true, features = ["timeout", "util"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2", "tokio", "service"] }
+hyper = { workspace = true, features = ["client", "http1", "http2"] }
+hyper-body = { workspace = true }
 
-anyhow = "1.0.92"
-thiserror = "1.0.68"
-url = "2.5.4"
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -24,43 +24,43 @@ rustls_ring = ["rustls_feat", "rustls/ring", "hyper-rustls/ring"]
 tower-trace = ["opentelemetry-otlp", "opentelemetry_sdk", "tracing-opentelemetry", "opentelemetry", "opentelemetry-http", "tracing", "tracing-subscriber"]
 
 [dependencies]
-serde = "^1.0"
-serde_derive = "^1.0"
-serde_json = "^1.0"
-url = { version = "^2.5", features = ["serde"] }
-async-trait = "0.1.83"
-dyn-clonable = "0.9.0"
-uuid = { version = "1.11.0", features = ["serde", "v4"] }
-serde_urlencoded = "0.7"
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+async-trait = { workspace = true }
+dyn-clonable = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
+serde_urlencoded = { workspace = true }
 
 # actix dependencies
-actix-web = { version = "4.9.0", features = ["rustls-0_23"], optional = true }
+actix-web = { workspace = true, optional = true }
 
-awc = { version = "3.5.1", optional = true }
+awc = { workspace = true, optional = true }
 # tower and hyper dependencies
-hyper = { version = "1.5.0", features = ["http1", "http2", "client"], optional = true }
-hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1", "http2", "tokio", "service"] }
-http-body-util = "0.1.2"
-tower = { version = "0.5.1", features = ["timeout", "util", "limit"], optional = true }
-tower-http = { version = "0.6.1", features = ["trace", "map-response-body", "auth"], optional = true }
-tokio = { version = "1.43.1", features = ["full"], optional = true }
-http-body = { version = "1.0.1", optional = true }
-futures = { version = "0.3.31", optional = true }
-pin-project = { version = "1.1.7", optional = true }
-hyper-body = { path = "../utils/hyper-body" }
+hyper = { workspace = true, features = ["http1", "http2", "client"], optional = true }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2", "tokio", "service"] }
+http-body-util = { workspace = true }
+tower = { workspace = true, features = ["timeout", "util", "limit"], optional = true }
+tower-http = { workspace = true, features = ["trace", "map-response-body", "auth"], optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
+http-body = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+pin-project = { workspace = true, optional = true }
+hyper-body = { workspace = true }
 
 # SSL
-rustls = { version = "0.23.19", default-features = false, optional = true }
-rustls-pemfile = "2.2.0"
-webpki = { version = "0.22.4", optional = true }
-hyper-rustls = { version = "0.27.3", default-features = false, optional = true }
-hyper-tls = { version = "0.6.0", optional = true }
-tokio-native-tls = { version = "0.3.1", optional = true }
+rustls = { workspace = true, default-features = false, optional = true }
+rustls-pemfile = { workspace = true }
+webpki = { workspace = true, optional = true }
+hyper-rustls = { workspace = true, default-features = false, features = ["rustls-native-certs"], optional = true }
+hyper-tls = { workspace = true, optional = true }
+tokio-native-tls = { workspace = true, optional = true }
 # tracing and telemetry
-opentelemetry-otlp = { version = "0.26.0", optional = true }
-opentelemetry_sdk = { version = "0.26.0", optional = true }
-tracing-opentelemetry = { version = "0.27.0", optional = true }
-opentelemetry = { version = "0.26.0", optional = true }
-opentelemetry-http = { version = "0.26.0", optional = true }
-tracing = { version = "0.1.40", optional = true }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"], optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry-http = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -4,16 +4,16 @@ version = "1.0.0"
 edition = "2021"
 
 [build-dependencies]
-tonic-build = "0.12.3"
+tonic-build = { workspace = true }
 
 [dependencies]
-tonic = "0.12.3"
-bytes = "1.8.0"
-prost = "0.13.3"
-prost-derive = "0.13.3"
-prost-types = "0.13.3"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_derive = "1.0.214"
-serde_json = "1.0.132"
-strum = "0.26.3"
-strum_macros = "0.26.4"
+tonic = { workspace = true }
+bytes = { workspace = true }
+prost = { workspace = true }
+prost-derive = { workspace = true }
+prost-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }

--- a/tests/io-engine/Cargo.toml
+++ b/tests/io-engine/Cargo.toml
@@ -12,7 +12,7 @@ name = "testlib"
 path = "src/lib.rs"
 
 [dev-dependencies]
-tokio = { version = "1.43.1", features = ["full"] }
+tokio = { version = "=1.45.1", features = ["full"] }
 openapi = { path = "../../openapi", features = ["tower-client", "tower-trace"] }
 deployer-cluster = { path = "../../utils/deployer-cluster" }
 stor-port = { path = "../../control-plane/stor-port" }
@@ -20,5 +20,5 @@ rpc = { path = "../../rpc" }
 grpc = { path = "../../control-plane/grpc" }
 utils = { path = "../../utils/utils-lib" }
 nvmeadm = { path = "../../utils/dependencies/nvmeadm" }
-tracing = "0.1.40"
-glob = "0.3.1"
+tracing = "0.1.43"
+glob = "0.3.3"

--- a/utils/bundle-sim/Cargo.toml
+++ b/utils/bundle-sim/Cargo.toml
@@ -4,18 +4,18 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-composer = { path = "../dependencies/composer", default-features = false }
-deployer = { path = "../../deployer" }
-stor-port = { path = "../../control-plane/stor-port" }
-rpc = { path = "../../rpc" }
-utils = { path = "../utils-lib" }
-clap = { version = "4.5.20", features = ["color", "derive", "env", "string"] }
-tokio = { version = "1.43.1", features = ["full"] }
-tonic = "0.12.3"
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-anyhow = "1.0.92"
-flate2 = "1.0"
-tar = "0.4"
-etcd-client = "0.14.0"
-serde_json = { version = "1.0.132" }
+composer = { workspace = true, default-features = false }
+deployer = { workspace = true }
+stor-port = { workspace = true }
+rpc = { workspace = true }
+utils = { workspace = true }
+clap = { workspace = true, features = ["color", "derive", "env", "string"] }
+tokio = { workspace = true, features = ["full"] }
+tonic = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+anyhow = { workspace = true }
+flate2 = { workspace = true }
+tar = { workspace = true }
+etcd-client = { workspace = true }
+serde_json = { workspace = true }

--- a/utils/deployer-cluster/Cargo.toml
+++ b/utils/deployer-cluster/Cargo.toml
@@ -7,28 +7,28 @@ description = "Create and Manage local deployer clusters"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.43.1", features = ["full"] }
-openapi = { path = "../../openapi", features = ["tower-client", "tower-trace"] }
-composer = { path = "../../utils/dependencies/composer", default-features = false }
-deployer = { path = "../../deployer" }
-rpc = { path = "../../rpc" }
+tokio = { workspace = true, features = ["full"] }
+openapi = { workspace = true, features = ["tower-client", "tower-trace"] }
+composer = { workspace = true, default-features = false }
+deployer = { workspace = true }
+rpc = { workspace = true }
 csi-driver = { path = "../../control-plane/csi-driver" }
-utils = { path = "../../utils/utils-lib" }
-anyhow = "1.0.92"
-stor-port = { path = "../../control-plane/stor-port" }
-clap = { version = "4.5.20", features = ["derive", "env", "string"] }
+utils = { workspace = true }
+anyhow = { workspace = true }
+stor-port = { workspace = true }
+clap = { workspace = true, features = ["derive", "env", "string"] }
 backtrace = "0.3.74"
-etcd-client = "0.14.0"
-grpc = { path = "../../control-plane/grpc" }
-tonic = "0.12.3"
-tower = { version = "0.5.1", features = ["timeout", "util"] }
-hyper-util = "0.1.10"
+etcd-client = { workspace = true }
+grpc = { workspace = true }
+tonic = { workspace = true }
+tower = { workspace = true, features = ["timeout", "util"] }
+hyper-util = { workspace = true }
 # Tracing
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tracing-opentelemetry = "0.27.0"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-opentelemetry = { workspace = true }
 # Open Telemetry
-opentelemetry = { version = "0.26.0" }
-opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio-current-thread"] }
-opentelemetry-otlp = { version = "0.26.0" }
-opentelemetry-semantic-conventions = "0.26.0"
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio-current-thread"] }
+opentelemetry-otlp = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }

--- a/utils/hyper-body/Cargo.toml
+++ b/utils/hyper-body/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hyper = { version = "1.5.0", default-features = false }
-http-body-util = { version = "0.1.2", default-features = false }
-tower = { version = "0.5.1", default-features = false }
+hyper = { workspace = true, default-features = false }
+http-body-util = { workspace = true, default-features = false }
+tower = { workspace = true, default-features = false }

--- a/utils/pstor-usage/Cargo.toml
+++ b/utils/pstor-usage/Cargo.toml
@@ -7,16 +7,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.43.1", features = ["full"] }
-openapi = { path = "../../openapi", default-features = false, features = ["tower-client", "tower-trace"] }
-deployer-cluster = { path = "../../utils/deployer-cluster" }
-utils = { path = "../utils-lib" }
-anyhow = "1.0.92"
-clap = { version = "4.5.20", features = ["color", "derive", "env", "string"] }
-parse-size = { version = "1.1.0", features = ["std"] }
-async-trait = "0.1.83"
-etcd-client = "0.14.0"
-prettytable-rs = "0.10.0"
-serde = "1.0.214"
-serde_yaml = "0.9.34"
-itertools = "0.13.0"
+tokio = { workspace = true, features = ["full"] }
+openapi = { workspace = true, default-features = false, features = ["tower-client", "tower-trace"] }
+deployer-cluster = { workspace = true }
+utils = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["color", "derive", "env", "string"] }
+parse-size = { workspace = true, features = ["std"] }
+async-trait = { workspace = true }
+etcd-client = { workspace = true }
+prettytable-rs = { workspace = true }
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+itertools = { workspace = true }

--- a/utils/pstor/Cargo.toml
+++ b/utils/pstor/Cargo.toml
@@ -6,21 +6,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-strum = "0.26.3"
-strum_macros = "0.26.4"
-serde_json = "1.0.132"
-tokio = { version = "1.43.1", features = ["full"] }
-snafu = "0.8.5"
-etcd-client = "0.14.0"
-serde = { version = "1.0.214", features = ["derive"] }
-async-trait = "0.1.83"
-tracing = "0.1.40"
-parking_lot = "0.12.3"
-utils = { path = "../utils-lib" }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+snafu = { workspace = true }
+etcd-client = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+parking_lot = { workspace = true }
+utils = { workspace = true }
 
 # Utils dependencies
-platform = { path = "../dependencies/platform" }
+platform = { workspace = true }
 
 [dev-dependencies]
-composer = { path = "../dependencies/composer" }
-tokio = { version = "1.43.1", features = ["full"] }
+composer = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/utils/shutdown/Cargo.toml
+++ b/utils/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.43.1", features = ["full"] }
-tracing = "0.1.40"
-lazy_static = "1.5.0"
-async-trait = "0.1.83"
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+lazy_static = { workspace = true }
+async-trait = { workspace = true }

--- a/utils/utils-lib/Cargo.toml
+++ b/utils/utils-lib/Cargo.toml
@@ -9,21 +9,21 @@ rls = ["event-publisher/rls-aws-lc-rs"]
 rls-ring = ["event-publisher/rls-ring"]
 
 [dependencies]
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
-tracing-opentelemetry = "0.27.0"
-tracing = "0.1.40"
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+tracing-opentelemetry = { workspace = true }
+tracing = { workspace = true }
 
-opentelemetry = { version = "0.26.0" }
+opentelemetry = { workspace = true }
 
-opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio-current-thread"] }
-opentelemetry-otlp = { version = "0.26.0" }
-opentelemetry-semantic-conventions = "0.26.0"
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio-current-thread"] }
+opentelemetry-otlp = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
 
-url = "2.5.4"
-strum = "0.26.3"
-strum_macros = "0.26.4"
-heck = "0.5.0"
-regex = "1.11.1"
+url = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+heck = { workspace = true }
+regex = { workspace = true }
 
 version-info = { path = "../dependencies/version-info", default-features = false }
 git-version-macro = { path = "../dependencies/git-version-macro" }


### PR DESCRIPTION
This will make crate upgrades easier to maintain.