### PR TITLE
Handle target failover for RWX block

### DIFF
--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -846,6 +846,7 @@ async fn republished_nexus_io_engine_txn_fail() {
         .unwrap();
 
     let node_idx0 = cluster.node(0);
+    let app_node_idx0 = cluster.csi_node(0);
     let node_idx1 = cluster.node(1);
     let app_id = cluster.csi_node(0);
     let vol_cli = cluster.grpc_client().volume();
@@ -869,7 +870,7 @@ async fn republished_nexus_io_engine_txn_fail() {
                 share: Some(VolumeShareProtocol::Nvmf),
                 target_node: Some(node_idx0.clone()),
                 publish_context: HashMap::new(),
-                frontend_nodes: vec![node_idx0.to_string()],
+                frontend_nodes: vec![app_node_idx0.to_string()],
                 access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
@@ -904,7 +905,7 @@ async fn republished_nexus_io_engine_txn_fail() {
                 target_node: Some(node_idx1),
                 share: VolumeShareProtocol::Nvmf,
                 reuse_existing: true,
-                frontend_node: node_idx0.clone(),
+                frontend_node: app_node_idx0.clone(),
                 reuse_existing_fallback: false,
             },
             None,
@@ -1061,6 +1062,7 @@ async fn republished_nexus_core_agent_txn_fail() {
         .unwrap();
 
     let node_idx0 = cluster.node(0);
+    let app_node_idx0 = cluster.csi_node(0);
     let node_idx1 = cluster.node(1);
     let csi_id = cluster.csi_container(0);
     let app_id = cluster.csi_node(0);
@@ -1085,7 +1087,7 @@ async fn republished_nexus_core_agent_txn_fail() {
                 share: Some(VolumeShareProtocol::Nvmf),
                 target_node: Some(node_idx0.clone()),
                 publish_context: HashMap::new(),
-                frontend_nodes: vec![node_idx0.to_string()],
+                frontend_nodes: vec![app_node_idx0.to_string()],
                 access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
@@ -1115,7 +1117,7 @@ async fn republished_nexus_core_agent_txn_fail() {
 
     let csi_node_ip = cluster.composer().container_ip(&csi_id);
     let vol_clone = volume.clone();
-    let node_idx0_spawn = node_idx0.clone();
+    let node_idx0_spawn = app_node_idx0.clone();
     let node_idx1_spawn = node_idx1.clone();
     let repub_task = tokio::spawn(async move {
         let mut vol_republished = vol_cli

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -554,6 +554,16 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
             }),
         }?;
 
+        let frontend = &request.frontend_node;
+        if self
+            .rerepublish(registry, &state, target_cfg, frontend)
+            .await?
+        {
+            tracing::info!(%frontend, "No changes, just re-republishing volume target");
+            let volume = registry.volume(&request.uuid).await?;
+            return Ok(volume);
+        }
+
         let mut older_nexus = specs.nexus(target_cfg.target().nexus()).await?;
         let mut move_nexus = true;
         let mut nexus_node = None;
@@ -613,7 +623,8 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
                 &Some(request.share),
                 &nodes,
             )
-            .await;
+            .await
+            .republish(frontend);
         let operation = VolumeOperation::Republish(RepublishOperation::new(target_cfg.clone()));
 
         let spec_clone = self.start_update(registry, &state, operation).await?;

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -29,7 +29,9 @@ use stor_port::{
         store::{
             nexus::{NexusSpec, ReplicaUri},
             nexus_child::NexusChild,
+            nexus_persistence::VolumeHealthPrefix,
             replica::ReplicaSpec,
+            volume::RepublishOperation,
             volume::{FrontendConfig, TargetConfig, VolumeOperation, VolumeSpec, VolumeTarget},
         },
         transport::{
@@ -43,7 +45,6 @@ use stor_port::{
 };
 
 use http::Uri;
-use stor_port::types::v0::store::nexus_persistence::VolumeHealthPrefix;
 
 impl OperationGuardArc<VolumeSpec> {
     /// Prune volume health from older targets.
@@ -876,5 +877,32 @@ impl OperationGuardArc<VolumeSpec> {
         }
 
         self.remove_health(registry);
+    }
+
+    /// Re-republishes the volume for the given frontend node.
+    /// Whenever a new target is recreated, all frontends must first rerepublish by attempting the reuse the new target
+    /// before attempting to recreate another one.
+    /// This is necessary because, in a RWX scenario we don't want the target to move for every initiator node, which
+    /// would inevitably break all the other initiators, resulting in a deadlock.
+    /// # WARNING
+    /// Note that we still can't fully prevent a deadlock as it's possible that a network partition may prevent some of
+    /// the initiators to connect, whilst not allowing the others.
+    pub(super) async fn rerepublish(
+        &mut self,
+        registry: &Registry,
+        state: &VolumeState,
+        target: &TargetConfig,
+        frontend: &NodeId,
+    ) -> Result<bool, SvcError> {
+        if !target.frontend().needs_rerepublish(frontend) {
+            return Ok(false);
+        }
+
+        let target = target.clone().rerepublish(frontend);
+        let operation = VolumeOperation::Republish(RepublishOperation::new(target));
+        let spec_clone = self.start_update(registry, state, operation).await?;
+        self.complete_update(registry, Ok(()), spec_clone).await?;
+
+        Ok(true)
     }
 }

--- a/control-plane/agents/src/bin/ha/cluster/etcd.rs
+++ b/control-plane/agents/src/bin/ha/cluster/etcd.rs
@@ -90,6 +90,7 @@ impl EtcdStore {
     ) -> Result<Vec<SwitchOverRequest>, anyhow::Error> {
         let mut store = self.store.lock().await;
         let key = key_prefix_obj(StorableObjectType::SwitchOver, API_VERSION);
+
         let store_entries = store.get_values_prefix(&key).await?;
 
         debug!(count = store_entries.len(), "fetched entries from etcd");

--- a/control-plane/agents/src/bin/ha/cluster/nodes.rs
+++ b/control-plane/agents/src/bin/ha/cluster/nodes.rs
@@ -27,7 +27,7 @@ impl PathRecord {
 #[derive(Debug, Default, Clone)]
 pub(crate) struct NodeList {
     list: Arc<Mutex<HashMap<NodeId, SocketAddr>>>,
-    failed_path: Arc<Mutex<HashMap<String, PathRecord>>>,
+    failed_path: Arc<Mutex<HashMap<String, HashMap<NodeId, PathRecord>>>>,
 }
 
 impl NodeList {
@@ -44,9 +44,18 @@ impl NodeList {
     }
 
     /// Remove path from failed_path list.
-    pub(crate) async fn remove_failed_path(&self, path: &str) {
+    pub(crate) async fn remove_failed_path(&self, node: &NodeId, path: &str) {
         let mut failed_path = self.failed_path.lock().await;
-        failed_path.remove(path);
+        let empty = {
+            let Some(failed_path) = failed_path.get_mut(path) else {
+                return;
+            };
+            failed_path.remove(node);
+            failed_path.is_empty()
+        };
+        if empty {
+            failed_path.remove(path);
+        }
     }
     /// Add a failed switchover request to the failed paths.
     /// Useful when reloading from the pstor after a crash/restart.
@@ -55,10 +64,17 @@ impl NodeList {
             _socket: request.socket(),
             stage: request.stage_arc(),
         };
-        self.failed_path
-            .lock()
-            .await
-            .insert(request.nqn().into(), record);
+        let mut failed_path = self.failed_path.lock().await;
+        let path = request.nqn().into();
+        let node = request.node().into();
+        match failed_path.get_mut(&path) {
+            None => {
+                failed_path.insert(path, HashMap::from([(node, record)]));
+            }
+            Some(nodes) => {
+                nodes.insert(node, record);
+            }
+        }
     }
 
     /// Send request to the switchover engine for the reported node and path.
@@ -79,30 +95,43 @@ impl NodeList {
         let mut failed_path = self.failed_path.lock().await;
 
         if let Some(record) = failed_path.get(&path) {
-            return match record.stage() {
-                Stage::ReplacePath | Stage::DeleteTarget | Stage::Successful | Stage::Errored => {
-                    Err(ReplyError::failed_precondition(
+            if let Some(record) = record.get(&node) {
+                return match record.stage() {
+                    Stage::ReplacePath
+                    | Stage::DeleteTarget
+                    | Stage::Successful
+                    | Stage::Errored => Err(ReplyError::failed_precondition(
                         ResourceKind::NvmePath,
                         path,
                         "Path is already reported for switchover".to_owned(),
-                    ))
-                }
-                Stage::Init | Stage::RepublishVolume => Err(ReplyError::already_exist(
-                    ResourceKind::NvmePath,
-                    path,
-                    "Path is already reported for switchover".to_owned(),
-                )),
-            };
+                    )),
+                    Stage::Init | Stage::RepublishVolume => Err(ReplyError::already_exist(
+                        ResourceKind::NvmePath,
+                        path,
+                        "Path is already reported for switchover".to_owned(),
+                    )),
+                };
+            }
+            tracing::info!(node.id=%node, %path, "A failed volume path is reported from another node");
         }
 
         info!(node.id=%node, %path, "Sending switchover");
 
-        let stage = mover.switchover(node, endpoint, path.clone()).await?;
+        let stage = mover
+            .switchover(node.clone(), endpoint, path.clone())
+            .await?;
         let record = PathRecord {
             _socket: endpoint,
             stage,
         };
-        failed_path.insert(path, record);
+        match failed_path.get_mut(&path) {
+            None => {
+                failed_path.insert(path, HashMap::from([(node, record)]));
+            }
+            Some(nodes) => {
+                nodes.insert(node, record);
+            }
+        }
         Ok(())
     }
 }

--- a/control-plane/agents/src/bin/ha/cluster/switchover.rs
+++ b/control-plane/agents/src/bin/ha/cluster/switchover.rs
@@ -313,8 +313,8 @@ impl SwitchOverRequest {
             _ => None,
         };
         if self.new_path.is_none() {
-            error!(volume.uuid=%self.volume_id, "Could not find device uri for the volume");
-            return Err(anyhow!("Couldnt find device uri for the volume"));
+            error!(volume.uuid=%self.volume_id, "Couldn't find device uri for the volume");
+            return Err(anyhow!("Couldn't find device uri for the volume"));
         }
         self.complete_op(true, "".to_string(), etcd).await?;
         self.update_next_stage();

--- a/control-plane/agents/src/bin/ha/cluster/switchover.rs
+++ b/control-plane/agents/src/bin/ha/cluster/switchover.rs
@@ -97,6 +97,7 @@ pub(crate) struct SwitchOverRequest {
     publish_context: Option<HashMap<String, String>>,
     /// The first time we handle exhaustion, retry right away.
     fast_exhaustion_retry: bool,
+    rwx: bool,
 }
 
 impl Ord for SwitchOverRequest {
@@ -134,6 +135,7 @@ impl SwitchOverRequest {
             reuse_existing: true,
             publish_context: None,
             fast_exhaustion_retry: true,
+            rwx: true,
         }
     }
 
@@ -154,6 +156,10 @@ impl SwitchOverRequest {
     /// Get the nqn of this path.
     pub(crate) fn nqn(&self) -> &str {
         &self.existing_nqn
+    }
+    /// Get the node name where this path is connected.
+    pub(crate) fn node(&self) -> &NodeId {
+        &self.node_name
     }
 
     /// Update stage with next stage.
@@ -388,7 +394,9 @@ impl SwitchOverRequest {
 
         match self.delete_request(etcd).await {
             Ok(_) => {
-                nodes.remove_failed_path(&self.existing_nqn).await;
+                nodes
+                    .remove_failed_path(&self.node_name, &self.existing_nqn)
+                    .await;
                 Ok(())
             }
             Err(_) => Err(anyhow!(
@@ -455,7 +463,9 @@ impl SwitchOverRequest {
             Err(error) => Err(anyhow!("Nvme path replacement failed: {error}")),
         }?;
 
-        nodes.remove_failed_path(&self.existing_nqn).await;
+        nodes
+            .remove_failed_path(&self.node_name, &self.existing_nqn)
+            .await;
         self.complete_op(true, "".to_string(), etcd).await?;
         self.update_next_stage();
         Ok(())
@@ -619,6 +629,7 @@ impl From<&SwitchOverRequest> for SwitchOverSpec {
             retry_count: req.retry_count,
             reuse_existing: req.reuse_existing,
             publish_context: req.publish_context.clone(),
+            rwx: req.rwx,
         }
     }
 }
@@ -642,6 +653,7 @@ impl From<&SwitchOverSpec> for SwitchOverRequest {
             reuse_existing: req.reuse_existing,
             publish_context: req.publish_context.clone(),
             fast_exhaustion_retry: true,
+            rwx: req.rwx,
         }
     }
 }

--- a/control-plane/agents/src/bin/ha/node/detector.rs
+++ b/control-plane/agents/src/bin/ha/node/detector.rs
@@ -296,6 +296,8 @@ impl PathFailureDetector {
                 if subsystem.hostnqn != gen_hostnqn
                     && (subsystem.hostnqn.starts_with(&host_nqn_prefix) || !in_deployer)
                 {
+                    // todo: would we ever see non-mayastor subsystems here?
+                    // tracing::trace!(subsystem.hostnqn, "Ignoring subsystem");
                     continue;
                 }
                 match subsystem.state.as_str() {

--- a/control-plane/agents/src/bin/ha/node/path_provider.rs
+++ b/control-plane/agents/src/bin/ha/node/path_provider.rs
@@ -172,9 +172,7 @@ impl CachedNvmePathProvider {
                     "Received UDEV hotplug event: {}: {} = {}",
                     event.event_type(),
                     event.device().syspath().display(),
-                    event
-                        .subsystem()
-                        .map_or("", |s| { s.to_str().unwrap_or("") })
+                    event.subsystem().map_or("", |s| s.to_str().unwrap_or(""))
                 );
 
                 // Make sure we have a valid UNICODE path.

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -430,11 +430,12 @@ impl CsiServer {
             probe_filesystems(),
             vol_client,
         );
+        let node_name = node_name.to_string();
         Ok(async move {
             Server::builder()
                 .add_service(NodeServer::new(node))
                 .add_service(IdentityServer::new(Identity {}))
-                .add_service(NvmeOperationsServer::new(NvmeOperationsSvc {}))
+                .add_service(NvmeOperationsServer::new(NvmeOperationsSvc::new(node_name)))
                 .serve_with_incoming_shutdown(incoming, Shutdown::wait())
                 .await
                 .map_err(|error| {

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -94,12 +94,12 @@ impl Node {
             )
         })?;
 
-        let Some(client) = &self.vol_client else {
-            return Ok(ctx_uri.to_string());
+        let uri = match &self.vol_client {
+            Some(client) => &client.volume_uri(volume_id).await?,
+            None => ctx_uri,
         };
 
-        let uri = client.volume_uri(volume_id).await?;
-        let uri = csi_driver::parse_host_uri(&self.node_name, &uri)?;
+        let uri = csi_driver::parse_host_uri(&self.node_name, uri)?;
         if &uri != ctx_uri {
             tracing::warn!(volume.uri=%uri, ctx.uri=%ctx_uri, "Overriding URI volume context with URI from REST");
         }

--- a/control-plane/csi-driver/src/bin/node/nodeplugin_nvme.rs
+++ b/control-plane/csi-driver/src/bin/node/nodeplugin_nvme.rs
@@ -27,6 +27,9 @@ impl NvmeOperations for NvmeOperationsSvc {
         info!(request=?req, "Nvme connection request to replace path");
 
         let uri = csi_driver::parse_host_uri(&self.node_name, &req.uri)?;
+        if uri != req.uri {
+            tracing::warn!(uri=%uri, %req.uri, "Overriding request URI");
+        }
 
         let uuid = volume_uuid_from_url_str(&uri)?;
 

--- a/control-plane/csi-driver/src/bin/node/nodeplugin_nvme.rs
+++ b/control-plane/csi-driver/src/bin/node/nodeplugin_nvme.rs
@@ -7,7 +7,15 @@ use std::collections::HashMap;
 use tracing::{info, warn};
 
 #[derive(Debug, Default)]
-pub(crate) struct NvmeOperationsSvc {}
+pub(crate) struct NvmeOperationsSvc {
+    node_name: String,
+}
+impl NvmeOperationsSvc {
+    /// Create a new `NvmeOperationsSvc` for the given node.
+    pub(crate) fn new(node_name: String) -> Self {
+        Self { node_name }
+    }
+}
 
 #[tonic::async_trait]
 impl NvmeOperations for NvmeOperationsSvc {
@@ -18,8 +26,9 @@ impl NvmeOperations for NvmeOperationsSvc {
         let req = request.into_inner();
         info!(request=?req, "Nvme connection request to replace path");
 
-        let uri: &str = req.uri.as_str();
-        let uuid = volume_uuid_from_url_str(uri)?;
+        let uri = csi_driver::parse_host_uri(&self.node_name, &req.uri)?;
+
+        let uuid = volume_uuid_from_url_str(&uri)?;
 
         // Create a new Volume Operation Guard.
         let _guard = VolumeOpGuard::new(uuid)?;
@@ -30,7 +39,7 @@ impl NvmeOperations for NvmeOperationsSvc {
         };
 
         // Get the nvmf device object from the uri.
-        let mut device = Device::parse(uri)?;
+        let mut device = Device::parse(&uri)?;
 
         // Parse the parameters from publish context.
         device.parse_parameters(&publish_context).await?;

--- a/control-plane/csi-driver/src/lib.rs
+++ b/control-plane/csi-driver/src/lib.rs
@@ -54,17 +54,40 @@ pub fn node_name_topology_key() -> String {
 }
 
 /// The volume's share uri contains the hostnqns for all allowed hosts.
-/// This function parses the and retains the hostnqn only for `node_id`.
+/// This function parses the uri and retains the hostnqn only for `node_id`.
+/// # Warning
+/// In case hostnqn are present in the uri but this node's nodenqn is not, then
+/// we error out with invalid_argument.
 pub fn parse_host_uri(node_id: &str, uri: &str) -> Result<String, tonic::Status> {
     let mut url =
         url::Url::parse(uri).map_err(|error| tonic::Status::internal(format!("{uri}: {error}")))?;
     let node_nqn: String =
         stor_port::types::v0::transport::NvmeNqn::from_nodename(node_id).to_string();
+
+    let mut matched_ours = false;
+    let mut host_nqns = false;
     let queries = url
         .query_pairs()
-        .filter(|(name, value)| name != "hostnqn" || value == &node_nqn)
+        .filter(|(name, value)| {
+            if name != "hostnqn" {
+                return true;
+            }
+            host_nqns = true;
+            if value == &node_nqn {
+                matched_ours = true;
+                true
+            } else {
+                false
+            }
+        })
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect::<Vec<(_, _)>>();
+
+    if host_nqns && !matched_ours {
+        let msg = format!("{uri} has hostnqn's but not mine ({node_nqn})");
+        return Err(tonic::Status::invalid_argument(msg));
+    }
+
     url.query_pairs_mut().clear().extend_pairs(queries);
 
     // we have to decode because otherwise the nqn would be encoded, ex:
@@ -76,20 +99,17 @@ pub fn parse_host_uri(node_id: &str, uri: &str) -> Result<String, tonic::Status>
 
 #[test]
 fn test_parse_host_uri() {
-    let uri = parse_host_uri("node-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2").unwrap();
-    assert_eq!(
-        uri,
-        "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?"
-    );
-    let uri = parse_host_uri("node-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2&a=1").unwrap();
-    assert_eq!(
-        uri,
-        "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?a=1"
-    );
+    let error = parse_host_uri("node-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2").unwrap_err();
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
     let uri = parse_host_uri("ksworker-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2").unwrap();
     assert_eq!(uri, "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1");
-    let uri = parse_host_uri("ksworker-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?a=1,hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2").unwrap();
-    assert_eq!(uri, "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?a=1,hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1");
+    let uri = parse_host_uri("ksworker-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2&a=1").unwrap();
+    assert_eq!(
+        uri,
+        "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&a=1"
+    );
+    let uri = parse_host_uri("ksworker-1", "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?a=1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-2").unwrap();
+    assert_eq!(uri, "nvmf://10.0.0.213:8420/nqn.2019-05.io.openebs:0a9bbaff-7b08-4160-b5d3-1c0a3a4539ae?a=1&hostnqn=nqn.2019-05.io.openebs:node-name:ksworker-1");
 }
 
 /// Volume Parameters parsed from context.

--- a/control-plane/stor-port/src/types/v0/store/switchover.rs
+++ b/control-plane/stor-port/src/types/v0/store/switchover.rs
@@ -67,6 +67,9 @@ pub struct SwitchOverSpec {
     pub reuse_existing: bool,
     /// Publish context of the volume.
     pub publish_context: Option<HashMap<String, String>>,
+    /// To support RWX we have to record switchover per frontend node.
+    #[serde(default)]
+    pub rwx: bool,
 }
 
 impl SwitchOverSpec {
@@ -107,24 +110,38 @@ impl SwitchOverSpec {
 }
 
 /// Persistent Store key for `SwitchOverSpec`.
-pub struct SwitchOverSpecKey(VolumeId);
+pub struct SwitchOverSpecKey(VolumeId, Option<NodeId>);
 
 impl StorableObject for SwitchOverSpec {
     type Key = SwitchOverSpecKey;
 
     fn key(&self) -> Self::Key {
-        SwitchOverSpecKey(self.volume.clone())
-    }
-}
-
-impl SwitchOverSpecKey {
-    pub fn new(id: VolumeId) -> Self {
-        SwitchOverSpecKey(id)
+        if self.rwx {
+            SwitchOverSpecKey(self.volume.clone(), Some(self.node_name.clone()))
+        } else {
+            SwitchOverSpecKey(self.volume.clone(), None)
+        }
     }
 }
 
 impl ObjectKey for SwitchOverSpecKey {
     type Kind = StorableObjectType;
+
+    fn key(&self) -> String {
+        let v = &self.0;
+        match &self.1 {
+            None => format!(
+                "{}/{}/{v}",
+                pstor::key_prefix(self.version()),
+                self.key_type()
+            ),
+            Some(node) => format!(
+                "{}/{}/{v}/node/{node}",
+                pstor::key_prefix(self.version()),
+                self.key_type()
+            ),
+        }
+    }
 
     fn version(&self) -> ApiVersion {
         ApiVersion::V0
@@ -135,7 +152,8 @@ impl ObjectKey for SwitchOverSpecKey {
     }
 
     fn key_uuid(&self) -> String {
-        self.0.to_string()
+        // The key is generated directly from the `key()` function above.
+        unreachable!()
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -98,6 +98,29 @@ impl FrontendConfig {
     pub fn needs_update(&self, hosts: &[InitiatorAC]) -> bool {
         hosts.iter().any(|h| !self.host_acl.contains(h))
     }
+    /// All nodes other than the given node will have to rerepublish.
+    pub fn republish(&mut self, node: &NodeId) {
+        for host in self.host_acl.iter_mut() {
+            if host.node_name.as_str() != node.as_str() {
+                host.needs_rerepublish = true;
+            }
+        }
+    }
+    /// Re-republishes the given node after a [`Self::republish`].
+    pub fn rerepublish(&mut self, node: &NodeId) {
+        for host in self.host_acl.iter_mut() {
+            if host.node_name.as_str() == node.as_str() {
+                host.needs_rerepublish = false;
+            }
+        }
+    }
+    /// Check if the given initiators are already allowed.
+    pub fn needs_rerepublish(&self, host: &NodeId) -> bool {
+        let Some(host) = self.host_acl.iter().find(|h| h.node_name == host.as_str()) else {
+            return false;
+        };
+        host.needs_rerepublish
+    }
 }
 
 /// Volume Frontend
@@ -107,6 +130,8 @@ pub struct InitiatorAC {
     node_name: String,
     /// The nvme nqn of the front-end node.
     node_nqn: HostNqn,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    needs_rerepublish: bool,
 }
 impl InitiatorAC {
     /// Get a new `Self` with the given parameters.
@@ -114,6 +139,7 @@ impl InitiatorAC {
         Self {
             node_name,
             node_nqn,
+            needs_rerepublish: false,
         }
     }
     /// Get the nodename of the front-end initiator.
@@ -343,6 +369,20 @@ impl TargetConfig {
             config,
             frontend,
         }
+    }
+
+    /// Republishing the volume for the given node.
+    /// This means all other initiators must reconnect to the republished target, before attempting
+    /// to republish the volume again.
+    pub fn republish(mut self, node: &NodeId) -> Self {
+        self.frontend.republish(node);
+        self
+    }
+
+    /// Re-republishes after a [`Self::republish`].
+    pub fn rerepublish(mut self, node: &NodeId) -> Self {
+        self.frontend.rerepublish(node);
+        self
     }
 
     /// Get the last target configuration.

--- a/tests/bdd/features/csi/node/test_csi.py
+++ b/tests/bdd/features/csi/node/test_csi.py
@@ -163,7 +163,7 @@ def published_nexus(volumes, share_type, volume_id):
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=NODE1,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     yield volume.state.target

--- a/tests/bdd/features/csi/node/test_parameters.py
+++ b/tests/bdd/features/csi/node/test_parameters.py
@@ -93,7 +93,7 @@ def staging_a_volume(staging_target_path, csi_instance, block_volume_capability)
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=NODE1,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     device_uri = volume.state.target.device_uri

--- a/tests/bdd/features/garbage-collection/replicas/test_feature.py
+++ b/tests/bdd/features/garbage-collection/replicas/test_feature.py
@@ -70,7 +70,7 @@ def init(create_pool_disk_images):
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=IO_ENGINE_1,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
 

--- a/tests/bdd/features/rebuild/test_rebuild.py
+++ b/tests/bdd/features/rebuild/test_rebuild.py
@@ -110,7 +110,7 @@ def an_existing_published_volume(disks):
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=NODE_1_NAME,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
 

--- a/tests/bdd/features/volume/delete/test_feature.py
+++ b/tests/bdd/features/volume/delete/test_feature.py
@@ -102,7 +102,7 @@ def a_volume_that_is_sharedpublished():
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=NODE1_NAME,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     assert volume.spec.target.protocol == "nvmf"

--- a/tests/bdd/features/volume/nexus-info/test_feature.py
+++ b/tests/bdd/features/volume/nexus-info/test_feature.py
@@ -166,7 +166,7 @@ def publish_volume():
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=NODE_NAME,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     assert volume.state.target

--- a/tests/bdd/features/volume/nexus/test_feature.py
+++ b/tests/bdd/features/volume/nexus/test_feature.py
@@ -52,7 +52,7 @@ def a_published_selfhealing_volume():
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=IO_ENGINE_1,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
 

--- a/tests/bdd/features/volume/publish/test_feature.py
+++ b/tests/bdd/features/volume/publish/test_feature.py
@@ -57,7 +57,7 @@ def a_published_volume():
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=NODE_NAME,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     assert volume.spec.target
@@ -86,7 +86,7 @@ def publishing_the_volume_should_return_an_already_published_error():
                 publish_context={},
                 protocol=VolumeShareProtocol("nvmf"),
                 node=NODE_NAME,
-                frontend_node="",
+                frontend_node=None,
             ),
         )
     except Exception as e:
@@ -106,7 +106,7 @@ def publishing_the_volume_should_succeed_with_a_returned_volume_object_containin
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=NODE_NAME,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     assert volume.spec.target

--- a/tests/bdd/features/volume/resize/test_resize_offline.py
+++ b/tests/bdd/features/volume/resize/test_resize_offline.py
@@ -107,7 +107,7 @@ def publish_volume(uuid, publish_on):
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=publish_on,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     assert volume.state.target
@@ -127,7 +127,7 @@ def create_and_publish_volume(uuid, size, rcount, publish_on):
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=publish_on,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     assert volume.state.target

--- a/tests/bdd/features/volume/resize/test_resize_online.py
+++ b/tests/bdd/features/volume/resize/test_resize_online.py
@@ -163,7 +163,7 @@ def publish_volume(uuid, publish_on):
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=publish_on,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     assert volume.state.target
@@ -178,7 +178,7 @@ def create_and_publish_volume(uuid, size, rcount, publish_on):
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=publish_on,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     assert volume.state.target

--- a/tests/bdd/features/volume/unpublish/test_feature.py
+++ b/tests/bdd/features/volume/unpublish/test_feature.py
@@ -64,7 +64,7 @@ def a_published_volume():
             publish_context={},
             protocol=VolumeShareProtocol("nvmf"),
             node=NODE_NAME,
-            frontend_node="",
+            frontend_node=None,
         ),
     )
     assert volume.spec.target


### PR DESCRIPTION
    feat(rwx): handle failure reports from multiple nodes
    
    With RWX the cluster-agent may receive failovers from multiple nodes
    for the same volume.
    We now record this this per node, allowing us to keep track of them
    separately.
    
    Ideally we should modify the switchover engine to process the requests
    for the same volume as a single operation, but this would require further
    refactoring of the switchover request.
    Since the core agents has now some tolerance ensuring that at least
    one republish will not trigger a move, this should sufficient.
    
    Also the switchover request on the pstor now has to contain the frontend
    node in the key, allowing us to store the requests independently.
    A new rwx parameter is stored, allowing us to store in either way, thus
    keeping back compatibility with older requests during upgrade.
    
---

    feat(rwx/ha): keep track of republished volume frontends
    
    When ha triggers failover, a republish of the volume is triggerd by the
    cluster agent.
    In case of RWX, multiple nodes may request the failover, but we should
    not allow each one to trigger a new failover, otherwise each request
    could undo the previous and potentially lead into a deadlock.
    
    To avoid this we ensure that each frontend must republish with no target
    changes at least once.
    
    Note that it's still possible to end up in disarray in case of a network
    partition affecting only some of the frontends.
    
---

    fix(rwx/ha): ensure hostnqn is used when replacing the failed path
    
    This fix is similar to another which had been done on the csi-node, but
    that was not sufficient as it only covered the CSI workflow.
    The ha path replacement is using another entrypoint, which did not use
    the corrected uri, meaning the subsystem could be connected without
    using the hostnqn.
    This would lead to infinite reconnect attempts...
