### PR TITLE
Support MultiNodeMultiWriter for block volumes (kubevirt)

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -58,7 +58,7 @@ jobs:
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
           sudo dpkg-reconfigure man-db || true
           sudo sysctl -w vm.nr_hugepages=3072
-          sudo apt-get update
+          sudo apt-get update || (sleep 5; sudo apt-get update)
           sudo apt-get install linux-modules-extra-$(uname -r)
           sudo modprobe nvme_tcp
           # Check if nvme config is valid, otherwise apply it

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -63,7 +63,7 @@ jobs:
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
           sudo dpkg-reconfigure man-db || true
           sudo sysctl -w vm.nr_hugepages=2560
-          sudo apt-get update
+          sudo apt-get update || (sleep 5; sudo apt-get update)
           sudo apt-get install linux-modules-extra-$(uname -r)
           sudo modprobe nvme_tcp
           # Check if nvme config is valid, otherwise apply it

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -534,11 +534,11 @@ pub(super) async fn fixup_nexus_protocol(
             if nexus_spec.share.shared() {
                 match NexusShareProtocol::try_from(nexus_spec.share) {
                     Ok(protocol) => {
-                        let allowed_host = nexus.lock().allowed_hosts.clone();
+                        let allowed_hosts = nexus_spec.allowed_hosts.clone();
                         nexus
                             .share(
                                 context.registry(),
-                                &ShareNexus::new(&nexus_state, protocol, allowed_host),
+                                &ShareNexus::new(&nexus_state, protocol, allowed_hosts),
                             )
                             .await?;
                         nexus_spec
@@ -549,6 +549,33 @@ pub(super) async fn fixup_nexus_protocol(
                             tracing::error!(error=%error, "Invalid configuration for nexus protocol, cannot apply it...")
                         });
                     }
+                }
+            }
+        } else if nexus_state.allowed_hosts != nexus_spec.allowed_hosts {
+            nexus_spec.warn_span(|| {
+                tracing::warn!(
+                    "Attempting to fix nexus share allowed hosts, current: '{:?}', expected: '{:?}'",
+                    nexus_state.allowed_hosts,
+                    nexus_spec.allowed_hosts
+                )
+            });
+
+            match NexusShareProtocol::try_from(nexus_spec.share) {
+                Ok(protocol) => {
+                    let allowed_hosts = nexus_spec.allowed_hosts.clone();
+                    nexus
+                        .share(
+                            context.registry(),
+                            &ShareNexus::new(&nexus_state, protocol, allowed_hosts),
+                        )
+                        .await?;
+                    nexus_spec
+                        .info_span(|| tracing::info!("Nexus allowed hosts changed successfully"));
+                }
+                Err(error) => {
+                    nexus_spec.error_span(|| {
+                        tracing::error!(error=%error, "Invalid configuration for nexus protocol, cannot apply it...")
+                    });
                 }
             }
         }

--- a/control-plane/agents/src/bin/core/nexus/specs.rs
+++ b/control-plane/agents/src/bin/core/nexus/specs.rs
@@ -51,11 +51,17 @@ impl SpecOperationsHelper for NexusSpec {
         op: Self::UpdateOp,
     ) -> Result<(), SvcError> {
         match &op {
-            NexusOperation::Share(_, _) if state.share.shared() => Err(SvcError::AlreadyShared {
-                kind: ResourceKind::Nexus,
-                id: self.uuid_str(),
-                share: state.share.to_string(),
-            }),
+            NexusOperation::Share(_, a)
+                if state.share.shared()
+                    && &state.allowed_hosts == a
+                    && &self.allowed_hosts == a =>
+            {
+                Err(SvcError::AlreadyShared {
+                    kind: ResourceKind::Nexus,
+                    id: self.uuid_str(),
+                    share: state.share.to_string(),
+                })
+            }
             NexusOperation::Share(_, _) => Ok(()),
             NexusOperation::Unshare if !state.share.shared() => Err(SvcError::NotShared {
                 kind: ResourceKind::Nexus,

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -7,7 +7,10 @@ use stor_port::types::v0::{
         node::NodeSpec,
         pool::{PoolSpec, PoolSpecStatus},
         replica::{PoolRef, ReplicaSpec, ReplicaSpecStatus},
-        volume::{TargetConfig, VolumeSpec, VolumeSpecStatus, VolumeTarget},
+        volume::{
+            TargetConfig, VolumeOperation, VolumeOperationState, VolumeSpec, VolumeSpecStatus,
+            VolumeTarget,
+        },
     },
     transport::{
         ChildUri, ExplicitNodeTopology, LabelledTopology, NexusId, NexusStatus, NodeTopology,
@@ -233,6 +236,30 @@ fn test_deserialization_v1_to_v2() {
             }),
         }
     ];
+
+    validate_deserialization(&test_entries);
+}
+
+#[test]
+fn test_deserialization_changes() {
+    let test_entries = vec![TestEntry {
+        json_str: r#"{"uuid":"359b7e1a-b724-443b-98b4-e6d97fabbb40","size":5242880,"labels":null,"num_replicas":2,"status":{"Created":"Online"},"policy":{"self_heal":true},"topology":null,"last_nexus_id":null,"operation":{"operation":"Unpublish","result":null},"thin":false,"target":null,"publish_context":null,"affinity_group":null,"encrypted":false,"cluster_size":4194304}"#,
+        expected: Expected::VolumeSpec(VolumeSpec {
+            uuid: VolumeId::try_from("359b7e1a-b724-443b-98b4-e6d97fabbb40").unwrap(),
+            size: 5242880,
+            labels: None,
+            num_replicas: 2,
+            status: VolumeSpecStatus::Created(VolumeStatus::Online),
+            policy: VolumePolicy { self_heal: true },
+            target_config: None,
+            operation: Some(VolumeOperationState {
+                operation: VolumeOperation::UnpublishOld,
+                result: None,
+            }),
+            cluster_size: 4194304,
+            ..Default::default()
+        }),
+    }];
 
     validate_deserialization(&test_entries);
 }

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -301,6 +301,167 @@ async fn publishing_test(cluster: &Cluster) {
     tracing::info!("Volumes: {:?}", volumes);
     assert_eq!(Some(&volume), volumes.first());
 
+    let nodes = |v: &Volume| -> Option<usize> {
+        match v.spec_ref().target_cfg() {
+            None => Some(0),
+            Some(x) => {
+                let len = x.frontend().nodes_info().len();
+                if len == 0 {
+                    None
+                } else {
+                    Some(len)
+                }
+            }
+        }
+    };
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["a".into()],
+            },
+            None,
+        )
+        .await
+        .expect("Should be able to publish a newly created volume");
+
+    let error = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["a".into()],
+            },
+            None,
+        )
+        .await
+        .expect_err("Already published for a");
+    assert!(matches!(
+        error,
+        ReplyError {
+            kind: ReplyErrorKind::AlreadyPublished,
+            resource: ResourceKind::Volume,
+            ..
+        },
+    ));
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["b".into()],
+            },
+            None,
+        )
+        .await
+        .expect("Should be able to publish for a new frontend node");
+
+    let volume = volume_client
+        .unpublish(
+            &UnpublishVolume::new(volume.uuid(), false, vec!["a".into(), "b".into()]),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["a".into(), "b".into()],
+            },
+            None,
+        )
+        .await
+        .expect("Should be able to publish a newly created volume");
+
+    let volume = volume_client
+        .unpublish(
+            &UnpublishVolume::new(volume.uuid(), false, vec!["a".into(), "c".into()]),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(nodes(&volume), Some(1));
+    let error = volume_client
+        .unpublish(
+            &UnpublishVolume::new(volume.uuid(), false, vec!["a".into()]),
+            None,
+        )
+        .await
+        .expect_err("node allowed to remove");
+    tracing::error!("error: {:?}", error);
+    assert!(matches!(
+        error,
+        ReplyError {
+            kind: ReplyErrorKind::PermissionDenied,
+            resource: ResourceKind::Volume,
+            ..
+        },
+    ));
+    let volume = volume_client
+        .unpublish(
+            &UnpublishVolume::new(volume.uuid(), false, vec!["b".into(), "c".into()]),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(nodes(&volume), Some(0));
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: None,
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![],
+            },
+            None,
+        )
+        .await
+        .expect("Should be able to publish a newly created volume");
+    assert_eq!(nodes(&volume), None);
+    let volume = volume_client
+        .unpublish(
+            &UnpublishVolume::new(volume.uuid(), false, vec!["b".into(), "c".into()]),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(nodes(&volume), Some(0));
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: None,
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["a".into()],
+            },
+            None,
+        )
+        .await
+        .expect("Should be able to publish a newly created volume");
+    let volume = volume_client
+        .unpublish(&UnpublishVolume::new(volume.uuid(), false, vec![]), None)
+        .await
+        .unwrap();
+    assert_eq!(nodes(&volume), Some(0));
+
     let volume = volume_client
         .publish(
             &PublishVolume {

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -32,16 +32,20 @@ use stor_port::{
         store::{
             nexus_persistence::NexusInfoKey,
             replica::ReplicaSpec,
-            volume::{PublishOperation, RepublishOperation, VolumeOperation, VolumeSpec},
+            volume::{
+                PublishOperation, RepublishOperation, UnpublishOperation, VolumeOperation,
+                VolumeSpec,
+            },
         },
         transport::{
             CreateReplica, CreateVolume, DestroyNexus, DestroyReplica, DestroyShutdownTargets,
             DestroyVolume, NodeTopology, Protocol, PublishVolume, Replica, ReplicaId,
             ReplicaOwners, RepublishVolume, ResizeVolume, SetVolumeProperty, SetVolumeReplica,
             ShareNexus, ShareVolume, ShutdownNexus, UnpublishVolume, UnshareNexus, UnshareVolume,
-            Volume,
+            Volume, VolumeShareProtocol,
         },
     },
+    HostAccessControl,
 };
 
 use itertools::Itertools;
@@ -321,6 +325,46 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         request: &Self::Publish,
     ) -> Result<Self::PublishOutput, SvcError> {
         let state = registry.volume_state(&request.uuid).await?;
+
+        if let Some(target_cfg) = self.as_ref().target_cfg() {
+            let target = target_cfg.target();
+
+            let host_acl =
+                registry.host_acl_nodename(HostAccessControl::Nexuses, &request.frontend_nodes);
+            if target_cfg.frontend().needs_update(&host_acl) {
+                let mut nexus = registry.specs().nexus(target.nexus()).await?;
+                let nexus_state = registry.nexus(target.nexus()).await?;
+
+                let mut target_cfg = target_cfg.clone();
+                target_cfg.frontend_mut().add_acls(host_acl);
+
+                let operation = VolumeOperation::Publish(PublishOperation::new(
+                    target_cfg.clone(),
+                    request.publish_context.clone(),
+                ));
+                let spec_clone = self.start_update(registry, &state, operation).await?;
+
+                let result = nexus
+                    .share(
+                        registry,
+                        &ShareNexus::new(
+                            &nexus_state,
+                            VolumeShareProtocol::Nvmf,
+                            target_cfg.frontend().node_nqns(),
+                        ),
+                    )
+                    .await;
+
+                self.complete_update(registry, result, spec_clone).await?;
+
+                let volume = registry.volume(&request.uuid).await?;
+                registry
+                    .notify_if_degraded(&volume, PollTriggerEvent::VolumeDegraded)
+                    .await;
+                return Ok(volume);
+            }
+        }
+
         let nexus_node = self
             .next_target_node(registry, request, &state, false)
             .await?;
@@ -400,36 +444,47 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
     ) -> Result<(), SvcError> {
         let specs = registry.specs();
 
-        let state = registry.volume_state(&request.uuid).await?;
-
-        let spec_clone = self
-            .start_update(registry, &state, VolumeOperation::Unpublish)
-            .await?;
-
-        let volume_target = spec_clone.target().expect("already validated");
-        let frontend_nodes = &request.frontend_nodes;
-        tracing::debug!("unpublish_volume: frontend nodes {frontend_nodes:?}");
-        if !frontend_nodes.is_empty() {
-            if let Some(tgt_cfg) = spec_clone.active_config() {
-                for unode in frontend_nodes {
-                    if !tgt_cfg.frontend().nodename_allowed(unode.as_str()) {
-                        self.validate_update_step(
-                            registry,
-                            Err(SvcError::FrontendNodeNotAllowed {
-                                node: unode.to_string(),
-                                vol_id: request.uuid.to_string(),
-                            }),
-                            &spec_clone,
-                        )
-                        .await?;
+        let mut host_acls =
+            registry.host_acl_nodename(HostAccessControl::Nexuses, &request.frontend_nodes);
+        if !host_acls.is_empty() {
+            let volume = self.lock();
+            if let Some(tgt_cfg) = volume.active_config() {
+                let mut disallowed = vec![];
+                let mut removing = vec![];
+                for initiator in host_acls {
+                    if tgt_cfg.frontend().nodename_allowed(initiator.node_name()) {
+                        removing.push(initiator);
+                    } else {
+                        disallowed.push(initiator);
                     }
+                }
+                host_acls = removing;
+                if host_acls.is_empty() {
+                    let node = disallowed.first().map(|n| n.node_name().to_string());
+                    return Err(SvcError::FrontendNodeNotAllowed {
+                        node: node.unwrap_or_default(),
+                        vol_id: request.uuid.to_string(),
+                    });
                 }
             }
         }
 
+        let op = VolumeOperation::Unpublish(UnpublishOperation::new(host_acls.clone()));
+        let state = registry.volume_state(&request.uuid).await?;
+        let spec_clone = self.start_update(registry, &state, op).await?;
+
+        let volume_target = spec_clone.target().expect("already validated");
+
+        let mut current_acs = spec_clone
+            .active_config()
+            .map(|t| t.frontend().nodes_info().clone())
+            .unwrap_or_default();
+        current_acs.retain(|f| !host_acls.contains(f));
+        let last_node = current_acs.is_empty() || host_acls.is_empty();
+
         let result = match specs.nexus_opt(volume_target.nexus()).await? {
             None => Ok(()),
-            Some(mut nexus) => {
+            Some(mut nexus) if last_node => {
                 let nexus_clone = nexus.lock().clone();
                 let destroy = DestroyNexus::from(&nexus_clone).with_disown(&request.uuid);
                 // Destroy the Nexus
@@ -453,6 +508,23 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
                             Err(error)
                         }
                     }
+                }
+            }
+            Some(mut nexus) => {
+                if let Some(state) = state.target.as_ref() {
+                    let shared = nexus.lock().share.shared();
+                    if shared {
+                        let nqns = current_acs
+                            .iter()
+                            .map(|n| n.node_nqn().clone())
+                            .collect::<Vec<_>>();
+                        let share = ShareNexus::new(state, VolumeShareProtocol::Nvmf, nqns);
+                        nexus.share(registry, &share).await.map(|_| ())
+                    } else {
+                        Ok(())
+                    }
+                } else {
+                    Ok(())
                 }
             }
         };

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -978,7 +978,8 @@ impl SpecOperationsHelper for VolumeSpec {
         if !matches!(
             &operation,
             VolumeOperation::Publish(..)
-                | VolumeOperation::Unpublish
+                | VolumeOperation::UnpublishOld
+                | VolumeOperation::Unpublish(..)
                 | VolumeOperation::Republish(..)
                 | VolumeOperation::CreateSnapshot(..)
                 | VolumeOperation::DestroySnapshot(..)
@@ -1030,11 +1031,15 @@ impl SpecOperationsHelper for VolumeSpec {
                 Some(protocol) => match protocol {
                     VolumeShareProtocol::Nvmf => {
                         if let Some(target) = self.target() {
-                            Err(SvcError::VolumeAlreadyPublished {
-                                vol_id: self.uuid_str(),
-                                node: target.node().to_string(),
-                                protocol: format!("{:?}", target.protocol()),
-                            })
+                            if self.publish_context == Some(args.publish_context()) {
+                                Ok(())
+                            } else {
+                                Err(SvcError::VolumeAlreadyPublished {
+                                    vol_id: self.uuid_str(),
+                                    node: target.node().to_string(),
+                                    protocol: format!("{:?}", target.protocol()),
+                                })
+                            }
                         } else {
                             self.publish_context = Some(args.publish_context());
                             Ok(())
@@ -1055,12 +1060,14 @@ impl SpecOperationsHelper for VolumeSpec {
                     share: format!("{:?}", args.protocol()),
                 }),
             },
-            VolumeOperation::Unpublish if self.target().is_none() => {
+            VolumeOperation::UnpublishOld | VolumeOperation::Unpublish(_)
+                if self.target().is_none() =>
+            {
                 Err(SvcError::VolumeNotPublished {
                     vol_id: self.uuid_str(),
                 })
             }
-            VolumeOperation::Unpublish => {
+            VolumeOperation::UnpublishOld | VolumeOperation::Unpublish(_) => {
                 self.publish_context = None;
                 Ok(())
             }

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -1,4 +1,5 @@
 use crate::CsiControllerConfig;
+use stor_port::types::v0::openapi::{client::Error, models::rest_json_error::Kind};
 use stor_port::types::v0::openapi::{
     clients,
     clients::tower::StatusCode,
@@ -437,11 +438,22 @@ impl RestApiClient {
             None,
             frontend_node,
         );
-        let volume = self
+        let volume = match self
             .rest_client
             .volumes_api()
             .put_volume_target(volume_id, publish_volume_body)
-            .await?;
+            .await
+        {
+            Ok(volume) => Ok(volume),
+            Err(Error::Response(error))
+                if error.status() == StatusCode::PRECONDITION_FAILED
+                    && error.error_body().map(|e| e.kind == Kind::AlreadyPublished)
+                        == Some(true) =>
+            {
+                self.rest_client.volumes_api().get_volume(volume_id).await
+            }
+            Err(error) => Err(error),
+        }?;
         Ok(volume.into_body())
     }
 

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -59,20 +59,15 @@ impl CsiControllerSvc {
     }
 }
 
-/// Check whether target volume capabilities are valid. As of now, only
-/// SingleNodeWriter capability is supported.
-fn check_volume_capabilities(capabilities: &[VolumeCapability]) -> Result<(), tonic::Status> {
+/// Check whether target volume capabilities are valid
+fn check_volume_capabilities(
+    capabilities: &[VolumeCapability],
+    rwx_block: &Option<bool>,
+) -> Result<(), tonic::Status> {
     for c in capabilities {
-        if let Some(access_mode) = c.access_mode.as_ref() {
-            if access_mode.mode != volume_capability::access_mode::Mode::SingleNodeWriter as i32
-                && access_mode.mode
-                    != volume_capability::access_mode::Mode::MultiNodeMultiWriter as i32
-            {
-                return Err(Status::invalid_argument(format!(
-                    "Invalid volume access mode: {:?}",
-                    access_mode.mode
-                )));
-            }
+        if c.access_mode.is_some() {
+            // todo: isn't access_mode required?
+            check_volume_capability(c, rwx_block)?;
         }
     }
     Ok(())
@@ -80,6 +75,7 @@ fn check_volume_capabilities(capabilities: &[VolumeCapability]) -> Result<(), to
 
 fn check_volume_capability(
     capability: &VolumeCapability,
+    rwx_block: &Option<bool>,
 ) -> Result<volume_capability::access_mode::Mode, tonic::Status> {
     let Some(access_mode) = capability.access_mode.as_ref() else {
         return Err(tonic::Status::invalid_argument("missing access_mode"));
@@ -93,7 +89,13 @@ fn check_volume_capability(
         volume_capability::access_mode::Mode::SingleNodeWriter => Ok(access_mode),
         volume_capability::access_mode::Mode::MultiNodeMultiWriter => {
             if matches!(access_type, AccessType::Block(_)) {
-                Ok(access_mode)
+                if rwx_block == &Some(true) {
+                    Ok(access_mode)
+                } else {
+                    Err(Status::invalid_argument(
+                        "MultiNodeMultiWriter requested but RWX Block is disabled".to_string(),
+                    ))
+                }
             } else {
                 Err(Status::invalid_argument(format!(
                     "{access_mode:?} only allowed with access_type of Block",
@@ -381,7 +383,8 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             None
         };
 
-        check_volume_capabilities(&args.volume_capabilities)?;
+        let context = CreateParams::try_from(&args.parameters)?;
+        check_volume_capabilities(&args.volume_capabilities, context.rwx_block())?;
 
         // Check volume size.
         let size = match args.capacity_range {
@@ -400,7 +403,6 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             }
         };
 
-        let context = CreateParams::try_from(&args.parameters)?;
         let replica_count = context.replica_count();
 
         let parsed_vol_uuid = Uuid::parse_str(&volume_uuid).map_err(|_e| {
@@ -572,17 +574,17 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         })?;
         let _guard = csi_driver::limiter::VolumeOpGuard::new(volume_id)?;
 
+        let create_ctx = CreateParams::try_from(&args.volume_context)?;
         let access_mode = match args.volume_capability {
-            Some(c) => check_volume_capability(&c),
+            Some(c) => check_volume_capability(&c, create_ctx.rwx_block()),
             None => Err(Status::invalid_argument("Missing volume capability")),
         }?;
 
         // Check if the volume is already published.
         let volume = RestApiClient::get_client().get_volume(&volume_id).await?;
 
-        let params = PublishParams::try_from(&args.volume_context)?;
-
         // Prepare the context for the csi-node plugin.
+        let params = PublishParams::try_from(&args.volume_context)?;
         let mut publish_context = params.into_context();
 
         let uri =
@@ -764,34 +766,25 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             // todo: this seems wrong...
             .map_err(|_e| Status::unimplemented("Not implemented"))?;
 
-        use volume_capability::access_mode::Mode;
-        let supported_caps = vec![Mode::SingleNodeWriter, Mode::MultiNodeMultiWriter];
-        let caps: Vec<VolumeCapability> = args
-            .volume_capabilities
-            .into_iter()
-            .filter(|cap| {
-                let cap_mode = cap.access_mode.as_ref();
-                let access_mode = cap_mode.map(|m| m.mode()).unwrap_or_default();
-                supported_caps.contains(&access_mode)
-            })
-            .collect();
+        let context = CreateParams::try_from(&args.parameters)?;
+        let validation = check_volume_capabilities(&args.volume_capabilities, context.rwx_block());
 
-        // todo: this seems wrong? See https://github.com/container-storage-interface/spec/blob/e981e2a057ca10f4a7f81289c97a4e829fd69152/spec.md?plain=1#L1502
-        let response = if !caps.is_empty() {
-            ValidateVolumeCapabilitiesResponse {
+        // todo: We need to validate the context and parameters?
+        //  See https://github.com/container-storage-interface/spec/blob/e981e2a057ca10f4a7f81289c97a4e829fd69152/spec.md?plain=1#L1502
+        let response = match validation {
+            Ok(_) => ValidateVolumeCapabilitiesResponse {
                 confirmed: Some(validate_volume_capabilities_response::Confirmed {
                     volume_context: HashMap::new(),
                     parameters: HashMap::new(),
-                    volume_capabilities: caps,
+                    volume_capabilities: args.volume_capabilities,
                     mutable_parameters: HashMap::new(),
                 }),
                 message: "".to_string(),
-            }
-        } else {
-            ValidateVolumeCapabilitiesResponse {
+            },
+            Err(status) => ValidateVolumeCapabilitiesResponse {
                 confirmed: None,
-                message: format!("The only supported capabilities are {supported_caps:?}"),
-            }
+                message: status.to_string(),
+            },
         };
 
         Ok(Response::new(response))
@@ -852,7 +845,8 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         let _ = csi_driver::trace::CsiRequest::new_trace("Get Node(s) Capacity");
 
         // Check capabilities.
-        check_volume_capabilities(&args.volume_capabilities)?;
+        let context = CreateParams::try_from(&args.parameters)?;
+        check_volume_capabilities(&args.volume_capabilities, context.rwx_block())?;
 
         // todo: this seems to be conflating app node vs storage node?
         // Determine target node, if requested.

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -64,7 +64,10 @@ impl CsiControllerSvc {
 fn check_volume_capabilities(capabilities: &[VolumeCapability]) -> Result<(), tonic::Status> {
     for c in capabilities {
         if let Some(access_mode) = c.access_mode.as_ref() {
-            if access_mode.mode != volume_capability::access_mode::Mode::SingleNodeWriter as i32 {
+            if access_mode.mode != volume_capability::access_mode::Mode::SingleNodeWriter as i32
+                && access_mode.mode
+                    != volume_capability::access_mode::Mode::MultiNodeMultiWriter as i32
+            {
                 return Err(Status::invalid_argument(format!(
                     "Invalid volume access mode: {:?}",
                     access_mode.mode
@@ -73,6 +76,34 @@ fn check_volume_capabilities(capabilities: &[VolumeCapability]) -> Result<(), to
         }
     }
     Ok(())
+}
+
+fn check_volume_capability(
+    capability: &VolumeCapability,
+) -> Result<volume_capability::access_mode::Mode, tonic::Status> {
+    let Some(access_mode) = capability.access_mode.as_ref() else {
+        return Err(tonic::Status::invalid_argument("missing access_mode"));
+    };
+    let access_mode = volume_capability::access_mode::Mode::try_from(access_mode.mode)
+        .map_err(|error| tonic::Status::invalid_argument(error.to_string()))?;
+    let Some(access_type) = capability.access_type.as_ref() else {
+        return Err(tonic::Status::invalid_argument("missing access_type"));
+    };
+    match access_mode {
+        volume_capability::access_mode::Mode::SingleNodeWriter => Ok(access_mode),
+        volume_capability::access_mode::Mode::MultiNodeMultiWriter => {
+            if matches!(access_type, AccessType::Block(_)) {
+                Ok(access_mode)
+            } else {
+                Err(Status::invalid_argument(format!(
+                    "{access_mode:?} only allowed with access_type of Block",
+                )))
+            }
+        }
+        _ => Err(Status::invalid_argument(format!(
+            "Invalid volume access mode: {access_mode:?}",
+        ))),
+    }
 }
 
 /// Parse string protocol into REST API protocol enum.
@@ -541,12 +572,10 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         })?;
         let _guard = csi_driver::limiter::VolumeOpGuard::new(volume_id)?;
 
-        match args.volume_capability {
-            Some(c) => check_volume_capabilities(&[c])?,
-            None => {
-                return Err(Status::invalid_argument("Missing volume capability"));
-            }
-        }
+        let access_mode = match args.volume_capability {
+            Some(c) => check_volume_capability(&c),
+            None => Err(Status::invalid_argument("Missing volume capability")),
+        }?;
 
         // Check if the volume is already published.
         let volume = RestApiClient::get_client().get_volume(&volume_id).await?;
@@ -562,34 +591,60 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                 Some(target) => {
                     if target.protocol != Some(protocol) {
                         let m = format!(
-                            "Volume {volume_id} already shared via different protocol: {:?}",
+                            "Volume already shared via different protocol: {:?}",
                             target.protocol,
                         );
-                        error!("{}", m);
+                        error!("{m}");
                         return Err(Status::failed_precondition(m));
                     }
 
                     if let Some((node, uri)) = get_volume_share_location(&volume) {
                         // Make sure volume is accessible from the same app node.
                         if let Err(allowed) = frontend_nodes_allowed(target, &node_id) {
-                            let m = format!(
-                                "Volume {volume_id} is only accessible to nodes: {allowed:?}, and not to {node_id}"
-                            );
-                            error!("{m}");
-                            return Err(Status::failed_precondition(m));
-                        }
 
-                        debug!("Volume {volume_id} already published for {node_id} on {node} => {uri}");
-                        uri
+                            if access_mode == volume_capability::access_mode::Mode::SingleNodeWriter {
+                                let m = format!(
+                                    "Volume {volume_id} is only accessible to nodes: {allowed:?}, and not to {node_id}"
+                                );
+                                tracing::error!("{m}");
+                                return Err(Status::failed_precondition(m));
+                            }
+                            tracing::info!("Volume is already published to nodes: {allowed:?} - publishing to {node_id}");
+
+                            // Issue a cleanup rpc to csi node to ensure the subsystem doesn't have any
+                            // path present before publishing
+                            if self.force_unstage_volume {
+                                let app_node = RestApiClient::get_client().get_app_node(&args.node_id).await?;
+                                force_unstage(app_node, volume_id.to_string()).await?;
+                            }
+
+                            let v = RestApiClient::get_client()
+                                .publish_volume(&volume_id, Some(&node), protocol, args.node_id.clone(), &publish_context)
+                                .await?;
+
+                            if let Some((node, uri)) = get_volume_share_location(&v) {
+                                debug!("Volume successfully published on node {node} via {uri}");
+                                uri
+                            } else {
+                                let m = format!(
+                                    "Volume {volume_id} has been successfully published but URI is not available"
+                                );
+                                error!("{m}");
+                                return Err(Status::internal(m));
+                            }
+                        } else {
+                            debug!("Volume already published for {node_id} on {node} => {uri}");
+                            uri
+                        }
                     } else {
                         let m = format!(
                             "Volume {volume_id} reports no info about its publishing status"
                         );
-                        error!("{}", m);
+                        error!("{m}");
                         return Err(Status::internal(m));
                     }
                 }
-                _ => {
+                None => {
                     // Check for node being cordoned.
                     fn cordon_check(spec: Option<&NodeSpec>) -> bool {
                         if let Some(spec) = spec {
@@ -626,7 +681,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                         .await?;
 
                     if let Some((node, uri)) = get_volume_share_location(&v) {
-                        debug!("Volume {volume_id} successfully published on node {node} via {uri}");
+                        debug!("Volume successfully published on node {node} via {uri}");
                         uri
                     } else {
                         let m = format!(
@@ -661,7 +716,8 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         let volume = match RestApiClient::get_client().get_volume(&volume_uuid).await {
             Ok(volume) => volume,
             Err(ApiClientError::ResourceNotExists { .. }) => {
-                debug!("Volume {} does not exist, not unpublishing", args.volume_id);
+                // todo: shouldn't this be a grpc NOT_FOUND?
+                debug!("Volume does not exist, not unpublishing");
                 return Ok(Response::new(ControllerUnpublishVolumeResponse {}));
             }
             Err(e) => return Err(Status::from(e)),
@@ -669,10 +725,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
         if volume.spec.target.is_none() {
             // Volume is not published, bail out.
-            debug!(
-                "Volume {} is not published, not unpublishing",
-                args.volume_id
-            );
+            debug!("Volume is not published, not unpublishing");
             return Ok(Response::new(ControllerUnpublishVolumeResponse {}));
         }
 
@@ -708,23 +761,22 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         let _volume = RestApiClient::get_client()
             .get_volume(&volume_uuid)
             .await
+            // todo: this seems wrong...
             .map_err(|_e| Status::unimplemented("Not implemented"))?;
 
+        use volume_capability::access_mode::Mode;
+        let supported_caps = vec![Mode::SingleNodeWriter, Mode::MultiNodeMultiWriter];
         let caps: Vec<VolumeCapability> = args
             .volume_capabilities
             .into_iter()
             .filter(|cap| {
-                if let Some(access_mode) = cap.access_mode.as_ref() {
-                    if access_mode.mode
-                        == volume_capability::access_mode::Mode::SingleNodeWriter as i32
-                    {
-                        return true;
-                    }
-                }
-                false
+                let cap_mode = cap.access_mode.as_ref();
+                let access_mode = cap_mode.map(|m| m.mode()).unwrap_or_default();
+                supported_caps.contains(&access_mode)
             })
             .collect();
 
+        // todo: this seems wrong? See https://github.com/container-storage-interface/spec/blob/e981e2a057ca10f4a7f81289c97a4e829fd69152/spec.md?plain=1#L1502
         let response = if !caps.is_empty() {
             ValidateVolumeCapabilitiesResponse {
                 confirmed: Some(validate_volume_capabilities_response::Confirmed {
@@ -738,7 +790,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         } else {
             ValidateVolumeCapabilitiesResponse {
                 confirmed: None,
-                message: "The only supported capability is SINGLE_NODE_WRITER".to_string(),
+                message: format!("The only supported capabilities are {supported_caps:?}"),
             }
         };
 
@@ -771,6 +823,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                 let volume = rpc::csi::Volume {
                     volume_id: v.spec.uuid.to_string(),
                     capacity_bytes: v.spec.size as i64,
+                    // todo: these 2 seem wrong?
                     volume_context: HashMap::new(),
                     content_source: None,
                     accessible_topology: vt_mapper.volume_accessible_topology(),
@@ -801,6 +854,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         // Check capabilities.
         check_volume_capabilities(&args.volume_capabilities)?;
 
+        // todo: this seems to be conflating app node vs storage node?
         // Determine target node, if requested.
         let node: Option<&String> = if let Some(topology) = args.accessible_topology.as_ref() {
             topology.segments.get(&csi_driver::node_name_topology_key())
@@ -828,6 +882,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
         let available_capacity: i64 = pools.into_iter().fold(0, |acc, p| match p.state {
             Some(state) => match state.status {
+                // todo: missing node/pool cordon checks...
                 PoolStatus::Online | PoolStatus::Degraded => acc + state.capacity as i64,
                 _ => {
                     warn!(

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -130,6 +130,7 @@ pub(crate) static RDMA_CONNECT_CHECK: OnceCell<CheckAndFallbackNvmeConnect> = On
 /// the readonly status
 fn check_access_mode(
     volume_capability: &Option<VolumeCapability>,
+    access_type: &AccessType,
     readonly: bool,
 ) -> Result<(), String> {
     match volume_capability {
@@ -137,6 +138,9 @@ fn check_access_mode(
             Some(access) => match Mode::try_from(access.mode) {
                 Ok(mode) => match mode {
                     Mode::SingleNodeWriter | Mode::MultiNodeSingleWriter => Ok(()),
+                    Mode::MultiNodeMultiWriter if matches!(access_type, AccessType::Block(_)) => {
+                        Ok(())
+                    }
                     Mode::SingleNodeReaderOnly | Mode::MultiNodeReaderOnly => {
                         if readonly {
                             return Ok(());
@@ -296,7 +300,16 @@ impl node_server::Node for Node {
             ));
         }
 
-        if let Err(error) = check_access_mode(&msg.volume_capability, msg.readonly) {
+        let access_type = get_access_type(&msg.volume_capability).map_err(|error| {
+            failure!(
+                Code::InvalidArgument,
+                "Failed to publish volume {}: {}",
+                &msg.volume_id,
+                error
+            )
+        })?;
+
+        if let Err(error) = check_access_mode(&msg.volume_capability, access_type, msg.readonly) {
             return Err(failure!(
                 Code::InvalidArgument,
                 "Failed to publish volume {}: {}",
@@ -328,14 +341,7 @@ impl node_server::Node for Node {
             ));
         }
 
-        match get_access_type(&msg.volume_capability).map_err(|error| {
-            failure!(
-                Code::InvalidArgument,
-                "Failed to publish volume {}: {}",
-                &msg.volume_id,
-                error
-            )
-        })? {
+        match access_type {
             AccessType::Mount(mnt) => {
                 publish_fs_volume(&msg, mnt, &self.filesystems).await?;
             }
@@ -675,19 +681,6 @@ impl node_server::Node for Node {
             ));
         }
 
-        if let Err(error) = check_access_mode(
-            &msg.volume_capability,
-            // relax the check a bit by pretending all stage mounts are ro
-            true,
-        ) {
-            return Err(failure!(
-                Code::InvalidArgument,
-                "Failed to stage volume {}: {}",
-                &msg.volume_id,
-                error
-            ));
-        };
-
         let access_type = match get_access_type(&msg.volume_capability) {
             Ok(accesstype) => accesstype,
             Err(error) => {
@@ -698,6 +691,20 @@ impl node_server::Node for Node {
                     error
                 ));
             }
+        };
+
+        if let Err(error) = check_access_mode(
+            &msg.volume_capability,
+            access_type,
+            // relax the check a bit by pretending all stage mounts are ro
+            true,
+        ) {
+            return Err(failure!(
+                Code::InvalidArgument,
+                "Failed to stage volume {}: {}",
+                &msg.volume_id,
+                error
+            ));
         };
 
         let uuid = Uuid::parse_str(&msg.volume_id).map_err(|error| {

--- a/control-plane/csi-driver/src/context.rs
+++ b/control-plane/csi-driver/src/context.rs
@@ -82,6 +82,8 @@ pub enum Parameters {
     OverrideGlobalFormatOpts,
     #[strum(serialize = "poolClusterSize")]
     PoolClusterSize,
+    #[strum(serialize = "rwxBlock")]
+    RwxBlock,
 }
 impl Parameters {
     fn parse_human_time(
@@ -177,6 +179,10 @@ impl Parameters {
             Some(value) => value.parse::<Uuid>().map(Some)?,
             None => None,
         })
+    }
+    /// Parse the value for `Self::RwxBlock`
+    pub fn rwx_block(value: Option<&String>) -> Result<Option<bool>, ParseBoolError> {
+        Self::parse_bool(value)
     }
     /// Parse the value for `Self::NvmeCtrlLossTmo`.
     pub fn ctrl_loss_tmo(value: Option<&String>) -> Result<Option<u32>, ParseIntError> {
@@ -382,7 +388,7 @@ impl TryFrom<&HashMap<String, String>> for PublishParams {
             .map_err(|_| tonic::Status::invalid_argument("Invalid I/O timeout"))?;
         let nvme_io_timeout =
             Parameters::nvme_io_timeout(args.get(Parameters::NvmeIoTimeout.as_ref()))
-                .map_err(|_| tonic::Status::invalid_argument("Invalid I/O timeout"))?;
+                .map_err(|_| tonic::Status::invalid_argument("Invalid nvme_io_timeout"))?;
         let ctrl_loss_tmo =
             Parameters::ctrl_loss_tmo(args.get(Parameters::NvmeCtrlLossTmo.as_ref()))
                 .map_err(|_| tonic::Status::invalid_argument("Invalid ctrl_loss_tmo"))?;
@@ -500,6 +506,7 @@ const ANNOTATION_KEY: &str = "openebs.io/stsAffinityGroup";
 #[derive(Debug)]
 pub struct CreateParams {
     publish_params: PublishParams,
+    rwx_block: Option<bool>,
     share_protocol: VolumeShareProtocol,
     replica_count: u8,
     sts_affinity_group: Option<bool>,
@@ -511,6 +518,10 @@ pub struct CreateParams {
     pool_cluster_size: Option<u64>,
 }
 impl CreateParams {
+    /// Get the `Parameters::RwxBlock` value.
+    pub fn rwx_block(&self) -> &Option<bool> {
+        &self.rwx_block
+    }
     /// Get the `Parameters::PublishParams` value.
     pub fn publish_params(&self) -> &PublishParams {
         &self.publish_params
@@ -663,6 +674,9 @@ impl TryFrom<&HashMap<String, String>> for CreateParams {
     fn try_from(args: &HashMap<String, String>) -> Result<Self, Self::Error> {
         let publish_params = PublishParams::try_from(args)?;
 
+        let rwx_block = Parameters::rwx_block(args.get(Parameters::RwxBlock.as_ref()))
+            .map_err(|_| tonic::Status::invalid_argument("Invalid rwx block boolean"))?;
+
         // Check storage protocol.
         let share_protocol = parse_protocol(args.get(Parameters::ShareProtocol.as_ref()))?;
 
@@ -718,6 +732,7 @@ impl TryFrom<&HashMap<String, String>> for CreateParams {
 
         Ok(Self {
             publish_params,
+            rwx_block,
             share_protocol,
             replica_count,
             sts_affinity_group,

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -56,6 +56,22 @@ impl FrontendConfig {
     pub fn from_acls(host_acl: Vec<InitiatorAC>) -> Self {
         Self { host_acl }
     }
+    /// Extend the existing host list.
+    pub fn add_acls(&mut self, host_acl: Vec<InitiatorAC>) {
+        for host in host_acl {
+            // todo: consider initiator from same node with different nqn?
+            if !self.host_acl.contains(&host) {
+                self.host_acl.push(host);
+            }
+        }
+    }
+    /// Extend the existing host list.
+    pub fn remove_acls(&mut self, host_acl: Vec<InitiatorAC>) {
+        if host_acl.is_empty() {
+            self.host_acl.drain(..);
+        }
+        self.host_acl.retain(|h| !host_acl.contains(h));
+    }
     /// Check if the nodename is allowed.
     pub fn nodename_allowed(&self, nodename: &str) -> bool {
         self.host_acl.is_empty() || self.host_acl.iter().any(|n| n.node_name() == nodename)
@@ -75,6 +91,10 @@ impl FrontendConfig {
     /// Get the frontend nodes information reference.
     pub fn nodes_info(&self) -> &Vec<InitiatorAC> {
         &self.host_acl
+    }
+    /// Check if the given initiators are already allowed.
+    pub fn needs_update(&self, hosts: &[InitiatorAC]) -> bool {
+        hosts.iter().any(|h| !self.host_acl.contains(h))
     }
 }
 
@@ -339,6 +359,10 @@ impl TargetConfig {
     pub fn frontend(&self) -> &FrontendConfig {
         &self.frontend
     }
+    /// Get a mutable reference to the frontend configuration.
+    pub fn frontend_mut(&mut self) -> &mut FrontendConfig {
+        &mut self.frontend
+    }
     /// Get the uuid of the target.
     pub fn uuid(&self) -> &NexusId {
         &self.target.nexus
@@ -389,14 +413,15 @@ impl VolumeSpec {
     }
     /// Get the currently active target.
     pub fn target(&self) -> Option<&VolumeTarget> {
-        self.target_config
-            .as_ref()
-            .filter(|t| t.active)
-            .map(|t| &t.target)
+        self.target_cfg().map(|t| &t.target)
     }
     /// Get the currently active target uuid.
     pub fn target_uuid(&self) -> Option<&NexusId> {
         self.target().map(|t| &t.nexus)
+    }
+    /// Get a reference to the active target configuration.
+    pub fn target_cfg(&self) -> Option<&TargetConfig> {
+        self.target_config.as_ref().filter(|t| t.active)
     }
     /// Get the target.
     pub fn target_mut(&mut self) -> Option<&mut VolumeTarget> {
@@ -517,8 +542,16 @@ impl SpecTransaction<VolumeOperation> for VolumeSpec {
                     self.last_nexus_id = None;
                     self.target_config = Some(args.config);
                 }
-                VolumeOperation::Unpublish => {
+                VolumeOperation::UnpublishOld => {
                     self.deactivate_target();
+                }
+                VolumeOperation::Unpublish(args) => {
+                    if let Some(target_config) = &mut self.target_config {
+                        target_config.frontend_mut().remove_acls(args.host_acls);
+                        if target_config.frontend().nodes_info().is_empty() {
+                            self.deactivate_target();
+                        }
+                    }
                 }
                 VolumeOperation::CreateSnapshot(snapshot) => {
                     self.metadata.insert_snapshot(snapshot);
@@ -596,7 +629,10 @@ pub enum VolumeOperation {
     #[serde(rename = "Publish2")]
     Publish(PublishOperation),
     Republish(RepublishOperation),
-    Unpublish,
+    #[serde(rename = "Unpublish")]
+    UnpublishOld,
+    #[serde(rename = "Unpublish2")]
+    Unpublish(UnpublishOperation),
     RemoveUnusedReplica(ReplicaId),
     CreateSnapshot(SnapshotId),
     DestroySnapshot(SnapshotId),
@@ -663,6 +699,18 @@ impl PublishOperation {
     }
 }
 
+/// Unpublish a volume from the specified hosts.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct UnpublishOperation {
+    host_acls: Vec<InitiatorAC>,
+}
+impl UnpublishOperation {
+    /// Create a new `Self` from the given initiators.
+    pub fn new(host_acls: Vec<InitiatorAC>) -> Self {
+        Self { host_acls }
+    }
+}
+
 /// Volume Republish Operation parameters.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RepublishOperation {
@@ -690,7 +738,8 @@ impl From<VolumeOperation> for models::volume_spec_operation::Operation {
             VolumeOperation::PublishOld(_) => models::volume_spec_operation::Operation::Publish,
             VolumeOperation::Publish(_) => models::volume_spec_operation::Operation::Publish,
             VolumeOperation::Republish(_) => models::volume_spec_operation::Operation::Republish,
-            VolumeOperation::Unpublish => models::volume_spec_operation::Operation::Unpublish,
+            VolumeOperation::UnpublishOld => models::volume_spec_operation::Operation::Unpublish,
+            VolumeOperation::Unpublish(_) => models::volume_spec_operation::Operation::Unpublish,
             VolumeOperation::RemoveUnusedReplica(_) => {
                 models::volume_spec_operation::Operation::RemoveUnusedReplica
             }

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -31,6 +31,11 @@ impl Volume {
         self.spec.clone()
     }
 
+    /// Get a ref to the volume spec.
+    pub fn spec_ref(&self) -> &VolumeSpec {
+        &self.spec
+    }
+
     /// Get the volume's uuid.
     pub fn uuid(&self) -> &VolumeId {
         &self.spec.uuid

--- a/tests/bdd/features/csi/controller/controller.feature
+++ b/tests/bdd/features/csi/controller/controller.feature
@@ -82,7 +82,7 @@ Scenario: unpublish volume idempotency
 Scenario: unpublish volume from a different node
     Given a volume published on a node
     When a ControllerUnpublishVolume request is sent to CSI controller to unpublish volume from a different node
-    Then a ControllerUnpublishVolume request should fail with NOT_FOUND error
+    Then a ControllerUnpublishVolume request should succeed
     And volume should report itself as published
 
 Scenario: unpublish not existing volume

--- a/tests/bdd/features/csi/controller/controller.feature
+++ b/tests/bdd/features/csi/controller/controller.feature
@@ -96,6 +96,13 @@ Scenario: republish volume on a different node
     Then a ControllerPublishVolume request should fail with FAILED_PRECONDITION error mentioning node mismatch
     And volume should report itself as published
 
+Scenario: republish rwx volume on a different node
+    Given a rwx volume published on a node
+    When a ControllerPublishVolume request is sent to CSI controller to re-publish rwx volume on a different node
+    Then a ControllerPublishVolume request should succeed
+    And volume should report itself as published
+    And both nodes should have access to the volume target
+
 Scenario: unpublish volume when nexus node is offline
     Given a volume published on a node
     When a node that hosts the nexus becomes offline

--- a/tests/bdd/features/csi/controller/test_controller.py
+++ b/tests/bdd/features/csi/controller/test_controller.py
@@ -165,7 +165,6 @@ def test_unpublish_volume_idempotency(setup):
     """unpublish volume idempotency"""
 
 
-@pytest.mark.skip("This test is no longer valid as local restriction is revoked")
 @scenario("controller.feature", "unpublish volume from a different node")
 def test_unpublish_volume_from_a_different_node(setup):
     """unpublish volume on a different node"""
@@ -339,9 +338,7 @@ def check_republish_volume_on_a_different_node(republish_volume_on_a_different_n
     target_fixture="unpublish_volume_on_a_different_node",
 )
 def unpublish_volume_on_a_different_node(populate_published_volume):
-    with pytest.raises(grpc.RpcError) as e:
-        do_unpublish_volume(VOLUME1_UUID, NODE2)
-    return e.value
+    return do_unpublish_volume(VOLUME1_UUID, NODE2)
 
 
 @when(
@@ -352,13 +349,10 @@ def unpublish_not_existing_volume():
     return do_unpublish_volume(NOT_EXISTING_VOLUME_UUID, NODE1)
 
 
-@then("a ControllerUnpublishVolume request should fail with NOT_FOUND error")
+@then("a ControllerUnpublishVolume request should succeed")
 def check_unpublish_volume_on_a_different_node(unpublish_volume_on_a_different_node):
     grpc_error = unpublish_volume_on_a_different_node
-
-    assert (
-        grpc_error.code() == grpc.StatusCode.NOT_FOUND
-    ), "Unexpected gRPC error code: %s" + str(grpc_error.code())
+    assert grpc_error == pb.ControllerUnpublishVolumeResponse()
 
 
 @when(

--- a/tests/bdd/features/csi/controller/test_controller.py
+++ b/tests/bdd/features/csi/controller/test_controller.py
@@ -180,6 +180,11 @@ def test_republish_volume_on_a_different_node(setup):
     """republish volume on a different node"""
 
 
+@scenario("controller.feature", "republish rwx volume on a different node")
+def test_republish_rwx_volume_on_a_different_node(setup):
+    """republish rwx volume on a different node"""
+
+
 @scenario("controller.feature", "unpublish volume when nexus node is offline")
 def test_unpublish_volume_with_offline_nexus_node(setup):
     """unpublish volume when nexus node is offline"""
@@ -223,6 +228,19 @@ def a_non_existing_volume():
 @given("a volume published on a node", target_fixture="populate_published_volume")
 def populate_published_volume(_create_1_replica_nvmf_volume):
     do_publish_volume(VOLUME1_UUID, NODE1)
+
+    # Make sure volume is published.
+    volume = ApiClient.volumes_api().get_volume(VOLUME1_UUID)
+
+    assert (
+        volume.spec.target.protocol.value == "nvmf"
+    ), "Protocol mismatches for published volume"
+    return volume
+
+
+@given("a rwx volume published on a node", target_fixture="populate_published_volume")
+def populate_published_rwx_volume(_create_1_replica_nvmf_rwx_volume):
+    do_publish_volume(VOLUME1_UUID, NODE1, rwx=True)
 
     # Make sure volume is published.
     volume = ApiClient.volumes_api().get_volume(VOLUME1_UUID)
@@ -309,6 +327,14 @@ def republish_volume_on_a_different_node(populate_published_volume):
     return e.value
 
 
+@when(
+    "a ControllerPublishVolume request is sent to CSI controller to re-publish rwx volume on a different node",
+    target_fixture="republish_volume_on_a_different_node",
+)
+def republish_volume_on_a_different_node():
+    return do_publish_volume(VOLUME1_UUID, NODE2, rwx=True)
+
+
 @then("a new local volume of requested size should be successfully created")
 def check_1_replica_local_nvmf_volume(create_1_replica_local_nvmf_volume):
     assert (
@@ -331,6 +357,13 @@ def check_republish_volume_on_a_different_node(republish_volume_on_a_different_n
     assert "is only accessible to nodes" in grpc_error.details(), (
         "Error message reflects a different failure: %s" % grpc_error.details()
     )
+
+
+@then("a ControllerPublishVolume request should succeed")
+def check_republish_volume_on_a_different_node_ok(republish_volume_on_a_different_node):
+    response = republish_volume_on_a_different_node
+
+    assert isinstance(response, pb.ControllerPublishVolumeResponse), f"{response}"
 
 
 @when(
@@ -389,19 +422,28 @@ def do_unpublish_volume(volume_id, node_id):
     return csi_rpc_handle().controller.ControllerUnpublishVolume(req)
 
 
-def do_publish_volume(volume_id, node_id, protocol=None):
+def do_publish_volume(volume_id, node_id, protocol=None, rwx=False):
     if protocol is None:
         protocol = "nvmf"
+
+    if rwx:
+        volume_context = {"protocol": protocol, "rwxBlock": "true" if rwx else "false"}
+    else:
+        volume_context = {"protocol": protocol}
 
     req = pb.ControllerPublishVolumeRequest(
         volume_id=volume_id,
         node_id=node_id,
-        volume_context={"protocol": protocol},
+        volume_context=volume_context,
         volume_capability={
             "access_mode": pb.VolumeCapability.AccessMode(
-                mode=pb.VolumeCapability.AccessMode.Mode.SINGLE_NODE_WRITER
+                mode=(
+                    pb.VolumeCapability.AccessMode.Mode.MULTI_NODE_MULTI_WRITER
+                    if rwx
+                    else pb.VolumeCapability.AccessMode.Mode.SINGLE_NODE_WRITER
+                )
             ),
-            "mount": pb.VolumeCapability.MountVolume(),
+            "block": pb.VolumeCapability.BlockVolume(),
         },
     )
     return csi_rpc_handle().controller.ControllerPublishVolume(req)
@@ -678,6 +720,23 @@ def csi_create_1_replica_nvmf_volume1():
     return csi_rpc_handle().controller.CreateVolume(req)
 
 
+def csi_create_1_replica_nvmf_rwx_volume1():
+    capacity = pb.CapacityRange(required_bytes=VOLUME1_SIZE, limit_bytes=0)
+    parameters = {
+        "protocol": "nvmf",
+        "ioTimeout": "30",
+        "repl": "1",
+        "local": "true",
+        "rwxBlock": "true",
+    }
+
+    req = pb.CreateVolumeRequest(
+        name=PVC_VOLUME1_NAME, capacity_range=capacity, parameters=parameters
+    )
+
+    return csi_rpc_handle().controller.CreateVolume(req)
+
+
 def csi_create_2_replica_nvmf_volume4():
     capacity = pb.CapacityRange(required_bytes=VOLUME4_SIZE, limit_bytes=0)
     parameters = {
@@ -812,6 +871,13 @@ def csi_delete_1_replica_nvmf_volume2():
 @pytest.fixture
 def _create_1_replica_nvmf_volume():
     yield csi_create_1_replica_nvmf_volume1()
+    if Cluster.fixture_cleanup():
+        csi_delete_1_replica_nvmf_volume1()
+
+
+@pytest.fixture
+def _create_1_replica_nvmf_rwx_volume():
+    yield csi_create_1_replica_nvmf_rwx_volume1()
     if Cluster.fixture_cleanup():
         csi_delete_1_replica_nvmf_volume1()
 
@@ -1037,6 +1103,13 @@ def check_volume_status_published():
     assert vol.state.target.device_uri.startswith(
         ("nvmf://", "nvmf+tcp://", "nvmf+rdma+tcp://")
     ), "Volume share URI mismatches"
+
+
+@then("both nodes should have access to the volume target")
+def check_volume_nodes_access():
+    vol = ApiClient.volumes_api().get_volume(VOLUME1_UUID)
+    assert vol.state.target.device_uri.__contains__("io-engine-1")
+    assert vol.state.target.device_uri.__contains__("io-engine-2")
 
 
 @then("volume should report itself as not published")

--- a/tests/bdd/features/csi/controller/test_controller.py
+++ b/tests/bdd/features/csi/controller/test_controller.py
@@ -400,7 +400,8 @@ def do_publish_volume(volume_id, node_id, protocol=None):
         volume_capability={
             "access_mode": pb.VolumeCapability.AccessMode(
                 mode=pb.VolumeCapability.AccessMode.Mode.SINGLE_NODE_WRITER
-            )
+            ),
+            "mount": pb.VolumeCapability.MountVolume(),
         },
     )
     return csi_rpc_handle().controller.ControllerPublishVolume(req)
@@ -446,7 +447,8 @@ def validate_non_single_node_writer_capability():
             {
                 "access_mode": pb.VolumeCapability.AccessMode(
                     mode=pb.VolumeCapability.AccessMode.Mode.MULTI_NODE_SINGLE_WRITER
-                )
+                ),
+                "mount": pb.VolumeCapability.MountVolume(),
             }
         ],
     )
@@ -475,7 +477,8 @@ def validate_single_node_writer_capability():
             {
                 "access_mode": pb.VolumeCapability.AccessMode(
                     mode=pb.VolumeCapability.AccessMode.Mode.SINGLE_NODE_WRITER
-                )
+                ),
+                "mount": pb.VolumeCapability.MountVolume(),
             }
         ],
     )


### PR DESCRIPTION
    test(csi/rwx): extend bdd with rwx block
    
    Attempts to republish volume to another node with rwx block
    todo: add negative tests
    
---

    feat(csi/controller): add rwx block enablement via volume context
    
    A new SC parameter "rwxBlock: true", may be used to enable rwx block.
    
---

    feat(kubevirt/live-migrate): support rwx for block volumes
    
    Allows multi-node writer access modes but only if the access type
    is for Block.
    This should only be enabled for applications which can handle
    having the same block device connected by multiple initiator nodes!
    
    todo: add kube-virt flag to the storage class parameters which will
    enable this feature (or global CLI flag)
    
    Allows multiple frontend nodes for the same volume target.
    Each node's nqn is added to the allowed hosts lists in the pstor and
    in the volume's nvmf target.
    
    When unpublishing, if all frontend nodes would be removed, then the
    nexus is also destroyed.
    Note that eventually when we switch to offline rebuilding, this will
    likely have to change. Nevertheless, this is equivalent to the current
    behaviour where the unpublish destroys the nexus as well.
    
---

    test(bdd): expect no error on unpublish from different node