### PR TITLE
RWX: fix unpublish/republish loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ dependencies = [
  "nvmeadm",
  "once_cell",
  "parse-size",
+ "percent-encoding",
  "prost",
  "prost-types",
  "regex",

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -22,6 +22,7 @@ use stor_port::{
     IntoOption,
 };
 
+use itertools::Itertools;
 use std::{convert::TryFrom, time::UNIX_EPOCH};
 
 /// Trait for converting agent messages to io-engine messages.
@@ -373,6 +374,7 @@ impl TryIoEngineToAgent for v1::nexus::Nexus {
                     transport::HostNqn::try_from(n)
                         .unwrap_or(transport::HostNqn::Invalid { nqn: n.to_string() })
                 })
+                .sorted()
                 .collect(),
         })
     }

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -122,6 +122,7 @@ pub(crate) struct RegistryInner<S: Store> {
     /// Blobstore cluster size(in bytes) required for pool creation and replica scheduling. This is
     /// not per-pool.
     pool_cluster_size: Option<u32>,
+    deprecated_access_mode: bool,
     /// Running in simulation mode.
     sim_args: Option<SimArgs>,
 }
@@ -153,6 +154,7 @@ impl Registry {
         allow_non_persistent_devlinks: bool,
         encrypted_pools_soft_scheduling: bool,
         pool_cluster_size: Option<u32>,
+        deprecated_access_mode: bool,
         sim_args: Option<SimArgs>,
     ) -> Result<Self, SvcError> {
         let store_endpoint = Self::format_store_endpoint(&store_url);
@@ -216,6 +218,7 @@ impl Registry {
                 allow_non_persistent_devlinks,
                 encrypted_pools_soft_scheduling,
                 pool_cluster_size: pool_cluster_size.or(Some(POOL_BS_CLUSTER_SIZE_DEFAULT)),
+                deprecated_access_mode,
                 sim_args,
             }),
         };
@@ -241,6 +244,11 @@ impl Registry {
         }
 
         Ok(registry)
+    }
+
+    // Check if we allow single access mode for an empty list of hostnqn (any access).
+    pub(crate) fn deprecated_access_mode(&self) -> bool {
+        self.deprecated_access_mode
     }
 
     /// Check if the HA feature is disabled.

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -163,6 +163,11 @@ pub(crate) struct CliArgs {
     #[clap(long)]
     pool_cluster_size: Option<u32>,
 
+    /// Allow any hostnqn access with single node access.
+    /// This is to be used for testing only.
+    #[clap(long)]
+    deprecated_access_mode: bool,
+
     /// Running in simulation mode.
     #[clap(long, env = "SIMULATION", requires = "bundle")]
     simulation: bool,
@@ -281,6 +286,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.allow_non_persistent_devlink,
         cli_args.encrypted_pools_soft_scheduling,
         cli_args.pool_cluster_size,
+        cli_args.deprecated_access_mode,
         sim_args,
     )
     .await?;

--- a/control-plane/agents/src/bin/core/nexus/operations.rs
+++ b/control-plane/agents/src/bin/core/nexus/operations.rs
@@ -195,7 +195,7 @@ impl ResourceSharing for Option<&mut OperationGuardArc<NexusSpec>> {
                 .start_update(
                     registry,
                     &status,
-                    NexusOperation::Share(request.protocol, request.allowed_hosts.clone()),
+                    NexusOperation::new_share(request.protocol, request.allowed_hosts.clone()),
                 )
                 .await?;
             let result = node.share_nexus(request).await;

--- a/control-plane/agents/src/bin/core/tests/event/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/event/mod.rs
@@ -86,6 +86,7 @@ async fn events() {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -1216,6 +1216,7 @@ async fn disown_unused_replicas() {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await

--- a/control-plane/agents/src/bin/core/tests/rebuild/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/rebuild/mod.rs
@@ -67,6 +67,7 @@ async fn rebuild_history_for_full_rebuild() {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await
@@ -197,6 +198,7 @@ async fn rebuild_history_for_partial_rebuild() {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await
@@ -359,6 +361,7 @@ async fn rebuild_partial_disabled() {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await

--- a/control-plane/agents/src/bin/core/tests/volume/capacity.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/capacity.rs
@@ -197,6 +197,7 @@ async fn common_enospc_builder(
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await
@@ -227,6 +228,7 @@ async fn common_enospc_builder(
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await

--- a/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/garbage_collection.rs
@@ -17,7 +17,7 @@ use stor_port::types::v0::{
     store::{nexus::ReplicaUri, nexus_child::NexusChild},
     transport::{
         strip_queries, CreateNexus, CreateVolume, DestroyVolume, Filter, NexusId, PublishVolume,
-        ReplicaId, VolumeId, VolumeShareProtocol,
+        ReplicaId, VolumeAccessMode, VolumeId, VolumeShareProtocol,
     },
 };
 
@@ -67,6 +67,7 @@ async fn deleting_volume_reconcile(cluster: &Cluster) {
                 target_node: None,
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -167,6 +168,7 @@ async fn offline_replicas_reconcile(cluster: &Cluster, reconcile_period: Duratio
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await
@@ -241,6 +243,7 @@ async fn unused_nexus_reconcile(cluster: &Cluster) {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await
@@ -334,6 +337,7 @@ async fn unused_reconcile(cluster: &Cluster) {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await
@@ -362,6 +366,7 @@ async fn unused_reconcile(cluster: &Cluster) {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await
@@ -450,6 +455,7 @@ async fn missing_nexus_reconcile(cluster: &Cluster) {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await

--- a/control-plane/agents/src/bin/core/tests/volume/hotspare.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/hotspare.rs
@@ -14,7 +14,7 @@ use stor_port::{
         store::volume::VolumeSpec,
         transport::{
             CreateReplica, CreateVolume, DestroyReplica, DestroyVolume, Filter, GetReplicas,
-            GetSpecs, PublishVolume, ReplicaId, ReplicaOwners,
+            GetSpecs, PublishVolume, ReplicaId, ReplicaOwners, VolumeAccessMode,
         },
     },
 };
@@ -68,6 +68,7 @@ async fn hotspare_faulty_children(cluster: &Cluster) {
                 None,
                 HashMap::new(),
                 vec![],
+                VolumeAccessMode::SingleNodeWriter,
             ),
             None,
         )
@@ -137,6 +138,7 @@ async fn hotspare_unknown_children(cluster: &Cluster) {
                 None,
                 HashMap::new(),
                 vec![],
+                VolumeAccessMode::SingleNodeWriter,
             ),
             None,
         )
@@ -211,6 +213,7 @@ async fn hotspare_missing_children(cluster: &Cluster) {
                 None,
                 HashMap::new(),
                 vec![],
+                VolumeAccessMode::SingleNodeWriter,
             ),
             None,
         )
@@ -453,6 +456,7 @@ async fn hotspare_nexus_replica_count(cluster: &Cluster) {
                 None,
                 HashMap::new(),
                 vec![],
+                VolumeAccessMode::SingleNodeWriter,
             ),
             None,
         )

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -32,8 +32,8 @@ use stor_port::{
         transport::{
             self, Child, ChildState, CreateVolume, DestroyVolume, Filter, GetNexuses, GetReplicas,
             GetVolumes, Nexus, NodeId, PublishVolume, SetVolumeReplica, ShareVolume, Topology,
-            UnpublishVolume, UnshareVolume, Volume, VolumeHealth, VolumeId, VolumeShareProtocol,
-            VolumeState, VolumeStatus,
+            UnpublishVolume, UnshareVolume, Volume, VolumeAccessMode, VolumeHealth, VolumeId,
+            VolumeShareProtocol, VolumeState, VolumeStatus,
         },
     },
 };
@@ -131,6 +131,7 @@ async fn nexus_persistence_test_iteration(
                 share: None,
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -212,6 +213,7 @@ async fn nexus_persistence_test_iteration(
                 share: None,
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -323,6 +325,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: Some(VolumeShareProtocol::Nvmf),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec!["a".into()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -337,6 +340,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: Some(VolumeShareProtocol::Nvmf),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec!["a".into()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -359,6 +363,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: Some(VolumeShareProtocol::Nvmf),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec!["b".into()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -381,6 +386,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: Some(VolumeShareProtocol::Nvmf),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec!["a".into(), "b".into()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -428,6 +434,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: None,
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -451,6 +458,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: None,
                 publish_context: HashMap::new(),
                 frontend_nodes: vec!["a".into()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -470,6 +478,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: None,
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -537,6 +546,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: None,
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -559,6 +569,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: Some(VolumeShareProtocol::Nvmf),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -594,6 +605,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: Some(VolumeShareProtocol::Iscsi),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -608,6 +620,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: Some(VolumeShareProtocol::Nvmf),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -630,6 +643,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: None,
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -1323,6 +1337,7 @@ async fn health() {
                 None,
                 HashMap::new(),
                 vec![],
+                VolumeAccessMode::SingleNodeWriter,
             ),
             None,
         )
@@ -1422,6 +1437,7 @@ async fn health() {
                 None,
                 HashMap::new(),
                 vec![],
+                VolumeAccessMode::SingleNodeWriter,
             ),
             None,
         )

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -317,6 +317,29 @@ async fn publishing_test(cluster: &Cluster) {
         }
     };
 
+    let error = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["a".into(), "b".into()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .expect_err("Can't publish multi nodes in single mode");
+    assert!(matches!(
+        error,
+        ReplyError {
+            kind: ReplyErrorKind::FrontendLimitExceeded,
+            resource: ResourceKind::Volume,
+            ..
+        },
+    ));
+
     let volume = volume_client
         .publish(
             &PublishVolume {
@@ -331,6 +354,28 @@ async fn publishing_test(cluster: &Cluster) {
         )
         .await
         .expect("Should be able to publish a newly created volume");
+
+    let error = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::MultiNodeMultiWriter,
+            },
+            None,
+        )
+        .await
+        .expect_err("Can't republish for all");
+    assert!(matches!(
+        error,
+        ReplyError {
+            kind: ReplyErrorKind::Internal,
+            ..
+        },
+    ));
 
     let error = volume_client
         .publish(
@@ -355,7 +400,30 @@ async fn publishing_test(cluster: &Cluster) {
         },
     ));
 
-    let volume = volume_client
+    let error = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::from([("".into(), "".into())]),
+                frontend_nodes: vec!["a".into()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .expect_err("Publish context differs!");
+    assert!(matches!(
+        error,
+        ReplyError {
+            kind: ReplyErrorKind::PublishedCtxDiffer,
+            resource: ResourceKind::Volume,
+            ..
+        },
+    ));
+
+    let error = volume_client
         .publish(
             &PublishVolume {
                 uuid: volume.spec().uuid.clone(),
@@ -364,6 +432,29 @@ async fn publishing_test(cluster: &Cluster) {
                 publish_context: HashMap::new(),
                 frontend_nodes: vec!["b".into()],
                 access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .expect_err("Can't add frontend nodes in single mode");
+    assert!(matches!(
+        error,
+        ReplyError {
+            kind: ReplyErrorKind::FrontendLimitExceeded,
+            resource: ResourceKind::Volume,
+            ..
+        },
+    ));
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["b".into()],
+                access_mode: VolumeAccessMode::MultiNodeMultiWriter,
             },
             None,
         )
@@ -386,7 +477,7 @@ async fn publishing_test(cluster: &Cluster) {
                 share: Some(VolumeShareProtocol::Nvmf),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec!["a".into(), "b".into()],
-                access_mode: VolumeAccessMode::SingleNodeWriter,
+                access_mode: VolumeAccessMode::MultiNodeMultiWriter,
             },
             None,
         )
@@ -561,7 +652,7 @@ async fn publishing_test(cluster: &Cluster) {
         .await
         .unwrap();
 
-    let volume = volume_client
+    let error = volume_client
         .publish(
             &PublishVolume {
                 uuid: volume_state.uuid.clone(),
@@ -570,6 +661,29 @@ async fn publishing_test(cluster: &Cluster) {
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![],
                 access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .expect_err("Need Multi Node Writer");
+    assert!(matches!(
+        error,
+        ReplyError {
+            kind: ReplyErrorKind::FrontendLimitExceeded,
+            resource: ResourceKind::Volume,
+            ..
+        },
+    ));
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume_state.uuid.clone(),
+                target_node: Some(cluster.node(0)),
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::MultiNodeMultiWriter,
             },
             None,
         )

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -46,7 +46,10 @@ async fn volume() {
         .with_io_engines(3)
         .with_tmpfs_pool(100 * 1024 * 1024)
         .with_cache_period("1s")
-        .with_options(|o| o.with_isolated_io_engine(true))
+        .with_options(|o| {
+            o.with_isolated_io_engine(true)
+                .no_deprecated_access_mode(true)
+        })
         // don't let the reconcile interfere with the tests
         .with_reconcile_period(Duration::from_secs(1000), Duration::from_secs(1000))
         .build()

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -23,7 +23,7 @@ use stor_port::{
         transport::{
             CreateReplica, CreateVolume, DestroyReplica, DestroyShutdownTargets, DestroyVolume,
             Filter, GetSpecs, Nexus, NodeStatus, PublishVolume, ReplicaId, RepublishVolume,
-            VolumeShareProtocol,
+            VolumeAccessMode, VolumeShareProtocol,
         },
     },
 };
@@ -76,6 +76,7 @@ async fn old_nexus_delete_after_vol_destroy() {
                 target_node: Some(cluster.node(0)),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![cluster.node(1).to_string()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -244,6 +245,7 @@ async fn lazy_delete_shutdown_targets() {
                 target_node: Some(cluster.node(0)),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![cluster.node(1).to_string()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -397,6 +399,7 @@ async fn volume_republish_nexus_recreation() {
                 target_node: Some(replica_node.into()),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![cluster.node(1).to_string()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -504,6 +507,7 @@ async fn node_exhaustion() {
                 target_node: None,
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![cluster.node(1).to_string()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -607,6 +611,7 @@ async fn shutdown_failed_replica_owner() {
                 target_node: Some(cluster.node(0)),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![cluster.node(1).to_string()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -737,6 +742,7 @@ async fn reshutdown(cluster: &Cluster) {
                 target_node: Some(cluster.node(1)),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![cluster.node(1).to_string()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -864,6 +870,7 @@ async fn republished_nexus_io_engine_txn_fail() {
                 target_node: Some(node_idx0.clone()),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![node_idx0.to_string()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )
@@ -1079,6 +1086,7 @@ async fn republished_nexus_core_agent_txn_fail() {
                 target_node: Some(node_idx0.clone()),
                 publish_context: HashMap::new(),
                 frontend_nodes: vec![node_idx0.to_string()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
         )

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -326,43 +326,37 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
     ) -> Result<Self::PublishOutput, SvcError> {
         let state = registry.volume_state(&request.uuid).await?;
 
-        if let Some(target_cfg) = self.as_ref().target_cfg() {
-            let target = target_cfg.target();
-
+        if let Some(mut target_cfg) = self.as_ref().target_cfg().cloned() {
             let host_acl =
                 registry.host_acl_nodename(HostAccessControl::Nexuses, &request.frontend_nodes);
-            if target_cfg.frontend().needs_update(&host_acl) {
-                let mut nexus = registry.specs().nexus(target.nexus()).await?;
-                let nexus_state = registry.nexus(target.nexus()).await?;
+            target_cfg.frontend_mut().add_acls(host_acl);
 
-                let mut target_cfg = target_cfg.clone();
-                target_cfg.frontend_mut().add_acls(host_acl);
+            let target = target_cfg.target();
+            let mut nexus = registry.specs().nexus(target.nexus()).await?;
+            let nexus_state = registry.nexus(target.nexus()).await?;
 
-                let operation = VolumeOperation::Publish(PublishOperation::new(
-                    target_cfg.clone(),
-                    request.publish_context.clone(),
-                ));
-                let spec_clone = self.start_update(registry, &state, operation).await?;
+            let operation =
+                VolumeOperation::Publish(PublishOperation::new(target_cfg.clone(), request));
+            let spec_clone = self.start_update(registry, &state, operation).await?;
 
-                let result = nexus
-                    .share(
-                        registry,
-                        &ShareNexus::new(
-                            &nexus_state,
-                            VolumeShareProtocol::Nvmf,
-                            target_cfg.frontend().node_nqns(),
-                        ),
-                    )
-                    .await;
+            let result = nexus
+                .share(
+                    registry,
+                    &ShareNexus::new(
+                        &nexus_state,
+                        VolumeShareProtocol::Nvmf,
+                        target_cfg.frontend().node_nqns(),
+                    ),
+                )
+                .await;
 
-                self.complete_update(registry, result, spec_clone).await?;
+            self.complete_update(registry, result, spec_clone).await?;
 
-                let volume = registry.volume(&request.uuid).await?;
-                registry
-                    .notify_if_degraded(&volume, PollTriggerEvent::VolumeDegraded)
-                    .await;
-                return Ok(volume);
-            }
+            let volume = registry.volume(&request.uuid).await?;
+            registry
+                .notify_if_degraded(&volume, PollTriggerEvent::VolumeDegraded)
+                .await;
+            return Ok(volume);
         }
 
         let nexus_node = self
@@ -380,10 +374,8 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
             )
             .await;
 
-        let operation = VolumeOperation::Publish(PublishOperation::new(
-            target_cfg.clone(),
-            request.publish_context.clone(),
-        ));
+        let operation =
+            VolumeOperation::Publish(PublishOperation::new(target_cfg.clone(), request));
         let spec_clone = self.start_update(registry, &state, operation).await?;
 
         // Create a Nexus on the requested or auto-selected node.

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -1067,10 +1067,7 @@ impl SpecOperationsHelper for VolumeSpec {
                     vol_id: self.uuid_str(),
                 })
             }
-            VolumeOperation::UnpublishOld | VolumeOperation::Unpublish(_) => {
-                self.publish_context = None;
-                Ok(())
-            }
+            VolumeOperation::UnpublishOld | VolumeOperation::Unpublish(_) => Ok(()),
 
             VolumeOperation::SetReplica(replica_count) => {
                 if *replica_count == self.num_replicas {

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -329,7 +329,11 @@ pub(crate) async fn healthy_volume_replicas(
     }
 }
 
-fn validate_publish(volume: &mut VolumeSpec, args: &PublishOperation) -> Result<(), SvcError> {
+fn validate_publish(
+    volume: &mut VolumeSpec,
+    args: &PublishOperation,
+    registry: &Registry,
+) -> Result<(), SvcError> {
     match args.protocol() {
         None => {
             // This can't happen in prod today as we always set a protocol, and it's not clear
@@ -364,7 +368,7 @@ fn validate_publish(volume: &mut VolumeSpec, args: &PublishOperation) -> Result<
             });
         }
 
-        if args.new_frontend_nodes().is_empty() {
+        if args.new_frontend_nodes().is_empty() && !frontend.nodes_info().is_empty() {
             return Err(SvcError::Internal {
                 details: "Can't re-publish for 0 frontend-nodes".to_string(),
             });
@@ -387,7 +391,7 @@ fn validate_publish(volume: &mut VolumeSpec, args: &PublishOperation) -> Result<
             });
         }
     } else if (args.new_frontend().nodes_info().len() > 1
-        || args.new_frontend().nodes_info().is_empty())
+        || (args.new_frontend().nodes_info().is_empty() && !registry.deprecated_access_mode()))
         && args.access_mode() == VolumeAccessMode::SingleNodeWriter
     {
         return Err(SvcError::VolumePublishSingle {
@@ -1099,7 +1103,7 @@ impl SpecOperationsHelper for VolumeSpec {
                 _ => Ok(()),
             },
             VolumeOperation::PublishOld(_) => Err(SvcError::InvalidArguments {}),
-            VolumeOperation::Publish(args) => validate_publish(self, args),
+            VolumeOperation::Publish(args) => validate_publish(self, args, registry),
             VolumeOperation::Republish(args) => match args.protocol() {
                 VolumeShareProtocol::Nvmf => Ok(()),
                 VolumeShareProtocol::Iscsi => Err(SvcError::InvalidShareProtocol {

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -34,13 +34,15 @@ use stor_port::{
             nexus_persistence::NexusInfoKey,
             replica::ReplicaSpec,
             snapshots::volume::{VolumeSnapshot, VolumeSnapshotUserSpec},
-            volume::{AffinityGroupId, AffinityGroupSpec, VolumeOperation, VolumeSpec},
+            volume::{
+                AffinityGroupId, AffinityGroupSpec, PublishOperation, VolumeOperation, VolumeSpec,
+            },
             SpecStatus, SpecTransaction,
         },
         transport::{
             CreateReplica, CreateVolume, NodeBugFix, NodeId, PoolId, Protocol, Replica, ReplicaId,
-            ReplicaName, ReplicaOwners, SnapshotId, VolumeId, VolumeShareProtocol, VolumeState,
-            VolumeStatus,
+            ReplicaName, ReplicaOwners, SnapshotId, VolumeAccessMode, VolumeId,
+            VolumeShareProtocol, VolumeState, VolumeStatus,
         },
     },
 };
@@ -325,6 +327,77 @@ pub(crate) async fn healthy_volume_replicas(
     } else {
         Ok(children)
     }
+}
+
+fn validate_publish(volume: &mut VolumeSpec, args: &PublishOperation) -> Result<(), SvcError> {
+    match args.protocol() {
+        None => {
+            // This can't happen in prod today as we always set a protocol, and it's not clear
+            // how it should be handled, so just set an internal error for now.
+            // This may become more appropriate once we do offline rebuilds...
+            if volume.target_cfg().is_some() {
+                return Err(SvcError::Internal {
+                    details: "Can't re-publish with no protocol".to_string(),
+                });
+            }
+            return Ok(());
+        }
+        Some(protocol) => match protocol {
+            VolumeShareProtocol::Nvmf => Ok(()),
+            VolumeShareProtocol::Iscsi => Err(SvcError::InvalidShareProtocol {
+                kind: ResourceKind::Volume,
+                id: volume.uuid_str(),
+                share: format!("{:?}", args.protocol()),
+            }),
+        }?,
+    }
+
+    if let Some(target_cfg) = volume.target_cfg() {
+        let target = target_cfg.target();
+        let frontend = target_cfg.frontend();
+
+        if volume.publish_context.as_ref() != Some(args.publish_context()) {
+            return Err(SvcError::VolumePublishCtxDiffer {
+                vol_id: volume.uuid_str(),
+                current: volume.publish_context.clone().unwrap_or_default(),
+                requested: args.publish_context().clone(),
+            });
+        }
+
+        if args.new_frontend_nodes().is_empty() {
+            return Err(SvcError::Internal {
+                details: "Can't re-publish for 0 frontend-nodes".to_string(),
+            });
+        }
+
+        if !frontend.needs_update(args.new_frontend().nodes_info()) {
+            return Err(SvcError::VolumeAlreadyPublished {
+                vol_id: volume.uuid_str(),
+                node: target.node().to_string(),
+                protocol: format!("{:?}", target.protocol()),
+            });
+        }
+
+        // Volume already published to different frontend node, and specified mode is SNW,
+        // then we must error out since this is not allowed
+        if args.access_mode() == VolumeAccessMode::SingleNodeWriter {
+            return Err(SvcError::VolumePublishSingle {
+                vol_id: volume.uuid_str(),
+                nodes: target_cfg.frontend().node_names(),
+            });
+        }
+    } else if (args.new_frontend().nodes_info().len() > 1
+        || args.new_frontend().nodes_info().is_empty())
+        && args.access_mode() == VolumeAccessMode::SingleNodeWriter
+    {
+        return Err(SvcError::VolumePublishSingle {
+            vol_id: volume.uuid_str(),
+            nodes: args.new_frontend().node_names(),
+        });
+    }
+
+    volume.publish_context = Some(args.publish_context().clone());
+    Ok(())
 }
 
 /// Check if any replica is on a pool that doesn't have sufficient space for
@@ -1026,32 +1099,7 @@ impl SpecOperationsHelper for VolumeSpec {
                 _ => Ok(()),
             },
             VolumeOperation::PublishOld(_) => Err(SvcError::InvalidArguments {}),
-            VolumeOperation::Publish(args) => match args.protocol() {
-                None => Ok(()),
-                Some(protocol) => match protocol {
-                    VolumeShareProtocol::Nvmf => {
-                        if let Some(target) = self.target() {
-                            if self.publish_context == Some(args.publish_context()) {
-                                Ok(())
-                            } else {
-                                Err(SvcError::VolumeAlreadyPublished {
-                                    vol_id: self.uuid_str(),
-                                    node: target.node().to_string(),
-                                    protocol: format!("{:?}", target.protocol()),
-                                })
-                            }
-                        } else {
-                            self.publish_context = Some(args.publish_context());
-                            Ok(())
-                        }
-                    }
-                    VolumeShareProtocol::Iscsi => Err(SvcError::InvalidShareProtocol {
-                        kind: ResourceKind::Volume,
-                        id: self.uuid_str(),
-                        share: format!("{:?}", args.protocol()),
-                    }),
-                },
-            },
+            VolumeOperation::Publish(args) => validate_publish(self, args),
             VolumeOperation::Republish(args) => match args.protocol() {
                 VolumeShareProtocol::Nvmf => Ok(()),
                 VolumeShareProtocol::Iscsi => Err(SvcError::InvalidShareProtocol {

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -1,4 +1,5 @@
 use snafu::{Error, Snafu};
+use std::collections::HashMap;
 use stor_port::{
     transport_api::{ErrorChain, ReplyError, ReplyErrorKind, ResourceKind},
     types::v0::{
@@ -167,16 +168,21 @@ pub enum SvcError {
         share: String,
     },
     #[snafu(display(
-        "Volume '{}' is already published on node '{}' with protocol '{}'",
-        vol_id,
-        node,
-        protocol
+        "Volume '{vol_id}' is already published on node '{node}' with protocol '{protocol}'"
     ))]
     VolumeAlreadyPublished {
         vol_id: String,
         node: String,
         protocol: String,
     },
+    #[snafu(display("Volume '{vol_id}' is already published with current context ({current:?}) != requested ({requested:?})"))]
+    VolumePublishCtxDiffer {
+        vol_id: String,
+        current: HashMap<String, String>,
+        requested: HashMap<String, String>,
+    },
+    #[snafu(display("Volume '{vol_id}' is already published for nodes '{nodes:?}'"))]
+    VolumePublishSingle { vol_id: String, nodes: Vec<String> },
     #[snafu(display(
         "Volume '{}' - required size is invalid. Current size: '{}', requested size: '{}'",
         vol_id,
@@ -800,6 +806,18 @@ impl From<SvcError> for ReplyError {
             },
             SvcError::VolumeAlreadyPublished { .. } => ReplyError {
                 kind: ReplyErrorKind::AlreadyPublished,
+                resource: ResourceKind::Volume,
+                source,
+                extra,
+            },
+            SvcError::VolumePublishCtxDiffer { .. } => ReplyError {
+                kind: ReplyErrorKind::PublishedCtxDiffer,
+                resource: ResourceKind::Volume,
+                source,
+                extra,
+            },
+            SvcError::VolumePublishSingle { .. } => ReplyError {
+                kind: ReplyErrorKind::FrontendLimitExceeded,
                 resource: ResourceKind::Volume,
                 source,
                 extra,

--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -54,6 +54,7 @@ utils = { workspace = true }
 shutdown = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 parse-size = { workspace = true }
+percent-encoding = { workspace = true }
 
 [target.'cfg(target_os="linux")'.dependencies]
 udev = { workspace = true }

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -1,13 +1,13 @@
 use crate::CsiControllerConfig;
-use stor_port::types::v0::openapi::{client::Error, models::rest_json_error::Kind};
 use stor_port::types::v0::openapi::{
+    client::Error,
     clients,
     clients::tower::StatusCode,
     models,
     models::{
-        AffinityGroup, AppNode, CreateVolumeBody, Node, NodeTopology, Pool, PoolTopology,
-        PublishVolumeBody, ResizeVolumeBody, RestJsonError, Topology, Volume, VolumePolicy,
-        VolumeShareProtocol, Volumes,
+        rest_json_error::Kind, AffinityGroup, AppNode, CreateVolumeBody, Node, NodeTopology, Pool,
+        PoolTopology, PublishVolumeBody, ResizeVolumeBody, RestJsonError, Topology, Volume,
+        VolumeAccessMode, VolumePolicy, VolumeShareProtocol, Volumes,
     },
 };
 
@@ -429,6 +429,7 @@ impl RestApiClient {
         protocol: VolumeShareProtocol,
         frontend_node: String,
         publish_context: &HashMap<String, String>,
+        access_mode: VolumeAccessMode,
     ) -> Result<Volume, ApiClientError> {
         let publish_volume_body = PublishVolumeBody::new_all(
             publish_context.clone(),
@@ -437,6 +438,7 @@ impl RestApiClient {
             protocol,
             None,
             frontend_node,
+            Some(access_mode),
         );
         let volume = match self
             .rest_client

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -14,7 +14,7 @@ use stor_port::types::v0::openapi::{
     models,
     models::{
         AffinityGroup, AppNode, LabelledTopology, NodeSpec, NodeStatus, Pool, PoolStatus,
-        PoolTopology, SpecStatus, Volume, VolumeShareProtocol,
+        PoolTopology, SpecStatus, Volume, VolumeAccessMode, VolumeShareProtocol,
     },
 };
 use utils::{dsp_created_by_key, DEFAULT_REQ_TIMEOUT, DSP_OPERATOR};
@@ -24,7 +24,6 @@ use std::{collections::HashMap, str::FromStr, time::Duration};
 use tonic::{transport::Uri, Code, Request, Response, Status};
 use tracing::{debug, error, instrument, trace, warn};
 use uuid::Uuid;
-use volume_capability::AccessType;
 
 const VOLUME_NAME_PATTERN: &str =
     r"pvc-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})";
@@ -76,7 +75,7 @@ fn check_volume_capabilities(
 fn check_volume_capability(
     capability: &VolumeCapability,
     rwx_block: &Option<bool>,
-) -> Result<volume_capability::access_mode::Mode, tonic::Status> {
+) -> Result<models::VolumeAccessMode, tonic::Status> {
     let Some(access_mode) = capability.access_mode.as_ref() else {
         return Err(tonic::Status::invalid_argument("missing access_mode"));
     };
@@ -86,11 +85,13 @@ fn check_volume_capability(
         return Err(tonic::Status::invalid_argument("missing access_type"));
     };
     match access_mode {
-        volume_capability::access_mode::Mode::SingleNodeWriter => Ok(access_mode),
+        volume_capability::access_mode::Mode::SingleNodeWriter => {
+            Ok(VolumeAccessMode::SingleNodeWriter)
+        }
         volume_capability::access_mode::Mode::MultiNodeMultiWriter => {
-            if matches!(access_type, AccessType::Block(_)) {
+            if matches!(access_type, volume_capability::AccessType::Block(_)) {
                 if rwx_block == &Some(true) {
-                    Ok(access_mode)
+                    Ok(VolumeAccessMode::MultiNodeMultiWriter)
                 } else {
                     Err(Status::invalid_argument(
                         "MultiNodeMultiWriter requested but RWX Block is disabled".to_string(),
@@ -604,7 +605,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                         // Make sure volume is accessible from the same app node.
                         if let Err(allowed) = frontend_nodes_allowed(target, &node_id) {
 
-                            if access_mode == volume_capability::access_mode::Mode::SingleNodeWriter {
+                            if access_mode == VolumeAccessMode::SingleNodeWriter {
                                 let m = format!(
                                     "Volume {volume_id} is only accessible to nodes: {allowed:?}, and not to {node_id}"
                                 );
@@ -621,7 +622,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                             }
 
                             let v = RestApiClient::get_client()
-                                .publish_volume(&volume_id, Some(&node), protocol, args.node_id.clone(), &publish_context)
+                                .publish_volume(&volume_id, Some(&node), protocol, args.node_id.clone(), &publish_context, access_mode)
                                 .await?;
 
                             if let Some((node, uri)) = get_volume_share_location(&v) {
@@ -679,7 +680,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
 
                     // Volume is not published.
                     let v = RestApiClient::get_client()
-                        .publish_volume(&volume_id, target_node, protocol, args.node_id.clone(), &publish_context)
+                        .publish_volume(&volume_id, target_node, protocol, args.node_id.clone(), &publish_context, access_mode)
                         .await?;
 
                     if let Some((node, uri)) = get_volume_share_location(&v) {
@@ -1130,7 +1131,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
         // Block type volume.
         let node_expansion_required = !matches!(
             args.volume_capability.as_ref(),
-            Some(vc) if matches!(vc.access_type, Some(AccessType::Block(_)))
+            Some(vc) if matches!(vc.access_type, Some(volume_capability::AccessType::Block(_)))
         );
 
         let _guard = csi_driver::limiter::VolumeOpGuard::new(vol_uuid)?;

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -696,7 +696,10 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                 }
             };
 
-        publish_context.insert("uri".to_string(), uri);
+        publish_context.insert(
+            "uri".to_string(),
+            csi_driver::parse_host_uri(&node_id, &uri)?,
+        );
 
         tracing::info!(?publish_context, "{}", req.log_str());
         Ok(Response::new(ControllerPublishVolumeResponse {

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -99,6 +99,7 @@ impl Node {
         };
 
         let uri = client.volume_uri(volume_id).await?;
+        let uri = csi_driver::parse_host_uri(&self.node_name, &uri)?;
         if &uri != ctx_uri {
             tracing::warn!(volume.uri=%uri, ctx.uri=%ctx_uri, "Overriding URI volume context with URI from REST");
         }

--- a/control-plane/csi-driver/src/lib.rs
+++ b/control-plane/csi-driver/src/lib.rs
@@ -53,6 +53,45 @@ pub fn node_name_topology_key() -> String {
     format!("{PRODUCT_DOMAIN_NAME}/nodename")
 }
 
+/// The volume's share uri contains the hostnqns for all allowed hosts.
+/// This function parses the and retains the hostnqn only for `node_id`.
+pub fn parse_host_uri(node_id: &str, uri: &str) -> Result<String, tonic::Status> {
+    let mut url =
+        url::Url::parse(uri).map_err(|error| tonic::Status::internal(format!("{uri}: {error}")))?;
+    let node_nqn: String =
+        stor_port::types::v0::transport::NvmeNqn::from_nodename(node_id).to_string();
+    let queries = url
+        .query_pairs()
+        .filter(|(name, value)| name != "hostnqn" || value == &node_nqn)
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect::<Vec<(_, _)>>();
+    url.query_pairs_mut().clear().extend_pairs(queries);
+
+    // we have to decode because otherwise the nqn would be encoded, ex:
+    // nqn.2019-05.io.openebs%3Anode-name%3Aksworker-1
+    Ok(percent_encoding::percent_decode_str(url.as_ref())
+        .decode_utf8_lossy()
+        .to_string())
+}
+
+#[test]
+fn test_parse_host_uri() {
+    let uri = parse_host_uri("node-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2").unwrap();
+    assert_eq!(
+        uri,
+        "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?"
+    );
+    let uri = parse_host_uri("node-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2&a=1").unwrap();
+    assert_eq!(
+        uri,
+        "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?a=1"
+    );
+    let uri = parse_host_uri("ksworker-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2").unwrap();
+    assert_eq!(uri, "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1");
+    let uri = parse_host_uri("ksworker-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?a=1,hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2").unwrap();
+    assert_eq!(uri, "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?a=1,hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1");
+}
+
 /// Volume Parameters parsed from context.
 pub use context::{CreateParams, Parameters, PublishParams};
 

--- a/control-plane/grpc/proto/v1/misc/common.proto
+++ b/control-plane/grpc/proto/v1/misc/common.proto
@@ -72,6 +72,8 @@ enum ReplyErrorKind {
   Cancelled = 32;
   DiskNotExtended = 33;
   DiskRescanFailed = 34;
+  PublishedCtxDiffer = 35;
+  FrontendLimitExceeded = 36;
 }
 
 // ResourceKind for the resource which has undergone this error

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -304,6 +304,11 @@ message CreateVolumeRequest {
   optional uint32 cluster_size = 13;
 }
 
+enum AccessMode {
+    SingleNodeWriter = 0;
+    MultiNodeMultiWriter = 1;
+}
+
 // Publish a volume on a node
 // Unpublishes the nexus if it's published somewhere else and creates a nexus on the given node.
 // Then, share the nexus via the provided share protocol.-
@@ -316,8 +321,10 @@ message PublishVolumeRequest {
   optional VolumeShareProtocol share = 3;
   // publish context
   map<string, string> publish_context = 4;
-  /// Hosts allowed to access target.
+  // Hosts allowed to access target.
   repeated string frontend_nodes = 5;
+  // Defaults to access mode of SingleNodeWriter.
+  optional AccessMode access_mode = 6;
 }
 
 // Republish a volume on a node by shutting down existing target

--- a/control-plane/grpc/src/misc/traits.rs
+++ b/control-plane/grpc/src/misc/traits.rs
@@ -105,6 +105,8 @@ impl From<ReplyErrorKind> for common::ReplyErrorKind {
             ReplyErrorKind::Cancelled => Self::Cancelled,
             ReplyErrorKind::DiskNotExtended => Self::DiskNotExtended,
             ReplyErrorKind::DiskRescanFailed => Self::DiskRescanFailed,
+            ReplyErrorKind::PublishedCtxDiffer => Self::PublishedCtxDiffer,
+            ReplyErrorKind::FrontendLimitExceeded => Self::FrontendLimitExceeded,
         }
     }
 }
@@ -147,6 +149,8 @@ impl From<common::ReplyErrorKind> for ReplyErrorKind {
             common::ReplyErrorKind::Cancelled => Self::Cancelled,
             common::ReplyErrorKind::DiskNotExtended => Self::DiskNotExtended,
             common::ReplyErrorKind::DiskRescanFailed => Self::DiskRescanFailed,
+            common::ReplyErrorKind::PublishedCtxDiffer => Self::PublishedCtxDiffer,
+            common::ReplyErrorKind::FrontendLimitExceeded => Self::FrontendLimitExceeded,
         }
     }
 }

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -7,7 +7,7 @@ use crate::{
     operations::{Event, Pagination},
     replica, volume,
     volume::{
-        get_volumes_request, CreateSnapshotVolumeRequest, CreateVolumeRequest,
+        get_volumes_request, AccessMode, CreateSnapshotVolumeRequest, CreateVolumeRequest,
         DestroyShutdownTargetRequest, DestroyVolumeRequest, PublishVolumeRequest,
         RegisteredTargets, RepublishVolumeRequest, ResizeVolumeRequest, SetVolumePropertyRequest,
         SetVolumeReplicaRequest, ShareVolumeRequest, UnpublishVolumeRequest, UnshareVolumeRequest,
@@ -31,8 +31,9 @@ use stor_port::{
             NexusNvmfConfig, NodeId, NodeTopology, NvmeNqn, PoolTopology, PublishVolume, ReplicaId,
             ReplicaStatus, ReplicaTopology, ReplicaUsage, RepublishVolume, ResizeVolume,
             SetVolumeProperty, SetVolumeReplica, ShareVolume, SnapshotId, Topology,
-            UnpublishVolume, UnshareVolume, Volume, VolumeHealth, VolumeId, VolumeLabels,
-            VolumePolicy, VolumeProperty, VolumeShareProtocol, VolumeState, VolumeUsage,
+            UnpublishVolume, UnshareVolume, Volume, VolumeAccessMode, VolumeHealth, VolumeId,
+            VolumeLabels, VolumePolicy, VolumeProperty, VolumeShareProtocol, VolumeState,
+            VolumeUsage,
         },
     },
     IntoOption, IntoVec, TryIntoOption,
@@ -1415,6 +1416,8 @@ pub trait PublishVolumeInfo: Send + Sync + std::fmt::Debug {
     fn publish_context(&self) -> HashMap<String, String>;
     /// Hosts allowed to access the nexus.
     fn frontend_nodes(&self) -> Vec<String>;
+    /// Access Mode for the volume.
+    fn access_mode(&self) -> VolumeAccessMode;
 }
 
 impl PublishVolumeInfo for PublishVolume {
@@ -1436,6 +1439,10 @@ impl PublishVolumeInfo for PublishVolume {
 
     fn frontend_nodes(&self) -> Vec<String> {
         self.frontend_nodes.clone()
+    }
+
+    fn access_mode(&self) -> VolumeAccessMode {
+        self.access_mode
     }
 }
 
@@ -1459,6 +1466,11 @@ impl PublishVolumeInfo for RepublishVolume {
     fn frontend_nodes(&self) -> Vec<String> {
         unimplemented!()
     }
+
+    fn access_mode(&self) -> VolumeAccessMode {
+        // Ignore for republish, access mode is kept...
+        VolumeAccessMode::default()
+    }
 }
 
 /// Intermediate structure that validates the conversion to PublishVolumeRequest type.
@@ -1468,6 +1480,7 @@ pub struct ValidatedPublishVolumeRequest {
     uuid: VolumeId,
     share: Option<VolumeShareProtocol>,
     frontend_nodes: Vec<String>,
+    access_mode: VolumeAccessMode,
 }
 
 impl PublishVolumeInfo for ValidatedPublishVolumeRequest {
@@ -1493,6 +1506,10 @@ impl PublishVolumeInfo for ValidatedPublishVolumeRequest {
     fn frontend_nodes(&self) -> Vec<String> {
         self.frontend_nodes.clone()
     }
+
+    fn access_mode(&self) -> VolumeAccessMode {
+        self.access_mode
+    }
 }
 
 impl ValidateRequestTypes for PublishVolumeRequest {
@@ -1515,6 +1532,9 @@ impl ValidateRequestTypes for PublishVolumeRequest {
             },
             inner: self.clone(),
             frontend_nodes: self.frontend_nodes,
+            access_mode: AccessMode::try_from(self.access_mode.unwrap_or_default())
+                .unwrap_or_default()
+                .into(),
         })
     }
 }
@@ -1527,6 +1547,7 @@ impl From<&dyn PublishVolumeInfo> for PublishVolume {
             share: data.share(),
             publish_context: data.publish_context(),
             frontend_nodes: data.frontend_nodes(),
+            access_mode: data.access_mode(),
         }
     }
 }
@@ -1546,6 +1567,24 @@ impl From<&dyn PublishVolumeInfo> for PublishVolumeRequest {
             share,
             publish_context: data.publish_context(),
             frontend_nodes: data.frontend_nodes(),
+            access_mode: Some(AccessMode::from(data.access_mode()) as i32),
+        }
+    }
+}
+
+impl From<VolumeAccessMode> for AccessMode {
+    fn from(value: VolumeAccessMode) -> Self {
+        match value {
+            VolumeAccessMode::SingleNodeWriter => Self::SingleNodeWriter,
+            VolumeAccessMode::MultiNodeMultiWriter => Self::MultiNodeMultiWriter,
+        }
+    }
+}
+impl From<AccessMode> for VolumeAccessMode {
+    fn from(value: AccessMode) -> Self {
+        match value {
+            AccessMode::SingleNodeWriter => VolumeAccessMode::SingleNodeWriter,
+            AccessMode::MultiNodeMultiWriter => VolumeAccessMode::MultiNodeMultiWriter,
         }
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -2587,9 +2587,9 @@ components:
           minimum: 4194304
           multipleOf: 4194304
           description: |-
-           Blobstore cluster size for the pool, in bytes. Must be >= 4 MiB and in multiples of 4MiB.
-           This is an advanced option. Please refer documentation to understand the implications
-           of changing this.
+            Blobstore cluster size for the pool, in bytes. Must be >= 4 MiB and in multiples of 4MiB.
+            This is an advanced option. Please refer documentation to understand the implications
+            of changing this.
         max_expansion:
           type: string
           description: |-
@@ -2815,8 +2815,8 @@ components:
           type: boolean
         cluster_size:
           description: |-
-           Choose only the pools matching this cluster_size for the replicas of this volume.
-           This is an advanced option. Please refer documentation to understand the usage.
+            Choose only the pools matching this cluster_size for the replicas of this volume.
+            This is an advanced option. Please refer documentation to understand the usage.
           type: integer
           format: int64
           minimum: 4194304
@@ -2930,12 +2930,22 @@ components:
             The node where the front-end workload resides.
             If the workload moves then the volume must be republished.
           type: string
+        access_mode:
+          description: Volume publish access mode, a la CSI.
+          allOf:
+            - $ref: '#/components/schemas/VolumeAccessMode'
       required:
         - publish_context
         - protocol
     JsonGeneric:
       description: 'Generic JSON value eg: { "size": 1024 }'
       type: object
+    VolumeAccessMode:
+      description: Volume Access Mode, a la CSI
+      type: string
+      enum:
+        - SingleNodeWriter
+        - MultiNodeMultiWriter
     NexusState:
       description: State of the Nexus
       type: string

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3436,6 +3436,8 @@ components:
             - Cancelled
             - DiskNotExtended
             - DiskRescanFailed
+            - PublishedCtxDiffer
+            - FrontendLimitExceeded
       required:
         - details
         - kind

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -267,6 +267,7 @@ impl apis::actix_server::Volumes for RestApi {
                             share: Some(publish_volume_body.protocol.into()),
                             publish_context: publish_volume_body.publish_context,
                             frontend_nodes: publish_volume_body.frontend_node.into_iter().collect(),
+                            access_mode: publish_volume_body.access_mode.unwrap_or_default().into(),
                         },
                         None,
                     )

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -323,6 +323,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await
@@ -551,6 +552,7 @@ async fn unpublish_from_nonfrontend_node() {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await

--- a/control-plane/stor-port/src/transport_api/mod.rs
+++ b/control-plane/stor-port/src/transport_api/mod.rs
@@ -447,6 +447,8 @@ pub enum ReplyErrorKind {
     Cancelled,
     DiskNotExtended,
     DiskRescanFailed,
+    PublishedCtxDiffer,
+    FrontendLimitExceeded,
 }
 
 impl From<tonic::Code> for ReplyErrorKind {

--- a/control-plane/stor-port/src/types/mod.rs
+++ b/control-plane/stor-port/src/types/mod.rs
@@ -106,6 +106,14 @@ impl From<ReplyError> for RestError<RestJsonError> {
                 let error = RestJsonError::new(details, message, Kind::AlreadyPublished);
                 (StatusCode::PRECONDITION_FAILED, error)
             }
+            ReplyErrorKind::PublishedCtxDiffer => {
+                let error = RestJsonError::new(details, message, Kind::PublishedCtxDiffer);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::FrontendLimitExceeded => {
+                let error = RestJsonError::new(details, message, Kind::FrontendLimitExceeded);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
             ReplyErrorKind::Deleting => {
                 let error = RestJsonError::new(details, message, Kind::Deleting);
                 (StatusCode::CONFLICT, error)

--- a/control-plane/stor-port/src/types/v0/store/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus.rs
@@ -335,6 +335,13 @@ pub enum NexusOperation {
     OwnerUpdate(NexusOwners),
     Resize(u64),
 }
+impl NexusOperation {
+    /// Create a new sorted share operation.
+    pub fn new_share(share: NexusShareProtocol, mut allowed_hosts: Vec<HostNqn>) -> Self {
+        allowed_hosts.sort();
+        Self::Share(share, allowed_hosts)
+    }
+}
 
 /// Key used by the store to uniquely identify a NexusSpec structure.
 pub struct NexusSpecKey(NexusId);

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -11,8 +11,8 @@ use crate::{
         },
         transport::{
             self, AffinityGroup, CreateVolume, HostNqn, NexusId, NexusNvmfConfig, NodeId,
-            ReplicaId, SnapshotId, Topology, VolumeId, VolumeLabels, VolumePolicy, VolumeProperty,
-            VolumeShareProtocol, VolumeStatus,
+            PublishVolume, ReplicaId, SnapshotId, Topology, VolumeAccessMode, VolumeId,
+            VolumeLabels, VolumePolicy, VolumeProperty, VolumeShareProtocol, VolumeStatus,
         },
     },
     IntoOption,
@@ -680,15 +680,20 @@ pub struct OldPublishOperation {
 /// The `PublishOperation` which is easier to manage and update.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct PublishOperation {
+    /// The new target configuration, considering a successful completion.
     config: TargetConfig,
     publish_context: HashMap<String, String>,
+    access_mode: VolumeAccessMode,
+    frontend_nodes: Vec<String>,
 }
 impl PublishOperation {
     /// Return new `Self` from the given parameters.
-    pub fn new(config: TargetConfig, publish_context: HashMap<String, String>) -> Self {
+    pub fn new(config: TargetConfig, publish_volume: &PublishVolume) -> Self {
         Self {
             config,
-            publish_context,
+            publish_context: publish_volume.publish_context.clone(),
+            access_mode: publish_volume.access_mode,
+            frontend_nodes: publish_volume.frontend_nodes.clone(),
         }
     }
     /// Get the share protocol.
@@ -696,8 +701,20 @@ impl PublishOperation {
         self.config.target.protocol
     }
     /// Get the publish context.
-    pub fn publish_context(&self) -> HashMap<String, String> {
-        self.publish_context.clone()
+    pub fn publish_context(&self) -> &HashMap<String, String> {
+        &self.publish_context
+    }
+    /// Get a reference to the new frontend configuration.
+    pub fn new_frontend(&self) -> &FrontendConfig {
+        self.config.frontend()
+    }
+    /// Get a reference to the new frontend nodes.
+    pub fn new_frontend_nodes(&self) -> &Vec<String> {
+        &self.frontend_nodes
+    }
+    /// Get the volume access mode.
+    pub fn access_mode(&self) -> VolumeAccessMode {
+        self.access_mode
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -458,11 +458,13 @@ impl VolumeSpec {
     pub fn active_config(&self) -> Option<&TargetConfig> {
         self.target_config.as_ref().filter(|t| t.active)
     }
-    /// Deactivate the current target but keep it's information around.
+    /// Deactivate the current target but keep its information around.
     pub fn deactivate_target(&mut self) {
         if let Some(cfg) = self.target_config.as_mut() {
             cfg.active = false;
         }
+        // todo: is there any case where we might want to keep it around?
+        self.publish_context = None;
     }
     /// Get the health info key which is used to retrieve the volume's replica health information.
     pub fn health_info_id(&self) -> Option<&NexusId> {

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -64,6 +64,7 @@ impl FrontendConfig {
                 self.host_acl.push(host);
             }
         }
+        self.host_acl.sort();
     }
     /// Extend the existing host list.
     pub fn remove_acls(&mut self, host_acl: Vec<InitiatorAC>) {
@@ -71,6 +72,7 @@ impl FrontendConfig {
             self.host_acl.drain(..);
         }
         self.host_acl.retain(|h| !host_acl.contains(h));
+        self.host_acl.sort();
     }
     /// Check if the nodename is allowed.
     pub fn nodename_allowed(&self, nodename: &str) -> bool {
@@ -99,7 +101,7 @@ impl FrontendConfig {
 }
 
 /// Volume Frontend
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Default)]
 pub struct InitiatorAC {
     /// The nodename where front-end IO will be sent from.
     node_name: String,

--- a/control-plane/stor-port/src/types/v0/transport/nvme_nqn.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nvme_nqn.rs
@@ -18,7 +18,7 @@ const DOMAIN_LABEL_MAX_LEN: usize = 63;
 /// For more information please refer to the NVMe SPEC, eg:
 /// https://nvmexpress.org/wp-content/uploads/NVMe-NVM-Express-2.0a-2021.07.26-Ratified.pdf
 /// Chapter 4.5.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum NvmeNqn {
     /// This naming format 1 may be used to create a human interpretable string to describe
     /// the host or NVM subsystem. This format consists of:
@@ -55,6 +55,25 @@ pub enum NvmeNqn {
     /// Invalid Nqn Format, may be useful as a temporary placeholder.
     Invalid { nqn: String },
 }
+impl Ord for NvmeNqn {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.to_string().cmp(&other.to_string())
+    }
+}
+
+impl PartialOrd for NvmeNqn {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for NvmeNqn {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string() == other.to_string()
+    }
+}
+
+impl Eq for NvmeNqn {}
 impl Default for NvmeNqn {
     fn default() -> Self {
         let uuid = uuid::Uuid::default();

--- a/control-plane/stor-port/src/types/v0/transport/nvme_nqn.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nvme_nqn.rs
@@ -116,7 +116,7 @@ impl NvmeNqn {
         Self::Unique { uuid }
     }
     /// Generate a product type name.
-    pub fn from_nodename(name: &String) -> Self {
+    pub fn from_nodename(name: &str) -> Self {
         Self::Org {
             date: utils::constants::NVME_NQN_DATE.to_string(),
             domain: utils::constants::NVME_NQN_ORG.to_string(),

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -606,6 +606,22 @@ pub struct RemoveVolumeNexus {
     pub node: Option<NodeId>,
 }
 
+/// The access mode a la CSI.
+#[derive(Serialize, Deserialize, Default, Debug, Copy, Clone, PartialEq)]
+pub enum VolumeAccessMode {
+    #[default]
+    SingleNodeWriter,
+    MultiNodeMultiWriter,
+}
+impl From<models::VolumeAccessMode> for VolumeAccessMode {
+    fn from(value: models::VolumeAccessMode) -> Self {
+        match value {
+            models::VolumeAccessMode::SingleNodeWriter => Self::SingleNodeWriter,
+            models::VolumeAccessMode::MultiNodeMultiWriter => Self::MultiNodeMultiWriter,
+        }
+    }
+}
+
 /// Publish a volume on a target node.
 /// If requested, it'll also share the nexus via the provided share protocol.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
@@ -621,6 +637,8 @@ pub struct PublishVolume {
     pub publish_context: HashMap<String, String>,
     /// Hosts allowed to access nexus.
     pub frontend_nodes: Vec<String>,
+    /// The access mode (a la csi) for the volume.
+    pub access_mode: VolumeAccessMode,
 }
 impl PublishVolume {
     /// Create new `PublishVolume` based on the provided arguments.
@@ -630,6 +648,7 @@ impl PublishVolume {
         share: Option<VolumeShareProtocol>,
         publish_context: HashMap<String, String>,
         frontend_nodes: Vec<String>,
+        access_mode: VolumeAccessMode,
     ) -> Self {
         Self {
             uuid,
@@ -637,6 +656,7 @@ impl PublishVolume {
             share,
             publish_context,
             frontend_nodes,
+            access_mode,
         }
     }
 }

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -77,6 +77,9 @@ impl ComponentAction for CoreAgent {
         if let Some(cluster_size) = options.pool_cluster_size {
             binary = binary.with_args(vec!["--pool-cluster-size", &cluster_size.to_string()]);
         }
+        if !options.no_deprecated_access_mode {
+            binary = binary.with_arg("--deprecated-access-mode");
+        }
 
         Ok(cfg.add_container_spec(
             ContainerSpec::from_binary(name, binary).with_portmap("50051", "50051"),

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -352,6 +352,8 @@ pub struct StartOptions {
     /// to configure cluster size per-pool.
     #[clap(long)]
     pool_cluster_size: Option<u32>,
+    #[clap(long, hide = true)]
+    no_deprecated_access_mode: bool,
 }
 
 /// List of KeyValues
@@ -634,6 +636,11 @@ impl StartOptions {
         let mut sorted = self.io_engine_api_versions.clone();
         sorted.sort();
         *sorted.last().unwrap_or(&IoEngineApiVersion::V1)
+    }
+    #[must_use]
+    pub fn no_deprecated_access_mode(mut self, value: bool) -> Self {
+        self.no_deprecated_access_mode = value;
+        self
     }
 }
 

--- a/terraform/cluster/mod/k8s/kubeadm_config.yaml
+++ b/terraform/cluster/mod/k8s/kubeadm_config.yaml
@@ -20,11 +20,11 @@ apiServer:
   timeoutForControlPlane: 4m0s
   certSANs:
     - ${cert_sans}
-  extraArgs:
-    "feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
+  # extraArgs:
+  #   "feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
 controllerManager:
-  extraArgs:
-    "feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
+  # extraArgs:
+  #   "feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
 clusterName: castrol
 kind: ClusterConfiguration
 networking:

--- a/terraform/cluster/mod/k8s/master.sh
+++ b/terraform/cluster/mod/k8s/master.sh
@@ -8,11 +8,21 @@ sudo kubeadm init --config /tmp/kubeadm_config.yaml \
 sudo cp /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
+# When this doesn't complete, you may debug the created containers, example:
+# sudo crictl --runtime-endpoint unix:///var/run/containerd/containerd.sock ps -a
+# CONTAINER           IMAGE               CREATED             STATE               NAME                      ATTEMPT             POD ID              POD
+# 186b1d4e98b4e       07d562355feda       19 seconds ago      Exited              kube-apiserver            8                   c2caa089e0d8d       kube-apiserver-ksmaster-1
+# 721c771742872       097a9f9514c71       25 seconds ago      Exited              kube-controller-manager   8                   2873b68d1a3d8       kube-controller-manager-ksmaster-1
+# ff1706cee6f41       c1f0d1cc8af40       16 minutes ago      Running             kube-scheduler            0                   47bf977e98d1f       kube-scheduler-ksmaster-1
+# ff01d32504e7f       3861cfcd7c04c       16 minutes ago      Running             etcd                      0                   85a15c8f5d6e6       etcd-ksmaster-1
+# sudo crictl --runtime-endpoint unix:///var/run/containerd/containerd.sock logs 721c771742872
+# ..
+# Error: invalid argument "LegacyServiceAccountTokenNoAutoGeneration=false" for "--feature-gates" flag: unrecognized feature gate: LegacyServiceAccountTokenNoAutoGeneration
 while ! nc -z localhost 6443; do
   echo "...Waiting on k8s API server to give a sign of life"
   sleep 5
 done
 
 kubectl apply -f ${cni_url}
-wget https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.3/components.yaml
-sed 's/- --secure-port=4443/- --secure-port=4443\n        - --kubelet-insecure-tls/' components.yaml | kubectl apply -f -
+wget https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.8.0/components.yaml
+sed 's/- --secure-port=10250/- --secure-port=10250\n        - --kubelet-insecure-tls/' components.yaml | kubectl apply -f -

--- a/terraform/cluster/mod/k8s/repo.sh
+++ b/terraform/cluster/mod/k8s/repo.sh
@@ -46,7 +46,7 @@ fi
 sudo mkdir -p /etc/apt/keyrings/
 KUBE_APT_V=$(echo "${kube_version}" | awk -F. '{ sub(/-.*/, ""); print "v" $1 "." $2 }')
 [ -f /etc/apt/keyrings/kubernetes-apt-keyring.gpg ] && sudo rm /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBE_APT_V/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 if ! grep "kubernetes-apt-keyring.gpg" /etc/apt/sources.list.d/kubernetes.list; then
   cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
 deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBE_APT_V/deb/ /

--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -107,7 +107,7 @@ variable "master_vcpu" {
 variable "kubernetes_version" {
   type        = string
   description = "Version of all kubernetes components"
-  default     = "1.26.14-1.1"
+  default     = "1.33.7-1.1"
 }
 
 variable "kubeconfig_output" {

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -228,6 +228,11 @@ class Deployer(object):
         return f"csi-node-{id + 1}"
 
     @staticmethod
+    def app_node_name(id: int):
+        assert id >= 0
+        return f"app-node-{id + 1}"
+
+    @staticmethod
     def create_disks(len=1, size=100 * 1024 * 1024):
         host_tmp = workspace_tmp()
         disks = list(map(lambda x: f"disk_{x}.img", range(1, len + 1)))

--- a/tests/bdd/features/csi/node/test_node.py
+++ b/tests/bdd/features/csi/node/test_node.py
@@ -329,7 +329,7 @@ def publish_nexus(setup, volumes, published_nexuses):
                 publish_context={},
                 protocol=VolumeShareProtocol("nvmf"),
                 node=NODE1,
-                frontend_node=Deployer.csi_node_name(0),
+                frontend_node=Deployer.app_node_name(0),
             ),
         )
         nexus = Nexus(uuid, protocol, volume.state.target.device_uri)

--- a/tests/io-engine/tests/allowed_hosts.rs
+++ b/tests/io-engine/tests/allowed_hosts.rs
@@ -152,6 +152,7 @@ async fn volume_allowed_host() {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await

--- a/tests/io-engine/tests/rebuild.rs
+++ b/tests/io-engine/tests/rebuild.rs
@@ -62,6 +62,7 @@ async fn concurrent_rebuilds() {
                     models::VolumeShareProtocol::Nvmf,
                     None,
                     "".to_string(),
+                    None,
                 ),
             )
             .await
@@ -408,6 +409,7 @@ async fn repeated_volume_rebuilds() {
                     models::VolumeShareProtocol::Nvmf,
                     None,
                     cluster.csi_node(0),
+                    None,
                 ),
             )
             .await
@@ -653,6 +655,7 @@ async fn repeated_volume_double_rebuilds() {
                     models::VolumeShareProtocol::Nvmf,
                     None,
                     cluster.csi_node(0),
+                    None,
                 ),
             )
             .await
@@ -832,6 +835,7 @@ async fn fault_rebuild_verify() {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await
@@ -959,6 +963,7 @@ async fn destroy_rebuilding_nexus() {
                     models::VolumeShareProtocol::Nvmf,
                     None,
                     cluster.csi_node(0),
+                    None,
                 ),
             )
             .await

--- a/tests/io-engine/tests/upgrade.rs
+++ b/tests/io-engine/tests/upgrade.rs
@@ -61,6 +61,7 @@ async fn upgrade() {
                 models::VolumeShareProtocol::Nvmf,
                 None,
                 cluster.csi_node(0),
+                None,
             ),
         )
         .await

--- a/utils/pstor-usage/src/volumes.rs
+++ b/utils/pstor-usage/src/volumes.rs
@@ -92,6 +92,7 @@ impl ResourceUpdates for Vec<models::Volume> {
                         models::VolumeShareProtocol::Nvmf,
                         None,
                         "".to_string(),
+                        None,
                     ),
                 )
                 .await?;


### PR DESCRIPTION
    fix(rwx/stage): connect to volume using node's own hostnqn
    
    Since we now publish the volume for multiple nodes, the share url contains
    many hostnqn's.
    On the node stage, we must connect using the node's hostnqn!
    
    It would be nice to start connecting using the target configuration, instead
    of the share uri, but that would require more changes and thought.
    So for now we just clip the nqn's which belong to other nodes from the share
    uri.
    The downside if this change is that we can no longer use custom nqn, but I
    think this is ok, because we're already using the nqn for the ha logic, so
    this is already expected.
    
---

    fix(rwx): reconcile due to unsorted host nqn list
    
    Always ensure the hostnqn lists are sorted, otherwise we may
    run reconcile to fix the hostnqn when it's not needed.
    
---

    fix: validate volume access mode on publish
    
    Publishing the volume on multiple nodes should only be allowed
    if RWX specified via the request.
    
---

    refactor: include access mode in the volume publish operation
    
    This will allow the core agent to evaluate and return appropriate errors.
    This is now required because we've modified the publish to support many
    initiators but we did not account for the error cases and idempotency for
    when rwx is on or off.
    
---

    chore: update terraform to K8s v1.33
    
    This is used out of band from CI, only for local isolated testing.
    
---

    fix(rwx): keep publish context until full unpublish
    
    Now that we have multiple publishes, we have to keep the context until
    the last unpublish completes.
