### PR TITLE
fix(csi/node): more robust on bad udev properties and disconnects

### DIFF
--- a/control-plane/csi-driver/src/bin/node/dev.rs
+++ b/control-plane/csi-driver/src/bin/node/dev.rs
@@ -44,8 +44,6 @@ mod nbd;
 pub(crate) mod nvmf;
 mod util;
 
-use utils::constants::nvme_target_nqn_prefix;
-
 pub(crate) use crate::error::DeviceError;
 use crate::match_dev;
 
@@ -134,15 +132,8 @@ impl Device {
             if let Some(devname) =
                 match_dev::match_nvmf_device_valid(&device, &nvmf_key, Some(multipath))?
             {
-                let nqn = if std::env::var("MOAC").is_ok() {
-                    format!("{}:nexus-{uuid}", nvme_target_nqn_prefix())
-                } else {
-                    format!("{}:{uuid}", nvme_target_nqn_prefix())
-                };
-                return Ok(Some(Box::new(nvmf::NvmfDetach::new(
-                    devname.to_string(),
-                    nqn,
-                ))));
+                let detach = nvmf::NvmfDetach::new(devname.to_string(), uuid, &device);
+                return Ok(Some(Box::new(detach)));
             }
         }
 

--- a/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
@@ -1,6 +1,6 @@
 use nvmeadm::{
     error::NvmeError,
-    nvmf_discovery::{disconnect, ConnectArgsBuilder, TrType},
+    nvmf_discovery::{ConnectArgsBuilder, TrType},
 };
 use std::{
     collections::HashMap,
@@ -9,6 +9,14 @@ use std::{
     str::FromStr,
 };
 
+use super::{Attach, AttachParameters, Detach, DeviceError, DeviceName};
+use crate::{
+    config::{config, NvmeConfig, NvmeParseParams},
+    dev::util::extract_uuid,
+    match_dev::match_nvmf_device,
+    node::RDMA_CONNECT_CHECK,
+    runtime,
+};
 use csi_driver::PublishParams;
 use glob::glob;
 use nvmeadm::nvmf_subsystem::Subsystem;
@@ -17,16 +25,6 @@ use tracing::warn;
 use udev::{Device, Enumerator};
 use url::Url;
 use uuid::Uuid;
-
-use crate::{
-    config::{config, NvmeConfig, NvmeParseParams},
-    dev::util::extract_uuid,
-    match_dev::match_nvmf_device,
-    node::RDMA_CONNECT_CHECK,
-    runtime,
-};
-
-use super::{Attach, AttachParameters, Detach, DeviceError, DeviceName};
 
 lazy_static::lazy_static! {
     static ref DEVICE_REGEX: Regex = Regex::new(r"nvme(\d{1,5})n(\d{1,5})").unwrap();
@@ -151,7 +149,7 @@ impl Attach for NvmfAttach {
         context: &HashMap<String, String>,
     ) -> Result<(), DeviceError> {
         let publish_context = PublishParams::try_from(context)
-            .map_err(|error| DeviceError::new(&error.to_string()))?;
+            .map_err(|error| DeviceError::new(error.to_string()))?;
 
         if let Some(val) = publish_context.ctrl_loss_tmo() {
             self.ctrl_loss_tmo = Some(*val);
@@ -273,7 +271,7 @@ impl Attach for NvmfAttach {
             })
             .collect::<Result<Vec<()>, DeviceError>>();
         match result {
-            Ok(r) if r.is_empty() => Err(DeviceError::new(&format!(
+            Ok(r) if r.is_empty() => Err(DeviceError::new(format!(
                 "look up of sysfs device directory \"{pattern}\" found 0 entries",
             ))),
             Ok(_) => Ok(()),
@@ -291,13 +289,84 @@ impl Attach for NvmfAttach {
 }
 
 pub(super) struct NvmfDetach {
+    /// Device name, ex: /dev/nvme4n1
     name: DeviceName,
+    /// Subsystem Nqn, ex: nqn.2019-05.io.openebs:a0000000-0000-0000-0000-0000000003ff
     nqn: String,
+    /// the sysfs DEVPATH, example: /sys/devices/virtual/nvme-subsystem/nvme-subsys4/nvme4n1/device
+    subsys_dev: std::path::PathBuf,
 }
 
+const SYSFS: &str = "/sys";
+
 impl NvmfDetach {
-    pub(super) fn new(name: DeviceName, nqn: String) -> NvmfDetach {
-        NvmfDetach { name, nqn }
+    pub(super) fn new(name: DeviceName, uuid: &Uuid, device: &Device) -> NvmfDetach {
+        // todo: we can query this from $subsys/subsysnqn
+        let nqn = if std::env::var("MOAC").is_ok() {
+            format!("{}:nexus-{uuid}", utils::nvme_target_nqn_prefix())
+        } else {
+            format!("{}:{uuid}", utils::nvme_target_nqn_prefix())
+        };
+
+        let sys = Path::new(SYSFS);
+        let devpath = Path::new(device.devpath());
+        let subsys_dev = if !devpath.has_root() {
+            sys.join(devpath)
+        } else {
+            sys.join(devpath.components().skip(1).collect::<std::path::PathBuf>())
+        }
+        .join("device");
+
+        NvmfDetach {
+            name,
+            nqn,
+            subsys_dev,
+        }
+    }
+
+    /// Returns a list of nvme controllers.
+    /// Unfortunately it's a rather complex type because I/O may fail at multiple levels.
+    /// > NOTE: `Subsystem` is a misnomer from the dependency library.
+    fn controllers_maybe(&self) -> Vec<Result<Result<Subsystem, NvmeError>, glob::GlobError>> {
+        let pattern = format!("{}/nvme*/", self.subsys_dev.display());
+        let glob = glob(&pattern).expect("valid pattern");
+        glob.into_iter()
+            .filter_map(|g| match g {
+                Ok(p) if p.is_symlink() => {
+                    // todo: change subsystem to allow this path
+                    let p = p.file_name().expect("we have the path");
+                    let rp = Path::new(nvmeadm::nvmf_subsystem::SYSFS_NVME_CTRLR_PREFIX);
+                    Some(Ok(Subsystem::new(&rp.join(p))))
+                }
+                Ok(_) => None,
+                Err(error) => Some(Err(error)),
+            })
+            .collect()
+    }
+    /// Get a list of subsystems and the concatenation of any seen errors.
+    fn controllers(&self) -> (Vec<Subsystem>, Option<DeviceError>) {
+        let mut controllers = vec![];
+        let mut error = String::new();
+
+        for controller in self.controllers_maybe() {
+            match controller {
+                Ok(Ok(controller)) => {
+                    controllers.push(controller);
+                }
+                Ok(Err(nvme)) => {
+                    error = format!("{error}, {nvme}");
+                }
+                Err(glob) => {
+                    error = format!("{error}, {glob}");
+                }
+            }
+        }
+        let error = if error.is_empty() {
+            None
+        } else {
+            Some(DeviceError::new(error))
+        };
+        (controllers, error)
     }
 }
 
@@ -305,16 +374,58 @@ impl NvmfDetach {
 impl Detach for NvmfDetach {
     async fn detach(&self) -> Result<(), DeviceError> {
         let nqn = self.nqn.clone();
-        runtime::spawn_blocking(move || match disconnect(&nqn) {
-            Ok(0) => Err(DeviceError::from(format!(
-                "nvmf disconnect {} failed: no device found",
-                nqn
-            ))),
-            Err(error) => Err(error.into()),
-            Ok(_) => Ok(()),
+        let name = &self.name;
+
+        tracing::info!(name, nqn, "Disconnecting NVMe subsystem...");
+
+        // Note that we may find multiple controllers in case of ANA
+        // We may encounter errors, but we can still clean the ones which we found correctly.
+        let (controllers, error) = self.controllers();
+        let device = name.clone();
+        let controllers = runtime::spawn_blocking(move || {
+            controllers.iter().for_each(|c| {
+                let traddr = c.address.as_str();
+                let name = c.name.as_str();
+                let _ = c
+                    .disconnect()
+                    .inspect(|_| {
+                        tracing::info!(name, device, traddr, "Disconnecting NVMe controller...")
+                    })
+                    .inspect_err(
+                        |error| tracing::error!(%error, "Failed to disconnect NVMe controller"),
+                    );
+            });
+            controllers
         })
         .await
-        .map_err(|error| DeviceError::from(error.to_string()))?
+        .map_err(|error| DeviceError::from(error.to_string()))?;
+
+        // Now we wait for the controllers to at least start deleting
+        let deadline = std::time::Duration::from_secs(15);
+        let start: std::time::Instant = std::time::Instant::now();
+        for mut controller in controllers.into_iter() {
+            let traddr = controller.address.clone().to_raw();
+            let name = controller.name.to_owned();
+            loop {
+                if controller.sync().is_err() {
+                    tracing::info!(name, traddr, "Controller has been removed");
+                    break;
+                } else if controller.state.starts_with("delet") {
+                    tracing::info!(name, traddr, state = %controller.state, "Controller deleted/deleting");
+                    break;
+                }
+                tracing::debug!(name, traddr, state = %controller.state, "Controller state sync");
+
+                if start.elapsed() >= deadline {
+                    return Err(DeviceError::new(format!(
+                        "Timeout waiting for {name}/{nqn}/{traddr} to get removed"
+                    )));
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+
+        error.map_or(Ok(()), Err)
     }
 
     fn devname(&self) -> DeviceName {
@@ -330,9 +441,9 @@ impl Detach for NvmfDetach {
 fn block_dev_q(device: &Device, multipath: Option<bool>) -> Result<String, DeviceError> {
     let dev_name = device.sysname().to_str().unwrap();
     let captures = DEVICE_REGEX.captures(dev_name).ok_or_else(|| {
-        DeviceError::new(&format!(
-            "NVMe device \"{}\" does not match \"{}\"",
-            dev_name, *DEVICE_REGEX,
+        DeviceError::new(format!(
+            "NVMe device \"{dev_name}\" does not match \"{}\"",
+            *DEVICE_REGEX
         ))
     })?;
     let major = captures.get(1).unwrap().as_str();

--- a/control-plane/csi-driver/src/bin/node/error.rs
+++ b/control-plane/csi-driver/src/bin/node/error.rs
@@ -27,9 +27,9 @@ pub(crate) enum DeviceErrorSource {
 
 impl DeviceError {
     /// Return a new `Self` with the given message.
-    pub(crate) fn new(message: &str) -> DeviceError {
+    pub(crate) fn new(message: impl Into<String>) -> DeviceError {
         DeviceError {
-            message: String::from(message),
+            message: message.into(),
             source: DeviceErrorSource::None,
         }
     }

--- a/control-plane/csi-driver/src/bin/node/match_dev.rs
+++ b/control-plane/csi-driver/src/bin/node/match_dev.rs
@@ -66,10 +66,34 @@ pub(super) fn match_iscsi_device(device: &Device) -> Option<(&str, &str)> {
 pub(super) fn match_nvmf_device<'a>(device: &'a Device, key: &str) -> Option<&'a str> {
     let model_id = utils::nvme_controller_model_id();
 
-    require!(model_id == device.property_value("ID_MODEL"));
-    require!(key == device.property_value("ID_WWN"));
-
     require!(let devname = device.property_value("DEVNAME"));
+
+    let id_wwn = device.property_value("ID_WWN");
+    let wwid = device.attribute_value("wwid");
+
+    if let Some(wwid) = &wwid {
+        // this is our device, matching only via the wwid attribute and not the ID_WWN property
+        if *wwid == key {
+            // attribute matches but the property doesn't, likely the udev db is bad!?
+            if Some(key) != id_wwn.and_then(|s| s.to_str()) {
+                tracing::error!(
+                    "{devname} has wwid of {key} != ID_WWN of {id_wwn:?}, is udev bad?",
+                );
+            }
+
+            // since we don't trust udev properties, we match the model using the attributes
+            if let Some(parent) = device.parent() {
+                if let Some(model) = parent.attribute_value("model") {
+                    if model.to_string_lossy().starts_with(model_id.as_str()) {
+                        return Some(devname);
+                    }
+                }
+            }
+        }
+    }
+
+    require!(key == id_wwn);
+    require!(model_id == device.property_value("ID_MODEL"));
 
     Some(devname)
 }

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 
 macro_rules! failure {
     (Code::$code:ident, $msg:literal) => {{ error!($msg); Status::new(Code::$code, $msg) }};
-    (Code::$code:ident, $fmt:literal $(,$args:expr)+) => {{ let message = format!($fmt $(,$args)+); error!("{}", message); Status::new(Code::$code, message) }};
+    (Code::$code:ident, $fmt:literal $(,$args:expr)+) => {{ let message = format!($fmt $(,$args)+); error!("{message}"); Status::new(Code::$code, message) }};
 }
 
 /// The Csi Node implementation.
@@ -173,25 +173,18 @@ fn get_access_type(volume_capability: &Option<VolumeCapability>) -> Result<&Acce
 /// Detach the nexus device from the system, either at volume unstage,
 /// or after failed filesystem mount at volume stage.
 pub(crate) async fn detach(uuid: &Uuid, errheader: String) -> Result<(), Status> {
-    if let Some(device) = Device::lookup(uuid).await.map_err(|error| {
-        failure!(
-            Code::Internal,
-            "{} error locating device: {}",
-            &errheader,
-            error
-        )
-    })? {
+    if let Some(device) = Device::lookup(uuid)
+        .await
+        .map_err(|error| failure!(Code::Internal, "{errheader} error locating device: {error}"))?
+    {
         let device_path = device.devname();
-        debug!("Detaching device {}", device_path);
+        debug!("Detaching device {device_path}");
 
         let mounts = crate::mount::find_src_mounts(&device_path, None);
         if !mounts.is_empty() {
             return Err(failure!(
                 Code::FailedPrecondition,
-                "{} device is still mounted {}: {:?}",
-                errheader,
-                device_path,
-                mounts
+                "{errheader} device is still mounted {device_path}: {mounts:?}"
             ));
         }
 
@@ -200,12 +193,11 @@ pub(crate) async fn detach(uuid: &Uuid, errheader: String) -> Result<(), Status>
         if let Err(error) = device.detach().await {
             return Err(failure!(
                 Code::Internal,
-                "{} failed to detach device {}: {}",
-                errheader,
-                device_path,
-                error
+                "{errheader} failed to detach device {device_path}: {error}"
             ));
         }
+    } else {
+        tracing::warn!(%uuid, "Volume device not found");
     }
     Ok(())
 }
@@ -870,9 +862,8 @@ impl node_server::Node for Node {
         let uuid = Uuid::parse_str(&msg.volume_id).map_err(|error| {
             failure!(
                 Code::Internal,
-                "Failed to unstage volume {}: not a valid UUID: {}",
-                &msg.volume_id,
-                error
+                "Failed to unstage volume {}: not a valid UUID: {error}",
+                &msg.volume_id
             )
         })?;
         let _guard = VolumeOpGuard::new(uuid)?;


### PR DESCRIPTION
When the udev properties don't match, try to use the sysfs attributes instead.

Also, when disconnecting try harder to wait for controller deletion and log the steps for better debug support.
This is done by fetching all the controllers from the subsystem and trying to issue controller delete 1 by 1.
We then wait for all these controllers to at least enter their deletion phase before completing the csi call.

todo: do we need to use udev at all?