### PR TITLE
feat: expose pool import failure reasons via rest/plugin

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
@@ -118,6 +118,8 @@ async fn missing_pool_state_reconciler(
 
         if pool_spec.cordoned().map(|s| s.import).unwrap_or_default() {
             tracing::trace!("Not allowed to import because the pool is cordoned for imports");
+
+            pool.mark_as_import_cordoned();
             return PollResult::Ok(PollerState::Idle);
         }
 
@@ -131,9 +133,8 @@ async fn missing_pool_state_reconciler(
                 )
             });
         };
-        let node = match context.registry().node_wrapper(&pool_spec.node).await {
-            Ok(node) if !node.read().await.is_online() => {
-                let node_status = node.read().await.status();
+        let node = match pool.node_wrapper(context.registry(), &pool_spec.node).await {
+            Ok(Err(node_status)) => {
                 warn_missing(&pool_spec, node_status);
                 return PollResult::Ok(PollerState::Idle);
             }
@@ -141,7 +142,7 @@ async fn missing_pool_state_reconciler(
                 warn_missing(&pool_spec, NodeStatus::Unknown);
                 return PollResult::Ok(PollerState::Idle);
             }
-            Ok(node) => node,
+            Ok(Ok(node)) => node,
         };
 
         async {

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -20,9 +20,9 @@ use stor_port::{
             replica::{PoolRef, ReplicaSpec},
         },
         transport::{
-            CreatePool, CtrlPoolState, DestroyReplica, GetBlockDevices, ImportPool, NodeId, Pool,
-            PoolDeviceUri, PoolDiag, PoolDiskError, PoolError, PoolErrorCode, PoolState,
-            ReplicaOwners,
+            CreatePool, CtrlPoolState, DestroyReplica, GetBlockDevices, ImportPool, NodeId,
+            NodeStatus, Pool, PoolDeviceUri, PoolDiag, PoolDiskError, PoolError, PoolErrorCode,
+            PoolState, PoolStatus, ReplicaOwners,
         },
     },
 };
@@ -48,6 +48,7 @@ impl OperationGuardArc<PoolSpec> {
             }
             CreatePool::from(spec.deref())
         };
+
         let node = registry.node_wrapper(&request.node).await?;
         if node.pool(&request.id).await.is_none() {
             return Ok(());
@@ -55,11 +56,69 @@ impl OperationGuardArc<PoolSpec> {
 
         let _ = self.start_create(registry, &request).await?;
         let result = node.create_pool(&request).await;
+
         let _state = self
             .complete_create(result, registry, OnCreateFail::LeaveAsIs)
             .await?;
 
         Ok(())
+    }
+
+    /// Get the [`NodeWrapper`] for this pool.
+    /// # NOTE
+    /// If the node is not online, its status is returned.
+    pub(crate) async fn node_wrapper(
+        &mut self,
+        registry: &Registry,
+        node: &NodeId,
+    ) -> Result<Result<Arc<RwLock<NodeWrapper>>, NodeStatus>, SvcError> {
+        let error = match registry.node_wrapper(node).await {
+            Ok(node) => {
+                let node_guard = node.read().await;
+                if !node_guard.is_online() {
+                    self.mark_as_offline(PoolError {
+                        code: PoolErrorCode::NodeIsOffline,
+                        msg: "".to_string(),
+                    });
+                    return Ok(Err(node_guard.status()));
+                }
+                drop(node_guard);
+                return Ok(Ok(node));
+            }
+            Err(error) => error,
+        };
+
+        self.mark_as_offline(PoolError {
+            code: PoolErrorCode::NodeIsUnknown,
+            msg: "".to_string(),
+        });
+        Err(error)
+    }
+
+    fn mark_as_diag(&mut self, status: PoolStatus, error: PoolError) {
+        let mut pool = self.lock();
+        let Some(ref mut diag) = &mut pool.metadata.runtime.diag else {
+            pool.metadata.runtime.diag = Some(PoolDiag {
+                import_errors: vec![],
+                error: Some(error),
+                status,
+            });
+            return;
+        };
+        diag.error = Some(error);
+        diag.status = status;
+    }
+    fn mark_as_offline(&mut self, error: PoolError) {
+        self.mark_as_diag(PoolStatus::Offline, error);
+    }
+    /// Mark the pool in [`PoolErrorCode::ImportDisabled`] since it cannot be
+    /// imported due to being cordoned for imports.
+    pub fn mark_as_import_cordoned(&mut self) {
+        let error = PoolError {
+            code: PoolErrorCode::ImportDisabled,
+            msg: "".to_string(),
+        };
+        self.mark_as_diag(PoolStatus::Offline, error);
     }
 
     /// Attempt to import a pool.
@@ -86,27 +145,16 @@ impl OperationGuardArc<PoolSpec> {
         );
         let result = node.import_pool(&request).await;
         if let Err(error) = &result {
-            let code_map = |code: tonic::Code| -> PoolError {
-                let code = match code {
-                    tonic::Code::InvalidArgument => PoolErrorCode::InvalidSuperBlock,
-                    tonic::Code::NotFound => PoolErrorCode::DiskNotFound,
-                    _ => PoolErrorCode::Unknown,
-                };
-                // todo: this is rather long as it includes details and metadata... trim it?
-                let msg = error.to_string();
-                PoolError { code, msg }
-            };
-            match error.tonic_code() {
-                tonic::Code::NotFound | tonic::Code::InvalidArgument => {
-                    let disks = pool_spec.disks.first().map(|d| d.to_string());
-                    *reporter.lock().expect("not poisoned") = Some(PoolDiag {
-                        import_errors: vec![PoolDiskError {
-                            error: code_map(error.tonic_code()),
-                            disk: disks.unwrap_or_default(),
-                        }],
-                    });
-                }
-                _ => {}
+            if let Some(error) = Self::pool_import_error(error) {
+                let disks = pool_spec.disks.first().map(|d| d.to_string());
+                *reporter.lock().expect("not poisoned") = Some(PoolDiag {
+                    import_errors: vec![PoolDiskError {
+                        error: error.clone(),
+                        disk: disks.unwrap_or_default(),
+                    }],
+                    status: PoolStatus::Offline,
+                    error: Some(error),
+                });
             }
         }
         self.complete_update(registry, result, pool_spec).await
@@ -117,6 +165,29 @@ impl OperationGuardArc<PoolSpec> {
     pub(crate) fn on_create_fail(&self, registry: &Registry) -> OnCreateFail {
         let spec = self.lock();
         on_create_fail(&spec, registry).unwrap_or(OnCreateFail::LeaveAsIs)
+    }
+
+    /// Maps a [`SvcError`] obtained after a failed creation or import to a [`PoolError`].
+    pub(super) fn pool_import_error(error: &SvcError) -> Option<PoolError> {
+        let code = match error.tonic_code() {
+            tonic::Code::InvalidArgument
+                if error.to_string().contains("EISDIR: Is a directory") =>
+            {
+                PoolErrorCode::DiskIsADirectory
+            }
+            tonic::Code::InvalidArgument => PoolErrorCode::InvalidSuperBlock,
+            tonic::Code::NotFound => PoolErrorCode::DiskNotFound,
+            tonic::Code::Cancelled => PoolErrorCode::TimeOut,
+            tonic::Code::Aborted => PoolErrorCode::TimeOut,
+            _ => return None,
+        };
+        let msg = match &error {
+            SvcError::GrpcRequestError { source, .. } => {
+                format!("{:?}: {}", source.code(), source.message())
+            }
+            _error => _error.to_string(),
+        };
+        Some(PoolError { code, msg })
     }
 
     // todo: fit in a trait

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -17,7 +17,10 @@ use stor_port::{
     transport_api::ResourceKind,
     types::v0::{
         store::pool::{PoolCordonOp, PoolOperation, PoolSpec},
-        transport::{CreatePool, CtrlPoolState, DestroyPool, ExpandPool, Pool},
+        transport::{
+            CreatePool, CtrlPoolState, DestroyPool, ExpandPool, Pool, PoolDiag, PoolDiskError,
+            PoolStatus,
+        },
     },
 };
 use utils::dsp_created_by_key;
@@ -77,6 +80,21 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
 
         let result = node.create_pool(request).await;
         let on_fail = OnCreateFail::on_pool_create_err(&result);
+        if matches!(on_fail, OnCreateFail::LeaveAsIs) {
+            if let Err(error) = &result {
+                if let Some(error) = Self::pool_import_error(error) {
+                    let disks = pool.as_ref().disks.first().map(|d| d.to_string());
+                    pool.lock().metadata.runtime.diag = Some(PoolDiag {
+                        import_errors: vec![PoolDiskError {
+                            error: error.clone(),
+                            disk: disks.unwrap_or_default(),
+                        }],
+                        status: PoolStatus::Unknown,
+                        error: Some(error),
+                    });
+                }
+            }
+        }
         let state = pool.complete_create(result, registry, on_fail).await?;
         let spec = pool.lock().clone();
         Ok(Pool::new(spec, Some(CtrlPoolState::new(state))))
@@ -106,6 +124,16 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
                     Err(error) => match error.tonic_code() {
                         tonic::Code::NotFound if allow_not_found => Ok(()),
                         tonic::Code::InvalidArgument => Ok(()),
+                        tonic::Code::Cancelled | tonic::Code::Aborted => {
+                            if let Some(error) = Self::pool_import_error(&error) {
+                                self.lock().metadata.runtime.diag = Some(PoolDiag {
+                                    import_errors: vec![],
+                                    status: PoolStatus::Unknown,
+                                    error: Some(error),
+                                });
+                            }
+                            Err(error)
+                        }
                         _other => Err(error),
                     },
                 }

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -6,8 +6,12 @@ import "google/protobuf/wrappers.proto";
 package v1.pool;
 
 message PoolDiag {
+  // The inferred status of the pool.
+  PoolStatus status = 1;
   // Errors encountered when importing the pool.
   repeated DiskError import_errors = 2;
+  /// Inferred error of the pool, if any.
+  optional ProbeError error = 3;
 }
 message DiskError {
   string disk = 1;
@@ -28,6 +32,16 @@ enum ProbeErrorCode {
   SuperBlock = 5;
   // Invalid super block (eg: CRC error)
   InvalidSuperBlock = 6;
+  // Disk is a directory (can happen when setting up incorrect volume mounts)
+  DiskIsADirectory = 7;
+  // Node hosting the pool is offline.
+  NodeIsOffline = 8;
+  // Node hosting the pool is in unknown state.
+  NodeIsUnknown = 9;
+  // The pool is cordoned for imports, so it cannot be imported.
+  ImportDisabled = 10;
+  // Import/Create has timed out.
+  TimeOut = 11;
 }
 message ProbeError {
   ProbeErrorCode code = 1;
@@ -130,6 +144,8 @@ enum PoolStatus {
   Faulted = 3;
   // pool is in a suspected state, with warning alerts or higher
   Suspected = 4;
+  // pool is in an offline state.
+  Offline   = 5;
 }
 
 // Get all pools based on the filter criteria

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -158,20 +158,12 @@ impl TryFrom<pool::PoolState> for PoolState {
     type Error = ReplyError;
 
     fn try_from(pool_state: pool::PoolState) -> Result<Self, Self::Error> {
+        let status = pool_state.status();
         Ok(PoolState {
             node: pool_state.node_id.into(),
             id: pool_state.pool_id.into(),
             disks: pool_state.disks_uri.iter().map(|i| i.into()).collect(),
-            status: match pool::PoolStatus::try_from(pool_state.status) {
-                Ok(status) => status.into(),
-                Err(error) => {
-                    return Err(ReplyError::invalid_argument(
-                        ResourceKind::Pool,
-                        "pool.state.status",
-                        error,
-                    ))
-                }
-            },
+            status: status.into(),
             capacity: pool_state.capacity,
             used: pool_state.used,
             committed: pool_state.committed,
@@ -420,6 +412,11 @@ impl From<PoolErrorCode> for pool::ProbeErrorCode {
             PoolErrorCode::ForeignPoolUid => Self::ForeignPoolUid,
             PoolErrorCode::SuperBlock => Self::SuperBlock,
             PoolErrorCode::InvalidSuperBlock => Self::InvalidSuperBlock,
+            PoolErrorCode::DiskIsADirectory => Self::DiskIsADirectory,
+            PoolErrorCode::NodeIsUnknown => Self::NodeIsUnknown,
+            PoolErrorCode::NodeIsOffline => Self::NodeIsOffline,
+            PoolErrorCode::ImportDisabled => Self::ImportDisabled,
+            PoolErrorCode::TimeOut => Self::TimeOut,
         }
     }
 }
@@ -434,6 +431,8 @@ impl From<PoolDiag> for pool::PoolDiag {
         };
         Self {
             import_errors: diag.import_errors.into_iter().map(import_error).collect(),
+            status: pool::PoolStatus::from(diag.status) as i32,
+            error: diag.error.into_opt(),
         }
     }
 }
@@ -447,25 +446,41 @@ impl From<pool::ProbeErrorCode> for PoolErrorCode {
             pool::ProbeErrorCode::ForeignPoolUid => Self::ForeignPoolUid,
             pool::ProbeErrorCode::SuperBlock => Self::SuperBlock,
             pool::ProbeErrorCode::InvalidSuperBlock => Self::InvalidSuperBlock,
+            pool::ProbeErrorCode::DiskIsADirectory => Self::DiskIsADirectory,
+            pool::ProbeErrorCode::NodeIsUnknown => Self::NodeIsUnknown,
+            pool::ProbeErrorCode::NodeIsOffline => Self::NodeIsOffline,
+            pool::ProbeErrorCode::ImportDisabled => Self::ImportDisabled,
+            pool::ProbeErrorCode::TimeOut => Self::TimeOut,
         }
     }
 }
 impl From<pool::PoolDiag> for PoolDiag {
     fn from(diag: pool::PoolDiag) -> Self {
         let import_error = |value: pool::DiskError| PoolDiskError {
-            error: {
-                let error = value.error.unwrap();
-                PoolError {
-                    code: PoolErrorCode::from(
-                        pool::ProbeErrorCode::try_from(error.code).unwrap_or_default(),
-                    ),
-                    msg: error.msg,
-                }
-            },
+            error: value.error.unwrap_or_default().into(),
             disk: value.disk,
         };
         Self {
+            status: diag.status().into(),
+            error: diag.error.into_opt(),
             import_errors: diag.import_errors.into_iter().map(import_error).collect(),
+        }
+    }
+}
+
+impl From<pool::ProbeError> for PoolError {
+    fn from(value: pool::ProbeError) -> Self {
+        PoolError {
+            code: PoolErrorCode::from(value.code()),
+            msg: value.msg,
+        }
+    }
+}
+impl From<PoolError> for pool::ProbeError {
+    fn from(value: PoolError) -> Self {
+        Self {
+            code: pool::ProbeErrorCode::from(value.code) as i32,
+            msg: value.msg,
         }
     }
 }
@@ -748,6 +763,7 @@ impl From<pool::PoolStatus> for PoolStatus {
             pool::PoolStatus::Suspected => Self::Suspected,
             pool::PoolStatus::Faulted => Self::Faulted,
             pool::PoolStatus::Unknown => Self::Unknown,
+            pool::PoolStatus::Offline => Self::Offline,
         }
     }
 }
@@ -756,6 +772,7 @@ impl From<PoolStatus> for pool::PoolStatus {
     fn from(pool_status: PoolStatus) -> Self {
         match pool_status {
             PoolStatus::Unknown => Self::Unknown,
+            PoolStatus::Offline => Self::Offline,
             PoolStatus::Online => Self::Online,
             PoolStatus::Degraded => Self::Degraded,
             PoolStatus::Suspected => Self::Suspected,

--- a/control-plane/plugin/src/lib.rs
+++ b/control-plane/plugin/src/lib.rs
@@ -10,13 +10,13 @@ use utils::tracing_telemetry::{FmtLayer, FmtStyle};
 
 use crate::{
     operations::{
-        Cordoning, Delete, Drain, Expand, Get, GetBlockDevices, GetSnapshotTopology, GetSnapshots,
-        GetWithArgs, List, ListExt, ListWithArgs, Operations, PluginResult, RebuildHistory,
-        ReplicaTopology, Scale,
+        Cordoning, Delete, Drain, Errors, Expand, Get, GetBlockDevices, GetSnapshotTopology,
+        GetSnapshots, GetWithArgs, List, ListExt, ListWithArgs, Operations, PluginResult,
+        RebuildHistory, ReplicaTopology, Scale,
     },
     resources::{
         blockdevice, cordon, drain, node, pool, snapshot, volume, volume::VolumeTopologiesArgs,
-        CordonResources, DeleteArgs, DeleteResources, DrainResources, ExpandResources,
+        ClearErrors, CordonResources, DeleteArgs, DeleteResources, DrainResources, ExpandResources,
         GetCordonArgs, GetDrainArgs, GetResources, ScaleResources, SetPropertyResources,
         SetVolumeProperties, UnCordonResources,
     },
@@ -114,6 +114,7 @@ impl ExecuteOperation for Operations {
             Operations::Scale(resource) => resource.execute(cli_args).await,
             Operations::Expand(resource) => resource.execute(cli_args).await,
             Operations::Set(resource) => resource.execute(cli_args).await,
+            Operations::ClearErrors(resource) => resource.execute(cli_args).await,
             Operations::Cordon(resource) => resource.execute(cli_args).await,
             Operations::Uncordon(resource) => resource.execute(cli_args).await,
             Operations::Label(resource) => resource.execute(cli_args).await,
@@ -245,6 +246,19 @@ impl ExecuteOperation for SetPropertyResources {
         match self {
             SetPropertyResources::Volume { id, properties } => {
                 volume::Volume::set_property(id, properties, &cli_args.output).await
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ExecuteOperation for ClearErrors {
+    type Args = CliArgs;
+    type Error = crate::resources::Error;
+    async fn execute(&self, cli_args: &CliArgs) -> PluginResult {
+        match self {
+            ClearErrors::Pool { id, options } => {
+                pool::Pool::clear(id, options, &cli_args.output).await
             }
         }
     }

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -1,5 +1,5 @@
 use crate::resources::{
-    error::Error, utils, CordonResources, DeleteArgs, DrainResources, ExpandResources,
+    error::Error, utils, ClearErrors, CordonResources, DeleteArgs, DrainResources, ExpandResources,
     GetResources, LabelResources, ScaleResources, SetPropertyResources, UnCordonResources,
 };
 use async_trait::async_trait;
@@ -25,6 +25,9 @@ pub enum Operations {
     /// 'Set' resources.
     #[clap(subcommand)]
     Set(SetPropertyResources),
+    /// `ClearError` resources.
+    #[clap(subcommand)]
+    ClearErrors(ClearErrors),
     /// 'Cordon' resources.
     #[clap(subcommand)]
     Cordon(CordonResources),
@@ -230,6 +233,19 @@ pub trait Delete {
     async fn del(
         id: &Self::ID,
         ignore_not_found: bool,
+        output: &utils::OutputFormat,
+    ) -> PluginResult;
+}
+
+/// Errors trait.
+/// To be implemented by resources which support the 'delete' operation.
+#[async_trait(?Send)]
+pub trait Errors {
+    type ID;
+    type REQ;
+    async fn clear(
+        id: &Self::ID,
+        request: &Option<Self::REQ>,
         output: &utils::OutputFormat,
     ) -> PluginResult;
 }

--- a/control-plane/plugin/src/resources/error.rs
+++ b/control-plane/plugin/src/resources/error.rs
@@ -141,6 +141,12 @@ pub enum Error {
     /// User has decided to abort the operation following a dialogue.
     #[snafu(display("Operation was aborted by the user"))]
     DialogueAbort {},
+    /// Error when pool clear-errors request fails.
+    #[snafu(display("Failed to clear errors for pool {id}. Error {source}"))]
+    PoolClearError {
+        id: String,
+        source: openapi::tower::client::Error<openapi::models::RestJsonError>,
+    },
 }
 
 /// Errors related to label topology formats.

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -115,6 +115,18 @@ pub enum SetVolumeProperties {
     },
 }
 
+/// The types of resources that support the 'Clear' operation.
+#[derive(clap::Subcommand, Debug)]
+pub enum ClearErrors {
+    /// Clear errors from a pool.
+    Pool {
+        /// ID of the pool.
+        id: PoolId,
+        #[clap(flatten)]
+        options: Option<pool::ClearErrorsRequest>,
+    },
+}
+
 /// The types of resources that support cordoning.
 #[derive(clap::Subcommand, Debug)]
 pub enum CordonResources {

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -60,12 +60,26 @@ impl CreateRow for openapi::models::Pool {
                 format!("{:?}, {}", state.status, PoolCordonDrainState::Cordoned)
             }
         };
+        let error_info = state.error_info.unwrap_or_default();
+        let status = error_info.alerts.status;
+        let alerts = { error_info.alerts.attention.iter() }
+            .chain(&error_info.alerts.warning)
+            .chain(&error_info.alerts.critical)
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        let alerts = if alerts.is_empty() {
+            status.to_string()
+        } else {
+            format!("{status} ({alerts})")
+        };
         row![
             self.id,
             disks,
             managed,
             state.node,
             statuses,
+            alerts,
             ::utils::bytes::into_human(state.capacity),
             ::utils::bytes::into_human(state.used),
             ::utils::bytes::into_human(free),

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -36,32 +36,42 @@ impl CreateRow for openapi::models::Pool {
         // control plane.
         let managed = self.spec.is_some();
         let spec = self.spec.clone().unwrap_or_default();
+        let diag = self.diag.clone().unwrap_or_default();
         // In case the state is not coming as filled, either due to pool, node lost, fill in
         // spec data and mark the status as Unknown.
         let state = self.state.clone().unwrap_or(openapi::models::PoolState {
-            capacity: 0,
             disks: spec.disks,
             id: spec.id,
             node: spec.node,
-            status: openapi::models::PoolStatus::Unknown,
-            used: 0,
-            committed: None,
             encrypted: spec.encryption.is_some(),
             cluster_size: Some(0),
-            disk_capacity: None,
-            max_expandable_size: None,
-            error_info: None,
+            ..Default::default()
         });
         let free = state.capacity.saturating_sub(state.used);
-        let disks = state.disks.join(", ");
-        let statuses = match spec.cordon_drain {
-            None => format!("{:?}", state.status),
-            Some(_) => {
-                format!("{:?}, {}", state.status, PoolCordonDrainState::Cordoned)
+
+        let status = match &self.diag {
+            Some(diag) => diag.status,
+            None => state.status,
+        };
+        let status = if managed && spec.status != models::SpecStatus::Created {
+            format!("{}/{status}", spec.status)
+        } else {
+            status.to_string()
+        };
+
+        let pool_diag_error = diag.error.as_ref().map(|e| e.code);
+        let statuses = match (spec.cordon_drain, pool_diag_error) {
+            (None, None) => status.to_string(),
+            (None, Some(error)) => format!("{status} ({error})"),
+            (Some(_), None) => {
+                format!("{status}, {}", PoolCordonDrainState::Cordoned)
+            }
+            (Some(_), Some(error)) => {
+                format!("{status} ({error}), {}", PoolCordonDrainState::Cordoned)
             }
         };
+        let alert_status = state.error_info.as_ref().map(|e| e.alerts.status);
         let error_info = state.error_info.unwrap_or_default();
-        let status = error_info.alerts.status;
         let alerts = { error_info.alerts.attention.iter() }
             .chain(&error_info.alerts.warning)
             .chain(&error_info.alerts.critical)
@@ -69,17 +79,33 @@ impl CreateRow for openapi::models::Pool {
             .collect::<Vec<_>>()
             .join(",");
         let alerts = if alerts.is_empty() {
-            status.to_string()
+            alert_status.map(|s| s.to_string())
         } else {
-            format!("{status} ({alerts})")
+            let alert_status = alert_status.unwrap_or_default();
+            Some(format!("{alert_status} ({alerts})"))
         };
+        let disk_status = |disk: &str| -> Option<models::PoolProbeError> {
+            diag.import_errors
+                .iter()
+                .find(|d| d.disk == disk)
+                .map(|d| d.error.clone())
+        };
+        let disks = state.disks.into_iter().map(|d| {
+            let Some(probe) = disk_status(&d) else {
+                return d;
+            };
+            if Some(probe.code) == pool_diag_error {
+                return d;
+            }
+            format!("{d} ({})", probe.code)
+        });
         row![
             self.id,
-            disks,
+            disks.collect::<Vec<_>>().join(", "),
             managed,
             state.node,
             statuses,
-            alerts,
+            optional_cell(alerts),
             ::utils::bytes::into_human(state.capacity),
             ::utils::bytes::into_human(state.used),
             ::utils::bytes::into_human(free),

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -1,7 +1,7 @@
 extern crate utils as external_utils;
 use super::VolumeId;
 use crate::{
-    operations::{Cordoning, Expand, GetWithArgs, Label, ListWithArgs, PluginResult},
+    operations::{Cordoning, Errors, Expand, GetWithArgs, Label, ListWithArgs, PluginResult},
     resources::{
         error::{Error, LabelAssignSnafu, OpError, TopologyError},
         utils::{
@@ -255,6 +255,57 @@ impl ListWithArgs for Pools {
 /// Pool resource.
 #[derive(clap::Args, Debug)]
 pub struct Pool {}
+
+/// Pool clear errors request.
+#[derive(Debug, Clone, Default, clap::Args)]
+pub struct ClearErrorsRequest {
+    /// If one or more disks is specified, only those errors associated with the
+    /// specified disk or disks are cleared.
+    #[clap(long)]
+    pub disks: Vec<String>,
+    /// Clear errors using the given method.
+    #[clap(long, default_value_t = ClearMethod::default())]
+    pub clear: ClearMethod,
+}
+
+/// Clear errors variants.
+#[derive(Debug, Clone, Copy, Default, EnumString, Display)]
+pub enum ClearMethod {
+    /// Clears all counted errors and related alerts.
+    /// Example, it clears the io stall transitions, but doesn't clear an io stall.
+    #[default]
+    All,
+}
+
+#[async_trait(?Send)]
+impl Errors for Pool {
+    type ID = PoolId;
+    type REQ = ClearErrorsRequest;
+
+    async fn clear(
+        id: &Self::ID,
+        request: &Option<Self::REQ>,
+        output: &OutputFormat,
+    ) -> PluginResult {
+        let request = request.as_ref().map(|r| models::PoolClearErrReq {
+            disks: r.disks.clone(),
+            clear: match r.clear {
+                ClearMethod::All => models::PoolClearErr::All,
+            },
+        });
+        let cli = RestClient::client().pools_api();
+        let pool = cli
+            .del_pool_errors(id, request)
+            .await
+            .map_err(|source| Error::PoolClearError {
+                id: id.to_owned(),
+                source,
+            })?
+            .into_body();
+        print_table(output, pool);
+        Ok(())
+    }
+}
 
 #[async_trait(?Send)]
 impl GetWithArgs for Pool {

--- a/control-plane/plugin/src/resources/tests.rs
+++ b/control-plane/plugin/src/resources/tests.rs
@@ -361,7 +361,7 @@ async fn get_replica_topology() {
             replica_ids[0],
             replica.node.as_ref().unwrap(),
             replica.pool.as_ref().unwrap(),
-            replica.state.to_string()
+            replica.state
         ),
         VolumeReplicaTopologies::from(replica_topo),
     );
@@ -432,7 +432,7 @@ fn pool_output(pool_state: PoolState, managed: bool) -> String {
         " {id}  {disks}  {managed}    {node}  {status}  {capacity}     {allocated}        {available}      {committed} \n",
         id = pool_state.id,
         node = pool_state.node,
-        status = pool_state.status.to_string(),
+        status = pool_state.status
     )
 }
 
@@ -447,7 +447,7 @@ fn volume_output(volume_spec: VolumeSpec, volume_state: VolumeState) -> String {
         volume_spec.num_replicas,
         "<none>",
         "<none>",
-        volume_state.status.to_string(),
+        volume_state.status,
         volume_state.size
     )
 }
@@ -461,8 +461,6 @@ fn node_output(node_state: NodeState) -> String {
         width_grpc = node_state.grpc_endpoint.len() + 2
     ) + &*format!(
         " {}  {}  {} \n",
-        node_state.id,
-        node_state.grpc_endpoint,
-        node_state.status.to_string()
+        node_state.id, node_state.grpc_endpoint, node_state.status
     )
 }

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -47,6 +47,7 @@ lazy_static! {
         "MANAGED",
         "NODE",
         "STATUS",
+        "ALERTS",
         "CAPACITY",
         "ALLOCATED",
         "AVAILABLE",

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3213,6 +3213,7 @@ components:
       type: string
       enum:
         - Unknown
+        - Offline
         - Online
         - Suspected
         - Degraded
@@ -3241,8 +3242,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PoolDiskError'
+        status:
+          $ref: '#/components/schemas/PoolStatus'
+        error:
+          $ref: '#/components/schemas/PoolProbeError'
       required:
         - import_errors
+        - status
     PoolDiskError:
       description: Errors seen on the given pool disk
       type: object
@@ -3263,11 +3269,11 @@ components:
         message:
           description: Human-Readable message error
           type: string
-        error:
+        code:
           $ref: '#/components/schemas/PoolProbeErrorCode'
       required:
         - message
-        - error
+        - code
     PoolProbeErrorCode:
       description: Pool Disk Probe Errors
       type: string
@@ -3279,6 +3285,11 @@ components:
         - ForeignPoolUid
         - SuperBlock
         - InvalidSuperBlock
+        - DiskIsADirectory
+        - NodeIsUnknown
+        - NodeIsOffline
+        - ImportDisabled
+        - TimeOut
     PoolErrorInfo:
       type: object
       description: Pool alerts and error information

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1462,11 +1462,11 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: [ ]
-  '/pools/{pool_id}/clear-errors':
-    put:
+  '/pools/{pool_id}/errors':
+    delete:
       tags:
         - Pools
-      operationId: put_pool_clearerrors
+      operationId: del_pool_errors
       parameters:
         - in: path
           name: pool_id

--- a/control-plane/rest/service/src/v0/pools.rs
+++ b/control-plane/rest/service/src/v0/pools.rs
@@ -176,7 +176,7 @@ impl apis::actix_server::Pools for RestApi {
         Ok(pool.into())
     }
 
-    async fn put_pool_clearerrors(
+    async fn del_pool_errors(
         Path(pool_id): Path<String>,
         Body(body): Body<Option<models::PoolClearErrReq>>,
     ) -> Result<models::Pool, RestError<RestJsonError>> {

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -98,6 +98,7 @@ impl PartialEq<CreatePool> for PoolSpec {
         other.status = self.status.clone();
         other.sequencer = self.sequencer.clone();
         other.creat_tsc = self.creat_tsc;
+        other.metadata = self.metadata.clone();
         &other == self
     }
 }
@@ -390,6 +391,7 @@ impl SpecTransaction<PoolOperation> for PoolSpec {
                 }
                 PoolOperation::Create => {
                     self.status = SpecStatus::Created(transport::PoolStatus::Online);
+                    self.metadata.runtime.diag = None;
                 }
                 PoolOperation::Label(PoolLabelOp { labels, .. }) => {
                     self.label(labels);

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -29,6 +29,8 @@ pub enum PoolStatus {
     Faulted,
     /// Pool has at least an alert level of warning.
     Suspected,
+    /// The pool is offline.
+    Offline,
 }
 
 impl Default for PoolStatus {
@@ -45,6 +47,7 @@ impl From<i32> for PoolStatus {
             2 => Self::Degraded,
             3 => Self::Faulted,
             4 => Self::Suspected,
+            5 => Self::Offline,
             _ => Self::Unknown,
         }
     }
@@ -53,6 +56,7 @@ impl From<PoolStatus> for models::PoolStatus {
     fn from(src: PoolStatus) -> Self {
         match src {
             PoolStatus::Unknown => Self::Unknown,
+            PoolStatus::Offline => Self::Offline,
             PoolStatus::Online => Self::Online,
             PoolStatus::Degraded => Self::Degraded,
             PoolStatus::Faulted => Self::Faulted,
@@ -89,21 +93,31 @@ impl Deref for CtrlPoolState {
 /// Different pool errors
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 pub enum PoolErrorCode {
-    /// Unknown error
+    /// Unknown error.
     #[default]
     Unknown,
-    /// Disk not found in the system
+    /// Disk not found in the system.
     DiskNotFound,
-    /// Disk read IO errors
+    /// Disk read IO errors.
     DiskReadIoError,
-    /// Pool on-disk name doesn't match the expected
+    /// Pool on-disk name doesn't match the expected.
     ForeignPoolName,
-    /// Pool on-disk uuid doesn't match the expected
+    /// Pool on-disk uuid doesn't match the expected.
     ForeignPoolUid,
-    /// Failed to check super block error
+    /// Failed to check super block error.
     SuperBlock,
-    /// Invalid super block (eg: CRC error)
+    /// Invalid super block (eg: CRC error).
     InvalidSuperBlock,
+    /// Disk is a directory (can happen when setting up incorrect volume mounts).
+    DiskIsADirectory,
+    /// Node is in unknown state.
+    NodeIsUnknown,
+    /// Node is offline.
+    NodeIsOffline,
+    /// Import is disable due to cordoning.
+    ImportDisabled,
+    /// gRPC to the pool timed out.
+    TimeOut,
 }
 
 /// Pool error code and human-readable message.
@@ -130,6 +144,21 @@ pub struct PoolDiskError {
 pub struct PoolDiag {
     /// Errors encountered when trying to import the pool.
     pub import_errors: Vec<PoolDiskError>,
+    /// Inferred error of the pool, if any.
+    #[serde(skip)]
+    pub error: Option<PoolError>,
+    /// Inferred status of the pool.
+    #[serde(skip)]
+    pub status: PoolStatus,
+}
+impl PoolDiag {
+    /// Add the status to the diagnostic information.
+    pub fn with_state(self, state: &PoolState) -> PoolDiag {
+        Self {
+            status: state.status.clone(),
+            ..self
+        }
+    }
 }
 
 /// Pool state information - as reported by the io-engine.
@@ -314,7 +343,7 @@ impl From<PoolAlertStatus> for models::PoolAlertStatus {
 
 impl From<PoolDiag> for models::PoolDiag {
     fn from(src: PoolDiag) -> Self {
-        Self::new_all(src.import_errors)
+        Self::new_all(src.import_errors, src.status, src.error.into_opt())
     }
 }
 
@@ -338,6 +367,11 @@ impl From<PoolErrorCode> for models::PoolProbeErrorCode {
             PoolErrorCode::ForeignPoolUid => Self::ForeignPoolUid,
             PoolErrorCode::SuperBlock => Self::SuperBlock,
             PoolErrorCode::InvalidSuperBlock => Self::InvalidSuperBlock,
+            PoolErrorCode::DiskIsADirectory => Self::DiskIsADirectory,
+            PoolErrorCode::NodeIsUnknown => Self::NodeIsUnknown,
+            PoolErrorCode::NodeIsOffline => Self::NodeIsOffline,
+            PoolErrorCode::ImportDisabled => Self::ImportDisabled,
+            PoolErrorCode::TimeOut => Self::TimeOut,
         }
     }
 }
@@ -351,6 +385,7 @@ impl PartialOrd for PoolStatus {
         match self {
             PoolStatus::Unknown => match other {
                 PoolStatus::Unknown => None,
+                PoolStatus::Offline => None,
                 PoolStatus::Online => Some(Ordering::Less),
                 PoolStatus::Degraded => Some(Ordering::Less),
                 PoolStatus::Suspected => Some(Ordering::Less),
@@ -358,6 +393,7 @@ impl PartialOrd for PoolStatus {
             },
             PoolStatus::Online => match other {
                 PoolStatus::Unknown => Some(Ordering::Greater),
+                PoolStatus::Offline => Some(Ordering::Greater),
                 PoolStatus::Online => Some(Ordering::Equal),
                 PoolStatus::Degraded => Some(Ordering::Greater),
                 PoolStatus::Suspected => Some(Ordering::Greater),
@@ -365,13 +401,23 @@ impl PartialOrd for PoolStatus {
             },
             PoolStatus::Degraded | PoolStatus::Suspected => match other {
                 PoolStatus::Unknown => Some(Ordering::Greater),
+                PoolStatus::Offline => Some(Ordering::Greater),
                 PoolStatus::Online => Some(Ordering::Less),
                 PoolStatus::Suspected => Some(Ordering::Equal),
                 PoolStatus::Degraded => Some(Ordering::Equal),
                 PoolStatus::Faulted => Some(Ordering::Greater),
             },
+            PoolStatus::Offline => match other {
+                PoolStatus::Unknown => None,
+                PoolStatus::Offline => Some(Ordering::Equal),
+                PoolStatus::Online => Some(Ordering::Less),
+                PoolStatus::Suspected => Some(Ordering::Less),
+                PoolStatus::Degraded => Some(Ordering::Less),
+                PoolStatus::Faulted => None,
+            },
             PoolStatus::Faulted => match other {
                 PoolStatus::Unknown => None,
+                PoolStatus::Offline => None,
                 PoolStatus::Online => Some(Ordering::Less),
                 PoolStatus::Degraded => Some(Ordering::Less),
                 PoolStatus::Suspected => Some(Ordering::Less),
@@ -422,7 +468,8 @@ impl Pool {
             id: state.id.clone(),
             diag: spec
                 .as_ref()
-                .and_then(|spec| spec.metadata.runtime.diag.clone()),
+                .and_then(|spec| spec.metadata.runtime.diag.clone())
+                .map(|d| d.with_state(&state.state)),
             spec: spec.map(|s| s.spec),
             state: Some(state),
         }

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -47,6 +47,10 @@ impl ComponentAction for IoEngine {
                 "--api-versions".to_string(),
                 IoEngineApiVersion::vec_to_str(options.io_engine_api_versions.clone()),
             ])
+            .with_env(
+                "IO_ERROR_THRESHOLD",
+                &options.pool.io_error_threshold.to_string(),
+            )
             .with_args(vec!["-r", format!("/host/tmp/{reg_name}.sock").as_str()])
             .with_args(vec!["--ptpl-dir", &ptpl_dir])
             .with_env("MAYASTOR_NVMF_HOSTID", Uuid::new_v4().to_string().as_str())

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -54,7 +54,7 @@ pub fn default_agents() -> &'static str {
     "Core"
 }
 
-#[derive(Debug, Default, Clone, Parser)]
+#[derive(Debug, Clone, Parser)]
 #[clap(about = "Create and start all components")]
 pub struct StartOptions {
     /// Use the following Control Plane Agents
@@ -354,6 +354,29 @@ pub struct StartOptions {
     pool_cluster_size: Option<u32>,
     #[clap(long, hide = true)]
     no_deprecated_access_mode: bool,
+
+    /// [`PoolCliArgs`].
+    #[clap(flatten)]
+    pub pool: PoolCliArgs,
+}
+impl Default for StartOptions {
+    fn default() -> Self {
+        Self::parse_from(Vec::<String>::new())
+    }
+}
+
+/// DiskPool related arguments.
+#[derive(Debug, clap::Parser, Clone)]
+pub struct PoolCliArgs {
+    /// I/O error count threshold.
+    /// After this many errors a pool alert is raised as Warning.
+    #[clap(long, env, default_value_t = 8)]
+    pub io_error_threshold: u64,
+}
+impl Default for PoolCliArgs {
+    fn default() -> Self {
+        Self::parse_from(Vec::<String>::new())
+    }
 }
 
 /// List of KeyValues

--- a/k8s/operators/src/pool/diskpool/crd/v1beta1.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta1.rs
@@ -154,10 +154,10 @@ impl From<RestPoolStatus> for PoolStatus {
     fn from(p: RestPoolStatus) -> Self {
         match p {
             RestPoolStatus::Unknown => Self::Unknown,
-            RestPoolStatus::Suspected => Self::Unknown,
             RestPoolStatus::Online => Self::Online,
             RestPoolStatus::Degraded => Self::Degraded,
             RestPoolStatus::Faulted => Self::Faulted,
+            _ => Self::Unknown,
         }
     }
 }

--- a/k8s/operators/src/pool/diskpool/crd/v1beta2.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta2.rs
@@ -179,10 +179,10 @@ impl From<RestPoolStatus> for PoolStatus {
     fn from(p: RestPoolStatus) -> Self {
         match p {
             RestPoolStatus::Unknown => Self::Unknown,
-            RestPoolStatus::Suspected => Self::Unknown,
             RestPoolStatus::Online => Self::Online,
             RestPoolStatus::Degraded => Self::Degraded,
             RestPoolStatus::Faulted => Self::Faulted,
+            _ => Self::Unknown,
         }
     }
 }

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -147,6 +147,8 @@ pub enum CrPoolState {
 pub enum PoolStatus {
     /// State is Unknown.
     Unknown,
+    /// State is Offline.
+    Offline,
     /// The pool is in normal working order.
     Online,
     /// The pool has experienced a failure but can still function.
@@ -262,6 +264,7 @@ impl From<RestPoolStatus> for PoolStatus {
     fn from(p: RestPoolStatus) -> Self {
         match p {
             RestPoolStatus::Unknown => Self::Unknown,
+            RestPoolStatus::Offline => Self::Offline,
             RestPoolStatus::Online => Self::Online,
             RestPoolStatus::Degraded => Self::Degraded,
             RestPoolStatus::Suspected => Self::Suspected,

--- a/openapi/templates/default/model.mustache
+++ b/openapi/templates/default/model.mustache
@@ -18,15 +18,16 @@ pub enum {{{classname}}} {
 {{/enumVars}}{{/allowableValues}}
 }
 
-impl ToString for {{{classname}}} {
-    fn to_string(&self) -> String {
-        match self {
+impl std::fmt::Display for {{{classname}}} {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str_value = match self {
             {{#allowableValues}}
             {{#enumVars}}
-            Self::{{{name}}} => String::from("{{{value}}}"),
+            Self::{{{name}}} => "{{{value}}}",
             {{/enumVars}}
             {{/allowableValues}}
-        }
+        };
+        write!(f, "{str_value}")
     }
 }
 

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -12,7 +12,6 @@ use opentelemetry_sdk::{propagation::TraceContextPropagator, trace as sdktrace};
 
 use stor_port::{transport_api::TimeoutOptions, types::v0::transport};
 
-use clap::Parser;
 pub use composer::ImagePullPolicy;
 pub use csi_driver::node::internal::*;
 use deployer_lib::infra::CsiNode;
@@ -75,9 +74,7 @@ async fn smoke_test() {
 
 /// Default options to create a cluster
 pub fn default_options() -> StartOptions {
-    // using from_iter as Default::default would not set the default_value from structopt
-    let options: StartOptions = StartOptions::parse_from([""]);
-    options
+    StartOptions::default()
         .with_agents(default_agents().split(',').collect())
         .with_jaeger(true)
         .with_io_engines(1)


### PR DESCRIPTION
    feat: expose pool import failure reasons via rest/plugin

    Adds more information to the openapi pool representation.
    Includes status and errors to the root of the pool diagnostics.
    This will give an inferred view of the pool issues and help
    diagnose why an import is failing (NodeOffline, Timeout etc).
    
    Also make use of this information to enrich the default tabled
    output of the rest-plugin, giving us a better view of the pool.
    
---

    feat: add pool alerts to rest plugin tabled output
    
---

    test: add pool cli args to deployer
    
---

    refactor(openapi): implement Display trait instead of ToString
    
    This is preferred since ToString is implement automatically for any
    string which implements Display.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
