### PR TITLE
feat(csi): allow restoring snapshots to larger PVCs

### DIFF
--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -122,6 +122,8 @@ pub(crate) struct RegistryInner<S: Store> {
     /// Blobstore cluster size(in bytes) required for pool creation and replica scheduling. This is
     /// not per-pool.
     pool_cluster_size: Option<u32>,
+    /// Enable snapshot clone resize to larger PVC sizes.
+    enable_snapshot_resize_on_clone: bool,
     deprecated_access_mode: bool,
     /// Running in simulation mode.
     sim_args: Option<SimArgs>,
@@ -154,6 +156,7 @@ impl Registry {
         allow_non_persistent_devlinks: bool,
         encrypted_pools_soft_scheduling: bool,
         pool_cluster_size: Option<u32>,
+        enable_snapshot_resize_on_clone: bool,
         deprecated_access_mode: bool,
         sim_args: Option<SimArgs>,
     ) -> Result<Self, SvcError> {
@@ -218,6 +221,7 @@ impl Registry {
                 allow_non_persistent_devlinks,
                 encrypted_pools_soft_scheduling,
                 pool_cluster_size: pool_cluster_size.or(Some(POOL_BS_CLUSTER_SIZE_DEFAULT)),
+                enable_snapshot_resize_on_clone,
                 deprecated_access_mode,
                 sim_args,
             }),
@@ -264,6 +268,11 @@ impl Registry {
     /// Get the configured pool cluster_size.
     pub(crate) fn pool_cluster_size(&self) -> Option<u32> {
         self.pool_cluster_size
+    }
+
+    /// Check if snapshot resize on clone is enabled.
+    pub(crate) fn snapshot_resize_on_clone_enabled(&self) -> bool {
+        self.enable_snapshot_resize_on_clone
     }
 
     /// Check if the partial rebuilds are disabled.

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -163,6 +163,12 @@ pub(crate) struct CliArgs {
     #[clap(long)]
     pool_cluster_size: Option<u32>,
 
+    /// Enable restoring snapshots to PVCs larger than the source volume.
+    /// When enabled, snapshot clones are created at the snapshot size and then
+    /// resized to the requested PVC size.
+    #[clap(long, env = "ENABLE_SNAPSHOT_RESIZE_ON_CLONE")]
+    pub(crate) enable_snapshot_resize_on_clone: bool,
+
     /// Allow any hostnqn access with single node access.
     /// This is to be used for testing only.
     #[clap(long)]
@@ -286,6 +292,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.allow_non_persistent_devlink,
         cli_args.encrypted_pools_soft_scheduling,
         cli_args.pool_cluster_size,
+        cli_args.enable_snapshot_resize_on_clone,
         cli_args.deprecated_access_mode,
         sim_args,
     )

--- a/control-plane/agents/src/bin/core/volume/clone_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/clone_operations.rs
@@ -108,7 +108,7 @@ impl CreateVolumeExeVal for SnapshotCloneOp<'_> {
         snafu::ensure!(new_volume.thin, errors::ClonedSnapshotVolumeThin {});
         snafu::ensure!(snapshot.status().created(), errors::SnapshotNotCreated {});
         snafu::ensure!(
-            new_volume.size == snapshot.metadata().spec_size(),
+            new_volume.size >= snapshot.metadata().spec_size(),
             errors::ClonedSnapshotVolumeSize {}
         );
 

--- a/control-plane/agents/src/bin/core/volume/service.rs
+++ b/control-plane/agents/src/bin/core/volume/service.rs
@@ -598,8 +598,27 @@ impl Service {
         let mut snapshot = self.specs().volume_snapshot(snap_uuid).await?;
         let cluster_size_for_clone_vol =
             snapshot.pool_cluster_size_for_clone(&self.registry).await?;
+        let snapshot_size = snapshot.as_ref().metadata().spec_size();
+        let requested_size = request.params().size;
         request.params_mut().cluster_size = Some(cluster_size_for_clone_vol);
+
+        let resize_after_clone = self.registry.snapshot_resize_on_clone_enabled()
+            && requested_size > snapshot_size;
+
+        if resize_after_clone {
+            request.params_mut().size = snapshot_size;
+        }
         snapshot.create_clone(&self.registry, request).await?;
+
+        if resize_after_clone {
+            let resize_req = ResizeVolume::new(
+                request.params().uuid.clone(),
+                requested_size,
+                None,
+            );
+            self.resize_volume(&resize_req).await?;
+        }
+
         self.registry.volume(&request.params().uuid).await
     }
 

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -396,7 +396,7 @@ pub enum SvcError {
     SnapshotMaxTransactions { snap_id: String },
     #[snafu(display("Cloned snapshot volumes must be thin provisioned"))]
     ClonedSnapshotVolumeThin {},
-    #[snafu(display("Cloned snapshot volume must match the snapshot size"))]
+    #[snafu(display("Cloned snapshot volume size must be greater than or equal to the snapshot size"))]
     ClonedSnapshotVolumeSize {},
     #[snafu(display("Cloned snapshot volume only supported for 1 replica"))]
     ClonedSnapshotVolumeRepl {},


### PR DESCRIPTION
## Problem

The CSI spec ([section 5.5, CreateVolume](https://github.com/container-storage-interface/spec/blob/master/spec.md#createvolume)) permits restoring a snapshot to a volume of equal **or greater** size. However, the control plane currently enforces an exact size match between the new volume and the snapshot, causing `CreateVolume` to fail whenever a PVC requests more capacity than the source snapshot.

This is a common scenario when users want to restore data into a larger volume (e.g., expanding storage during a migration or restore).

## Solution

1. **Relax the pre-flight validation** in `clone_operations.rs` from `==` to `>=`, so requests for larger volumes are not rejected upfront.

2. **Create-then-resize strategy** in `service.rs`: when the requested size exceeds the snapshot size, create the clone at the snapshot size first (so the volume spec matches the replica), then resize both spec and replicas to the requested size. This avoids the mismatch where `create_clone` sets the spec size but the replica remains at snapshot size.

3. **Feature flag**: the resize-after-clone logic is gated behind a new `--enable-snapshot-resize-on-clone` CLI flag (env: `ENABLE_SNAPSHOT_RESIZE_ON_CLONE`) that defaults to **disabled**, preserving current behavior for existing deployments.

## Changes

| File | Change |
|------|--------|
| `clone_operations.rs` | `==` -> `>=` size check |
| `service.rs` | Create clone at snapshot size, then resize if flag enabled |
| `registry.rs` | Store and expose the feature flag |
| `main.rs` | Add `--enable-snapshot-resize-on-clone` CLI arg |
| `errors.rs` | Update error message to reflect `>=` semantics |

## Testing

- Tested on a production Mayastor cluster with a snapshot from a 5Gi PVC restored to a 10Gi PVC
- Verified the cloned volume is created at snapshot size, then resized to the requested size
- Confirmed that without the flag, existing behavior (exact match only) is preserved
- Confirmed that restoring to a PVC of equal size still works as before

----