### PR TITLE
 feat(k8s/dsp): add pool errors and diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,6 +2526,7 @@ checksum = "19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "schemars",
  "serde",
  "serde-value",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ bindgen = "0.69.5"
 flate2 = "1.0"
 tar = "0.4"
 
-k8s-openapi = { version = "0.22.0", default-features = false, features = ["v1_24"] }
+k8s-openapi = { version = "0.22.0", default-features = false, features = ["v1_24", "schemars"] }
 kube = { version = "0.94.2", features = ["runtime", "derive"] }
 schemars = { version = "0.8.21" }
 async-nats = { version = "0.37.0", default-features = false }

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -386,7 +386,11 @@ impl Service {
         request: &GetBlockDevices,
     ) -> Result<BlockDevices, SvcError> {
         let node = self.registry.node_wrapper(&request.node).await?;
-
+        if !node.read().await.is_online() {
+            return Err(SvcError::NodeNotOnline {
+                node: request.node.clone(),
+            });
+        }
         node.list_blockdevices(request).await
     }
 

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -824,6 +824,11 @@ impl ResourceContext {
                 "Critical",
             )
             .await;
+            self.mark_pool_error(Some(PoolError {
+                code: PoolErrorCode::EncryptionSecretError,
+                message: Some(format!("Failed to get encryption secret: {name}")),
+            }))
+            .await?;
             return Err(Error::Kube { source: error });
         }
 

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -233,7 +233,7 @@ impl ResourceContext {
 
     /// Mark Pool state as None as couldn't find already provisioned pool in control plane.
     async fn mark_pool_error(&self, error: Option<PoolError>) -> Result<Action, Error> {
-        self.patch_status(DiskPoolStatus::not_found(&self.inner.status, error))
+        self.patch_status(DiskPoolStatus::not_found(&self.inner, error))
             .await?;
         Ok(Action::requeue(Duration::from_secs(30)))
     }
@@ -241,7 +241,7 @@ impl ResourceContext {
     /// Mark Pool state as None and error as DiskNotFound as we couldn't find the
     /// pool disk during the creation/import attempt.
     async fn mark_disk_not_found(&self) -> Result<(), Error> {
-        self.patch_status(DiskPoolStatus::disk_not_found(&self.inner.status))
+        self.patch_status(DiskPoolStatus::disk_not_found(&self.inner))
             .await?;
         Ok(())
     }
@@ -251,7 +251,7 @@ impl ResourceContext {
         let msg = "Timed out whilst trying to create the diskpool";
         self.k8s_notify("Create/Import", "Timeout", msg, "Warning")
             .await;
-        let mut pool = DiskPoolStatus::from(pool);
+        let mut pool = DiskPoolStatus::from(pool).with_conditions(self);
         pool.cr_state = CrPoolState::Creating;
         error!(?pool, msg);
         self.patch_status(pool).await?;
@@ -284,7 +284,7 @@ impl ResourceContext {
 
     /// Patch the resource state to terminating.
     async fn mark_terminating_when_unknown(&self) -> Result<Action, Error> {
-        self.patch_status(DiskPoolStatus::terminating_when_unknown())
+        self.patch_status(DiskPoolStatus::terminating_when_unknown().with_conditions(self))
             .await?;
         Ok(Action::requeue(Duration::from_secs(self.ctx.interval)))
     }
@@ -292,7 +292,8 @@ impl ResourceContext {
     /// Used to patch the DiskPool when the data plane state is Unknown.
     /// The diagnostics may or may not be set.
     async fn mark_unknown_state(&self, pool: Pool) -> Result<Action, Error> {
-        self.patch_status(DiskPoolStatus::from(pool)).await?;
+        self.patch_status(DiskPoolStatus::from(pool).with_conditions(self))
+            .await?;
         Ok(Action::requeue(Duration::from_secs(self.ctx.interval)))
     }
 
@@ -553,7 +554,9 @@ impl ResourceContext {
             .into_body();
 
         if pool.state.is_some() {
-            let _ = self.patch_status(DiskPoolStatus::from(pool)).await?;
+            let _ = self
+                .patch_status(DiskPoolStatus::from(pool).with_conditions(&self))
+                .await?;
 
             self.k8s_notify(
                 "Create/Import",
@@ -784,8 +787,11 @@ impl ResourceContext {
                         .await
                     {
                         Ok(pool) => {
-                            if dsp.status.as_ref().unwrap().cr_state != CrPoolState::Terminating {
-                                let new_status = DiskPoolStatus::terminating(pool.into_body());
+                            if dsp.status.as_ref().map(|d| d.cr_state)
+                                != Some(CrPoolState::Terminating)
+                            {
+                                let new_status =
+                                    DiskPoolStatus::terminating(&dsp, pool.into_body());
                                 let _ = self.patch_status(new_status).await?;
                             }
                             Self::delete_finalizer(self.clone(), true).await

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -100,7 +100,7 @@ impl OperatorContext {
         };
 
         let mut i = self.inventory.write().await;
-        debug!(count = ?i.keys().count(), "current number of CRs");
+        debug!(count = i.keys().count(), "current number of CRs");
 
         match i.get_mut(&resource.name_any()) {
             Some(p) => {
@@ -115,7 +115,7 @@ impl OperatorContext {
                         return p.clone();
                     }
 
-                    debug!(status =? resource.status, "duplicate event or long running operation");
+                    debug!(status = ?resource.status, "duplicate event or long running operation");
 
                     // The status should be the same here as well
                     assert_eq!(&p.status, &resource.status);
@@ -143,7 +143,7 @@ impl OperatorContext {
     pub(crate) async fn remove(&self, name: String) -> Option<ResourceContext> {
         let mut i = self.inventory.write().await;
         if let Some(removed) = i.remove(&name) {
-            info!(name =? removed.name_any(), "removed from inventory");
+            info!(name = ?removed.name_any(), "removed from inventory");
             return Some(removed);
         }
         None
@@ -152,13 +152,13 @@ impl OperatorContext {
 
 impl ResourceContext {
     /// Called when putting our finalizer on top of the resource.
-    #[tracing::instrument(fields(name = ?_dsp.name_any()))]
+    #[tracing::instrument(fields(name = _dsp.name_any()))]
     pub(crate) async fn put_finalizer(_dsp: Arc<DiskPool>) -> Result<Action, Error> {
         Ok(Action::await_change())
     }
 
     /// Remove pool from control plane if exist, Then delete it from map.
-    #[tracing::instrument(fields(name = ?resource.name_any()) skip(resource))]
+    #[tracing::instrument(fields(name = resource.name_any()), skip(resource))]
     pub(crate) async fn delete_finalizer(
         resource: ResourceContext,
         attempt_delete: bool,
@@ -170,7 +170,7 @@ impl ResourceContext {
         if ctx.remove(resource.name_any()).await.is_none() {
             // In an unlikely event where we cant remove from inventory. We will requeue and
             // reattempt again in 10 seconds.
-            error!(name = ?resource.name_any(), "Failed to remove from inventory");
+            error!("Failed to remove from inventory");
             return Ok(Action::requeue(Duration::from_secs(10)));
         }
         Ok(Action::await_change())
@@ -215,7 +215,7 @@ impl ResourceContext {
             .await
             .map_err(|source| Error::Kube { source })?;
 
-        debug!(name = ?o.name_any(), old = ?self.status, new =?o.status, "status changed");
+        debug!(name = o.name_any(), old = ?self.status, new = ?o.status, "status changed");
         Ok(o)
     }
 
@@ -232,7 +232,7 @@ impl ResourceContext {
     async fn mark_pool_not_found(&self) -> Result<Action, Error> {
         self.patch_status(DiskPoolStatus::not_found(&self.inner.status))
             .await?;
-        error!(name = ?self.name_any(), "Pool not found, clearing status");
+        error!(name = self.name_any(), "Pool not found, clearing status");
         Ok(Action::requeue(Duration::from_secs(30)))
     }
 
@@ -359,7 +359,7 @@ impl ResourceContext {
                                 "Critical",
                             )
                             .await;
-                            error!("Unable to create or import pool {}", error);
+                            error!("Unable to create or import pool {error}");
                             Err(error.into())
                         }
                     }
@@ -384,7 +384,7 @@ impl ResourceContext {
                             "Critical",
                         )
                         .await;
-                        error!("Unable to create or import pool {}", error);
+                        error!("Unable to create or import pool {error}");
                         Err(error.into())
                     }
                 };
@@ -403,7 +403,7 @@ impl ResourceContext {
     }
 
     /// Delete the pool from the io-engine instance
-    #[tracing::instrument(fields(name = ?self.name_any(), status = ?self.status) skip(self))]
+    #[tracing::instrument(fields(name = self.name_any(), status = ?self.status), skip(self))]
     async fn delete_pool(&self) -> Result<Action, Error> {
         let res = self
             .pools_api()
@@ -438,7 +438,7 @@ impl ResourceContext {
     }
 
     /// Gets pool from control plane and sets state as applicable.
-    #[tracing::instrument(fields(name = ?self.name_any(), status = ?self.status) skip(self))]
+    #[tracing::instrument(fields(name = self.name_any(), status = ?self.status), skip(self))]
     async fn pool_created(self) -> Result<Action, Error> {
         let pool = self
             .pools_api()
@@ -477,31 +477,27 @@ impl ResourceContext {
     /// accordingly. If the control plane returns a pool state, set the CRD to 'Online'. If the
     /// control plane does not return a pool state (occurs when a node is missing), set the CRD to
     /// 'Unknown' and let the reconciler retry later.
-    #[tracing::instrument(fields(name = ?self.name_any(), status = ?self.status) skip(self))]
+    #[tracing::instrument(fields(name = self.name_any(), status = ?self.status), skip(self))]
     pub(crate) async fn pool_check(&self) -> Result<Action, Error> {
+        let name = self.name_any();
         if let Some(annotation) = self.metadata.annotations.clone() {
-            if let Some(value) = annotation.get("openebs.io/expand") {
-                if value == "true" {
-                    info!("Attempting to expand {}", self.name_any());
-                    match self.pools_api().put_pool_expand(&self.name_any()).await {
-                        Err(e) => {
-                            if matches!(
+            if Some("true") == annotation.get("openebs.io/expand").map(|s| s.as_str()) {
+                info!("Attempting to expand DiskPool");
+                match self.pools_api().put_pool_expand(&name).await {
+                    Err(e) => {
+                        if matches!(
                             e.error_body(),
-                            Some(body) if matches!(body.kind, Kind::OutOfRange | Kind::DiskNotExtended | Kind::DiskRescanFailed )
-                            ) {
-                                error!(
-                                    "DiskPool expansion failed, Stopping reconciliation err: {:?}",
-                                    e
-                                );
-                                let _ = self.remove_expand_annotation().await;
-                            } else {
-                                error!("DiskPool expansion failed, {:?}", e);
-                            }
-                        }
-                        Ok(_) => {
-                            info!("DiskPool {} expanded successfully", self.name_any());
+                            Some(body) if matches!(body.kind, Kind::OutOfRange | Kind::DiskNotExtended | Kind::DiskRescanFailed)
+                        ) {
+                            error!("DiskPool expansion failed, Stopping reconciliation err: {e:?}");
                             let _ = self.remove_expand_annotation().await;
+                        } else {
+                            error!("DiskPool expansion failed, {e:?}");
                         }
+                    }
+                    Ok(_) => {
+                        info!("DiskPool expanded successfully");
+                        let _ = self.remove_expand_annotation().await;
                     }
                 }
             }
@@ -509,30 +505,32 @@ impl ResourceContext {
 
         let pool = match self
             .pools_api()
-            .get_node_pool(&self.spec.node(), &self.name_any())
+            .get_node_pool(&self.spec.node(), &name)
             .await
         {
             Ok(response) => response,
             Err(clients::tower::Error::Response(response)) => {
                 return if response.status() == clients::tower::StatusCode::NOT_FOUND {
                     if self.metadata.deletion_timestamp.is_some() {
-                        tracing::debug!(name = ?self.name_any(), "deleted stopping checker");
+                        tracing::debug!("DiskPool deleted, exiting pool_check");
                         Ok(Action::await_change())
                     } else {
-                        tracing::warn!(pool = ?self.name_any(), "deleted by external event NOT recreating");
+                        tracing::warn!("deleted by external event NOT recreating");
                         self.k8s_notify(
                             "Notfound",
                             "Check",
                             "The pool has been deleted through an external API request",
                             "Warning",
                         )
-                            .await;
+                        .await;
 
                         // We expected the control plane to have a spec for this pool. It didn't so
                         // set the pool_status in CRD to None.
                         self.mark_pool_not_found().await
                     }
-                } else if response.status() == clients::tower::StatusCode::SERVICE_UNAVAILABLE || response.status() == clients::tower::StatusCode::REQUEST_TIMEOUT {
+                } else if response.status() == clients::tower::StatusCode::SERVICE_UNAVAILABLE
+                    || response.status() == clients::tower::StatusCode::REQUEST_TIMEOUT
+                {
                     // Probably grpc server is not yet up
                     self.k8s_notify(
                         "Unreachable",
@@ -540,25 +538,25 @@ impl ResourceContext {
                         "Could not reach Rest API service. Please check control plane health",
                         "Warning",
                     )
-                        .await;
+                    .await;
                     self.mark_pool_not_found().await
-                }
-                else {
+                } else {
                     self.k8s_notify(
                         "Missing",
                         "Check",
                         &format!("The pool information is not available: {response}"),
                         "Warning",
                     )
-                        .await;
+                    .await;
                     self.is_missing().await
-                }
+                };
             }
             Err(clients::tower::Error::Request(_)) => {
                 // Probably grpc server is not yet up
-                return self.mark_pool_not_found().await
+                return self.mark_pool_not_found().await;
             }
-        }.into_body();
+        }
+        .into_body();
         // As pool exists, set the status based on the presence of pool state.
         self.set_status_or_unknown(pool).await
     }
@@ -566,24 +564,24 @@ impl ResourceContext {
     /// If the pool, has a state we set that status to the CR and if it does not have a state
     /// we set the status as unknown so that we can try again later.
     async fn set_status_or_unknown(&self, pool: Pool) -> Result<Action, Error> {
-        if pool.state.is_some() {
-            if let Some(status) = &self.status {
-                let mut new_status = DiskPoolStatus::from(pool);
-                if self.metadata.deletion_timestamp.is_some() {
-                    new_status.cr_state = CrPoolState::Terminating;
-                }
-                if status != &new_status {
-                    // update the usage state such that users can see the values changes
-                    // as replica's are added and/or removed.
-                    let _ = self.patch_status(new_status).await;
-                }
-            }
-        } else {
+        if pool.state.is_none() {
             return if self.metadata.deletion_timestamp.is_some() {
                 self.mark_terminating_when_unknown().await
             } else {
                 self.mark_unknown().await
             };
+        }
+
+        if let Some(status) = &self.status {
+            let mut new_status = DiskPoolStatus::from(pool);
+            if self.metadata.deletion_timestamp.is_some() {
+                new_status.cr_state = CrPoolState::Terminating;
+            }
+            if status != &new_status {
+                // update the usage state such that users can see the values changes
+                // as replica's are added and/or removed.
+                let _ = self.patch_status(new_status).await;
+            }
         }
 
         // always reschedule though
@@ -610,44 +608,44 @@ impl ResourceContext {
         let e: Api<Event> = Api::namespaced(client.clone(), &ns);
         let pp = PostParams::default();
         let time = Utc::now();
-        let contains = {
-            self.event_info
-                .lock()
-                .unwrap()
-                .contains(&message.to_string())
-        };
-        if !contains {
-            self.event_info.lock().unwrap().push(message.to_string());
-            let metadata = ObjectMeta {
-                // the name must be unique for all events we post
-                generate_name: Some(format!("{}.{:x}", self.name_any(), time.timestamp())),
-                namespace: Some(ns),
-                ..Default::default()
-            };
-
-            let _ = e
-                .create(
-                    &pp,
-                    &Event {
-                        event_time: Some(MicroTime(time)),
-                        involved_object: self.object_ref(&()),
-                        action: Some(action.into()),
-                        reason: Some(reason.into()),
-                        type_: Some(type_.into()),
-                        metadata,
-                        reporting_component: Some(WHO_AM_I_SHORT.into()),
-                        reporting_instance: Some(
-                            std::env::var("MY_POD_NAME")
-                                .ok()
-                                .unwrap_or_else(|| WHO_AM_I_SHORT.into()),
-                        ),
-                        message: Some(message.into()),
-                        ..Default::default()
-                    },
-                )
-                .await
-                .map_err(|error| error!(?error));
+        if self
+            .event_info
+            .lock()
+            .unwrap()
+            .contains(&message.to_string())
+        {
+            return;
         }
+        self.event_info.lock().unwrap().push(message.to_string());
+        let metadata = ObjectMeta {
+            // the name must be unique for all events we post
+            generate_name: Some(format!("{}.{:x}", self.name_any(), time.timestamp())),
+            namespace: Some(ns),
+            ..Default::default()
+        };
+
+        _ = e
+            .create(
+                &pp,
+                &Event {
+                    event_time: Some(MicroTime(time)),
+                    involved_object: self.object_ref(&()),
+                    action: Some(action.into()),
+                    reason: Some(reason.into()),
+                    type_: Some(type_.into()),
+                    metadata,
+                    reporting_component: Some(WHO_AM_I_SHORT.into()),
+                    reporting_instance: Some(
+                        std::env::var("MY_POD_NAME")
+                            .ok()
+                            .unwrap_or_else(|| WHO_AM_I_SHORT.into()),
+                    ),
+                    message: Some(message.into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .inspect_err(|error| error!(?error, "Failed to create event"));
     }
 
     /// Callback hooks for the finalizers
@@ -659,28 +657,25 @@ impl ResourceContext {
             |event| async move {
                 match event {
                     finalizer::Event::Apply(dsp) => Self::put_finalizer(dsp).await,
-                    finalizer::Event::Cleanup(dsp) => {
-                        match self
-                            .pools_api()
-                            .get_node_pool(&self.spec.node(), &self.name_any())
-                            .await
-                        {
-                            Ok(pool) => {
-                                if dsp.status.as_ref().unwrap().cr_state != CrPoolState::Terminating
-                                {
-                                    let new_status = DiskPoolStatus::terminating(pool.into_body());
-                                    let _ = self.patch_status(new_status).await?;
-                                }
-                                Self::delete_finalizer(self.clone(), true).await
+                    finalizer::Event::Cleanup(dsp) => match self
+                        .pools_api()
+                        .get_node_pool(&self.spec.node(), &self.name_any())
+                        .await
+                    {
+                        Ok(pool) => {
+                            if dsp.status.as_ref().unwrap().cr_state != CrPoolState::Terminating {
+                                let new_status = DiskPoolStatus::terminating(pool.into_body());
+                                let _ = self.patch_status(new_status).await?;
                             }
-                            Err(clients::tower::Error::Response(response))
-                                if response.status() == StatusCode::NOT_FOUND =>
-                            {
-                                Self::delete_finalizer(self.clone(), false).await
-                            }
-                            Err(error) => Err(error.into()),
+                            Self::delete_finalizer(self.clone(), true).await
                         }
-                    }
+                        Err(clients::tower::Error::Response(response))
+                            if response.status() == StatusCode::NOT_FOUND =>
+                        {
+                            Self::delete_finalizer(self.clone(), false).await
+                        }
+                        Err(error) => Err(error.into()),
+                    },
                 }
             },
         )
@@ -693,21 +688,18 @@ impl ResourceContext {
         &self,
         config: EncryptionSecretConfig,
     ) -> Result<Encryption, Error> {
-        if let Err(error) = self.secret_api().get(&config.name).await {
+        let name = config.name;
+        if let Err(error) = self.secret_api().get(&name).await {
             self.k8s_notify(
                 "Create or Import Failure",
                 "Failure",
-                format!(
-                    "Failed to get k8s secret for encryption {}, error: {error}",
-                    &config.name
-                )
-                .as_str(),
+                &format!("Failed to get k8s secret for encryption {name}, error: {error}"),
                 "Critical",
             )
             .await;
             return Err(Error::Kube { source: error });
         }
 
-        Ok(Encryption::secret(EncryptionSecret { name: config.name }))
+        Ok(Encryption::secret(EncryptionSecret { name }))
     }
 }

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -3,10 +3,12 @@ use super::{
     dsp_api,
     error::Error,
 };
-use crate::diskpool::crd::v1beta3::{EncryptionSecretConfig, EncryptionSource};
+use crate::diskpool::crd::v1beta3::{
+    EncryptionSecretConfig, EncryptionSource, PoolError, PoolErrorCode,
+};
 use openapi::{
     apis::StatusCode,
-    clients,
+    clients, models,
     models::{rest_json_error::Kind, CreatePoolBody, Encryption, EncryptionSecret, Pool},
 };
 use tracing::{debug, error, info};
@@ -19,6 +21,7 @@ use kube::{
     runtime::{controller::Action, finalizer},
     Client, Resource, ResourceExt,
 };
+use openapi::models::SpecStatus;
 use serde_json::json;
 use std::{
     collections::HashMap,
@@ -220,20 +223,39 @@ impl ResourceContext {
     }
 
     /// Create a pool when there is no status found. When no status is found for
-    /// this resource it implies that it does not exist yet and so we create
-    /// it. We set the state of the of the object to Creating, such that we
-    /// can track the its progress
+    /// this resource it implies that it does not exist yet, and so we create
+    /// it. We set the state of the object to Creating, such that we
+    /// can track its progress.
     pub(crate) async fn init_cr(&self) -> Result<Action, Error> {
         let _ = self.patch_status(DiskPoolStatus::default()).await?;
         Ok(Action::await_change())
     }
 
-    /// Mark Pool state as None as couldnt find already provisioned pool in control plane.
-    async fn mark_pool_not_found(&self) -> Result<Action, Error> {
-        self.patch_status(DiskPoolStatus::not_found(&self.inner.status))
+    /// Mark Pool state as None as couldn't find already provisioned pool in control plane.
+    async fn mark_pool_error(&self, error: Option<PoolError>) -> Result<Action, Error> {
+        self.patch_status(DiskPoolStatus::not_found(&self.inner.status, error))
             .await?;
-        error!(name = self.name_any(), "Pool not found, clearing status");
         Ok(Action::requeue(Duration::from_secs(30)))
+    }
+
+    /// Mark Pool state as None and error as DiskNotFound as we couldn't find the
+    /// pool disk during the creation/import attempt.
+    async fn mark_disk_not_found(&self) -> Result<(), Error> {
+        self.patch_status(DiskPoolStatus::disk_not_found(&self.inner.status))
+            .await?;
+        Ok(())
+    }
+
+    /// Mark Pool as Creating as couldn't complete the creation attempt.
+    async fn mark_pool_creating(&self, pool: Pool) -> Result<(), Error> {
+        let msg = "Timed out whilst trying to create the diskpool";
+        self.k8s_notify("Create/Import", "Timeout", msg, "Warning")
+            .await;
+        let mut pool = DiskPoolStatus::from(pool);
+        pool.cr_state = CrPoolState::Creating;
+        error!(?pool, msg);
+        self.patch_status(pool).await?;
+        Ok(())
     }
 
     /// Removes pool expand annotation from the CR.
@@ -267,14 +289,15 @@ impl ResourceContext {
         Ok(Action::requeue(Duration::from_secs(self.ctx.interval)))
     }
 
-    /// Used to patch control plane state as Unknown.
-    async fn mark_unknown(&self) -> Result<Action, Error> {
-        self.patch_status(DiskPoolStatus::mark_unknown()).await?;
+    /// Used to patch the DiskPool when the data plane state is Unknown.
+    /// The diagnostics may or may not be set.
+    async fn mark_unknown_state(&self, pool: Pool) -> Result<Action, Error> {
+        self.patch_status(DiskPoolStatus::from(pool)).await?;
         Ok(Action::requeue(Duration::from_secs(self.ctx.interval)))
     }
 
     /// Create or import the pool, on failure try again.
-    #[tracing::instrument(fields(name = ?self.name_any(), status = ?self.status) skip(self))]
+    #[tracing::instrument(fields(name = self.name_any(), status = ?self.status), skip(self))]
     pub(crate) async fn create_or_import(self) -> Result<Action, Error> {
         let mut labels: HashMap<String, String> = HashMap::new();
         labels.insert(dsp_created_by_key(), String::from(utils::DSP_OPERATOR));
@@ -310,89 +333,16 @@ impl ResourceContext {
             cluster_size,
             self.spec.max_expansion(),
         );
-        match self
+        if let Err(error) = self
             .pools_api()
             .put_node_pool(&self.spec.node(), &self.name_any(), body)
             .await
         {
-            Ok(_) => {}
-            Err(clients::tower::Error::Response(response))
-                if response.status() == clients::tower::StatusCode::UNPROCESSABLE_ENTITY =>
-            {
-                // UNPROCESSABLE_ENTITY indicates that the pool spec already exists in the
-                // control plane. Marking cr_state as Created and control plane state as Unknown.
-                return self.mark_unknown().await;
-            }
-            Err(error) => {
-                return match self
-                    .block_devices_api()
-                    .get_node_block_devices(&self.spec.node(), Some(true))
-                    .await
-                {
-                    Ok(response) => {
-                        if !response.into_body().into_iter().any(|b| {
-                            b.devname == normalize_disk(&self.spec.disks()[0])
-                                || b.devlinks
-                                    .iter()
-                                    .any(|d| *d == normalize_disk(&self.spec.disks()[0]))
-                        }) {
-                            self.k8s_notify(
-                                "Create or import",
-                                "Missing",
-                                &format!(
-                                    "The block device(s): {} can not be found",
-                                    &self.spec.disks()[0]
-                                ),
-                                "Warn",
-                            )
-                            .await;
-                            error!(
-                                "The block device(s): {} can not be found",
-                                &self.spec.disks()[0]
-                            );
-                            Err(error.into())
-                        } else {
-                            self.k8s_notify(
-                                "Create or Import Failure",
-                                "Failure",
-                                format!("Unable to create or import pool {error}").as_str(),
-                                "Critical",
-                            )
-                            .await;
-                            error!("Unable to create or import pool {error}");
-                            Err(error.into())
-                        }
-                    }
-                    Err(clients::tower::Error::Response(response))
-                        if response.status() == StatusCode::NOT_FOUND =>
-                    {
-                        self.k8s_notify(
-                            "Create or Import Failure",
-                            "Failure",
-                            format!("Unable to find io-engine node {}", &self.spec.node()).as_str(),
-                            "Critical",
-                        )
-                        .await;
-                        error!("Unable to find io-engine node {}", &self.spec.node());
-                        Err(error.into())
-                    }
-                    _ => {
-                        self.k8s_notify(
-                            "Create or Import Failure",
-                            "Failure",
-                            format!("Unable to create or import pool {error}").as_str(),
-                            "Critical",
-                        )
-                        .await;
-                        error!("Unable to create or import pool {error}");
-                        Err(error.into())
-                    }
-                };
-            }
+            self.handle_create_failed(error).await?;
         }
 
         self.k8s_notify(
-            "Create or Import",
+            "Create/Import",
             "Created",
             "Created or imported pool",
             "Normal",
@@ -400,6 +350,162 @@ impl ResourceContext {
         .await;
 
         self.pool_created().await
+    }
+
+    async fn handle_create_failed(
+        &self,
+        error: openapi::tower::client::Error<models::RestJsonError>,
+    ) -> Result<(), Error> {
+        if let Ok(pool) = self
+            .pools_api()
+            .get_node_pool(&self.spec.node, &self.name_any())
+            .await
+        {
+            let pool = pool.into_body();
+            let spec_state = pool.spec.as_ref().map(|s| s.status);
+            match spec_state.unwrap_or_default() {
+                SpecStatus::Creating => {
+                    // Backend device is probably too large / too slow...
+                    self.mark_pool_creating(pool).await?;
+                    return Err(error.into());
+                }
+                SpecStatus::Created => {
+                    // somehow the pool got created meanwhile, so let's go ahead with success.
+                    return Ok(());
+                }
+                // unexpected, let's handle it generically below
+                SpecStatus::Deleting | SpecStatus::Deleted => {}
+            }
+        }
+
+        match &error {
+            clients::tower::Error::Response(response)
+                if response.status() == StatusCode::NOT_FOUND =>
+            {
+                let error_str = response.to_string();
+                // The current API does not specify this via the type system, so we have to resort to this hackery...
+                if error_str.contains("NodeNotFound") {
+                    return Err(self
+                        .handle_node_offline(PoolErrorCode::NodeIsUnknown, error)
+                        .await?);
+                } else {
+                    // probably disk not found, but we're not sure yet...?
+                }
+            }
+            clients::tower::Error::Response(response)
+                if response.status() == StatusCode::PRECONDITION_FAILED =>
+            {
+                return Err(self
+                    .handle_node_offline(PoolErrorCode::NodeIsOffline, error)
+                    .await?);
+            }
+            _ => return Err(self.handle_create_error(error).await?),
+        }
+
+        // todo: do we really need this or is the is the NOT_FOUND status sufficient?
+        let response = match self
+            .block_devices_api()
+            .get_node_block_devices(&self.spec.node(), Some(true))
+            .await
+        {
+            Ok(response) => response.into_body(),
+            Err(clients::tower::Error::Response(response))
+                if response.status() == StatusCode::PRECONDITION_FAILED =>
+            {
+                return Err(self
+                    .handle_node_offline(PoolErrorCode::NodeIsOffline, error)
+                    .await?)
+            }
+            Err(clients::tower::Error::Response(response))
+                if response.status() == StatusCode::NOT_FOUND =>
+            {
+                return Err(self
+                    .handle_node_offline(PoolErrorCode::NodeIsUnknown, error)
+                    .await?)
+            }
+            _ => return Err(self.handle_create_error(error).await?),
+        };
+
+        if !response.into_iter().any(|b| {
+            b.devname == normalize_disk(&self.spec.disks()[0])
+                || b.devlinks
+                    .iter()
+                    .any(|d| *d == normalize_disk(&self.spec.disks()[0]))
+        }) {
+            self.k8s_notify(
+                "Create/Import",
+                "DiskNotFound",
+                &format!(
+                    "The block device(s): {} can not be found",
+                    &self.spec.disks()[0]
+                ),
+                "Warning",
+            )
+            .await;
+            error!(
+                "The block device(s): {} can not be found",
+                &self.spec.disks()[0]
+            );
+            self.mark_disk_not_found().await?;
+        } else {
+            let error_str = match error.error_body() {
+                None => format!(
+                    "Unable to create or import pool, cause: {:?}",
+                    error.status(),
+                ),
+                Some(body) => format!(
+                    "Unable to create or import pool, cause: {:?}: {}",
+                    error.status(),
+                    body.message
+                ),
+            };
+            self.k8s_notify("Create/Import", "Failure", &error_str, "Critical")
+                .await;
+            error!(%error, "Unable to create or import pool");
+        }
+        Err(error.into())
+    }
+
+    async fn handle_node_offline(
+        &self,
+        code: PoolErrorCode,
+        error: openapi::tower::client::Error<models::RestJsonError>,
+    ) -> Result<Error, Error> {
+        self.k8s_notify("Create/Import", code.as_ref(), "", "Warning")
+            .await;
+        self.mark_pool_error(Some(PoolError {
+            code,
+            message: None,
+        }))
+        .await?;
+        error!("Unable to find io-engine node {}", self.spec.node);
+        Err(error.into())
+    }
+
+    async fn handle_create_error(
+        &self,
+        error: openapi::tower::client::Error<models::RestJsonError>,
+    ) -> Result<Error, Error> {
+        let error_str = match error.error_body() {
+            None => format!(
+                "Unable to create or import pool, cause: {:?}",
+                error.status(),
+            ),
+            Some(body) => format!(
+                "Unable to create or import pool, cause: {:?}: {}",
+                error.status(),
+                body.message
+            ),
+        };
+        self.k8s_notify("Create/Import", "Failure", &error_str, "Critical")
+            .await;
+        self.mark_pool_error(Some(PoolError {
+            code: PoolErrorCode::Unknown,
+            message: Some(error.to_string()),
+        }))
+        .await?;
+        error!(%error, "Unable to create or import pool");
+        Err(error.into())
     }
 
     /// Delete the pool from the io-engine instance
@@ -413,8 +519,8 @@ impl ResourceContext {
         match res {
             Ok(_) => {
                 self.k8s_notify(
-                    "Destroyed pool",
                     "Destroy",
+                    "Destroyed",
                     "The pool has been destroyed",
                     "Normal",
                 )
@@ -425,8 +531,8 @@ impl ResourceContext {
                 if response.status() == StatusCode::NOT_FOUND =>
             {
                 self.k8s_notify(
-                    "Destroyed pool",
                     "Destroy",
+                    "AlreadyDestroyed",
                     "The pool was already destroyed",
                     "Normal",
                 )
@@ -450,7 +556,7 @@ impl ResourceContext {
             let _ = self.patch_status(DiskPoolStatus::from(pool)).await?;
 
             self.k8s_notify(
-                "Online pool",
+                "Create/Import",
                 "Online",
                 "Pool online and ready to roll!",
                 "Normal",
@@ -515,45 +621,60 @@ impl ResourceContext {
                         tracing::debug!("DiskPool deleted, exiting pool_check");
                         Ok(Action::await_change())
                     } else {
+                        let message = "The pool has disappeared from the control-plane";
                         tracing::warn!("deleted by external event NOT recreating");
-                        self.k8s_notify(
-                            "Notfound",
-                            "Check",
-                            "The pool has been deleted through an external API request",
-                            "Warning",
-                        )
-                        .await;
-
+                        self.k8s_notify("PoolCheck", "PoolNotFound", message, "Error")
+                            .await;
                         // We expected the control plane to have a spec for this pool. It didn't so
                         // set the pool_status in CRD to None.
-                        self.mark_pool_not_found().await
+                        self.mark_pool_error(Some(PoolError {
+                            code: PoolErrorCode::PoolDeleted,
+                            message: Some(message.to_string()),
+                        }))
+                        .await
                     }
                 } else if response.status() == clients::tower::StatusCode::SERVICE_UNAVAILABLE
                     || response.status() == clients::tower::StatusCode::REQUEST_TIMEOUT
                 {
+                    let message =
+                        "Could not reach Rest API service. Please check control plane health";
                     // Probably grpc server is not yet up
-                    self.k8s_notify(
-                        "Unreachable",
-                        "Check",
-                        "Could not reach Rest API service. Please check control plane health",
-                        "Warning",
-                    )
-                    .await;
-                    self.mark_pool_not_found().await
+                    self.k8s_notify("PoolCheck", "ApiUnreachable", message, "Warning")
+                        .await;
+                    self.mark_pool_error(Some(PoolError {
+                        code: PoolErrorCode::Unreachable,
+                        message: Some(message.to_string()),
+                    }))
+                    .await
                 } else {
-                    self.k8s_notify(
-                        "Missing",
-                        "Check",
-                        &format!("The pool information is not available: {response}"),
-                        "Warning",
-                    )
-                    .await;
+                    let message = match response.error_body() {
+                        None => format!(
+                            "The pool information is not available, cause {}",
+                            response.status(),
+                        ),
+                        Some(body) => format!(
+                            "The pool information is not available, cause {}: {}",
+                            response.status(),
+                            body.message
+                        ),
+                    };
+                    self.k8s_notify("PoolCheck", "UnexpectedApiError", &message, "Warning")
+                        .await;
+                    // what is this covering? Is leaving the object in default state the correct thing?
                     self.is_missing().await
                 };
             }
-            Err(clients::tower::Error::Request(_)) => {
+            Err(clients::tower::Error::Request(req)) => {
                 // Probably grpc server is not yet up
-                return self.mark_pool_not_found().await;
+                let message = format!("The pool information is not available: {req}");
+                self.k8s_notify("PoolCheck", "ApiClientError", &message, "Warning")
+                    .await;
+                return self
+                    .mark_pool_error(Some(PoolError {
+                        code: PoolErrorCode::Unreachable,
+                        message: Some("Failed to send request".to_string()),
+                    }))
+                    .await;
             }
         }
         .into_body();
@@ -568,7 +689,7 @@ impl ResourceContext {
             return if self.metadata.deletion_timestamp.is_some() {
                 self.mark_terminating_when_unknown().await
             } else {
-                self.mark_unknown().await
+                self.mark_unknown_state(pool).await
             };
         }
 
@@ -579,7 +700,7 @@ impl ResourceContext {
             }
             if status != &new_status {
                 // update the usage state such that users can see the values changes
-                // as replica's are added and/or removed.
+                // as replicas are added and/or removed.
                 let _ = self.patch_status(new_status).await;
             }
         }
@@ -593,7 +714,7 @@ impl ResourceContext {
     /// information. Events are GC-ed by k8s automatically.
     ///
     /// action:
-    ///     What action was taken/failed regarding to the Regarding object.
+    ///     What action was taken/failed regarding the object.
     /// reason:
     ///     This should be a short, machine understandable string that gives the
     ///     reason for the transition into the object's current status.
@@ -601,7 +722,7 @@ impl ResourceContext {
     ///     A human-readable description of the status of this operation.
     /// type_:
     ///     Type of this event (Normal, Warning), new types could be added in
-    ///     the  future
+    ///     the future
     async fn k8s_notify(&self, action: &str, reason: &str, message: &str, type_: &str) {
         let client = self.ctx.k8s.clone();
         let ns = self.namespace().expect("must be namespaced");
@@ -691,8 +812,8 @@ impl ResourceContext {
         let name = config.name;
         if let Err(error) = self.secret_api().get(&name).await {
             self.k8s_notify(
-                "Create or Import Failure",
-                "Failure",
+                "Create/Import",
+                "SecretValidation",
                 &format!("Failed to get k8s secret for encryption {name}, error: {error}"),
                 "Critical",
             )

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -1,10 +1,10 @@
 use kube::CustomResource;
+#[cfg(feature = "openapi")]
+use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-#[cfg(feature = "openapi")]
-use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
+use strum_macros::AsRefStr;
 
 use super::quantity::Quantity;
 
@@ -24,7 +24,9 @@ use super::quantity::Quantity;
     shortname = "dsp",
     printcolumn = r#"{ "name":"node", "type":"string", "description":"node the pool is on", "jsonPath":".spec.node"}"#,
     printcolumn = r#"{ "name":"state", "type":"string", "description":"dsp cr state", "jsonPath":".status.cr_state"}"#,
-    printcolumn = r#"{ "name":"pool-status", "type":"string", "description":"Control plane pool status", "jsonPath":".status.pool_status"}"#,
+    printcolumn = r#"{ "name":"status", "type":"string", "description":"Control plane pool status", "jsonPath":".status.status"}"#,
+    printcolumn = r#"{ "name":"error", "type":"string", "description":"Control plane pool status", "jsonPath":".status.error.code"}"#,
+    printcolumn = r#"{ "name":"alerts", "type":"string", "description":"Control plane pool status", "jsonPath":".status.alertError"}"#,
     printcolumn = r#"{ "name":"encrypted", "type":"boolean", "description":"encryption enabled", "jsonPath":".status.encrypted"}"#,
     printcolumn = r#"{ "name":"capacity", "type":"string", "nullable": "true", "description":"total bytes", "jsonPath":".status.capacity_q"}"#,
     printcolumn = r#"{ "name":"used", "type":"string", "nullable": "true", "description":"used bytes", "jsonPath":".status.used_q"}"#,
@@ -53,10 +55,141 @@ pub struct DiskPoolSpec {
     pub max_expansion: Option<String>,
 }
 
+/// Pool diagnostic information.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PoolDiag {
+    /// Errors encountered when trying to import the pool.
+    pub import_errors: Vec<DiskInfo>,
+    /// Inferred error of the pool, if any.
+    pub error: Option<PoolError>,
+    /// Inferred status of the pool.
+    pub status: PoolStatus,
+}
+
+/// Different pool errors.
+#[derive(
+    Debug, Default, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, JsonSchema, AsRefStr,
+)]
+pub enum PoolErrorCode {
+    /// Unknown error.
+    #[default]
+    Unknown,
+    /// Disk not found in the system.
+    DiskNotFound,
+    /// Disk read IO errors.
+    DiskReadIoError,
+    /// Pool on-disk name doesn't match the expected.
+    ForeignPoolName,
+    /// Pool on-disk uuid doesn't match the expected.
+    ForeignPoolUid,
+    /// Failed to check super block error.
+    SuperBlock,
+    /// Invalid super block (eg: CRC error).
+    InvalidSuperBlock,
+    /// Disk is a directory (can happen when setting up incorrect volume mounts).
+    DiskIsADirectory,
+    /// Node is in unknown state.
+    NodeIsUnknown,
+    /// Node is offline.
+    NodeIsOffline,
+    /// Imports are disabled due to cordon restrictions.
+    ImportDisabled,
+    /// gRPC to the pool timed out.
+    TimeOut,
+    /// Pool deleted under the Custom Resource.
+    PoolDeleted,
+    /// Control-Plane service is unreachable.
+    Unreachable,
+}
+
+/// Pool error code and human-readable message.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+pub struct PoolError {
+    /// Code of the encountered error.
+    pub code: PoolErrorCode,
+    /// Human-readable message.
+    pub message: Option<String>,
+}
+
+/// Pool information related to a specific disk.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DiskInfo {
+    /// The disk uri used to open the disk.
+    pub uri: String,
+    /// Errors seen for this disk.
+    pub errors: PoolError,
+}
+
+/// Alerts and error information for a pool.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PoolErrorInfo {
+    /// These are generated from the below metrics.
+    pub alerts: PoolAlerts,
+    /// Count of all disk errors since the pool has been opened.
+    pub io_error_count: u64,
+    /// The I/O is stalled.
+    pub io_stalled: bool,
+    /// Number of stall transitions.
+    pub io_stall_transition_count: u64,
+}
+
+/// Pool alerts and inferred status.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PoolAlerts {
+    /// The [`PoolAlertStatus`] of the pool.
+    pub status: PoolAlertStatus,
+    /// No status alerts are raised.
+    pub notice: Vec<PoolAlert>,
+    /// Raises an Attention level, but pool state is left as is.
+    pub attention: Vec<PoolAlert>,
+    /// Warnings downgrades the pool state to Suspected.
+    pub warning: Vec<PoolAlert>,
+    /// Pools with critical alerts should not be used.
+    pub critical: Vec<PoolAlert>,
+}
+
+/// Alert-based status for the DiskPool.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+pub enum PoolAlertStatus {
+    /// No issues detected; pool is operating normally.
+    Healthy,
+    /// Non‑critical issues present; user attention is recommended.
+    Attention,
+    /// Conditions have exceeded warning thresholds (fixed or based on trends over a defined time window).
+    Warning,
+    /// Severe issues detected; pool usage should be avoided.
+    Critical,
+    /// Unknown Alert Status
+    #[default]
+    Unknown,
+}
+
+/// The various alerts that can be raised by the pool.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+pub enum PoolAlert {
+    /// Unrecognized or unsupported alert type.
+    #[default]
+    Unknown,
+    /// Pool I/O is currently stalled.
+    IoStalled,
+    /// I/O is not stalled as of now, but stalls have occurred over a defined time window.
+    IoStallIntermittent,
+    /// I/O is not stalled as of now, but stalls have occurred too frequently over a defined time window.
+    IoStallIntermittentExc,
+    /// I/O errors have been detected for the pool.
+    IoError,
+    /// I/O errors exceed defined thresholds.
+    IoErrorExc,
+}
+
 /// Placement pool topology used by volume operations.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
 pub struct Topology {
-    /// Label for topology
+    /// Label for topology.
     #[serde(default)]
     pub labelled: HashMap<String, String>,
 }
@@ -127,7 +260,7 @@ impl DiskPoolSpec {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, JsonSchema, Default)]
 /// PoolState represents operator specific states for DSP CR.
 pub enum CrPoolState {
     /// The pool is a new OR missing resource, and it has not been created or
@@ -142,10 +275,11 @@ pub enum CrPoolState {
     Terminating,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
 /// PoolStatus is Control plane status of a given DSP CR.
 pub enum PoolStatus {
     /// State is Unknown.
+    #[default]
     Unknown,
     /// State is Offline.
     Offline,
@@ -155,10 +289,11 @@ pub enum PoolStatus {
     Degraded,
     /// The pool is completely inaccessible.
     Faulted,
+    /// The pool is in a suspected state, with notice or more severed alerts.
     Suspected,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
 /// Status of the pool which is driven and changed by the controller loop.
 pub struct DiskPoolStatus {
     #[serde(default)]
@@ -189,33 +324,74 @@ pub struct DiskPoolStatus {
     /// This is an absolute max. No expansion is allowed beyond this size.
     #[serde(rename = "maxExpandableSize")]
     pub max_expandable_size: Option<Quantity>,
-}
-
-impl Default for DiskPoolStatus {
-    fn default() -> Self {
-        Self {
-            cr_state: CrPoolState::Creating,
-            pool_status: None,
-            capacity: 0,
-            used: 0,
-            available: 0,
-            capacity_q: None,
-            used_q: None,
-            available_q: None,
-            encrypted: None,
-            cluster_size: None,
-            disk_capacity: None,
-            max_expandable_size: None,
-        }
-    }
+    /// Information for each pool disk.
+    #[serde(rename = "diskInfo")]
+    pub disk_info: Option<Vec<DiskInfo>>,
+    /// Error information at the pool top-level.
+    #[serde(rename = "errorInfo")]
+    pub error_info: Option<PoolErrorInfo>,
+    /// The pool diagnostic information.
+    pub diag: Option<PoolDiag>,
+    /// The inferred status obtained from the data-plane and the diagnostics.
+    pub status: Option<PoolStatus>,
+    /// The inferred error obtained from the openapi diagnostics or the creation/import result.
+    pub error: Option<PoolError>,
+    /// Combined alert and errors for the pretty columns.
+    #[serde(rename = "alertError")]
+    pub alert_error: Option<String>,
 }
 
 impl DiskPoolStatus {
+    fn inferred_status(pool: &Pool) -> PoolStatus {
+        if let Some(ref diag) = pool.diag {
+            return diag.status.into();
+        }
+        let Some(ref state) = pool.state else {
+            return PoolStatus::Unknown;
+        };
+
+        state.status.into()
+    }
+    fn combine_alert_error(mut self) -> Self {
+        let Some(error_info) = self.error_info.as_ref() else {
+            return self;
+        };
+
+        let alerts = { error_info.alerts.attention.iter() }
+            .chain(&error_info.alerts.warning)
+            .chain(&error_info.alerts.critical)
+            .map(|x| format!("{x:?}"))
+            .collect::<Vec<_>>();
+
+        let status = &error_info.alerts.status;
+        if alerts.is_empty() {
+            self.alert_error = Some(format!("{status:?}"));
+        } else {
+            self.alert_error = Some(format!("{status:?} ({})", alerts.join(",")));
+        }
+
+        self
+    }
+
     /// Set when Pool is not found for some reason.
-    pub fn not_found(status: &Option<Self>) -> Self {
+    pub fn not_found(status: &Option<Self>, error: Option<PoolError>) -> Self {
         Self {
-            cr_state: status.clone().unwrap_or_default().cr_state,
-            pool_status: None,
+            cr_state: status.as_ref().map(|s| s.cr_state).unwrap_or_default(),
+            status: Some(PoolStatus::Unknown),
+            error,
+            ..Default::default()
+        }
+    }
+
+    /// Set when Pool is not found for some reason.
+    pub fn disk_not_found(status: &Option<Self>) -> Self {
+        Self {
+            cr_state: status.as_ref().map(|s| s.cr_state).unwrap_or_default(),
+            status: Some(PoolStatus::Offline),
+            error: Some(PoolError {
+                code: PoolErrorCode::DiskNotFound,
+                message: None,
+            }),
             ..Default::default()
         }
     }
@@ -223,6 +399,7 @@ impl DiskPoolStatus {
     /// Set when operator is attempting to delete on pool.
     #[cfg(feature = "openapi")]
     pub fn terminating(p: Pool) -> Self {
+        let status = Self::inferred_status(&p);
         let state = p.state.unwrap_or_default();
         let free = state.capacity.saturating_sub(state.used);
         Self {
@@ -238,7 +415,11 @@ impl DiskPoolStatus {
             cluster_size: state.cluster_size.map(Quantity::from_bytes),
             disk_capacity: state.disk_capacity.map(Quantity::from_bytes),
             max_expandable_size: state.max_expandable_size.map(Quantity::from_bytes),
+            error_info: state.error_info.map(Into::into),
+            status: Some(status),
+            ..Default::default()
         }
+        .combine_alert_error()
     }
 
     /// Set when deleting a Pool which is not accessible.
@@ -246,14 +427,11 @@ impl DiskPoolStatus {
         Self {
             cr_state: CrPoolState::Terminating,
             pool_status: Some(PoolStatus::Unknown),
-            ..Default::default()
-        }
-    }
-
-    pub fn mark_unknown() -> Self {
-        Self {
-            cr_state: CrPoolState::Created,
-            pool_status: Some(PoolStatus::Unknown),
+            status: Some(PoolStatus::Unknown),
+            error: Some(PoolError {
+                code: PoolErrorCode::Unknown,
+                message: Some("pool is terminating".to_string()),
+            }),
             ..Default::default()
         }
     }
@@ -277,6 +455,8 @@ impl From<RestPoolStatus> for PoolStatus {
 #[cfg(feature = "openapi")]
 impl From<Pool> for DiskPoolStatus {
     fn from(p: Pool) -> Self {
+        let status = Self::inferred_status(&p);
+        let diag: Option<PoolDiag> = p.diag.map(Into::into);
         if let Some(state) = p.state {
             let free = state.capacity.saturating_sub(state.used);
             Self {
@@ -292,12 +472,116 @@ impl From<Pool> for DiskPoolStatus {
                 cluster_size: Some(Quantity::from_bytes(state.cluster_size.unwrap_or(0))),
                 disk_capacity: state.disk_capacity.map(Quantity::from_bytes),
                 max_expandable_size: state.max_expandable_size.map(Quantity::from_bytes),
+                error: diag.as_ref().and_then(|d| d.error.clone()),
+                error_info: state.error_info.map(Into::into),
+                diag,
+                status: Some(status),
+                ..Default::default()
             }
+            .combine_alert_error()
         } else {
             Self {
                 cr_state: CrPoolState::Created,
+                status: Some(status),
+                error: diag.as_ref().and_then(|d| d.error.clone()),
+                diag,
                 ..Default::default()
             }
+        }
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl From<openapi::models::PoolAlert> for PoolAlert {
+    fn from(value: openapi::models::PoolAlert) -> Self {
+        match value {
+            openapi::models::PoolAlert::Unknown => Self::Unknown,
+            openapi::models::PoolAlert::IoStalled => Self::IoStalled,
+            openapi::models::PoolAlert::IoError => Self::IoError,
+            openapi::models::PoolAlert::IoErrorExc => Self::IoErrorExc,
+            openapi::models::PoolAlert::IoStallIntermittent => Self::IoStallIntermittent,
+            openapi::models::PoolAlert::IoStallIntermittentExc => Self::IoStallIntermittentExc,
+        }
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl From<openapi::models::PoolErrorInfo> for PoolErrorInfo {
+    fn from(value: openapi::models::PoolErrorInfo) -> Self {
+        use openapi::apis::IntoVec;
+        PoolErrorInfo {
+            alerts: PoolAlerts {
+                status: match value.alerts.status {
+                    openapi::models::PoolAlertStatus::Unknown => PoolAlertStatus::Unknown,
+                    openapi::models::PoolAlertStatus::Healthy => PoolAlertStatus::Healthy,
+                    openapi::models::PoolAlertStatus::Attention => PoolAlertStatus::Attention,
+                    openapi::models::PoolAlertStatus::Warning => PoolAlertStatus::Warning,
+                    openapi::models::PoolAlertStatus::Critical => PoolAlertStatus::Critical,
+                },
+                notice: value.alerts.notice.into_vec(),
+                attention: value.alerts.attention.into_vec(),
+                warning: value.alerts.warning.into_vec(),
+                critical: value.alerts.critical.into_vec(),
+            },
+            io_error_count: value.io_error_count,
+            io_stalled: value.io_stalled,
+            io_stall_transition_count: value.io_stall_transition_count,
+        }
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl From<openapi::models::PoolProbeError> for PoolError {
+    fn from(value: openapi::models::PoolProbeError) -> Self {
+        Self {
+            code: value.code.into(),
+            message: Some(value.message),
+        }
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl From<openapi::models::PoolProbeErrorCode> for PoolErrorCode {
+    fn from(value: openapi::models::PoolProbeErrorCode) -> Self {
+        match value {
+            openapi::models::PoolProbeErrorCode::Unknown => PoolErrorCode::Unknown,
+            openapi::models::PoolProbeErrorCode::DiskNotFound => PoolErrorCode::DiskNotFound,
+            openapi::models::PoolProbeErrorCode::DiskReadIoError => PoolErrorCode::DiskReadIoError,
+            openapi::models::PoolProbeErrorCode::ForeignPoolName => PoolErrorCode::ForeignPoolName,
+            openapi::models::PoolProbeErrorCode::ForeignPoolUid => PoolErrorCode::ForeignPoolUid,
+            openapi::models::PoolProbeErrorCode::SuperBlock => PoolErrorCode::SuperBlock,
+            openapi::models::PoolProbeErrorCode::InvalidSuperBlock => {
+                PoolErrorCode::InvalidSuperBlock
+            }
+            openapi::models::PoolProbeErrorCode::DiskIsADirectory => {
+                PoolErrorCode::DiskIsADirectory
+            }
+            openapi::models::PoolProbeErrorCode::NodeIsUnknown => PoolErrorCode::NodeIsUnknown,
+            openapi::models::PoolProbeErrorCode::NodeIsOffline => PoolErrorCode::NodeIsOffline,
+            openapi::models::PoolProbeErrorCode::ImportDisabled => PoolErrorCode::ImportDisabled,
+            openapi::models::PoolProbeErrorCode::TimeOut => PoolErrorCode::TimeOut,
+        }
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl From<openapi::models::PoolDiag> for PoolDiag {
+    fn from(value: openapi::models::PoolDiag) -> Self {
+        use openapi::apis::IntoVec;
+        Self {
+            import_errors: value.import_errors.into_vec(),
+            error: value.error.map(Into::into),
+            status: value.status.into(),
+        }
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl From<openapi::models::PoolDiskError> for DiskInfo {
+    fn from(value: openapi::models::PoolDiskError) -> Self {
+        Self {
+            uri: value.disk,
+            errors: value.error.into(),
         }
     }
 }

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -99,6 +99,8 @@ pub enum PoolErrorCode {
     PoolDeleted,
     /// Control-Plane service is unreachable.
     Unreachable,
+    /// The encryption secret was not found.
+    EncryptionSecretError,
 }
 
 /// Pool error code and human-readable message.

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -1,3 +1,4 @@
+use k8s_openapi::apimachinery::pkg::apis::meta::v1 as meta_v1;
 use kube::CustomResource;
 #[cfg(feature = "openapi")]
 use openapi::models::{pool_status::PoolStatus as RestPoolStatus, Pool};
@@ -8,9 +9,7 @@ use strum_macros::AsRefStr;
 
 use super::quantity::Quantity;
 
-#[derive(
-    CustomResource, Serialize, Deserialize, Default, Debug, Eq, PartialEq, Clone, JsonSchema,
-)]
+#[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone, JsonSchema)]
 #[kube(
     group = "openebs.io",
     version = "v1beta3",
@@ -19,7 +18,6 @@ use super::quantity::Quantity;
     // The name of the struct that gets created that represents a resource
     namespaced,
     status = "DiskPoolStatus",
-    derive = "PartialEq",
     derive = "Default",
     shortname = "dsp",
     printcolumn = r#"{ "name":"node", "type":"string", "description":"node the pool is on", "jsonPath":".spec.node"}"#,
@@ -275,7 +273,7 @@ pub enum CrPoolState {
     Terminating,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
 /// PoolStatus is Control plane status of a given DSP CR.
 pub enum PoolStatus {
     /// State is Unknown.
@@ -293,7 +291,7 @@ pub enum PoolStatus {
     Suspected,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 /// Status of the pool which is driven and changed by the controller loop.
 pub struct DiskPoolStatus {
     #[serde(default)]
@@ -339,6 +337,17 @@ pub struct DiskPoolStatus {
     /// Combined alert and errors for the pretty columns.
     #[serde(rename = "alertError")]
     pub alert_error: Option<String>,
+    /// Information about the state of a DiskPool using standard K8s conditions.
+    /// PoolReady: Indicates whether this dsp is ready and usable for volumes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) conditions: Vec<meta_v1::Condition>,
+}
+
+/// The various DiskPool conditions.
+#[derive(AsRefStr, strum_macros::Display)]
+pub(crate) enum DspCondition {
+    /// Indicates whether this dsp is online and ready to be used.
+    PoolReady,
 }
 
 impl DiskPoolStatus {
@@ -374,19 +383,22 @@ impl DiskPoolStatus {
     }
 
     /// Set when Pool is not found for some reason.
-    pub fn not_found(status: &Option<Self>, error: Option<PoolError>) -> Self {
+    pub fn not_found(dsp: &DiskPool, error: Option<PoolError>) -> Self {
+        let status = dsp.status.as_ref();
         Self {
-            cr_state: status.as_ref().map(|s| s.cr_state).unwrap_or_default(),
+            cr_state: status.map(|s| s.cr_state).unwrap_or_default(),
             status: Some(PoolStatus::Unknown),
             error,
             ..Default::default()
         }
+        .with_conditions(dsp)
     }
 
     /// Set when Pool is not found for some reason.
-    pub fn disk_not_found(status: &Option<Self>) -> Self {
+    pub fn disk_not_found(dsp: &DiskPool) -> Self {
+        let status = dsp.status.as_ref();
         Self {
-            cr_state: status.as_ref().map(|s| s.cr_state).unwrap_or_default(),
+            cr_state: status.map(|s| s.cr_state).unwrap_or_default(),
             status: Some(PoolStatus::Offline),
             error: Some(PoolError {
                 code: PoolErrorCode::DiskNotFound,
@@ -394,11 +406,12 @@ impl DiskPoolStatus {
             }),
             ..Default::default()
         }
+        .with_conditions(dsp)
     }
 
     /// Set when operator is attempting to delete on pool.
     #[cfg(feature = "openapi")]
-    pub fn terminating(p: Pool) -> Self {
+    pub fn terminating(dsp: &DiskPool, p: Pool) -> Self {
         let status = Self::inferred_status(&p);
         let state = p.state.unwrap_or_default();
         let free = state.capacity.saturating_sub(state.used);
@@ -420,6 +433,7 @@ impl DiskPoolStatus {
             ..Default::default()
         }
         .combine_alert_error()
+        .with_conditions(dsp)
     }
 
     /// Set when deleting a Pool which is not accessible.
@@ -434,6 +448,51 @@ impl DiskPoolStatus {
             }),
             ..Default::default()
         }
+    }
+
+    fn ready_condition(&self, dsp: &DiskPool) -> meta_v1::Condition {
+        // todo: what about I/O stall?
+        let ready = matches!(
+            self.status.unwrap_or_default(),
+            PoolStatus::Online | PoolStatus::Degraded
+        );
+        let error_code = self.error.as_ref().map(|e| e.code).unwrap_or_default();
+        let reason = if ready {
+            "".to_string()
+        } else {
+            format!("{error_code:?}")
+        };
+        meta_v1::Condition {
+            last_transition_time: meta_v1::Time(chrono::Utc::now()),
+            // todo: build nice messages
+            message: String::new(),
+            observed_generation: dsp.metadata.generation,
+            reason,
+            status: if ready { "True" } else { "False" }.to_string(),
+            type_: DspCondition::PoolReady.to_string(),
+        }
+    }
+
+    /// Fill the DiskPool conditions.
+    pub(crate) fn with_conditions(mut self, dsp: &DiskPool) -> Self {
+        // todo: we should always have a state, we should change the upper-level api to
+        //  ensure this is always the case from the signatures.
+        let Some(status) = dsp.status.as_ref() else {
+            return self;
+        };
+
+        let ready_cond = self.ready_condition(dsp);
+        let mut conditions = status.conditions.iter();
+        let Some(existing) = conditions.find(|c| c.type_ == DspCondition::PoolReady.as_ref())
+        else {
+            self.conditions = vec![ready_cond];
+            return self;
+        };
+
+        if existing.status != ready_cond.status || existing.reason != ready_cond.reason {
+            self.conditions = vec![ready_cond];
+        }
+        self
     }
 }
 

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -64,7 +64,7 @@ async fn reconcile(dsp: Arc<DiskPool>, ctx: Arc<OperatorContext>) -> Result<Acti
 
     if !ctx.inventory_contains(dsp.name_any()).await {
         return Ok(Action::await_change());
-    };
+    }
 
     match dsp.status {
         Some(DiskPoolStatus {
@@ -79,7 +79,7 @@ async fn reconcile(dsp: Arc<DiskPool>, ctx: Arc<OperatorContext>) -> Result<Acti
             cr_state: CrPoolState::Terminating,
             ..
         }) => dsp.pool_check().await,
-        // We use this state to indicate its a new CRD however, we could (and
+        // We use this state to indicate it's a new CRD however, we could (and
         // perhaps should) use the finalizer callback.
         None => dsp.init_cr().await,
     }


### PR DESCRIPTION
    feat(k8s/dsp): add pool errors and diagnostics
    
    Adds the errors and diagnostics changes to the DiskPool CRD.
    Along with it, a whole bunch of conversions, which we may
    want to improve in the future, either by somehow using the
    openapi models directly in the CRD or perhaps some auto conversion.
    
---

    refactor(k8s/dsp): tidy up context tracing and scoping
    
    The tracing of the pool name was duplicated in many cases.
    Debug was used when Display was available.
    Too much identation is used, and its not fully fixed.
    Instrument macros was missing a comma somehow...
    etc
