### PR TITLE
feat: use new io-engine status error codes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -83,6 +83,8 @@ impl OnCreateFail {
             tonic::Code::InvalidArgument => Self::Delete,
             // 1. the pool disk is not available (ie not found or broken somehow)
             tonic::Code::NotFound => Self::Delete,
+            // 1. the pool failed to be created due to I/O errors
+            tonic::Code::DataLoss => Self::Delete,
             // In this case, it's the pool operator's job to attempt re-creation of the pool.
             // 1. pre-2.6 dataplane, contention on the pool service
             // 2. pool disk is very slow or extremely large

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -169,11 +169,16 @@ impl OperationGuardArc<PoolSpec> {
 
     /// Maps a [`SvcError`] obtained after a failed creation or import to a [`PoolError`].
     pub(super) fn pool_import_error(error: &SvcError) -> Option<PoolError> {
-        let code = match error.tonic_code() {
+        let (code, errno) = error.tonic_errno();
+        let code = match code {
             tonic::Code::InvalidArgument
                 if error.to_string().contains("EISDIR: Is a directory") =>
             {
                 PoolErrorCode::DiskIsADirectory
+            }
+            tonic::Code::DataLoss if errno == nix::Error::EIO => PoolErrorCode::SuperBlock,
+            tonic::Code::DataLoss if errno == nix::Error::EILSEQ => {
+                PoolErrorCode::InvalidSuperBlock
             }
             tonic::Code::InvalidArgument => PoolErrorCode::InvalidSuperBlock,
             tonic::Code::NotFound => PoolErrorCode::DiskNotFound,

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -317,6 +317,7 @@ impl OperationGuardArc<PoolSpec> {
                     Err(error) => match error.tonic_code() {
                         tonic::Code::NotFound if allow_not_found => Ok(()),
                         tonic::Code::InvalidArgument => Ok(()),
+                        tonic::Code::DataLoss => Ok(()),
                         tonic::Code::Cancelled | tonic::Code::Aborted => {
                             if let Some(error) = Self::pool_import_error(&error) {
                                 self.lock().metadata.runtime.diag = Some(PoolDiag {

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -492,7 +492,7 @@ pub enum SvcError {
 }
 
 impl SvcError {
-    /// Get comparable `tonic::Code`.
+    /// Get comparable [`tonic::Code`].
     /// todo: use existing conversion Self->ReplyError->tonic instead.
     pub fn tonic_code(&self) -> tonic::Code {
         match self {
@@ -514,6 +514,22 @@ impl SvcError {
             Self::ReplicaSetPropertyFailed { .. } => tonic::Code::DataLoss,
             Self::ReplaceNqnNotFound { .. } => tonic::Code::FailedPrecondition,
             _ => tonic::Code::Internal,
+        }
+    }
+    /// Get comparable [`tonic::Code`] and [`nix::Error`].
+    /// # NOTE
+    /// The `nix::Error` is retrievable only if the io-engine set the errno metadata field.
+    pub fn tonic_errno(&self) -> (tonic::Code, nix::Error) {
+        match self {
+            Self::GrpcRequestError { source, .. } => {
+                let errno = match source.metadata().get("errno") {
+                    None => "",
+                    Some(x) => x.to_str().unwrap_or(""),
+                };
+                let errno = nix::Error::from_raw(errno.parse().unwrap_or(1));
+                (source.code(), errno)
+            }
+            _ => (self.tonic_code(), nix::Error::EPERM),
         }
     }
 }

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -48,7 +48,7 @@ impl ComponentAction for IoEngine {
                 IoEngineApiVersion::vec_to_str(options.io_engine_api_versions.clone()),
             ])
             .with_env(
-                "IO_ERROR_THRESHOLD",
+                "POOL_IO_ERROR_THRESHOLD",
                 &options.pool.io_error_threshold.to_string(),
             )
             .with_args(vec!["-r", format!("/host/tmp/{reg_name}.sock").as_str()])


### PR DESCRIPTION
    feat: use new io-engine status error codes
    
    New io-engine will now return DataLoss with errno set to EIO or EILSEQ
    depending on whether import failed with I/O error or invalid superblock.
    
---

    fix: adjust to new name for the io error threshold env var
    
    The variable has been renamed to include the pool prefix.
