### PR TITLE
Handle graceful node shutdown

### DIFF
--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -316,16 +316,17 @@ impl Service {
     /// Deregister a node through the deregister information.
     #[tracing::instrument(level = "debug", skip(self), fields(node.id = %node.id))]
     pub(super) async fn deregister(&self, node: &Deregister) {
-        let nodes = self.registry.nodes().read().await;
-        match nodes.get(&node.id) {
-            None => {}
+        if let Err(error) = self.specs().deregister_node(&self.registry, node).await {
+            tracing::error!(node=%node.id, %error, "Failed to deregister node with pstor");
+        }
+
+        let nodes = self.registry.nodes().read().await.get(&node.id).cloned();
+        if let Some(node) = nodes {
             // ideally we want this node to disappear completely when it's not
             // part of the daemonset, but we just don't have that kind of
             // information at this level :(
             // maybe nodes should also be registered/deregistered via REST?
-            Some(node) => {
-                node.write().await.set_status(NodeStatus::Unknown);
-            }
+            node.write().await.set_status(NodeStatus::Offline);
         }
     }
 

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -62,6 +62,7 @@ impl ResourceSpecsLocked {
                         node.features.clone(),
                         node.bugfixes.clone(),
                         node.version.clone(),
+                        false,
                     );
                     specs.nodes.insert(node.clone());
                     (true, node)

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -1,7 +1,10 @@
 use crate::controller::{
     registry::Registry,
     resources::{
-        operations_helper::{OperationSequenceGuard, ResourceSpecsLocked},
+        operations_helper::{
+            GuardedOperationsHelper, OperationSequenceGuard, ResourceSpecs, ResourceSpecsLocked,
+            SpecOperationsHelper,
+        },
         OperationGuardArc, ResourceMutex,
     },
 };
@@ -14,12 +17,8 @@ use stor_port::{
             node::{NodeLabelOp, NodeLabels, NodeOperation, NodeSpec, NodeUnLabelOp},
             SpecStatus, SpecTransaction,
         },
-        transport::{NodeBugFix, NodeId, Register},
+        transport::{Deregister, NodeBugFix, NodeId, Register},
     },
-};
-
-use crate::controller::resources::operations_helper::{
-    GuardedOperationsHelper, ResourceSpecs, SpecOperationsHelper,
 };
 
 impl ResourceSpecsLocked {
@@ -39,7 +38,8 @@ impl ResourceSpecsLocked {
                         || node_spec.node_nqn() != &node.node_nqn
                         || node_spec.features() != &node.features
                         || node_spec.bugfixes() != &node.bugfixes
-                        || node_spec.version() != &node.version;
+                        || node_spec.version() != &node.version
+                        || node_spec.is_shutdown();
 
                     if changed {
                         node_spec.set_endpoint(node.grpc_endpoint);
@@ -47,7 +47,9 @@ impl ResourceSpecsLocked {
                         node_spec.set_features(node.features.clone());
                         node_spec.set_bugfixes(node.bugfixes.clone());
                         node_spec.set_version(node.version.clone());
+                        node_spec.set_shutdown(false);
                     }
+
                     (changed, node_spec.clone())
                 }
                 None => {
@@ -70,6 +72,30 @@ impl ResourceSpecsLocked {
             registry.store_obj(&node).await?;
         }
         Ok(node)
+    }
+
+    /// Deregister the node by marking it as shutdown.
+    pub(crate) async fn deregister_node(
+        &self,
+        registry: &Registry,
+        node: &Deregister,
+    ) -> Result<(), SvcError> {
+        let node = {
+            let specs = self.write();
+            let Some(node_spec) = specs.nodes.get(&node.id) else {
+                return Ok(());
+            };
+
+            let mut node_spec = node_spec.lock();
+
+            if node_spec.is_shutdown() {
+                return Ok(());
+            }
+            node_spec.set_shutdown(true);
+            node_spec.clone()
+        };
+
+        registry.store_obj(&node).await
     }
 
     /// Get node spec by its `NodeId`

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -645,6 +645,10 @@ impl NodeWrapper {
     pub(crate) fn is_online(&self) -> bool {
         self.status() == NodeStatus::Online
     }
+    /// Is the node offline.
+    pub(crate) fn is_offline(&self) -> bool {
+        self.status() == NodeStatus::Offline
+    }
 
     /// Load the node by fetching information from io-engine.
     pub(crate) async fn load(&mut self, startup: bool) -> Result<(), SvcError> {

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -511,7 +511,7 @@ impl NodeWrapper {
     }
     /// Get the node `NodeStatus`.
     pub(crate) fn status(&self) -> NodeStatus {
-        self.node_state().status().clone()
+        *self.node_state().status()
     }
 
     /// Get the node grpc endpoint as string.

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -75,7 +75,7 @@ impl OperationGuardArc<PoolSpec> {
         let error = match registry.node_wrapper(node).await {
             Ok(node) => {
                 let node_guard = node.read().await;
-                if !node_guard.is_online() {
+                if node_guard.is_offline() {
                     self.mark_as_offline(PoolError {
                         code: PoolErrorCode::NodeIsOffline,
                         msg: "".to_string(),
@@ -88,7 +88,17 @@ impl OperationGuardArc<PoolSpec> {
             Err(error) => error,
         };
 
-        self.mark_as_offline(PoolError {
+        if let Ok(node) = registry.specs().node(node) {
+            if node.is_shutdown() {
+                self.mark_as_offline(PoolError {
+                    code: PoolErrorCode::NodeIsOffline,
+                    msg: "".to_string(),
+                });
+                return Ok(Err(NodeStatus::Offline));
+            }
+        }
+
+        self.mark_as_unknown(PoolError {
             code: PoolErrorCode::NodeIsUnknown,
             msg: "".to_string(),
         });
@@ -110,6 +120,9 @@ impl OperationGuardArc<PoolSpec> {
     }
     fn mark_as_offline(&mut self, error: PoolError) {
         self.mark_as_diag(PoolStatus::Offline, error);
+    }
+    fn mark_as_unknown(&mut self, error: PoolError) {
+        self.mark_as_diag(PoolStatus::Unknown, error);
     }
     /// Mark the pool in [`PoolErrorCode::ImportDisabled`] since it cannot be
     /// imported due to being cordoned for imports.

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -213,7 +213,8 @@ fn test_deserialization_v1_to_v2() {
                 None,
                 None,
                 None,
-                None
+                None,
+                false
             )),
         },
         TestEntry {

--- a/control-plane/agents/src/bin/core/tests/node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/node/mod.rs
@@ -27,6 +27,7 @@ fn new_node(
             None,
             None,
             version.clone(),
+            false,
         )),
         Some(NodeState::new(
             id,

--- a/control-plane/agents/src/bin/core/tests/node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/node/mod.rs
@@ -120,7 +120,7 @@ async fn node() {
     assert_eq!(nodes.0.len(), 1);
     assert_eq!(
         nodes.0.first().unwrap(),
-        &Node::new(maya_name.clone(), node.spec().cloned(), None)
+        &Node::new(maya_name.clone(), node.spec().cloned(), None).with_shutdown(true)
     );
 }
 

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -429,16 +429,15 @@ async fn pool_larger_cluster_size() {
 
     cluster.composer().stop("io-engine-1").await.unwrap();
     cluster
-        .wait_node_status(NodeId::from("io-engine-1"), NodeStatus::Unknown)
+        .wait_node_status(NodeId::from("io-engine-1"), NodeStatus::Offline)
         .await
         .unwrap();
     cluster.composer().start("io-engine-1").await.unwrap();
     cluster.wait_pool_online(poolid.clone()).await.unwrap();
     let replicas = rep_client.get(Filter::None, None).await.unwrap();
-    replicas.into_inner().iter().all(|r| {
+    replicas.into_inner().iter().for_each(|r| {
         assert!(r.online());
         assert_eq!(r.space.as_ref().unwrap().cluster_size, POOL_BS_CLUSTER_SIZE);
-        true
     });
 }
 

--- a/control-plane/agents/src/bin/core/tests/pool/purge.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/purge.rs
@@ -24,7 +24,7 @@ async fn pool_purge() {
         .with_pools(2) // pool-1 for purge tests, pool-2 for normal delete
         .with_cache_period("100ms")
         .with_node_deadline("100ms")
-        .with_reconcile_period(Duration::from_millis(200), Duration::from_millis(1))
+        .with_reconcile_period(Duration::from_millis(100), Duration::from_millis(100))
         .build()
         .await
         .unwrap();
@@ -77,7 +77,7 @@ async fn pool_purge() {
     // --- Phase 2: io-engine offline ---
     cluster.composer().stop("io-engine-1").await.unwrap();
     cluster
-        .wait_node_status_tmo(cluster.node(0), NodeStatus::Unknown, NODE_OFFLINE_TIMEOUT)
+        .wait_node_status_tmo(cluster.node(0), NodeStatus::Offline, NODE_OFFLINE_TIMEOUT)
         .await
         .expect("Node should go offline");
 

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -1343,7 +1343,7 @@ async fn offline_node(cluster: &Cluster) {
         .await
         .unwrap_or_else(|_| panic!("The {kill_node} container should stop"));
     cluster
-        .wait_node_status(&NodeId::from(&kill_node), transport::NodeStatus::Unknown)
+        .wait_node_status(&NodeId::from(&kill_node), transport::NodeStatus::Offline)
         .await
         .unwrap();
 
@@ -1597,7 +1597,7 @@ async fn health() {
     // a stop is a clean shutdown and should be so marked in the health info!
     cluster.composer().stop(&cluster.node(1)).await.unwrap();
     cluster
-        .wait_node_status(cluster.node(1), transport::NodeStatus::Unknown)
+        .wait_node_status(cluster.node(1), transport::NodeStatus::Offline)
         .await
         .unwrap();
 

--- a/control-plane/grpc/proto/v1/node/target_node.proto
+++ b/control-plane/grpc/proto/v1/node/target_node.proto
@@ -15,6 +15,8 @@ message Node {
   optional NodeSpec spec = 2;
   // Runtime state of the node.
   optional NodeState state = 3;
+  // Perceived status of the node.
+  optional NodeStatus status = 4;
 }
 
 message NodeSpec {

--- a/control-plane/grpc/proto/v1/node/target_node.proto
+++ b/control-plane/grpc/proto/v1/node/target_node.proto
@@ -30,6 +30,8 @@ message NodeSpec {
   optional string node_nqn = 5;
   // the io-engine version
   optional string version = 6;
+  // If the node has signaled shutdown by sending deregistration message
+  optional bool shutdown = 7;
 }
 
 message NodeState {
@@ -72,7 +74,7 @@ message GetNodesRequest {
   bool ignore_notfound = 2;
 }
 
-// Reponse to the GetNodes request
+// Response to the GetNodes request
 message GetNodesReply {
   oneof reply {
     Nodes nodes = 1;

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -97,6 +97,7 @@ impl TryFrom<node::Node> for Node {
                 None,
                 None,
                 spec.version,
+                spec.shutdown.unwrap_or_default(),
             )),
             None => None,
         };
@@ -182,6 +183,7 @@ impl From<Node> for node::Node {
             },
             node_nqn: types_v0_spec.node_nqn().as_ref().map(|nqn| nqn.to_string()),
             version: types_v0_spec.version().clone(),
+            shutdown: Some(types_v0_spec.is_shutdown()),
         });
         let grpc_node_state = match types_v0_node.state() {
             None => None,

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -188,7 +188,7 @@ impl From<Node> for node::Node {
         let grpc_node_state = match types_v0_node.state() {
             None => None,
             Some(types_v0_state) => {
-                let grpc_node_status: node::NodeStatus = types_v0_state.status.clone().into();
+                let grpc_node_status: node::NodeStatus = types_v0_state.status.into();
                 Some(node::NodeState {
                     node_id: types_v0_state.id.to_string(),
                     endpoint: types_v0_state.grpc_endpoint.to_string(),
@@ -202,6 +202,7 @@ impl From<Node> for node::Node {
             node_id: types_v0_node.id().to_string(),
             spec: grpc_node_spec,
             state: grpc_node_state,
+            status: Some(node::NodeStatus::from(types_v0_node.status()) as i32),
         }
     }
 }

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -76,11 +76,7 @@ impl CreateRow for openapi::models::Node {
         let state = self.state.clone().unwrap_or(openapi::models::NodeState {
             id: spec.id,
             grpc_endpoint: spec.grpc_endpoint,
-            status: if spec.shutdown == Some(true) {
-                openapi::models::NodeStatus::Offline
-            } else {
-                openapi::models::NodeStatus::Unknown
-            },
+            status: self.status.unwrap_or_default(),
             node_nqn: spec.node_nqn,
             version: spec.version,
         });

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -76,7 +76,11 @@ impl CreateRow for openapi::models::Node {
         let state = self.state.clone().unwrap_or(openapi::models::NodeState {
             id: spec.id,
             grpc_endpoint: spec.grpc_endpoint,
-            status: openapi::models::NodeStatus::Unknown,
+            status: if spec.shutdown == Some(true) {
+                openapi::models::NodeStatus::Offline
+            } else {
+                openapi::models::NodeStatus::Unknown
+            },
             node_nqn: spec.node_nqn,
             version: spec.version,
         });

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3371,6 +3371,8 @@ components:
           $ref: '#/components/schemas/NodeSpec'
         state:
           $ref: '#/components/schemas/NodeState'
+        status:
+          $ref: '#/components/schemas/NodeStatus'
       required:
         - id
     PoolStatus:

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3330,6 +3330,9 @@ components:
         version:
           description: Version of the io-engine instance
           type: string
+        shutdown:
+          description: Set when the node has deregistered.
+          type: boolean
       additionalProperties: false
       required:
         - grpcEndpoint

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -112,6 +112,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
             cordondrainstate: None,
             node_nqn: Some(HostNqn::from_nodename(&io_engine1.to_string()).to_string()),
             version: version.clone(),
+            shutdown: Some(false),
         }),
         state: Some(models::NodeState {
             id: io_engine1.to_string(),

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -124,6 +124,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
             node_nqn: Some(HostNqn::from_nodename(&io_engine1.to_string()).to_string()),
             version,
         }),
+        status: Some(models::NodeStatus::Online),
     };
     assert_eq!(listed_node, node);
 
@@ -435,7 +436,11 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
 
     test.stop("io-engine-1").await.unwrap();
     wait_until_node_not_online(&client, &io_engine1, Duration::from_secs(1)).await;
-    node.state.as_mut().unwrap().status = models::NodeStatus::Unknown;
+    node.state.as_mut().unwrap().status = models::NodeStatus::Offline;
+    node.status = Some(models::NodeStatus::Offline);
+    if let Some(ref mut spec) = node.spec {
+        spec.shutdown = Some(true);
+    }
     assert_eq!(
         client
             .nodes_api()

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -195,6 +195,9 @@ pub struct NodeSpec {
     /// Version of the io-engine.
     #[serde(skip_serializing_if = "Option::is_none")]
     version: Option<String>,
+    /// If the node has signaled shutdown by sending deregistration message.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    shutdown: bool,
 }
 
 impl NodeSpec {
@@ -223,6 +226,7 @@ impl NodeSpec {
             features,
             bugfixes,
             version,
+            shutdown: false,
         }
     }
 
@@ -278,6 +282,10 @@ impl NodeSpec {
     /// Set Node version.
     pub fn set_version(&mut self, version: Option<String>) {
         self.version = version;
+    }
+    /// Set as true when the node has deregistered itself.
+    pub fn set_shutdown(&mut self, shutdown: bool) {
+        self.shutdown = shutdown;
     }
 
     /// Ensure the state is consistent with the labels.
@@ -507,6 +515,11 @@ impl NodeSpec {
             None => false,
             Some(bugfixes) => bugfixes.contains(fix),
         }
+    }
+
+    /// Returns whether the node is shutdown.
+    pub fn is_shutdown(&self) -> bool {
+        self.shutdown
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -212,6 +212,7 @@ impl NodeSpec {
         features: Option<NodeFeatures>,
         bugfixes: Option<NodeBugFixes>,
         version: Option<String>,
+        shutdown: bool,
     ) -> Self {
         Self {
             id,
@@ -226,7 +227,7 @@ impl NodeSpec {
             features,
             bugfixes,
             version,
-            shutdown: false,
+            shutdown,
         }
     }
 
@@ -537,6 +538,7 @@ impl From<NodeSpec> for models::NodeSpec {
             src.cordon_drain_state.into_opt(),
             src.node_nqn.into_opt(),
             src.version,
+            src.shutdown,
         )
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -101,6 +101,13 @@ impl Node {
     pub fn state(&self) -> Option<&NodeState> {
         self.state.as_ref()
     }
+    /// Set the shutdown flag.
+    pub fn with_shutdown(mut self, shutdown: bool) -> Self {
+        if let Some(ref mut spec) = self.spec {
+            spec.set_shutdown(shutdown);
+        }
+        self
+    }
 }
 
 impl From<Node> for models::Node {

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -93,6 +93,18 @@ impl Node {
     pub fn id(&self) -> &NodeId {
         &self.id
     }
+    /// Get perceived status of the node.
+    /// Either the status as determined from the state or the perceived status via
+    /// the node spec shutdown flag.
+    pub fn status(&self) -> NodeStatus {
+        match &self.state {
+            Some(state) => state.status,
+            None => match &self.spec {
+                Some(spec) if spec.is_shutdown() => NodeStatus::Offline,
+                _ => NodeStatus::Unknown,
+            },
+        }
+    }
     /// Get the node specification
     pub fn spec(&self) -> Option<&NodeSpec> {
         self.spec.as_ref()
@@ -112,12 +124,18 @@ impl Node {
 
 impl From<Node> for models::Node {
     fn from(src: Node) -> Self {
-        Self::new_all(src.id, src.spec.map(Into::into), src.state.map(Into::into))
+        let status = src.status();
+        Self::new_all(
+            src.id,
+            src.spec.map(Into::into),
+            src.state.map(Into::into),
+            Some(status.into()),
+        )
     }
 }
 
 /// Status of the Node
-#[derive(Serialize, Deserialize, Debug, Clone, EnumString, Display, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, EnumString, Display, Eq, PartialEq)]
 pub enum NodeStatus {
     /// Node has unexpectedly disappeared
     Unknown,

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -410,7 +410,7 @@ impl Cluster {
     /// Replace the given old node with a new one from the idles.
     pub async fn replace_node(&self, old: NodeId, new: NodeId) -> Result<(), ()> {
         self.composer().stop(&old).await.unwrap();
-        self.wait_node_status(old, NodeStatus::Unknown)
+        self.wait_node_status(old, NodeStatus::Offline)
             .await
             .unwrap();
         self.composer().start(&new).await.unwrap();

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -281,7 +281,7 @@ impl Cluster {
                 if node.state().map(|n| &n.status) == Some(&status) {
                     return Ok(());
                 }
-                seen_status = node.state().map(|n| n.status.clone());
+                seen_status = node.state().map(|n| n.status);
             }
             if std::time::Instant::now() > (start + timeout) {
                 break;


### PR DESCRIPTION

    feat: add perceived node status to internal and public api
    
    This allows caller to quickly glance the perceived node status,
    without having to check state is missing and infer by itself
    that the node is offline/unknown.
    
    Instead the api fills the correct status by checking the state
    and other checking if the node was shutdown or otherwise.
    
---

    test: take into account new node shutdown state changes
    
    When a node is gracefully shutdown its state now transitions to Offline
    in the registry and also shutdown is persisted to the pstor and then
    exposed via the public api.
    
---

    feat: expose node shutdown via openapi
    
---

    feat: shutdown flag to the io-engine node
    
    When a node deregisters itself, mark it as shutdown.
    
---

    fix(diag): when node is unknown mark pool as unknown as well
