### PR TITLE
Refactor Dsp Operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,6 +2548,8 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "strum",
+ "strum_macros",
  "tokio",
  "tracing",
  "utils",

--- a/k8s/operators/Cargo.toml
+++ b/k8s/operators/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["rls", "bin"]
-bin = ["openapi", "utils", "anyhow", "chrono", "clap", "futures", "snafu", "tokio", "humantime", "tracing"]
+bin = ["openapi", "utils", "anyhow", "chrono", "clap", "futures", "snafu", "tokio", "humantime", "tracing", "strum_macros", "strum"]
 rls = ["openapi/tower-client-rls"]
 tls = ["openapi/tower-client-tls"]
 
@@ -39,3 +39,5 @@ tokio = { workspace = true, features = ["full"], optional = true }
 humantime = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 parse-size = { workspace = true }
+strum_macros = { workspace = true, optional = true }
+strum = { workspace = true, optional = true }

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -1,24 +1,21 @@
-use super::v1beta3_api;
 use super::{
     diskpool::crd::v1beta3::{CrPoolState, DiskPool, DiskPoolStatus},
+    dsp_api,
     error::Error,
 };
 use crate::diskpool::crd::v1beta3::{EncryptionSecretConfig, EncryptionSource};
-use openapi::models::rest_json_error::Kind;
-use openapi::models::{Encryption, EncryptionSecret};
 use openapi::{
     apis::StatusCode,
     clients,
-    models::{CreatePoolBody, Pool},
+    models::{rest_json_error::Kind, CreatePoolBody, Encryption, EncryptionSecret, Pool},
 };
 use tracing::{debug, error, info};
 use utils::{disk::normalize_disk, dsp_created_by_key};
 
 use chrono::Utc;
 use k8s_openapi::{api::core::v1::Event, apimachinery::pkg::apis::meta::v1::MicroTime};
-use kube::api::{Patch, PostParams};
 use kube::{
-    api::{Api, ObjectMeta, PatchParams},
+    api::{Api, ObjectMeta, Patch, PatchParams, PostParams},
     runtime::{controller::Action, finalizer},
     Client, Resource, ResourceExt,
 };
@@ -186,7 +183,7 @@ impl ResourceContext {
 
     /// Construct an API handle for the resource
     fn api(&self) -> Api<DiskPool> {
-        v1beta3_api(&self.ctx.k8s, &self.namespace().unwrap())
+        dsp_api(&self.ctx.k8s, &self.namespace().unwrap())
     }
 
     /// Construct an API handle for the k8s secret

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -48,7 +48,7 @@ pub(crate) async fn create_crd(k8s: Client) -> Result<CustomResourceDefinition, 
 }
 
 /// This discards older unserved schema from the crd.
-pub(crate) async fn discard_older_schema(k8s: &Client, new_version: &str) -> Result<(), Error> {
+pub(crate) async fn discard_older_schema(k8s: &Client) -> Result<(), Error> {
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
     let mut new_crd = DiskPool::crd();
     let crd_name = new_crd
@@ -63,7 +63,7 @@ pub(crate) async fn discard_older_schema(k8s: &Client, new_version: &str) -> Res
             "Replacing CRD: {}",
             serde_json::to_string_pretty(&new_crd).unwrap()
         );
-        update_stored_version(k8s, crd_name, new_version).await?;
+        update_stored_version(k8s, crd_name).await?;
         if let Ok(modified_crd) = crd_api.get(crd_name).await {
             new_crd.metadata.resource_version = modified_crd.resource_version();
             let pp = PostParams::default();
@@ -122,19 +122,16 @@ pub(crate) async fn create_missing_cr(
     Ok(())
 }
 
-/// Updates stored version in CRD status to the new version passed as arg,
+/// Updates stored version in CRD status to the latest version.
 /// Please ensure that older versions are served:false, stored:false before calling this method,
 /// This would allow us to remove older schema from CRD versions.
-async fn update_stored_version(
-    k8s: &Client,
-    crd_name: &str,
-    new_version: &str,
-) -> Result<(), Error> {
+/// todo: Shouldn't we just ensure that here rather leave it for chance??
+async fn update_stored_version(k8s: &Client, crd_name: &str) -> Result<(), Error> {
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
     if let Ok(mut crd) = crd_api.get_status(crd_name).await {
         let param = PatchParams::apply("status_patch").force();
         if let Some(status) = crd.status.as_mut() {
-            status.stored_versions = Some(vec![new_version.to_string()]);
+            status.stored_versions = Some(vec![ApiVersion::Latest.to_string()]);
         } else {
             return Err(Error::CrdFieldMissing {
                 name: crd_name.to_string(),
@@ -177,24 +174,24 @@ pub(crate) async fn list_existing_cr(
     Ok(pools)
 }
 
-/// Return the api_version of the present crd if any, otherwise retuen None.
-pub(crate) async fn get_api_version(k8s: Client) -> Option<ApiVersion> {
+/// Returns the [`ApiVersion`] of the present crd, if any.
+pub(crate) async fn runtime_api_version(k8s: Client) -> Result<Option<ApiVersion>, kube::Error> {
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s);
-    if let Ok(crd) = crd_api.get_status(&diskpools_name()).await {
-        if let Some(status) = crd.status {
-            if status.stored_versions == Some(vec!["v1alpha1".to_string()]) {
-                return Some(ApiVersion::V1Alpha1);
-            } else if status.stored_versions == Some(vec!["v1beta1".to_string()]) {
-                return Some(ApiVersion::V1Beta1);
-            } else if status.stored_versions == Some(vec!["v1beta2".to_string()]) {
-                return Some(ApiVersion::V1Beta2);
-            } else if status.stored_versions == Some(vec!["v1beta3".to_string()]) {
-                return Some(ApiVersion::V1Beta3);
-            } else {
-                return None;
-            }
-        }
-    }
-    // Return None if no crd present i.e. fresh installation
-    None
+
+    let crd = match crd_api.get_status(&diskpools_name()).await {
+        // CRD not installed yet, this is fine.
+        Err(kube::Error::Api(r)) if r.code == 404 => return Ok(None),
+        _else => _else,
+    }?;
+
+    let crd_version = |crd: CustomResourceDefinition| -> Option<ApiVersion> {
+        // todo: shouldn't this be an error?
+        let status = crd.status?;
+
+        // todo: is this right? Can't we have multiple stored versions during upgrade?
+        let stored_version = status.stored_versions.as_ref()?.first()?;
+        stored_version.parse().ok()
+    };
+
+    Ok(crd_version(crd))
 }

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -186,7 +186,7 @@ pub(crate) async fn list_existing_cr(
 }
 
 /// Returns the [`ApiVersion`] of the present crd, if any.
-pub(crate) async fn runtime_api_version(k8s: Client) -> Result<Option<ApiVersion>, kube::Error> {
+pub(crate) async fn runtime_api_version(k8s: Client) -> Result<Option<ApiVersion>, Error> {
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s);
 
     let crd = match crd_api.get_status(&diskpools_name()).await {
@@ -195,14 +195,39 @@ pub(crate) async fn runtime_api_version(k8s: Client) -> Result<Option<ApiVersion
         _else => _else,
     }?;
 
-    let crd_version = |crd: CustomResourceDefinition| -> Option<ApiVersion> {
-        // todo: shouldn't this be an error?
-        let status = crd.status?;
+    let status = crd.status.as_ref().ok_or(Error::CrdFieldMissing {
+        name: crd.name_any(),
+        field: "status".to_string(),
+    })?;
 
-        // todo: is this right? Can't we have multiple stored versions during upgrade?
-        let stored_version = status.stored_versions.as_ref()?.first()?;
-        stored_version.parse().ok()
-    };
+    let versions = status.stored_versions.iter().flatten();
+    let mut api_versions = versions
+        .map(|v| {
+            v.parse().map_err(|e| Error::Generic {
+                message: format!("DiskPool CRD version {v} is unrecognized: {e}"),
+            })
+        })
+        .collect::<Result<Vec<ApiVersion>, _>>()?;
+    api_versions.sort();
 
-    Ok(crd_version(crd))
+    let version = match api_versions.as_slice() {
+        [] => Err(Error::Generic {
+            message: "No api versions found in the CRD".to_string(),
+        }),
+        [any] => Ok(*any),
+        [deprecated, latest] => {
+            if latest != &ApiVersion::Latest {
+                Err(Error::Generic {
+                    message: format!("More than 1 deprecated versions: {api_versions:?}"),
+                })
+            } else {
+                Ok(*deprecated)
+            }
+        }
+        _ => Err(Error::Generic {
+            message: format!("More than 2 api versions is not supported: {api_versions:?}"),
+        }),
+    }?;
+
+    Ok(Some(version))
 }

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -11,7 +11,7 @@ use kube::{
 use tracing::{info, warn};
 
 /// Get the DiskPool v1beta3 api.
-pub(crate) fn v1beta3_api(client: &Client, namespace: &str) -> Api<DiskPool> {
+pub(crate) fn dsp_api(client: &Client, namespace: &str) -> Api<DiskPool> {
     Api::namespaced(client.clone(), namespace)
 }
 
@@ -23,7 +23,7 @@ pub(crate) async fn create_v1beta3_cr(
     spec: DiskPoolSpec,
 ) -> Result<(), Error> {
     let post_params = PostParams::default();
-    let api = v1beta3_api(client, namespace);
+    let api = dsp_api(client, namespace);
     let new_disk_pool: DiskPool = DiskPool::new(name, spec);
     match api.create(&post_params, &new_disk_pool).await {
         Ok(_) => Ok(()),
@@ -81,7 +81,7 @@ pub(crate) async fn create_missing_cr(
     namespace: &str,
 ) -> Result<(), Error> {
     if let Ok(pools) = control_client.pools_api().get_pools(None).await {
-        let pools_api: Api<DiskPool> = v1beta3_api(k8s, namespace);
+        let pools_api: Api<DiskPool> = dsp_api(k8s, namespace);
         let param = PostParams::default();
         for pool in pools.into_body().iter_mut() {
             match pools_api.get(&pool.id).await {
@@ -154,11 +154,11 @@ pub(crate) async fn list_existing_cr(
 ) -> Result<Vec<DiskPool>, Error> {
     // Create the list params with pagination limit.
     let mut list_params = ListParams::default().limit(pagination_limit);
-    // Since v1alpha1/v1beta1/v1beta2 is not served at this stage we cannot use v1alpha1/v1beta1/v1beta2 api client
-    // to list existing CRs. Existing CRs which were created and stored as v1alpha1/v1beta1/v1beta2 can
-    // be retrieved using v1beta3 client. Kube api server performs the required conversions and
+    // Since older/deprecated versions are not served at this stage we cannot use their api client
+    // to list existing CRs. Existing CRs which were created and stored as deprecated versions can
+    // be retrieved using the latest client. Kube api server performs the required conversions and
     // returns us the resources.
-    let pools_api: Api<DiskPool> = v1beta3_api(client, namespace);
+    let pools_api: Api<DiskPool> = dsp_api(client, namespace);
     let mut pools: Vec<DiskPool> = vec![];
     loop {
         let mut result = pools_api.list(&list_params).await?;

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -1,7 +1,6 @@
 use super::crd::v1beta3::{DiskPool, DiskPoolSpec, EncryptionSource};
 use crate::{diskpool::crd::diskpools_name, error::Error, ApiVersion};
-use openapi::models::PoolSpecEncryption;
-use openapi::{apis::StatusCode, clients};
+use openapi::{apis::StatusCode, clients, models::PoolSpecEncryption};
 
 use crate::diskpool::crd::v1beta3;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
@@ -38,12 +37,13 @@ pub(crate) async fn create_crd(k8s: Client) -> Result<CustomResourceDefinition, 
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
     let new_crd = DiskPool::crd();
     info!(
-        "Creating CRD: {}",
-        serde_json::to_string_pretty(&new_crd).unwrap_or_default()
+        "Creating DiskPool CRD: {}",
+        serde_json::to_string(&new_crd).unwrap_or_default()
     );
     let pp = PostParams::default();
     let result = crd_api.create(&pp, &new_crd).await;
     let crd = result.map_err(|e| Error::Kube { source: e })?;
+    info!("Created DiskPool CRD");
     Ok(crd)
 }
 

--- a/k8s/operators/src/pool/diskpool/client.rs
+++ b/k8s/operators/src/pool/diskpool/client.rs
@@ -58,18 +58,13 @@ pub(crate) async fn discard_older_schema(k8s: &Client) -> Result<(), Error> {
         .ok_or(Error::InvalidCRField {
             field: "diskpool.metadata.name".to_string(),
         })?;
-    if crd_api.get(crd_name).await.is_ok() {
-        info!(
-            "Replacing CRD: {}",
-            serde_json::to_string_pretty(&new_crd).unwrap()
-        );
-        update_stored_version(k8s, crd_name).await?;
-        if let Ok(modified_crd) = crd_api.get(crd_name).await {
-            new_crd.metadata.resource_version = modified_crd.resource_version();
-            let pp = PostParams::default();
-            crd_api.replace(crd_name, &pp, &new_crd).await?;
-        }
-    }
+    let crd = update_stored_version(k8s, crd_name).await?;
+
+    // todo: is this replace to erase the stale api versions?
+    new_crd.metadata.resource_version = crd.resource_version();
+    crd_api
+        .replace(crd_name, &PostParams::default(), &new_crd)
+        .await?;
     Ok(())
 }
 
@@ -126,24 +121,40 @@ pub(crate) async fn create_missing_cr(
 /// Please ensure that older versions are served:false, stored:false before calling this method,
 /// This would allow us to remove older schema from CRD versions.
 /// todo: Shouldn't we just ensure that here rather leave it for chance??
-async fn update_stored_version(k8s: &Client, crd_name: &str) -> Result<(), Error> {
+async fn update_stored_version(
+    k8s: &Client,
+    crd_name: &str,
+) -> Result<CustomResourceDefinition, Error> {
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
-    if let Ok(mut crd) = crd_api.get_status(crd_name).await {
-        let param = PatchParams::apply("status_patch").force();
-        if let Some(status) = crd.status.as_mut() {
-            status.stored_versions = Some(vec![ApiVersion::Latest.to_string()]);
-        } else {
-            return Err(Error::CrdFieldMissing {
-                name: crd_name.to_string(),
-                field: "status".to_string(),
-            });
-        }
-        crd.metadata.managed_fields = None;
-        let _ = crd_api
-            .patch_status(crd_name, &param, &Patch::Apply(&crd))
-            .await?;
+
+    let mut crd = crd_api.get_status(crd_name).await?;
+
+    let status = crd.status.as_mut().ok_or(Error::CrdFieldMissing {
+        name: crd_name.to_string(),
+        field: "status".to_string(),
+    })?;
+
+    let set_latest = Some(vec![ApiVersion::Latest.to_string()]);
+    if status.stored_versions == set_latest {
+        return Ok(crd);
     }
-    Ok(())
+
+    warn!(
+        stored_versions = ?status.stored_versions,
+        latest = ?set_latest,
+        "Replacing stored version with the latest version"
+    );
+
+    status.stored_versions = set_latest;
+    // todo: why is this being cleared?
+    crd.metadata.managed_fields = None;
+
+    let param = PatchParams::apply("status_patch").force();
+    let crd = crd_api
+        .patch_status(crd_name, &param, &Patch::Apply(&crd))
+        .await?;
+
+    Ok(crd)
 }
 
 /// List of all pools.

--- a/k8s/operators/src/pool/diskpool/crd/migration.rs
+++ b/k8s/operators/src/pool/diskpool/crd/migration.rs
@@ -29,11 +29,11 @@ pub(crate) async fn ensure_and_migrate_crd(
 ) -> Result<(), Error> {
     match ensure_crd(&k8s, api_version).await {
         Ok(o) => {
-            info!(crd = ?o.name_any(), "Created");
+            info!(crd = ?o.name_any(), "Updated DiskPool CRD");
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
         Err(error) => {
-            error!(%error, "Failed to create CRD");
+            error!(%error, "Failed to create DiskPool CRD");
             tokio::time::sleep(Duration::from_secs(1)).await;
             return Err(error);
         }
@@ -54,12 +54,11 @@ pub(crate) async fn ensure_crd(
 ) -> Result<CustomResourceDefinition, Error> {
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
 
-    let mut crd = if api_version == &ApiVersion::V1Alpha1 {
-        AlphaDiskPool::crd()
-    } else if api_version == &ApiVersion::V1Beta1 {
-        Beta1DiskPool::crd()
-    } else {
-        Beta2DiskPool::crd()
+    let mut crd = match api_version {
+        ApiVersion::V1Alpha1 => AlphaDiskPool::crd(),
+        ApiVersion::V1Beta1 => Beta1DiskPool::crd(),
+        ApiVersion::V1Beta2 => Beta2DiskPool::crd(),
+        ApiVersion::V1Beta3 => Beta2DiskPool::crd(),
     };
 
     let crd_name = crd.metadata.name.as_ref().ok_or(Error::InvalidCRField {
@@ -75,8 +74,9 @@ pub(crate) async fn ensure_crd(
     let result = match crd_api.get(crd_name).await {
         Ok(_) => {
             info!(
-                "Replacing CRD: {}",
-                serde_json::to_string_pretty(&new_crd).unwrap_or_default()
+                crd = new_crd.name_any(),
+                "Replacing DiskPool CRD: {}",
+                serde_json::to_string(&new_crd).unwrap_or_default()
             );
             let param = if api_version == &ApiVersion::V1Alpha1 {
                 PatchParams::apply("merge_v1alpha1_v1beta3").force()
@@ -109,9 +109,7 @@ async fn run_cr_migration(
         ApiVersion::V1Alpha1 | ApiVersion::V1Beta1 | ApiVersion::V1Beta2 | ApiVersion::V1Beta3 => {
             migrate_to_v1beta3(k8s.clone(), namespace, PAGINATION_LIMIT).await?;
             _ = discard_older_schema(&k8s, target_schema).await;
-        } //ApiVersion::V1Beta3 => {
-          //    info!("CRD has the latest schema. Skipping CRD Operations");
-          //}
+        }
     }
     Ok(())
 }
@@ -138,7 +136,7 @@ pub(crate) async fn migrate_to_v1beta3(
                     DiskPoolSpec::new(node, disk, topology, None, None, None),
                 )
                 .await?;
-                info!(crd = ?dsp.name_any(), "CR creation successful");
+                info!(dsp.name = ?dsp.name_any(), "DiskPool CR migration successful");
             } else {
                 return Err(Error::CrdFieldMissing {
                     name: dsp.name_any(),

--- a/k8s/operators/src/pool/diskpool/crd/migration.rs
+++ b/k8s/operators/src/pool/diskpool/crd/migration.rs
@@ -85,8 +85,7 @@ pub(crate) async fn ensure_crd(
     let result = match crd_api.get(&crd_name).await {
         Ok(_) => {
             info!(
-                crd = new_crd.name_any(),
-                "Replacing DiskPool CRD: {}",
+                "Merging {api_version} DiskPool CRD with {latest_api_version}: {}",
                 serde_json::to_string(&new_crd).unwrap_or_default()
             );
             let manager = format!("merge_{api_version}_{}", ApiVersion::Latest);

--- a/k8s/operators/src/pool/diskpool/crd/migration.rs
+++ b/k8s/operators/src/pool/diskpool/crd/migration.rs
@@ -5,7 +5,7 @@ use super::{
     v1beta3::{DiskPool, DiskPoolSpec},
 };
 use crate::{
-    diskpool::client::{discard_older_schema, list_existing_cr, v1beta3_api},
+    diskpool::client::{discard_older_schema, dsp_api, list_existing_cr},
     error::Error,
     ApiVersion, PrevApiVersion,
 };
@@ -37,7 +37,7 @@ pub(crate) async fn ensure_and_migrate_crd(
             return Err(error);
         }
     }
-    run_cr_migration(k8s.clone(), namespace, api_version).await?;
+    run_cr_migration(k8s.clone(), namespace).await?;
     Ok(())
 }
 
@@ -102,20 +102,16 @@ pub(crate) async fn ensure_crd(
     Ok(crd)
 }
 
-/// Migrate existing v1alpha1/v1beta1/v1beta2 CR in cluster to v1beta3 CR.
-async fn run_cr_migration(
-    k8s: Client,
-    namespace: &str,
-    _api_version: ApiVersion,
-) -> Result<(), Error> {
-    migrate_to_v1beta3(k8s.clone(), namespace, PAGINATION_LIMIT).await?;
+/// Migrate existing deprecated CRs in cluster to the latest CR.
+async fn run_cr_migration(k8s: Client, namespace: &str) -> Result<(), Error> {
+    migrate_to_latest(k8s.clone(), namespace, PAGINATION_LIMIT).await?;
     _ = discard_older_schema(&k8s).await;
     Ok(())
 }
 
-/// Lists existing v1alpha1/v1beta1/v1beta2 CR in cluster and replaces them with v1beta3 CR.
-/// This ensures that there is no v1alpha1/v1beta1/v1beta2 stored objects in cluster.
-pub(crate) async fn migrate_to_v1beta3(
+/// Lists existing deprecated CRs in cluster and replaces them with the latest CR.
+/// This ensures that there is no deprecated stored objects in cluster.
+pub(crate) async fn migrate_to_latest(
     k8s: Client,
     ns: &str,
     pagination_limit: u32,
@@ -127,7 +123,7 @@ pub(crate) async fn migrate_to_v1beta3(
                 let node = dsp.spec.node();
                 let disk = dsp.spec.disks();
                 let topology = dsp.spec.topology();
-                replace_with_v1beta3(
+                replace_with_latest(
                     &k8s,
                     &name,
                     ns,
@@ -151,8 +147,8 @@ pub(crate) async fn migrate_to_v1beta3(
     Ok(())
 }
 
-/// Replaces a given disk pool CR with v1beta3 schema CR.
-pub(crate) async fn replace_with_v1beta3(
+/// Replaces a given disk pool CR with the latest schema CR.
+pub(crate) async fn replace_with_latest(
     client: &Client,
     cr_name: &str,
     namespace: &str,
@@ -160,12 +156,15 @@ pub(crate) async fn replace_with_v1beta3(
     spec: DiskPoolSpec,
 ) -> Result<(), Error> {
     let post_params = PostParams::default();
-    let api = v1beta3_api(client, namespace);
+    let api = dsp_api(client, namespace);
+    let latest_api = ApiVersion::Latest;
+
     let mut new_disk_pool: DiskPool = DiskPool::new(cr_name, spec);
     new_disk_pool.metadata.resource_version = res_ver;
+
     info!(
         pool.cr_name = cr_name,
-        "Patching existing pool with v1beta3 schema"
+        "Patching existing pool with {latest_api} schema"
     );
     match api.replace(cr_name, &post_params, &new_disk_pool).await {
         Ok(_) => Ok(()),
@@ -173,7 +172,7 @@ pub(crate) async fn replace_with_v1beta3(
             error!(
                 ?error,
                 pool.cr_name = cr_name,
-                "Failed to patch pool with v1beta3 schema"
+                "Failed to patch pool with {latest_api} schema"
             );
             Err(error.into())
         }

--- a/k8s/operators/src/pool/diskpool/crd/migration.rs
+++ b/k8s/operators/src/pool/diskpool/crd/migration.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     diskpool::client::{discard_older_schema, list_existing_cr, v1beta3_api},
     error::Error,
-    ApiVersion,
+    ApiVersion, PrevApiVersion,
 };
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::{
@@ -24,8 +24,7 @@ const PAGINATION_LIMIT: u32 = 100;
 pub(crate) async fn ensure_and_migrate_crd(
     k8s: Client,
     namespace: &str,
-    api_version: &ApiVersion,
-    target_schema: &str,
+    api_version: ApiVersion,
 ) -> Result<(), Error> {
     match ensure_crd(&k8s, api_version).await {
         Ok(o) => {
@@ -38,7 +37,7 @@ pub(crate) async fn ensure_and_migrate_crd(
             return Err(error);
         }
     }
-    run_cr_migration(k8s.clone(), namespace, api_version, target_schema).await?;
+    run_cr_migration(k8s.clone(), namespace, api_version).await?;
     Ok(())
 }
 
@@ -50,15 +49,18 @@ pub(crate) async fn ensure_and_migrate_crd(
 /// is wrong would be to consult the logs.
 pub(crate) async fn ensure_crd(
     k8s: &Client,
-    api_version: &ApiVersion,
+    api_version: ApiVersion,
 ) -> Result<CustomResourceDefinition, Error> {
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
 
+    let api_version = match api_version {
+        ApiVersion::Deprecated(api_version) => api_version,
+        ApiVersion::Latest => todo!("should be obvious now that we have a bug here"),
+    };
     let mut crd = match api_version {
-        ApiVersion::V1Alpha1 => AlphaDiskPool::crd(),
-        ApiVersion::V1Beta1 => Beta1DiskPool::crd(),
-        ApiVersion::V1Beta2 => Beta2DiskPool::crd(),
-        ApiVersion::V1Beta3 => Beta2DiskPool::crd(),
+        PrevApiVersion::V1Alpha1 => AlphaDiskPool::crd(),
+        PrevApiVersion::V1Beta1 => Beta1DiskPool::crd(),
+        PrevApiVersion::V1Beta2 => Beta2DiskPool::crd(),
     };
 
     let crd_name = crd.metadata.name.as_ref().ok_or(Error::InvalidCRField {
@@ -78,13 +80,8 @@ pub(crate) async fn ensure_crd(
                 "Replacing DiskPool CRD: {}",
                 serde_json::to_string(&new_crd).unwrap_or_default()
             );
-            let param = if api_version == &ApiVersion::V1Alpha1 {
-                PatchParams::apply("merge_v1alpha1_v1beta3").force()
-            } else if api_version == &ApiVersion::V1Beta1 {
-                PatchParams::apply("merge_v1beta1_v1beta3").force()
-            } else {
-                PatchParams::apply("merge_v1beta2_v1beta3").force()
-            };
+            let manager = format!("merge_{api_version}_{}", ApiVersion::Latest);
+            let param = PatchParams::apply(&manager).force();
             crd_api
                 .patch(&super::diskpools_name(), &param, &Patch::Apply(&new_crd))
                 .await
@@ -100,17 +97,10 @@ pub(crate) async fn ensure_crd(
 async fn run_cr_migration(
     k8s: Client,
     namespace: &str,
-    api_version: &ApiVersion,
-    target_schema: &str,
+    _api_version: ApiVersion,
 ) -> Result<(), Error> {
-    match api_version {
-        // Handle migration irrespective of version, for cases where some new changes to
-        // CRD come in within same CRD version.
-        ApiVersion::V1Alpha1 | ApiVersion::V1Beta1 | ApiVersion::V1Beta2 | ApiVersion::V1Beta3 => {
-            migrate_to_v1beta3(k8s.clone(), namespace, PAGINATION_LIMIT).await?;
-            _ = discard_older_schema(&k8s, target_schema).await;
-        }
-    }
+    migrate_to_v1beta3(k8s.clone(), namespace, PAGINATION_LIMIT).await?;
+    _ = discard_older_schema(&k8s).await;
     Ok(())
 }
 

--- a/k8s/operators/src/pool/diskpool/crd/migration.rs
+++ b/k8s/operators/src/pool/diskpool/crd/migration.rs
@@ -51,11 +51,20 @@ pub(crate) async fn ensure_crd(
     k8s: &Client,
     api_version: ApiVersion,
 ) -> Result<CustomResourceDefinition, Error> {
+    let dsp_name = super::diskpools_name();
+    let latest_api_version = ApiVersion::Latest;
     let crd_api: Api<CustomResourceDefinition> = Api::all(k8s.clone());
 
     let api_version = match api_version {
         ApiVersion::Deprecated(api_version) => api_version,
-        ApiVersion::Latest => todo!("should be obvious now that we have a bug here"),
+        ApiVersion::Latest => {
+            let manager = format!("merge_{api_version}_{latest_api_version}");
+            let param = PatchParams::apply(&manager).force();
+            let crd = crd_api
+                .patch(&dsp_name, &param, &Patch::Apply(&DiskPool::crd()))
+                .await?;
+            return Ok(crd);
+        }
     };
     let mut crd = match api_version {
         PrevApiVersion::V1Alpha1 => AlphaDiskPool::crd(),
@@ -63,17 +72,17 @@ pub(crate) async fn ensure_crd(
         PrevApiVersion::V1Beta2 => Beta2DiskPool::crd(),
     };
 
-    let crd_name = crd.metadata.name.as_ref().ok_or(Error::InvalidCRField {
+    let crd_name = crd.metadata.name.clone().ok_or(Error::InvalidCRField {
         field: "diskpool.metadata.name".to_string(),
     })?;
     crd.spec.versions[0].served = false;
     let new_crd = DiskPool::crd();
-    let all_crds = vec![crd.clone(), new_crd.clone()];
-    let new_crd =
-        merge_crds(all_crds, "v1beta3").map_err(|source| Error::CrdMergeError { source })?;
+    let all_crds = vec![crd, new_crd];
+    let new_crd = merge_crds(all_crds, &latest_api_version.to_string())
+        .map_err(|source| Error::CrdMergeError { source })?;
 
     // If diskpool exist then replace it with new generated one.
-    let result = match crd_api.get(crd_name).await {
+    let result = match crd_api.get(&crd_name).await {
         Ok(_) => {
             info!(
                 crd = new_crd.name_any(),
@@ -83,7 +92,7 @@ pub(crate) async fn ensure_crd(
             let manager = format!("merge_{api_version}_{}", ApiVersion::Latest);
             let param = PatchParams::apply(&manager).force();
             crd_api
-                .patch(&super::diskpools_name(), &param, &Patch::Apply(&new_crd))
+                .patch(&crd_name, &param, &Patch::Apply(&new_crd))
                 .await
         }
         Err(err) => return Err(Error::Kube { source: err }),

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -9,7 +9,7 @@ pub(crate) mod error;
 mod mayastorpool;
 
 use crate::diskpool::client::{
-    create_crd, create_missing_cr, create_v1beta3_cr, get_api_version, v1beta3_api,
+    create_crd, create_missing_cr, create_v1beta3_cr, runtime_api_version, v1beta3_api,
 };
 
 use context::OperatorContext;
@@ -18,7 +18,6 @@ use diskpool::crd::{
     v1beta3::{CrPoolState, DiskPool, DiskPoolSpec, DiskPoolStatus},
 };
 use error::Error;
-use kube::CustomResourceExt;
 use mayastorpool::client::{check_crd, delete, list};
 use openapi::clients::{self, tower::Url};
 use tracing::{error, info, trace, warn};
@@ -33,13 +32,13 @@ use kube::{
         controller::{Action, Controller},
         watcher,
     },
-    Client, ResourceExt,
+    Client, CustomResourceExt, Resource, ResourceExt,
 };
 use std::{collections::HashMap, fs::File, io::Write, path::Path, sync::Arc, time::Duration};
+use strum_macros::{Display, EnumString, VariantNames};
 
 const PAGINATION_LIMIT: u32 = 100;
 const BACKOFF_PERIOD: u64 = 20;
-const LATEST_API_VERSION: &str = "v1beta3";
 /// Determine what we want to do when dealing with errors from the
 /// reconciliation loop
 fn error_policy(_object: Arc<DiskPool>, error: &Error, _ctx: Arc<OperatorContext>) -> Action {
@@ -85,36 +84,70 @@ async fn reconcile(dsp: Arc<DiskPool>, ctx: Arc<OperatorContext>) -> Result<Acti
         None => dsp.init_cr().await,
     }
 }
-/// Api version of DSP.
-#[derive(Debug, Clone, PartialEq)]
-pub enum ApiVersion {
+/// Previous Api versions for the [`DiskPool`].
+#[derive(Debug, Clone, Copy, PartialEq, Display, EnumString, VariantNames)]
+#[strum(serialize_all = "lowercase")]
+pub enum PrevApiVersion {
     /// Represents v1alpha1
     V1Alpha1,
     /// Represents v1beta1
     V1Beta1,
     /// Represents v1beta2
     V1Beta2,
-    /// Represents v1beta3
-    V1Beta3,
 }
 
+/// Current Api versions for the [`DiskPool`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ApiVersion {
+    Deprecated(PrevApiVersion),
+    Latest,
+}
+impl std::fmt::Display for ApiVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            ApiVersion::Deprecated(version) => version.to_string(),
+            ApiVersion::Latest => DiskPool::version(&()).to_string(),
+        };
+        write!(f, "{s}")
+    }
+}
+impl std::str::FromStr for ApiVersion {
+    type Err = strum::ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == Self::Latest.to_string() {
+            Ok(Self::Latest)
+        } else {
+            Ok(Self::Deprecated(s.parse::<PrevApiVersion>()?))
+        }
+    }
+}
+
+impl ApiVersion {
+    /// The [`ApiVersion`] we want to use.
+    /// > It should be the latest version.
+    pub fn validate_latest() -> anyhow::Result<()> {
+        use kube::Resource;
+        let version = DiskPool::version(&());
+        let latest: Self = version.parse().map_err(|e| {
+            anyhow::anyhow!("Please update ApiVersion to account for {version}: {e}")
+        })?;
+
+        anyhow::ensure!(latest == Self::Latest, "Please update ApiVersion::Latest");
+
+        Ok(())
+    }
+}
 async fn pool_controller(args: ArgMatches) -> anyhow::Result<()> {
     let k8s = Client::try_default().await?;
     let namespace = args.get_one::<String>("namespace").unwrap();
-    let api_version = get_api_version(k8s.clone()).await;
+    let api_version = runtime_api_version(k8s.clone()).await?;
+
+    ApiVersion::validate_latest()?;
 
     match api_version {
-        Some(version) => match version {
-            // Run the ensure and merge flow also for cases where some new changes to
-            // CRD come in within same/existing CRD version.
-            ApiVersion::V1Alpha1
-            | ApiVersion::V1Beta1
-            | ApiVersion::V1Beta2
-            | ApiVersion::V1Beta3 => {
-                ensure_and_migrate_crd(k8s.clone(), namespace, &version, LATEST_API_VERSION)
-                    .await?;
-            }
-        },
+        Some(version) => {
+            ensure_and_migrate_crd(k8s.clone(), namespace, version).await?;
+        }
         None => {
             create_crd(k8s.clone()).await?;
         }
@@ -396,4 +429,29 @@ pub(crate) async fn migrate_and_clean_msps(k8s: &Client, namespace: &str) -> Res
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ApiVersion, PrevApiVersion};
+    use k8s_operators::diskpool::crd::DiskPool;
+    use kube::Resource;
+
+    #[test]
+    fn test_parse_api_version() {
+        assert_eq!(PrevApiVersion::V1Alpha1.to_string(), "v1alpha1");
+        assert_eq!(
+            "v1alpha1".parse::<ApiVersion>().unwrap(),
+            ApiVersion::Deprecated(PrevApiVersion::V1Alpha1)
+        );
+        assert_eq!(
+            ApiVersion::Deprecated(PrevApiVersion::V1Alpha1).to_string(),
+            PrevApiVersion::V1Alpha1.to_string()
+        );
+        let latest_v = "v1beta3";
+        assert_eq!(latest_v, DiskPool::version(&()));
+        assert_eq!(latest_v.parse::<ApiVersion>(), Ok(ApiVersion::Latest));
+        assert_eq!(ApiVersion::Latest.to_string(), DiskPool::version(&()));
+        assert_eq!(ApiVersion::Latest.to_string(), latest_v);
+    }
 }

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -35,10 +35,7 @@ use kube::{
     },
     Client, ResourceExt,
 };
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, fs::File, io::Write, path::Path, sync::Arc, time::Duration};
 
 const PAGINATION_LIMIT: u32 = 100;
 const BACKOFF_PERIOD: u64 = 20;
@@ -88,7 +85,6 @@ async fn reconcile(dsp: Arc<DiskPool>, ctx: Arc<OperatorContext>) -> Result<Acti
         None => dsp.init_cr().await,
     }
 }
-
 /// Api version of DSP.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ApiVersion {
@@ -117,9 +113,7 @@ async fn pool_controller(args: ArgMatches) -> anyhow::Result<()> {
             | ApiVersion::V1Beta3 => {
                 ensure_and_migrate_crd(k8s.clone(), namespace, &version, LATEST_API_VERSION)
                     .await?;
-            } //ApiVersion::V1Beta3 => {
-              //    info!("CRD has the latest schema. Skipping CRD Operations");
-              //}
+            }
         },
         None => {
             create_crd(k8s.clone()).await?;

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -421,7 +421,7 @@ pub(crate) async fn migrate_and_clean_msps(k8s: &Client, namespace: &str) -> Res
                 })
             }
         },
-        Ok(false) => warn!("MayastorPool CRD was not found in the cluster, skipping migration"),
+        Ok(false) => info!("MayastorPool CRD was not found in the cluster, skipping migration"),
         Err(error) => {
             return Err(Error::Generic {
                 message: format!("Failed to check for MayastorPool CRD: {error:?}"),

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -9,7 +9,7 @@ pub(crate) mod error;
 mod mayastorpool;
 
 use crate::diskpool::client::{
-    create_crd, create_missing_cr, create_v1beta3_cr, runtime_api_version, v1beta3_api,
+    create_crd, create_missing_cr, create_v1beta3_cr, dsp_api, runtime_api_version,
 };
 
 use context::OperatorContext;
@@ -156,7 +156,7 @@ async fn pool_controller(args: ArgMatches) -> anyhow::Result<()> {
     // Migrate the MayastorPool CRs to the DiskPool.
     migrate_and_clean_msps(&k8s, namespace).await?;
 
-    let newdsp: Api<DiskPool> = v1beta3_api(&k8s, namespace);
+    let newdsp: Api<DiskPool> = dsp_api(&k8s, namespace);
 
     let url = Url::parse(args.get_one::<String>("endpoint").unwrap())
         .expect("endpoint is not a valid URL");

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -35,7 +35,7 @@ use kube::{
     Client, CustomResourceExt, Resource, ResourceExt,
 };
 use std::{collections::HashMap, fs::File, io::Write, path::Path, sync::Arc, time::Duration};
-use strum_macros::{Display, EnumString, VariantNames};
+use strum_macros::{Display, EnumString};
 
 const PAGINATION_LIMIT: u32 = 100;
 const BACKOFF_PERIOD: u64 = 20;
@@ -85,7 +85,7 @@ async fn reconcile(dsp: Arc<DiskPool>, ctx: Arc<OperatorContext>) -> Result<Acti
     }
 }
 /// Previous Api versions for the [`DiskPool`].
-#[derive(Debug, Clone, Copy, PartialEq, Display, EnumString, VariantNames)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Display, EnumString)]
 #[strum(serialize_all = "lowercase")]
 pub enum PrevApiVersion {
     /// Represents v1alpha1
@@ -97,10 +97,15 @@ pub enum PrevApiVersion {
 }
 
 /// Current Api versions for the [`DiskPool`].
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum ApiVersion {
     Deprecated(PrevApiVersion),
     Latest,
+}
+impl From<PrevApiVersion> for ApiVersion {
+    fn from(value: PrevApiVersion) -> Self {
+        Self::Deprecated(value)
+    }
 }
 impl std::fmt::Display for ApiVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -117,7 +122,7 @@ impl std::str::FromStr for ApiVersion {
         if s == Self::Latest.to_string() {
             Ok(Self::Latest)
         } else {
-            Ok(Self::Deprecated(s.parse::<PrevApiVersion>()?))
+            Ok(s.parse::<PrevApiVersion>()?.into())
         }
     }
 }
@@ -448,11 +453,28 @@ mod tests {
             ApiVersion::Deprecated(PrevApiVersion::V1Alpha1).to_string(),
             PrevApiVersion::V1Alpha1.to_string()
         );
-        let latest_v = "v1beta3";
-        assert_eq!(latest_v, DiskPool::version(&()));
+        let latest_v = DiskPool::version(&());
         assert_eq!(latest_v.parse::<ApiVersion>(), Ok(ApiVersion::Latest));
         assert_eq!(ApiVersion::Latest.to_string(), DiskPool::version(&()));
         assert_eq!(ApiVersion::Latest.to_string(), latest_v);
+    }
+
+    #[test]
+    fn test_api_version_order() {
+        let mut versions = vec![
+            ApiVersion::Latest,
+            ApiVersion::Deprecated(PrevApiVersion::V1Alpha1),
+            ApiVersion::Deprecated(PrevApiVersion::V1Beta2),
+        ];
+        versions.sort();
+        assert_eq!(
+            versions,
+            vec![
+                ApiVersion::Deprecated(PrevApiVersion::V1Alpha1),
+                ApiVersion::Deprecated(PrevApiVersion::V1Beta2),
+                ApiVersion::Latest,
+            ]
+        )
     }
 
     #[test]

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -433,9 +433,9 @@ pub(crate) async fn migrate_and_clean_msps(k8s: &Client, namespace: &str) -> Res
 
 #[cfg(test)]
 mod tests {
-    use crate::{ApiVersion, PrevApiVersion};
+    use crate::{diskpool::crd::diskpools_name, ApiVersion, PrevApiVersion};
     use k8s_operators::diskpool::crd::DiskPool;
-    use kube::Resource;
+    use kube::{CustomResourceExt, Resource};
 
     #[test]
     fn test_parse_api_version() {
@@ -453,5 +453,12 @@ mod tests {
         assert_eq!(latest_v.parse::<ApiVersion>(), Ok(ApiVersion::Latest));
         assert_eq!(ApiVersion::Latest.to_string(), DiskPool::version(&()));
         assert_eq!(ApiVersion::Latest.to_string(), latest_v);
+    }
+
+    #[test]
+    fn test_crd_name() {
+        let crd = DiskPool::crd();
+        let crd_name = crd.metadata.name.as_ref();
+        assert_eq!(Some(&diskpools_name()), crd_name)
     }
 }


### PR DESCRIPTION
Some behaviors in the operator, in the way api versions are handled seemed incorrect so I've refactored the code.
This aims to fix and also ensure correctness by leveraging the type system.

    fix(k8s/dsp): handle mixed stored versions
    
    If the operator crashes between merging the crd and discarding
    the older schema, we end up with 2 stored versions when starting.
    
    The previous code would just pick the first element, which is not
    clear and may potentially be incorrect.
    
    Enforce the stored version restrictions, allowing it to crash
    rather than do something incorrectly.
    
    todo: we could also skip the merge when we have already merged!
    
----

    fix(k8s/dsp): migrate crd only if necessary
    
    If the stored version is already the latest, then we can simply
    patch to the latest crd, and avoid the large dump.
    
---

    refactor(k8s/dsp): remove hardcoded versions
    
    Use latest where applicable instead of v1beta3.
    Replace explicit names with deprecated/latest lingo.
    
---

    chore: don't warn when no msp is found
    
    We're way past someone having an msp, so we don't need to make
    a glaring notification.
    
---

    fix(k8s/dsp): merge crd with previous version only if required
    
    In case the current version of the CRD is already the latest, then we
    can simply patch to the current schema.
    
    This is possible now that the api is clear, and we know we're on the
    latest version.
    
---

    refactor(k8s/dsp): clarify api versions
    
    There's currently a bug which causes the operator to merge v1beta2 with
    v1beta3 even if the v1beta2 was never installed in the cluster.
    
    This change makes use of the type system to clarify the distinction
    between the previous and the current/latest api version.
    
    Also removes a lot of redundant code passing the latest version
    as a raw string.
    
---

    refactor(k8s/dsp): tidy up some of the logging
    
    Removes the pretty json (devs can just copy and use jq).
    Adds missing logs after CRD creation.
    Use correct verbs after update, etc.
