### PR TITLE
Add pool diagnostics to the internal transport and agent-core

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
@@ -9,11 +9,9 @@ use crate::controller::{
     },
     task_poller::{PollContext, PollPeriods, PollResult, PollTimer, PollerState, TaskPoller},
 };
-
-use crate::controller::io_engine::PoolApi;
 use stor_port::types::v0::{
     store::pool::PoolSpec,
-    transport::{DestroyPool, ImportPool, NodeStatus},
+    transport::{DestroyPool, NodeStatus},
 };
 use tracing::Instrument;
 
@@ -149,13 +147,13 @@ async fn missing_pool_state_reconciler(
         async {
             pool_spec.warn_span(|| tracing::warn!("Attempting to import the pool"));
 
-            let request = ImportPool::new(&pool_spec.node, &pool_spec.id, &pool_spec.disks, &pool_spec.encryption);
-            match node.import_pool(&request).await {
+            match pool.import(context.registry(), &pool_spec, node).await {
                 Ok(_) => {
                     pool_spec.info_span(|| tracing::info!("Pool successfully imported"));
                     PollResult::Ok(PollerState::Idle)
                 }
                 Err(error) => {
+                    // todo: only if error is first runtime
                     pool_spec.error_span(
                         || tracing::error!(error=%error, "Failed to import the pool")
                     );

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -1,8 +1,6 @@
-use crate::controller::io_engine::HostApi;
-use crate::node::wrapper::NodeWrapper;
 use crate::{
     controller::{
-        io_engine::PoolApi,
+        io_engine::{HostApi, PoolApi},
         registry::Registry,
         resources::{
             operations::ResourceLifecycle,
@@ -10,25 +8,27 @@ use crate::{
             OperationGuardArc,
         },
     },
-    node::wrapper::GetterOps,
+    node::wrapper::{GetterOps, NodeWrapper},
 };
 use agents::{errors, errors::SvcError};
-use stor_port::transport_api::ResourceKind;
-use stor_port::types::v0::transport::{GetBlockDevices, PoolDeviceUri};
-use stor_port::types::v0::{
-    store::{
-        pool::PoolSpec,
-        replica::{PoolRef, ReplicaSpec},
+use stor_port::{
+    transport_api::ResourceKind,
+    types::v0::{
+        store::{
+            pool::{PoolImportOp, PoolOperation, PoolSpec},
+            replica::{PoolRef, ReplicaSpec},
+        },
+        transport::{
+            CreatePool, DestroyReplica, GetBlockDevices, ImportPool, NodeId, PoolDeviceUri,
+            PoolDiag, PoolDiskError, PoolError, PoolErrorCode, PoolState, ReplicaOwners,
+        },
     },
-    transport::{CreatePool, DestroyReplica, NodeId, ReplicaOwners},
 };
 
 use itertools::Itertools;
 use regex::Regex;
 use snafu::OptionExt;
-use std::collections::HashSet;
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{collections::HashSet, ops::Deref, sync::Arc};
 use tokio::sync::RwLock;
 
 impl OperationGuardArc<PoolSpec> {
@@ -58,6 +58,56 @@ impl OperationGuardArc<PoolSpec> {
             .await?;
 
         Ok(())
+    }
+
+    /// Attempt to import a pool.
+    /// # NOTE
+    /// In case the import fails, we try to map the failure reason into the pool diagnostics.
+    /// This should give the user more visibility into the failure.
+    pub(crate) async fn import(
+        &mut self,
+        registry: &Registry,
+        spec: &PoolSpec,
+        node: Arc<RwLock<NodeWrapper>>,
+    ) -> Result<PoolState, SvcError> {
+        let reporter = Arc::new(std::sync::Mutex::new(None));
+        let operation = PoolOperation::Import(PoolImportOp {
+            report: reporter.clone(),
+        });
+        let pool_spec = self.start_update(registry, spec, operation).await?;
+
+        let request = ImportPool::new(
+            &pool_spec.node,
+            &pool_spec.id,
+            &pool_spec.disks,
+            &pool_spec.encryption,
+        );
+        let result = node.import_pool(&request).await;
+        if let Err(error) = &result {
+            let code_map = |code: tonic::Code| -> PoolError {
+                let code = match code {
+                    tonic::Code::InvalidArgument => PoolErrorCode::InvalidSuperBlock,
+                    tonic::Code::NotFound => PoolErrorCode::DiskNotFound,
+                    _ => PoolErrorCode::Unknown,
+                };
+                // todo: this is rather long as it includes details and metadata... trim it?
+                let msg = error.to_string();
+                PoolError { code, msg }
+            };
+            match error.tonic_code() {
+                tonic::Code::NotFound | tonic::Code::InvalidArgument => {
+                    let disks = pool_spec.disks.first().map(|d| d.to_string());
+                    *reporter.lock().expect("not poisoned") = Some(PoolDiag {
+                        import_errors: vec![PoolDiskError {
+                            error: code_map(error.tonic_code()),
+                            disk: disks.unwrap_or_default(),
+                        }],
+                    });
+                }
+                _ => {}
+            }
+        }
+        self.complete_update(registry, result, pool_spec).await
     }
 
     /// Ge the `OnCreateFail` policy.

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -5,7 +5,7 @@ use stor_port::types::v0::{
         nexus_child::NexusChild,
         nexus_persistence::{ChildInfo, NexusInfo},
         node::NodeSpec,
-        pool::{PoolSpec, PoolSpecStatus},
+        pool::{PoolSpec, PoolSpecStatus, PoolUSpec},
         replica::{PoolRef, ReplicaSpec, ReplicaSpecStatus},
         volume::{TargetConfig, VolumeSpec, VolumeSpecStatus, VolumeTarget},
     },
@@ -139,25 +139,27 @@ fn test_deserialization_v1_to_v2() {
         TestEntry {
             json_str: r#"{"node":"mayastor-node1","id":"pool-1-on-mayastor-node1","disks":["/dev/sdb"],"status":{"Created":"Online"},"labels":{"org.com/created-by":"msp-operator"},"operation":null, "cluster_size":4194304}"#,
             expected: Expected::PoolSpec(PoolSpec {
-                node: "mayastor-node1".into(),
-                id: "pool-1-on-mayastor-node1".into(),
-                disks: vec!["/dev/sdb".into()],
-                status: PoolSpecStatus::Created(PoolStatus::Online),
-                labels: {
-                    let mut labels = HashMap::new();
-                    labels.insert(
-                        "org.com/created-by".to_string(),
-                        "msp-operator".to_string(),
-                    );
-                    Some(labels)
+                spec: PoolUSpec {
+                    node: "mayastor-node1".into(),
+                    id: "pool-1-on-mayastor-node1".into(),
+                    disks: vec!["/dev/sdb".into()],
+                    status: PoolSpecStatus::Created(PoolStatus::Online),
+                    labels: {
+                        let mut labels = HashMap::new();
+                        labels.insert(
+                            "org.com/created-by".to_string(),
+                            "msp-operator".to_string(),
+                        );
+                        Some(labels)
+                    },
+                    sequencer: Default::default(),
+                    operation: None,
+                    creat_tsc: None,
+                    encryption: None,
+                    cordon_drain: None,
+                    cluster_size: 4194304,
+                    max_expansion: None,
                 },
-                sequencer: Default::default(),
-                operation: None,
-                creat_tsc: None,
-                encryption: None,
-                cordon_drain: None,
-                cluster_size: 4194304,
-                max_expansion: None,
                 metadata: Default::default(),
             }),
         },

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -158,6 +158,7 @@ fn test_deserialization_v1_to_v2() {
                 cordon_drain: None,
                 cluster_size: 4194304,
                 max_expansion: None,
+                metadata: Default::default(),
             }),
         },
         TestEntry {

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -28,9 +28,9 @@ use stor_port::{
         },
         transport::{
             CreatePool, CreateReplica, DestroyPool, DestroyReplica, ExpandPool, Filter,
-            GetBlockDevices, GetSpecs, NexusId, NodeId, NodeStatus, Protocol, Replica, ReplicaId,
-            ReplicaName, ReplicaOwners, ReplicaShareProtocol, ReplicaStatus, ShareReplica,
-            UnshareReplica, Volume, VolumeId,
+            GetBlockDevices, GetSpecs, NexusId, NodeId, NodeStatus, PoolErrorCode, Protocol,
+            Replica, ReplicaId, ReplicaName, ReplicaOwners, ReplicaShareProtocol, ReplicaStatus,
+            ShareReplica, UnshareReplica, Volume, VolumeId,
         },
     },
 };
@@ -845,8 +845,9 @@ async fn reconciler_missing_pool_state() {
         .with_rest(true)
         .with_io_engines(1)
         .with_pool(0, disk.uri())
-        .with_cache_period("1s")
-        .with_reconcile_period(Duration::from_secs(1), Duration::from_millis(1))
+        .with_cache_period("100ms")
+        .with_node_deadline("100ms")
+        .with_reconcile_period(Duration::from_millis(200), Duration::from_millis(1))
         .build()
         .await
         .unwrap();
@@ -880,7 +881,7 @@ async fn reconciler_missing_pool_state() {
     let maya = cluster.node(0);
     async fn pool_checker(cluster: &Cluster, state: Option<&PoolState>) {
         let maya = cluster.node(0);
-        let tm = Duration::from_secs(3);
+        let tm = Duration::from_secs(1);
 
         let pool = wait_till_pool_state(cluster, (0, 0), false, tm).await;
         assert!(pool.state.is_none());
@@ -907,6 +908,19 @@ async fn reconciler_missing_pool_state() {
     let new_disk = deployer_cluster::TmpDiskFile::new(POOL_FILE_NAME, POOL_SIZE_BYTES);
     pool_checker(&cluster, None).await;
 
+    let pool_client = cluster.grpc_client().pool();
+    let pools = pool_client
+        .get(Filter::Pool(pool.id.clone().into()), None)
+        .await
+        .unwrap();
+    tracing::info!("Pools: {:?}", pools);
+
+    let hpool = pools.0.first().unwrap();
+    let pool_diag = hpool.diag.as_ref().unwrap();
+    assert_eq!(pool_diag.import_errors.len(), 1);
+    let error = pool_diag.import_errors.first().unwrap();
+    assert_eq!(error.error.code, PoolErrorCode::InvalidSuperBlock);
+
     // move original disk back and now import should succeed!
     drop(new_disk);
     disk.rename(POOL_FILE_NAME).unwrap();
@@ -925,6 +939,28 @@ async fn reconciler_missing_pool_state() {
             .sorted_by(|a, b| a.uuid.cmp(&b.uuid))
             .collect::<Vec<_>>()
     );
+
+    cluster.composer().kill(maya.as_str()).await.unwrap();
+
+    // move pool disk to another location
+    // this means import should fail with not found error
+    assert_ne!(POOL_FILE_NAME, POOL_FILE_NAME_2);
+    disk.rename(POOL_FILE_NAME_2).unwrap();
+
+    pool_checker(&cluster, None).await;
+
+    let pool_client = cluster.grpc_client().pool();
+    let pools = pool_client
+        .get(Filter::Pool(pool.id.clone().into()), None)
+        .await
+        .unwrap();
+    tracing::info!("Pools: {:?}", pools);
+
+    let hpool = pools.0.first().unwrap();
+    let pool_diag = hpool.diag.as_ref().unwrap();
+    assert_eq!(pool_diag.import_errors.len(), 1);
+    let error = pool_diag.import_errors.first().unwrap();
+    assert_eq!(error.error.code, PoolErrorCode::DiskNotFound);
 }
 
 /// Wait until the specified pool state option presence matches the `has_state` flag
@@ -953,7 +989,7 @@ async fn wait_till_pool_state(
                 "Timeout waiting for the pool to have 'has_state': '{has_state}'. Pool: '{pool:#?}'"
             );
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_millis(250)).await;
     }
 }
 

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -468,7 +468,7 @@ impl OperationGuardArc<VolumeSnapshot> {
         let source = replica_snapshot.spec().source_id();
 
         // Get the pool using the replica snapshot's pool and extract the node_id.
-        let node_id = specs.pool(source.pool_id())?.node;
+        let node_id = specs.pool(source.pool_id())?.spec.node;
 
         // Get the corresponding node wrapper for the same.
         let node_wrapper = registry.node_wrapper(&node_id).await?;
@@ -491,7 +491,7 @@ impl OperationGuardArc<VolumeSnapshot> {
         // Get the list of nodes from the list of replica_snaps.
         for snap in txns.flat_map(|(_, v)| v) {
             if let Ok(pool_spec) = registry.specs().pool(snap.spec().source_id().pool_id()) {
-                nodes.insert(pool_spec.node);
+                nodes.insert(pool_spec.spec.node);
             }
         }
         // If at least one node is online return true.

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -8,7 +8,6 @@ use stor_port::{
         },
     },
 };
-use tonic::Code;
 
 /// Common error type for send/receive
 #[derive(Debug, Snafu)]
@@ -141,7 +140,7 @@ pub enum SvcError {
         pools: String,
         reason: String,
         kind: ResourceKind,
-        code: Code,
+        code: tonic::Code,
     },
     #[snafu(display("{} '{}' not found", kind.to_string(), id))]
     NotFound { kind: ResourceKind, id: String },
@@ -1189,6 +1188,7 @@ fn grpc_to_reply_error(error: SvcError) -> ReplyError {
             request,
             resource,
         } => {
+            use tonic::Code;
             let kind = match source.code() {
                 Code::Ok => ReplyErrorKind::Internal,
                 Code::Cancelled => ReplyErrorKind::Cancelled,

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -5,6 +5,36 @@ import "google/protobuf/wrappers.proto";
 
 package v1.pool;
 
+message PoolDiag {
+  // Errors encountered when importing the pool.
+  repeated DiskError import_errors = 2;
+}
+message DiskError {
+  string disk = 1;
+  ProbeError error = 2;
+}
+enum ProbeErrorCode {
+  // Unknown error
+  ProbeUnknown = 0;
+  // Disk not found in the system
+  DiskNotFound = 1;
+  // Disk read IO errors
+  DiskReadIoError = 2;
+  // Pool on-disk name doesn't match the expected
+  ForeignPoolName = 3;
+  // Pool on-disk uuid doesn't match the expected
+  ForeignPoolUid = 4;
+  // Failed to check super block error
+  SuperBlock = 5;
+  // Invalid super block (eg: CRC error)
+  InvalidSuperBlock = 6;
+}
+message ProbeError {
+  ProbeErrorCode code = 1;
+  // additional as human readable
+  string          msg = 2;
+}
+
 // An IoEngine Storage Pool
 // It may have a spec which is the specification provided by the creator
 // It may have a state if such state is retrieved from a io-engine storage node
@@ -13,6 +43,8 @@ message Pool {
   optional PoolDefinition definition = 1;
   // Runtime state of the pool as seen by the dataplane.
   optional PoolState state = 2;
+  // Diagnostic information about the pool
+  optional PoolDiag diag = 3;
 }
 
 // Multiple pools

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -13,7 +13,7 @@ use stor_port::{
     types::v0::{
         store::pool::{
             CordonDrainState, CordonedState, Encryption, EncryptionSecret, PoolLabel, PoolMetadata,
-            PoolRuntimeMetadata, PoolSpec, PoolSpecStatus, POOL_BS_CLUSTER_SIZE_DEFAULT,
+            PoolRuntimeMetadata, PoolSpec, PoolSpecStatus, PoolUSpec, POOL_BS_CLUSTER_SIZE_DEFAULT,
         },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, ExpandPool, Filter, LabelPool, NodeId, Pool,
@@ -95,37 +95,39 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
             }
         };
         Ok(PoolSpec {
-            node: pool_spec.node_id.into(),
-            id: pool_spec.pool_id.into(),
-            disks: pool_spec.disks.iter().map(|i| i.into()).collect(),
-            status: pool_spec_status,
-            labels: match pool_spec.labels {
-                Some(labels) => Some(labels.value),
-                None => None,
-            },
-            sequencer: Default::default(),
-            operation: None,
-            creat_tsc: None,
-            encryption: pool_spec
-                .secret
-                .map(|details| Encryption::Secret(EncryptionSecret { name: details.name })),
-            cordon_drain: match pool_spec.cordon_drain {
-                Some(state) => match state {
-                    pool::pool_spec::CordonDrain::Cordoned(state) => {
-                        Some(CordonDrainState::Cordoned(CordonedState {
-                            replicas: state.replicas,
-                            snapshots: state.snapshots,
-                            restores: state.restores,
-                            import: state.import,
-                        }))
-                    }
+            spec: PoolUSpec {
+                node: pool_spec.node_id.into(),
+                id: pool_spec.pool_id.into(),
+                disks: pool_spec.disks.iter().map(|i| i.into()).collect(),
+                status: pool_spec_status,
+                labels: match pool_spec.labels {
+                    Some(labels) => Some(labels.value),
+                    None => None,
                 },
-                None => None,
+                sequencer: Default::default(),
+                operation: None,
+                creat_tsc: None,
+                encryption: pool_spec
+                    .secret
+                    .map(|details| Encryption::Secret(EncryptionSecret { name: details.name })),
+                cordon_drain: match pool_spec.cordon_drain {
+                    Some(state) => match state {
+                        pool::pool_spec::CordonDrain::Cordoned(state) => {
+                            Some(CordonDrainState::Cordoned(CordonedState {
+                                replicas: state.replicas,
+                                snapshots: state.snapshots,
+                                restores: state.restores,
+                                import: state.import,
+                            }))
+                        }
+                    },
+                    None => None,
+                },
+                cluster_size: pool_spec
+                    .cluster_size
+                    .unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
+                max_expansion: None,
             },
-            cluster_size: pool_spec
-                .cluster_size
-                .unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
-            max_expansion: None,
             metadata: Default::default(),
         })
     }
@@ -203,8 +205,8 @@ impl TryFrom<pool::Pool> for Pool {
     }
 }
 
-impl From<PoolSpec> for pool::PoolDefinition {
-    fn from(pool_spec: PoolSpec) -> Self {
+impl From<PoolUSpec> for pool::PoolDefinition {
+    fn from(pool_spec: PoolUSpec) -> Self {
         let spec_status: common::SpecStatus = pool_spec.status.into();
         pool::PoolDefinition {
             spec: Some(pool::PoolSpec {

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -17,7 +17,8 @@ use stor_port::{
         },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, ExpandPool, Filter, LabelPool, NodeId, Pool,
-            PoolDeviceUri, PoolId, PoolState, PoolStatus, UnlabelPool, VolumeId,
+            PoolDeviceUri, PoolDiag, PoolDiskError, PoolErrorCode, PoolId, PoolState, PoolStatus,
+            UnlabelPool, VolumeId,
         },
     },
     IntoOption,
@@ -246,13 +247,40 @@ impl From<PoolState> for pool::PoolState {
     }
 }
 
+impl From<PoolErrorCode> for pool::ProbeErrorCode {
+    fn from(value: PoolErrorCode) -> Self {
+        match value {
+            PoolErrorCode::ProbeUnknown => Self::ProbeUnknown,
+            PoolErrorCode::DiskNotFound => Self::DiskNotFound,
+            PoolErrorCode::DiskReadIoError => Self::DiskReadIoError,
+            PoolErrorCode::ForeignPoolName => Self::ForeignPoolName,
+            PoolErrorCode::ForeignPoolUid => Self::ForeignPoolUid,
+            PoolErrorCode::SuperBlock => Self::SuperBlock,
+            PoolErrorCode::InvalidSuperBlock => Self::InvalidSuperBlock,
+        }
+    }
+}
+impl From<PoolDiag> for pool::PoolDiag {
+    fn from(diag: PoolDiag) -> Self {
+        let import_error = |value: PoolDiskError| pool::DiskError {
+            error: Some(pool::ProbeError {
+                code: pool::ProbeErrorCode::from(value.error.code) as i32,
+                msg: value.error.msg,
+            }),
+            disk: value.disk,
+        };
+        Self {
+            import_errors: diag.import_errors.into_iter().map(import_error).collect(),
+        }
+    }
+}
+
 impl From<Pool> for pool::Pool {
     fn from(pool: Pool) -> Self {
-        let definition = pool.spec().map(|pool_spec| pool_spec.into());
-        let state = pool.ctrl_state();
         pool::Pool {
-            definition,
-            state: state.map(|p| p.state()).cloned().into_opt(),
+            definition: pool.spec.map(|pool_spec| pool_spec.into()),
+            state: pool.state.map(|p| p.state).into_opt(),
+            diag: pool.diag.map(Into::into),
         }
     }
 }

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -12,13 +12,13 @@ use stor_port::{
     transport_api::{v0::Pools, ReplyError, ResourceKind},
     types::v0::{
         store::pool::{
-            CordonDrainState, CordonedState, Encryption, EncryptionSecret, PoolLabel, PoolSpec,
-            PoolSpecStatus, POOL_BS_CLUSTER_SIZE_DEFAULT,
+            CordonDrainState, CordonedState, Encryption, EncryptionSecret, PoolLabel, PoolMetadata,
+            PoolRuntimeMetadata, PoolSpec, PoolSpecStatus, POOL_BS_CLUSTER_SIZE_DEFAULT,
         },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, ExpandPool, Filter, LabelPool, NodeId, Pool,
-            PoolDeviceUri, PoolDiag, PoolDiskError, PoolErrorCode, PoolId, PoolState, PoolStatus,
-            UnlabelPool, VolumeId,
+            PoolDeviceUri, PoolDiag, PoolDiskError, PoolError, PoolErrorCode, PoolId, PoolState,
+            PoolStatus, UnlabelPool, VolumeId,
         },
     },
     IntoOption,
@@ -126,6 +126,7 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
                 .cluster_size
                 .unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
             max_expansion: None,
+            metadata: Default::default(),
         })
     }
 }
@@ -161,6 +162,18 @@ impl TryFrom<pool::PoolState> for PoolState {
     }
 }
 
+fn pool_with_diag(mut pool_spec: PoolSpec, diag: Option<pool::PoolDiag>) -> PoolSpec {
+    if let Some(diag) = diag {
+        pool_spec.metadata = PoolMetadata {
+            persisted: Default::default(),
+            runtime: PoolRuntimeMetadata {
+                diag: Some(diag.into()),
+            },
+        };
+    }
+    pool_spec
+}
+
 impl TryFrom<pool::Pool> for Pool {
     type Error = ReplyError;
     fn try_from(pool: pool::Pool) -> Result<Self, Self::Error> {
@@ -174,8 +187,12 @@ impl TryFrom<pool::Pool> for Pool {
 
         let pool_spec = match pool.definition {
             None => None,
-            Some(pool_definition) => Some(PoolSpec::try_from(pool_definition)?),
+            Some(pool_definition) => Some(pool_with_diag(
+                PoolSpec::try_from(pool_definition)?,
+                pool.diag,
+            )),
         };
+
         match Pool::try_new(pool_spec, state) {
             Some(pool) => Ok(pool),
             None => Err(ReplyError::missing_argument(
@@ -250,7 +267,7 @@ impl From<PoolState> for pool::PoolState {
 impl From<PoolErrorCode> for pool::ProbeErrorCode {
     fn from(value: PoolErrorCode) -> Self {
         match value {
-            PoolErrorCode::ProbeUnknown => Self::ProbeUnknown,
+            PoolErrorCode::Unknown => Self::ProbeUnknown,
             PoolErrorCode::DiskNotFound => Self::DiskNotFound,
             PoolErrorCode::DiskReadIoError => Self::DiskReadIoError,
             PoolErrorCode::ForeignPoolName => Self::ForeignPoolName,
@@ -267,6 +284,38 @@ impl From<PoolDiag> for pool::PoolDiag {
                 code: pool::ProbeErrorCode::from(value.error.code) as i32,
                 msg: value.error.msg,
             }),
+            disk: value.disk,
+        };
+        Self {
+            import_errors: diag.import_errors.into_iter().map(import_error).collect(),
+        }
+    }
+}
+impl From<pool::ProbeErrorCode> for PoolErrorCode {
+    fn from(value: pool::ProbeErrorCode) -> Self {
+        match value {
+            pool::ProbeErrorCode::ProbeUnknown => Self::Unknown,
+            pool::ProbeErrorCode::DiskNotFound => Self::DiskNotFound,
+            pool::ProbeErrorCode::DiskReadIoError => Self::DiskReadIoError,
+            pool::ProbeErrorCode::ForeignPoolName => Self::ForeignPoolName,
+            pool::ProbeErrorCode::ForeignPoolUid => Self::ForeignPoolUid,
+            pool::ProbeErrorCode::SuperBlock => Self::SuperBlock,
+            pool::ProbeErrorCode::InvalidSuperBlock => Self::InvalidSuperBlock,
+        }
+    }
+}
+impl From<pool::PoolDiag> for PoolDiag {
+    fn from(diag: pool::PoolDiag) -> Self {
+        let import_error = |value: pool::DiskError| PoolDiskError {
+            error: {
+                let error = value.error.unwrap();
+                PoolError {
+                    code: PoolErrorCode::from(
+                        pool::ProbeErrorCode::try_from(error.code).unwrap_or_default(),
+                    ),
+                    msg: error.msg,
+                }
+            },
             disk: value.disk,
         };
         Self {

--- a/control-plane/grpc/src/operations/registry/traits.rs
+++ b/control-plane/grpc/src/operations/registry/traits.rs
@@ -119,7 +119,7 @@ impl From<transport::Specs> for registry::Specs {
             pools: value
                 .pools
                 .into_iter()
-                .map(|pool_spec| pool_spec.into())
+                .map(|pool_spec| pool_spec.spec.into())
                 .collect(),
             nexuses: value
                 .nexuses

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -1,12 +1,15 @@
 //! Definition of pool types that can be saved to the persistent store.
 
-use crate::types::v0::{
-    openapi::{models, models::PoolSpecEncryption},
-    store::{
-        definitions::{ObjectKey, StorableObject, StorableObjectType},
-        AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
+use crate::{
+    types::v0::{
+        openapi::{models, models::PoolSpecEncryption},
+        store::{
+            definitions::{ObjectKey, StorableObject, StorableObjectType},
+            AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
+        },
+        transport::{self, CreatePool, ImportPool, NodeId, PoolDeviceUri, PoolDiag, PoolId},
     },
-    transport::{self, CreatePool, ImportPool, NodeId, PoolDeviceUri, PoolId},
+    IntoOption,
 };
 
 pub const POOL_BS_CLUSTER_SIZE_DEFAULT: u32 = 4194304;
@@ -18,7 +21,6 @@ pub fn default_pool_cluster_size() -> u32 {
 // PoolLabel is the type for the labels
 pub type PoolLabel = HashMap<String, String>;
 
-use crate::IntoOption;
 use pstor::ApiVersion;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::From, fmt::Debug};
@@ -65,6 +67,7 @@ impl From<&CreatePool> for PoolSpec {
             // Default is 4MiB today.
             cluster_size: request.cluster_size.unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
             max_expansion: request.max_expansion.clone(),
+            metadata: PoolMetadata::default(),
         }
     }
 }
@@ -141,6 +144,32 @@ pub struct PoolSpec {
     /// Maximum expansion size for this pool.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_expansion: Option<String>,
+    /// Pool metadata information.
+    #[serde(default, skip_serializing_if = "super::is_default")]
+    pub metadata: PoolMetadata,
+}
+
+/// Pool meta information.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct PoolMetadata {
+    /// Persisted metadata information.
+    #[serde(default, skip_serializing_if = "super::is_default")]
+    pub persisted: PoolPersistedMetadata,
+    /// Runtime information, useful to quick checks without having to read out from PSTOR
+    /// or any other control-plane related registry.
+    #[serde(skip)]
+    pub runtime: PoolRuntimeMetadata,
+}
+
+/// Pool meta information.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct PoolPersistedMetadata {}
+
+/// Runtime pool information.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct PoolRuntimeMetadata {
+    /// Diagnostic info for the pool.
+    pub diag: Option<PoolDiag>,
 }
 
 impl PoolSpec {
@@ -341,13 +370,23 @@ impl SpecTransaction<PoolOperation> for PoolSpec {
                 PoolOperation::Uncordon(op) => {
                     self.uncordon(op);
                 }
+                PoolOperation::Import(_) => {
+                    self.metadata.runtime.diag = None;
+                }
             }
         }
         self.clear_op();
     }
 
     fn clear_op(&mut self) {
-        self.operation = None;
+        let Some(op) = self.operation.take() else {
+            return;
+        };
+        if let PoolOperation::Import(op) = &op.operation {
+            if let Some(h) = op.report.lock().expect("not poisoned").take() {
+                self.metadata.runtime.diag = Some(h);
+            }
+        }
     }
 
     fn start_op(&mut self, operation: PoolOperation) {
@@ -378,6 +417,7 @@ impl SpecTransaction<PoolOperation> for PoolSpec {
             PoolOperation::Unlabel(_) => (false, true),
             PoolOperation::Cordon(_) => (false, true),
             PoolOperation::Uncordon(_) => (false, true),
+            PoolOperation::Import(_) => (false, false),
         }
     }
 }
@@ -391,6 +431,20 @@ pub enum PoolOperation {
     Unlabel(PoolUnLabelOp),
     Cordon(PoolCordonOp),
     Uncordon(PoolCordonOp),
+    Import(PoolImportOp),
+}
+
+/// Pool importing info.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PoolImportOp {
+    /// The report which is used to retrieve the pool diagnostic info.
+    #[serde(skip)]
+    pub report: std::sync::Arc<std::sync::Mutex<Option<PoolDiag>>>,
+}
+impl PartialEq for PoolImportOp {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 
 /// Parameter for adding/removing pool cordons.

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -23,7 +23,12 @@ pub type PoolLabel = HashMap<String, String>;
 
 use pstor::ApiVersion;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::From, fmt::Debug};
+use std::{
+    collections::HashMap,
+    convert::From,
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 /// Pool data structure used by the persistent store.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -54,19 +59,21 @@ pub type PoolSpecStatus = SpecStatus<transport::PoolStatus>;
 impl From<&CreatePool> for PoolSpec {
     fn from(request: &CreatePool) -> Self {
         Self {
-            node: request.node.clone(),
-            id: request.id.clone(),
-            disks: request.disks.clone(),
-            status: PoolSpecStatus::Creating,
-            labels: request.labels.clone(),
-            sequencer: OperationSequence::new(),
-            operation: None,
-            creat_tsc: None,
-            encryption: request.encryption.clone(),
-            cordon_drain: None,
-            // Default is 4MiB today.
-            cluster_size: request.cluster_size.unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
-            max_expansion: request.max_expansion.clone(),
+            spec: PoolUSpec {
+                node: request.node.clone(),
+                id: request.id.clone(),
+                disks: request.disks.clone(),
+                status: PoolSpecStatus::Creating,
+                labels: request.labels.clone(),
+                sequencer: OperationSequence::new(),
+                operation: None,
+                creat_tsc: None,
+                encryption: request.encryption.clone(),
+                cordon_drain: None,
+                // Default is 4MiB today.
+                cluster_size: request.cluster_size.unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
+                max_expansion: request.max_expansion.clone(),
+            },
             metadata: PoolMetadata::default(),
         }
     }
@@ -112,6 +119,28 @@ pub struct EncryptionSecret {
 /// User specification of a pool.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct PoolSpec {
+    #[serde(flatten)]
+    pub spec: PoolUSpec,
+    /// Pool metadata information.
+    #[serde(default, skip_serializing_if = "super::is_default")]
+    pub metadata: PoolMetadata,
+}
+
+impl Deref for PoolSpec {
+    type Target = PoolUSpec;
+    fn deref(&self) -> &Self::Target {
+        &self.spec
+    }
+}
+impl DerefMut for PoolSpec {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.spec
+    }
+}
+
+/// User specification of a pool.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct PoolUSpec {
     /// id of the io-engine instance
     pub node: NodeId,
     /// id of the pool
@@ -144,9 +173,6 @@ pub struct PoolSpec {
     /// Maximum expansion size for this pool.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_expansion: Option<String>,
-    /// Pool metadata information.
-    #[serde(default, skip_serializing_if = "super::is_default")]
-    pub metadata: PoolMetadata,
 }
 
 /// Pool meta information.
@@ -314,6 +340,13 @@ impl AsOperationSequencer for PoolSpec {
 
 impl From<PoolSpec> for models::PoolSpec {
     fn from(src: PoolSpec) -> Self {
+        let spec = src.spec;
+        Self::from(spec)
+    }
+}
+
+impl From<PoolUSpec> for models::PoolSpec {
+    fn from(src: PoolUSpec) -> Self {
         let encryption = match src.encryption {
             None => None,
             Some(encr) => match encr {

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -85,7 +85,7 @@ impl Deref for CtrlPoolState {
 pub enum PoolErrorCode {
     /// Unknown error
     #[default]
-    ProbeUnknown,
+    Unknown,
     /// Disk not found in the system
     DiskNotFound,
     /// Disk read IO errors
@@ -222,7 +222,8 @@ pub struct Pool {
     pub spec: Option<PoolSpec>,
     /// Runtime state of the pool.
     pub state: Option<CtrlPoolState>,
-    /// Diagnostic information for the pool.
+    /// Health of the pool.
+    /// todo: is this needed since we have it on the "spec" misnomer.
     pub diag: Option<PoolDiag>,
 }
 
@@ -231,27 +232,29 @@ impl Pool {
     pub fn new(spec: PoolSpec, state: Option<CtrlPoolState>) -> Self {
         Self {
             id: spec.id.clone(),
+            diag: spec.metadata.runtime.diag.clone(),
             spec: Some(spec),
             state,
-            diag: None,
         }
     }
     /// Construct a new pool with spec but no state.
     pub fn from_spec(spec: PoolSpec) -> Self {
         Self {
             id: spec.id.clone(),
+            diag: spec.metadata.runtime.diag.clone(),
             spec: Some(spec),
             state: None,
-            diag: None,
         }
     }
     /// Construct a new pool with optional spec and state.
     pub fn from_state(state: CtrlPoolState, spec: Option<PoolSpec>) -> Self {
         Self {
             id: state.id.clone(),
+            diag: spec
+                .as_ref()
+                .and_then(|spec| spec.metadata.runtime.diag.clone()),
             spec,
             state: Some(state),
-            diag: None,
         }
     }
     /// Try to construct a new pool from spec and state.

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -60,7 +60,7 @@ impl From<PoolStatus> for models::PoolStatus {
 #[serde(rename_all = "camelCase")]
 pub struct CtrlPoolState {
     /// The state, mostly as returned by the data-plane.
-    state: PoolState,
+    pub state: PoolState,
 }
 impl CtrlPoolState {
     /// Construct a new pool with spec and state.
@@ -78,6 +78,52 @@ impl Deref for CtrlPoolState {
     fn deref(&self) -> &Self::Target {
         &self.state
     }
+}
+
+/// Different pool errors
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub enum PoolErrorCode {
+    /// Unknown error
+    #[default]
+    ProbeUnknown,
+    /// Disk not found in the system
+    DiskNotFound,
+    /// Disk read IO errors
+    DiskReadIoError,
+    /// Pool on-disk name doesn't match the expected
+    ForeignPoolName,
+    /// Pool on-disk uuid doesn't match the expected
+    ForeignPoolUid,
+    /// Failed to check super block error
+    SuperBlock,
+    /// Invalid super block (eg: CRC error)
+    InvalidSuperBlock,
+}
+
+/// Pool error code and human-readable message.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct PoolError {
+    /// Code of the encountered error.
+    pub code: PoolErrorCode,
+    /// Human-readable message.
+    pub msg: String,
+}
+
+/// Pool Disk Errors.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct PoolDiskError {
+    /// Affected Disk.
+    pub disk: String,
+    /// Error encountered.
+    pub error: PoolError,
+}
+
+/// Pool diagnostic information.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PoolDiag {
+    /// Errors encountered when trying to import the pool.
+    pub import_errors: Vec<PoolDiskError>,
 }
 
 /// Pool state information - as reported by the io-engine.
@@ -167,15 +213,17 @@ impl PartialOrd for PoolStatus {
 /// A Storage Pool.
 /// It may have a spec which is the specification provided by the creator.
 /// It may have a state if such state is retrieved from a storage node.
-#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Pool {
     /// Pool identification.
     id: PoolId,
     /// Desired specification of the pool.
-    spec: Option<PoolSpec>,
+    pub spec: Option<PoolSpec>,
     /// Runtime state of the pool.
-    state: Option<CtrlPoolState>,
+    pub state: Option<CtrlPoolState>,
+    /// Diagnostic information for the pool.
+    pub diag: Option<PoolDiag>,
 }
 
 impl Pool {
@@ -185,6 +233,7 @@ impl Pool {
             id: spec.id.clone(),
             spec: Some(spec),
             state,
+            diag: None,
         }
     }
     /// Construct a new pool with spec but no state.
@@ -193,6 +242,7 @@ impl Pool {
             id: spec.id.clone(),
             spec: Some(spec),
             state: None,
+            diag: None,
         }
     }
     /// Construct a new pool with optional spec and state.
@@ -201,6 +251,7 @@ impl Pool {
             id: state.id.clone(),
             spec,
             state: Some(state),
+            diag: None,
         }
     }
     /// Try to construct a new pool from spec and state.

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::{
-    types::v0::store::pool::{Encryption, EncryptionSecret, PoolLabel, PoolSpec},
+    types::v0::store::pool::{Encryption, EncryptionSecret, PoolLabel, PoolSpec, PoolUSpec},
     IntoOption,
 };
 use serde::{Deserialize, Serialize};
@@ -219,7 +219,7 @@ pub struct Pool {
     /// Pool identification.
     id: PoolId,
     /// Desired specification of the pool.
-    pub spec: Option<PoolSpec>,
+    pub spec: Option<PoolUSpec>,
     /// Runtime state of the pool.
     pub state: Option<CtrlPoolState>,
     /// Health of the pool.
@@ -233,7 +233,7 @@ impl Pool {
         Self {
             id: spec.id.clone(),
             diag: spec.metadata.runtime.diag.clone(),
-            spec: Some(spec),
+            spec: Some(spec.spec),
             state,
         }
     }
@@ -242,7 +242,7 @@ impl Pool {
         Self {
             id: spec.id.clone(),
             diag: spec.metadata.runtime.diag.clone(),
-            spec: Some(spec),
+            spec: Some(spec.spec),
             state: None,
         }
     }
@@ -253,7 +253,7 @@ impl Pool {
             diag: spec
                 .as_ref()
                 .and_then(|spec| spec.metadata.runtime.diag.clone()),
-            spec,
+            spec: spec.map(|s| s.spec),
             state: Some(state),
         }
     }
@@ -267,7 +267,7 @@ impl Pool {
         }
     }
     /// Get the pool spec.
-    pub fn spec(&self) -> Option<PoolSpec> {
+    pub fn spec(&self) -> Option<PoolUSpec> {
         self.spec.clone()
     }
     /// Get the pool identification.


### PR DESCRIPTION
    refactor(pstor/pool): split pool spec types
    
    As with other types, the pool pstor info was incorrectly stored as the spec.
    This makes it harder to separate user spec and other information.
    
    For now we simply create an innter type PoolUSpec which is basically the user
    specification of a pool.
    This allows us to transport pool spec and pool diag separately.
    
---

    test(pool/diag): add pool diag info check to pool reconciler
    
    Tests both disk not found and invalid superblock.
    
---

    feat(pool/diag): collect import errors during pool import
    
    When pool import fails, collect error reason.
    This is stored in runtime information within the PoolSpec.
    
    A downside of this is that the PoolSpec in the pstor, alike the volume,
    is now a misnomer.
    In the future we should introduce an upgrade way of updating the entries.
    
---

    feat(pool/diag): add grpc proto and transport interface
