### PR TITLE
feat(k8s/operator): add support for pool Purge via the DiskPool operator

### DIFF
--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -9,9 +9,11 @@ use crate::diskpool::crd::v1beta3::{
 use openapi::{
     apis::StatusCode,
     clients, models,
-    models::{rest_json_error::Kind, CreatePoolBody, Encryption, EncryptionSecret, Pool},
+    models::{
+        rest_json_error::Kind, CreatePoolBody, DeletePoolBody, Encryption, EncryptionSecret, Pool,
+    },
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 use utils::{disk::normalize_disk, dsp_created_by_key};
 
 use chrono::Utc;
@@ -32,6 +34,386 @@ use std::{
 
 const WHO_AM_I: &str = "DiskPool Operator";
 const WHO_AM_I_SHORT: &str = "dsp-operator";
+
+/// Annotation key for declarative pool deletion options.
+///
+/// The value is a comma-separated list of `key=value` pairs. Bare keys
+/// (without `=`) are treated as `key=true`. Options are processed left to
+/// right and latter options take precedence.
+///
+/// Supported keys:
+///   purge                - Force removal without contacting io-engine.
+///   accept               - Confirm deletion of replicas owned by volumes.
+///   accept-volume-loss   - Confirm volume data loss.
+///   accept-snapshot-loss - Confirm snapshot data loss.
+///   accept-data-loss     - Shorthand: sets both accept-volume-loss and
+///                          accept-snapshot-loss.
+///   purge-accept-all     - Shorthand: sets purge, accept, accept-volume-loss,
+///                          and accept-snapshot-loss.
+///
+/// Examples:
+/// ```
+/// openebs.io/delete-opts: purge=true,accept=true,accept-data-loss=true
+/// openebs.io/delete-opts: purge-accept-all
+/// openebs.io/delete-opts: purge-accept-all,accept-volume-loss=false
+/// ```
+const DELETE_OPTS_ANNOTATION: &str = "openebs.io/delete-opts";
+
+/// Recognised keys in the `openebs.io/delete-opts` annotation value.
+#[derive(Debug)]
+enum DeleteOptKey {
+    /// Force removal without contacting io-engine.
+    Purge,
+    /// Confirm deletion of replicas owned by volumes.
+    Accept,
+    /// Confirm volume data loss.
+    AcceptVolumeLoss,
+    /// Confirm snapshot data loss.
+    AcceptSnapshotLoss,
+    /// Shorthand: sets both `AcceptVolumeLoss` and `AcceptSnapshotLoss`.
+    AcceptDataLoss,
+    /// Shorthand: sets `Purge`, `Accept`, `AcceptVolumeLoss`, and `AcceptSnapshotLoss`.
+    PurgeAcceptAll,
+}
+
+impl DeleteOptKey {
+    fn parse(s: &str) -> Result<Self, Error> {
+        match s {
+            "purge" => Ok(Self::Purge),
+            "accept" => Ok(Self::Accept),
+            "accept-volume-loss" => Ok(Self::AcceptVolumeLoss),
+            "accept-snapshot-loss" => Ok(Self::AcceptSnapshotLoss),
+            "accept-data-loss" => Ok(Self::AcceptDataLoss),
+            "purge-accept-all" => Ok(Self::PurgeAcceptAll),
+            _ => Err(Error::Generic {
+                message: format!(
+                    "unknown key '{s}' in '{DELETE_OPTS_ANNOTATION}' annotation. \
+                     Valid keys: purge, accept, accept-volume-loss, accept-snapshot-loss, \
+                     accept-data-loss, purge-accept-all"
+                ),
+            }),
+        }
+    }
+}
+
+/// Parse the `openebs.io/delete-opts` annotation value into a `DeletePoolBody`.
+///
+/// Returns `Some(body)` only when `purge` is set to `true`.
+/// A normal (non-purge) deletion must not send a request body, so any
+/// annotation that omits `purge` or sets it to `false` yields `None`.
+fn parse_delete_opts_value(input: &str) -> Result<Option<DeletePoolBody>, Error> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(None);
+    }
+
+    let mut purge = None;
+    let mut accept = None;
+    let mut accept_volume_loss = None;
+    let mut accept_snapshot_loss = None;
+
+    for token in input.split(',') {
+        let token = token.trim();
+        if token.is_empty() {
+            continue;
+        }
+
+        let (key_str, value) = match token.split_once('=') {
+            Some((k, v)) => (k.trim(), v.trim()),
+            None => (token, "true"),
+        };
+
+        let key = DeleteOptKey::parse(key_str)?;
+
+        let bool_val = value.parse::<bool>().map_err(|_| Error::Generic {
+            message: format!(
+                "invalid value '{value}' for key '{key_str}' in '{DELETE_OPTS_ANNOTATION}' \
+                 annotation: expected 'true' or 'false'"
+            ),
+        })?;
+
+        match key {
+            DeleteOptKey::PurgeAcceptAll => {
+                purge = Some(bool_val);
+                accept = Some(bool_val);
+                accept_volume_loss = Some(bool_val);
+                accept_snapshot_loss = Some(bool_val);
+            }
+            DeleteOptKey::Purge => purge = Some(bool_val),
+            DeleteOptKey::Accept => accept = Some(bool_val),
+            DeleteOptKey::AcceptDataLoss => {
+                accept_volume_loss = Some(bool_val);
+                accept_snapshot_loss = Some(bool_val);
+            }
+            DeleteOptKey::AcceptVolumeLoss => accept_volume_loss = Some(bool_val),
+            DeleteOptKey::AcceptSnapshotLoss => accept_snapshot_loss = Some(bool_val),
+        }
+    }
+
+    // Only produce a body when purge is explicitly requested.
+    // Normal deletion expects no body (server returns 204).
+    if purge != Some(true) {
+        return Ok(None);
+    }
+
+    Ok(Some(DeletePoolBody {
+        purge,
+        accept,
+        accept_volume_loss,
+        accept_snapshot_loss,
+    }))
+}
+
+/// Guidance for the user when a pool delete fails with a recoverable error.
+struct PurgeGuidance {
+    /// Short, bounded message for K8s events (cause + remediation command).
+    /// Must not include variable-length data like volume/snapshot lists.
+    event: String,
+    /// Full message for operator logs, may include unbounded details such
+    /// as affected volume and snapshot lists from the REST error body.
+    log: PurgeGuidanceLog,
+}
+
+struct PurgeGuidanceLog {
+    msg: String,
+    example_command: Option<String>,
+}
+
+/// Return user-facing guidance when a pool delete fails with a recoverable
+/// error that the user can fix by cordoning or updating the annotation.
+///
+/// Returns `None` for errors that are not actionable (transient failures,
+/// internal errors, etc.) — those are logged by the normal error path.
+fn purge_error_guidance(
+    pool_name: &str,
+    ns: &str,
+    error: &clients::tower::Error<models::RestJsonError>,
+) -> Option<PurgeGuidance> {
+    // Compile-time validated event message formatter.
+    //
+    // Asserts at compile time that the format template, with pool_name and ns
+    // each at their maximum K8s name length (63 chars), fits within the K8s
+    // event message size limit. The literal length already includes placeholder
+    // syntax (e.g. `{pool_name}` = 11 chars, `{ns}` = 4 chars), so adding
+    // 2 × MAX_K8S_NAME_LEN is a safe overestimate. Any template that would
+    // overflow with max-length names will fail the build.
+    macro_rules! event_msg {
+        ($fmt:literal, pool_name = $pn:expr, ns = $ns:expr) => {{
+            // Maximum length of a Kubernetes resource name (RFC 1123 DNS label).
+            #[allow(dead_code)]
+            const MAX_K8S_NAME_LEN: usize = 63;
+            const _: () = assert!(
+                $fmt.len() + 2 * MAX_K8S_NAME_LEN <= MAX_EVENT_MESSAGE_BYTES,
+                "event message template may exceed K8s event size limit with max-length names"
+            );
+            format!($fmt, pool_name = $pn, ns = $ns)
+        }};
+        ($fmt:literal) => {{
+            const _: () = assert!(
+                $fmt.len() <= MAX_EVENT_MESSAGE_BYTES,
+                "event message template exceeds K8s event size limit"
+            );
+            $fmt.to_string()
+        }};
+    }
+
+    let body = error.error_body()?;
+    let details = if body.details.is_empty() {
+        String::new()
+    } else {
+        format!("\n  {}", body.details)
+    };
+
+    match body.kind {
+        Kind::Unavailable => {
+            let event = event_msg!(
+                "Pool is offline, normal deletion is not possible: \
+                 to purge, annotate the DiskPool CR with delete options."
+            );
+            let msg = format!(
+                "Pool is offline, normal deletion is not possible. \
+                 To purge, annotate the DiskPool CR with delete options:\n \
+                 -------------------\n \
+                 Example annotation:\n \
+                 -------------------\n   \
+                 {DELETE_OPTS_ANNOTATION}: purge=true\n\n",
+            );
+            let example_command = Some(format!(
+                "kubectl annotate dsp {pool_name} -n {ns} \
+                 {DELETE_OPTS_ANNOTATION}=purge=true --overwrite"
+            ));
+            Some(PurgeGuidance {
+                event,
+                log: PurgeGuidanceLog {
+                    msg,
+                    example_command,
+                },
+            })
+        }
+        Kind::PoolNotPurgeable => {
+            let event = event_msg!(
+                "Cannot purge: pool state is known (Online/Degraded/Faulted/Suspected). \
+                 Purge is only allowed when pool state is Unknown or Offline. \
+                 Remove the delete options annotation to use normal deletion."
+            );
+            let msg = "Cannot purge: pool state is known (Online/Degraded/Faulted/Suspected). \
+                 Purge is only allowed when pool state is Unknown or Offline. \
+                 Remove the annotation to use normal deletion:\n"
+                .to_string();
+            let example_command = Some(format!(
+                "kubectl annotate dsp {pool_name} -n {ns} {DELETE_OPTS_ANNOTATION}-"
+            ));
+            Some(PurgeGuidance {
+                event,
+                log: PurgeGuidanceLog {
+                    msg,
+                    example_command,
+                },
+            })
+        }
+        Kind::PoolNotCordoned => {
+            let event = event_msg!(
+                "Cannot purge: pool is not cordoned. \
+                 The operator should have cordoned the pool automatically \
+                 — this will be retried."
+            );
+            let msg = event.clone();
+            let example_command = None;
+            Some(PurgeGuidance {
+                event,
+                log: PurgeGuidanceLog {
+                    msg,
+                    example_command,
+                },
+            })
+        }
+        Kind::PoolCordonInsufficient => {
+            let event = event_msg!(
+                "Cannot purge: pool cordon does not block both replica \
+                 placement and snapshot creation. The operator should have \
+                 cordoned the pool automatically — this will be retried."
+            );
+            let msg = event.clone();
+            let example_command = None;
+            Some(PurgeGuidance {
+                event,
+                log: PurgeGuidanceLog {
+                    msg,
+                    example_command,
+                },
+            })
+        }
+        Kind::PoolPurgeAcceptRequired => {
+            let event = event_msg!(
+                "Cannot purge: pool has replicas owned by volumes. \
+                 Set 'accept=true' in the delete options annotation."
+            );
+            let msg = format!(
+                "Cannot purge: pool has replicas owned by volumes. \
+                 Set 'accept=true' in the delete options annotation:\n \
+                 -------------------\n \
+                 Example annotation:\n \
+                 -------------------\n   \
+                 {DELETE_OPTS_ANNOTATION}: purge=true,accept=true\n\n"
+            );
+            let example_command = Some(format!(
+                "kubectl annotate dsp {pool_name} -n {ns} \
+                 {DELETE_OPTS_ANNOTATION}=purge=true,accept=true --overwrite"
+            ));
+            Some(PurgeGuidance {
+                event,
+                log: PurgeGuidanceLog {
+                    msg,
+                    example_command,
+                },
+            })
+        }
+        Kind::PoolPurgeVolumeLossAcceptRequired => {
+            let event = event_msg!(
+                "Cannot purge: volumes would lose their last healthy replica. \
+                 Set 'accept-volume-loss=true' to accept this volume data loss \
+                 and move ahead with pool purge. (Alternatively, set \
+                 'accept-data-loss=true' to accept the loss of volume data and \
+                 snapshot data)."
+            );
+            let msg = format!(
+                "Cannot purge: volumes would lose their last healthy replica.{details}\n\
+                 Set 'accept-volume-loss=true' to accept this volume data loss \
+                 and move ahead with pool purge. (Alternatively, set \
+                 'accept-data-loss=true' to accept the loss of volume data and \
+                 snapshot data):\n \
+                 -------------------\n \
+                 Example annotation:\n \
+                 -------------------\n   \
+                 {DELETE_OPTS_ANNOTATION}: purge=true,accept=true,accept-data-loss=true\n\n"
+            );
+            let example_command = Some(format!(
+                "kubectl annotate dsp {pool_name} -n {ns} \
+                 {DELETE_OPTS_ANNOTATION}=purge=true,accept=true,accept-data-loss=true --overwrite"
+            ));
+            Some(PurgeGuidance {
+                event,
+                log: PurgeGuidanceLog {
+                    msg,
+                    example_command,
+                },
+            })
+        }
+        Kind::PoolPurgeSnapshotLossAcceptRequired => {
+            let event = event_msg!(
+                "Cannot purge: snapshots would lose their last replica snapshot. \
+                 Set 'accept-snapshot-loss=true' to accept this snapshot data loss \
+                 and move ahead with pool purge. (Alternatively, set \
+                 'accept-data-loss=true' to accept the loss of volume data and \
+                 snapshot data)."
+            );
+            let msg = format!(
+                "Cannot purge: snapshots would lose their last replica snapshot.{details}\n\
+                 Set 'accept-snapshot-loss=true' to accept this snapshot data loss \
+                 and move ahead with pool purge. (Alternatively, set \
+                 'accept-data-loss=true' to accept the loss of volume data and \
+                 snapshot data):\n \
+                 -------------------\n \
+                 Example annotation:\n \
+                 -------------------\n   \
+                 {DELETE_OPTS_ANNOTATION}: purge=true,accept=true,accept-data-loss=true\n\n"
+            );
+            let example_command = Some(format!(
+                "kubectl annotate dsp {pool_name} -n {ns} \
+                 {DELETE_OPTS_ANNOTATION}=purge=true,accept=true,accept-data-loss=true --overwrite"
+            ));
+            Some(PurgeGuidance {
+                event,
+                log: PurgeGuidanceLog {
+                    msg,
+                    example_command,
+                },
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Maximum byte length for a K8s event message.
+/// The API server rejects events whose message exceeds ~1 KiB.
+const MAX_EVENT_MESSAGE_BYTES: usize = 1024;
+
+/// Truncate a message to fit within the K8s event message size limit.
+/// If truncated, appends "..." to indicate the message was cut.
+///
+/// Applied inside `k8s_notify` as a runtime safety net for dynamic messages.
+/// Handwritten guidance templates are validated at compile time via `event_msg!`.
+fn truncate_for_event(msg: &str) -> String {
+    if msg.len() <= MAX_EVENT_MESSAGE_BYTES {
+        return msg.to_string();
+    }
+    let mut end = MAX_EVENT_MESSAGE_BYTES - 3;
+    // Avoid splitting a multi-byte UTF-8 character.
+    while end > 0 && !msg.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &msg[..end])
+}
 
 /// Additional per resource context during the runtime; it is volatile
 #[derive(Clone)]
@@ -160,16 +542,14 @@ impl ResourceContext {
         Ok(Action::await_change())
     }
 
-    /// Remove pool from control plane if exist, Then delete it from map.
+    /// Delete pool from the control plane (if it exists) and remove from inventory.
     #[tracing::instrument(fields(name = resource.name_any()), skip(resource))]
     pub(crate) async fn delete_finalizer(
         resource: ResourceContext,
-        attempt_delete: bool,
+        delete_body: Option<DeletePoolBody>,
     ) -> Result<Action, Error> {
         let ctx = resource.ctx.clone();
-        if attempt_delete {
-            resource.delete_pool().await?;
-        }
+        resource.delete_pool(delete_body).await?;
         if ctx.remove(resource.name_any()).await.is_none() {
             // In an unlikely event where we cant remove from inventory. We will requeue and
             // reattempt again in 10 seconds.
@@ -274,6 +654,133 @@ impl ResourceContext {
             .await
             .map_err(|source| Error::Kube { source })?;
         Ok(())
+    }
+
+    /// Parse the `openebs.io/delete-opts` annotation from a DiskPool resource.
+    ///
+    /// Takes a `&DiskPool` explicitly so the caller can pass the freshest copy
+    /// (e.g. `dsp` from a finalizer Cleanup event rather than a potentially stale
+    /// `self`).
+    ///
+    /// Returns `Some(DeletePoolBody)` if the annotation is present, valid, and
+    /// contains `purge=true`. Returns `None` if the annotation is absent or if
+    /// `purge` is not set to `true` — in both cases the caller should proceed
+    /// with a normal (body-less) deletion.
+    ///
+    /// Returns an error if the annotation is present but contains invalid syntax.
+    /// The caller must not silently fall back to normal deletion on error —
+    /// if the user set the annotation they intended purge, and a malformed
+    /// annotation should block deletion until the user fixes it.
+    fn parse_delete_opts(dsp: &DiskPool) -> Result<Option<DeletePoolBody>, Error> {
+        let annotations = match dsp.metadata.annotations.as_ref() {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+        let value = match annotations.get(DELETE_OPTS_ANNOTATION) {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+        let body = parse_delete_opts_value(value)?;
+        if let Some(ref b) = body {
+            trace!(name = dsp.name_any(), ?b, "parsed delete-opts annotation");
+        }
+        Ok(body)
+    }
+
+    /// Cordon the pool for replicas and snapshots before a purge deletion.
+    ///
+    /// Purge requires the pool to be cordoned so no new replicas or snapshots
+    /// are scheduled while resources are being cleaned up. The operator
+    /// handles this automatically so the user does not need to run a separate
+    /// cordon command.
+    ///
+    /// Idempotent: if the pool is already cordoned with the required
+    /// constraints, the `AlreadyExists` response is treated as success.
+    async fn cordon_for_purge(&self) -> Result<(), Error> {
+        let pool_name = self.name_any();
+        let body = models::PoolCordonReq::new_all(
+            true,  // replicas
+            true,  // snapshots
+            false, // restores (implicitly blocked by replica placement block)
+            false, // import
+        );
+        match self.pools_api().put_pool_cordon(&pool_name, body).await {
+            Ok(_) => {
+                info!(
+                    pool.name = %pool_name,
+                    "cordoned pool for replicas and snapshots before purge"
+                );
+                self.k8s_notify(
+                    "Destroy",
+                    "Cordoned",
+                    "Pool cordoned for replicas and snapshots before purge",
+                    "Normal",
+                )
+                .await;
+                Ok(())
+            }
+            Err(error) if error.error_body().map(|b| b.kind) == Some(Kind::AlreadyExists) => {
+                info!(
+                    pool.name = %pool_name,
+                    "pool already cordoned, proceeding with purge"
+                );
+                Ok(())
+            }
+            Err(error) => {
+                let msg = format!("Failed to cordon pool before purge: {error}");
+                error!(pool.name = %pool_name, "{msg}");
+                self.k8s_notify("Destroy", "CordonFailed", &msg, "Warning")
+                    .await;
+                Err(error.into())
+            }
+        }
+    }
+
+    /// Mark pool as Deleted when its spec has been removed from the control plane.
+    async fn mark_deleted(&self) -> Result<Action, Error> {
+        self.patch_status(DiskPoolStatus::deleted().with_conditions(self))
+            .await?;
+        Ok(Action::requeue(Duration::from_secs(self.ctx.interval)))
+    }
+
+    /// Remove the operator's finalizer from the CR.
+    ///
+    /// Called when the CR is in `Deleted` state — the pool spec is already gone
+    /// from the control plane, so there is nothing for the finalizer to clean up.
+    /// Stripping it allows the user to `kubectl delete dsp` without the
+    /// operator needing to be running.
+    pub(crate) async fn strip_finalizer(&self) -> Result<Action, Error> {
+        let finalizer_name = utils::constants::dsp_finalizer();
+        let current = self.metadata.finalizers.as_deref().unwrap_or_default();
+        if !current.contains(&finalizer_name) {
+            return Ok(Action::await_change());
+        }
+        let remaining: Vec<&String> = current.iter().filter(|f| **f != finalizer_name).collect();
+        let patch = Patch::Merge(json!({
+            "metadata": {
+                "finalizers": remaining
+            }
+        }));
+        let ps = PatchParams::default();
+        match self.api().patch(&self.name_any(), &ps, &patch).await {
+            Ok(_) => {
+                info!(
+                    name = self.name_any(),
+                    "stripped finalizer from orphaned CR"
+                );
+            }
+            // The user may delete the DiskPool CR immediately after the pool
+            // is removed. It's expected that the CR can disappear between
+            // reconciles, so a 404 here is not an error.
+            Err(kube::Error::Api(e)) if e.code == StatusCode::NOT_FOUND => {
+                tracing::warn!(
+                    name = self.name_any(),
+                    "CR already deleted, finalizer strip not needed"
+                );
+            }
+            Err(source) => return Err(Error::Kube { source }),
+        }
+        Ok(Action::await_change())
     }
 
     /// Patch the resource state to creating.
@@ -509,23 +1016,36 @@ impl ResourceContext {
         Err(error.into())
     }
 
-    /// Delete the pool from the io-engine instance
-    #[tracing::instrument(fields(name = self.name_any(), status = ?self.status), skip(self))]
-    async fn delete_pool(&self) -> Result<Action, Error> {
+    /// Delete the pool via the REST API.
+    ///
+    /// Two modes:
+    /// - Normal deletion (`delete_body` is `None`): the control plane contacts
+    ///   the io-engine to destroy the pool on disk. Returns 204 on success.
+    /// - Purge deletion (`delete_body` contains `purge=true`): the control plane
+    ///   removes the pool spec from etcd without contacting the io-engine, for
+    ///   offline/faulted pools. Returns 200 with impact details on success.
+    ///
+    /// On 409/503 errors that the user can fix by updating the annotation or
+    /// cordoning the pool, a K8s event is emitted with instructions on how to
+    /// proceed. The error is still propagated so the operator retries on the
+    /// next reconcile.
+    #[tracing::instrument(fields(name = self.name_any(), status = ?self.status), skip(self, delete_body))]
+    async fn delete_pool(&self, delete_body: Option<DeletePoolBody>) -> Result<Action, Error> {
+        let is_purge = delete_body.as_ref().and_then(|b| b.purge).unwrap_or(false);
+
         let res = self
             .pools_api()
-            .del_node_pool(&self.spec.node(), &self.name_any(), None)
+            .del_node_pool(&self.spec.node(), &self.name_any(), delete_body)
             .await;
 
         match res {
             Ok(_) => {
-                self.k8s_notify(
-                    "Destroy",
-                    "Destroyed",
-                    "The pool has been destroyed",
-                    "Normal",
-                )
-                .await;
+                let (reason, message) = if is_purge {
+                    ("Purged", "The pool has been purged")
+                } else {
+                    ("Destroyed", "The pool has been destroyed")
+                };
+                self.k8s_notify("Destroy", reason, message, "Normal").await;
                 Ok(Action::await_change())
             }
             Err(clients::tower::Error::Response(response))
@@ -540,7 +1060,29 @@ impl ResourceContext {
                 .await;
                 Ok(Action::await_change())
             }
-            Err(error) => Err(error.into()),
+            Err(error) => {
+                let pool_name = self.name_any();
+                let ns = self.namespace().unwrap_or_default();
+                match purge_error_guidance(&pool_name, &ns, &error) {
+                    Some(guidance) => {
+                        match guidance.log.example_command {
+                            Some(cmd) => {
+                                error!(example_command = %cmd, pool.name = %pool_name, "{}", guidance.log.msg)
+                            }
+                            None => error!(pool.name = %pool_name, "{}", guidance.log.msg),
+                        }
+                        self.k8s_notify("Destroy", "PurgeBlocked", &guidance.event, "Warning")
+                            .await;
+                    }
+                    None => {
+                        let msg = format!("Pool deletion failed: {error}");
+                        error!(pool.name = %pool_name, "{msg}");
+                        self.k8s_notify("Destroy", "DeleteFailed", &msg, "Warning")
+                            .await;
+                    }
+                }
+                Err(error.into())
+            }
         }
     }
 
@@ -624,17 +1166,18 @@ impl ResourceContext {
                         tracing::debug!("DiskPool deleted, exiting pool_check");
                         Ok(Action::await_change())
                     } else {
+                        // Pool spec is gone from the control plane but the CR still exists.
+                        // This can happen when the pool was deleted externally (via REST
+                        // API or kubectl plugin) without also deleting the CR. Mark the
+                        // CR as Deleted so users see a clear state when listing DiskPool
+                        // resources.
                         let message = "The pool has disappeared from the control-plane";
-                        tracing::warn!("deleted by external event NOT recreating");
-                        self.k8s_notify("PoolCheck", "PoolNotFound", message, "Error")
+                        tracing::warn!(
+                            "pool spec gone (purged or deleted externally), marking CR as Deleted"
+                        );
+                        self.k8s_notify("PoolCheck", "PoolNotFound", message, "Warning")
                             .await;
-                        // We expected the control plane to have a spec for this pool. It didn't so
-                        // set the pool_status in CRD to None.
-                        self.mark_pool_error(Some(PoolError {
-                            code: PoolErrorCode::PoolDeleted,
-                            message: Some(message.to_string()),
-                        }))
-                        .await
+                        self.mark_deleted().await
                     }
                 } else if response.status() == clients::tower::StatusCode::SERVICE_UNAVAILABLE
                     || response.status() == clients::tower::StatusCode::REQUEST_TIMEOUT
@@ -727,20 +1270,16 @@ impl ResourceContext {
     ///     Type of this event (Normal, Warning), new types could be added in
     ///     the future
     async fn k8s_notify(&self, action: &str, reason: &str, message: &str, type_: &str) {
+        let message = truncate_for_event(message);
         let client = self.ctx.k8s.clone();
         let ns = self.namespace().expect("must be namespaced");
         let e: Api<Event> = Api::namespaced(client.clone(), &ns);
         let pp = PostParams::default();
         let time = Utc::now();
-        if self
-            .event_info
-            .lock()
-            .unwrap()
-            .contains(&message.to_string())
-        {
+        if self.event_info.lock().unwrap().contains(&message) {
             return;
         }
-        self.event_info.lock().unwrap().push(message.to_string());
+        self.event_info.lock().unwrap().push(message.clone());
         let metadata = ObjectMeta {
             // the name must be unique for all events we post
             generate_name: Some(format!("{}.{:x}", self.name_any(), time.timestamp())),
@@ -764,7 +1303,7 @@ impl ResourceContext {
                             .ok()
                             .unwrap_or_else(|| WHO_AM_I_SHORT.into()),
                     ),
-                    message: Some(message.into()),
+                    message: Some(message),
                     ..Default::default()
                 },
             )
@@ -781,28 +1320,66 @@ impl ResourceContext {
             |event| async move {
                 match event {
                     finalizer::Event::Apply(dsp) => Self::put_finalizer(dsp).await,
-                    finalizer::Event::Cleanup(dsp) => match self
-                        .pools_api()
-                        .get_node_pool(&self.spec.node(), &self.name_any())
-                        .await
-                    {
-                        Ok(pool) => {
-                            if dsp.status.as_ref().map(|d| d.cr_state)
-                                != Some(CrPoolState::Terminating)
-                            {
-                                let new_status =
-                                    DiskPoolStatus::terminating(&dsp, pool.into_body());
-                                let _ = self.patch_status(new_status).await?;
+                    finalizer::Event::Cleanup(dsp) => {
+                        // Check the fresh `dsp` (not `self`, which may be stale) for
+                        // the openebs.io/delete-opts annotation.
+                        //
+                        // - No annotation (or purge not set): normal deletion — the
+                        //   control plane contacts io-engine to destroy the pool on disk.
+                        // - Annotation with purge=true: purge deletion — the control
+                        //   plane removes the pool spec without contacting io-engine.
+                        //
+                        // If the annotation is present but malformed, this is a hard
+                        // error: the user intended purge, and silently falling back to
+                        // normal deletion could fail (503 for offline pool) or destroy
+                        // data the user wanted to preserve via the accept flags.
+                        let delete_body = match Self::parse_delete_opts(&dsp) {
+                            Ok(body) => body,
+                            Err(e) => {
+                                let msg = format!(
+                                    "Invalid {DELETE_OPTS_ANNOTATION} annotation: {e}. \
+                                     Fix the annotation to proceed with deletion."
+                                );
+                                error!(pool = %self.name_any(), "{msg}");
+                                self.k8s_notify("Destroy", "InvalidDeleteOpts", &msg, "Warning")
+                                    .await;
+                                return Err(e);
                             }
-                            Self::delete_finalizer(self.clone(), true).await
+                        };
+
+                        // If purge is requested, automatically cordon the pool
+                        // for replicas and snapshots before proceeding. This
+                        // removes the manual cordon step for the user.
+                        let is_purge = delete_body.as_ref().and_then(|b| b.purge).unwrap_or(false);
+                        if is_purge {
+                            self.cordon_for_purge().await?;
                         }
-                        Err(clients::tower::Error::Response(response))
-                            if response.status() == StatusCode::NOT_FOUND =>
+
+                        if dsp.status.as_ref().map(|d| d.cr_state) != Some(CrPoolState::Terminating)
                         {
-                            Self::delete_finalizer(self.clone(), false).await
+                            // Best-effort: if the pool is reachable, update the CR
+                            // with its real state while terminating. If not, leave
+                            // the current CR status as-is and proceed to delete.
+                            if let Ok(pool) = self
+                                .pools_api()
+                                .get_node_pool(&self.spec.node(), &self.name_any())
+                                .await
+                            {
+                                let _ = self
+                                    .patch_status(DiskPoolStatus::terminating(
+                                        &dsp,
+                                        pool.into_body(),
+                                    ))
+                                    .await?;
+                            }
                         }
-                        Err(error) => Err(error.into()),
-                    },
+
+                        // delete_pool handles all response codes:
+                        //   - success (200/204): pool destroyed or purged
+                        //   - 404: pool already gone ("AlreadyDestroyed")
+                        //   - other errors: propagated, operator retries
+                        Self::delete_finalizer(self.clone(), delete_body).await
+                    }
                 }
             },
         )
@@ -833,5 +1410,74 @@ impl ResourceContext {
         }
 
         Ok(Encryption::secret(EncryptionSecret { name }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_opts_parsing() {
+        // Normal deletes must not produce a body (server returns 204).
+        assert!(parse_delete_opts_value("accept=true").unwrap().is_none());
+        assert!(parse_delete_opts_value("purge=false,accept=true")
+            .unwrap()
+            .is_none());
+        assert!(parse_delete_opts_value("").unwrap().is_none());
+        assert!(parse_delete_opts_value("  ").unwrap().is_none());
+
+        // purge=true must produce a body.
+        let body = parse_delete_opts_value("purge=true").unwrap().unwrap();
+        assert_eq!(body.purge, Some(true));
+        assert_eq!(body.accept, None);
+
+        // accept-data-loss fans out to both volume and snapshot loss.
+        let body = parse_delete_opts_value("purge=true,accept-data-loss=true")
+            .unwrap()
+            .unwrap();
+        assert_eq!(body.accept_volume_loss, Some(true));
+        assert_eq!(body.accept_snapshot_loss, Some(true));
+
+        // Latter option takes precedence over earlier shorthand.
+        let body =
+            parse_delete_opts_value("purge=true,accept-data-loss=true,accept-volume-loss=false")
+                .unwrap()
+                .unwrap();
+        assert_eq!(body.accept_volume_loss, Some(false));
+        assert_eq!(body.accept_snapshot_loss, Some(true));
+
+        // purge-accept-all sets everything.
+        let body = parse_delete_opts_value("purge-accept-all")
+            .unwrap()
+            .unwrap();
+        assert_eq!(body.purge, Some(true));
+        assert_eq!(body.accept, Some(true));
+        assert_eq!(body.accept_volume_loss, Some(true));
+        assert_eq!(body.accept_snapshot_loss, Some(true));
+
+        // purge-accept-all=true also works.
+        let body = parse_delete_opts_value("purge-accept-all=true")
+            .unwrap()
+            .unwrap();
+        assert_eq!(body.purge, Some(true));
+
+        // purge-accept-all can be overridden by later options.
+        let body = parse_delete_opts_value("purge-accept-all,accept-volume-loss=false")
+            .unwrap()
+            .unwrap();
+        assert_eq!(body.accept_volume_loss, Some(false));
+        assert_eq!(body.accept_snapshot_loss, Some(true));
+
+        // Bare key without = is treated as true.
+        let body = parse_delete_opts_value("purge,accept").unwrap().unwrap();
+        assert_eq!(body.purge, Some(true));
+        assert_eq!(body.accept, Some(true));
+
+        // Unknown key is an error.
+        assert!(parse_delete_opts_value("purge=true,bogus=true").is_err());
+
+        // Invalid value is an error.
+        assert!(parse_delete_opts_value("purge=yes").is_err());
     }
 }

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -284,6 +284,10 @@ pub enum CrPoolState {
     Created,
     /// This state is set when we receive delete event on the dsp cr.
     Terminating,
+    /// The pool spec has been removed from the control plane (via normal
+    /// deletion or purge). The CR is orphaned and can be safely deleted
+    /// by the user.
+    Deleted,
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
@@ -423,7 +427,7 @@ impl DiskPoolStatus {
         .with_conditions(dsp)
     }
 
-    /// Set when operator is attempting to delete on pool.
+    /// Set when operator is attempting to delete a pool whose state is available.
     #[cfg(feature = "openapi")]
     pub fn terminating(dsp: &DiskPool, p: Pool) -> Self {
         let status = Self::inferred_status(&p);
@@ -459,6 +463,21 @@ impl DiskPoolStatus {
             error: Some(PoolError {
                 code: PoolErrorCode::Unknown,
                 message: Some("pool is terminating".to_string()),
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Set when the pool spec has been removed from the control plane.
+    /// The CR is orphaned and can be safely deleted by the user.
+    pub fn deleted() -> Self {
+        Self {
+            cr_state: CrPoolState::Deleted,
+            pool_status: None,
+            status: Some(PoolStatus::Offline),
+            error: Some(PoolError {
+                code: PoolErrorCode::PoolDeleted,
+                message: Some("pool spec was removed from the control plane".to_string()),
             }),
             ..Default::default()
         }

--- a/k8s/operators/src/pool/error.rs
+++ b/k8s/operators/src/pool/error.rs
@@ -8,9 +8,7 @@ use snafu::Snafu;
 pub enum Error {
     #[snafu(display("Kubernetes client error: {}", source))]
     /// k8s client error
-    Kube {
-        source: kube::Error,
-    },
+    Kube { source: kube::Error },
     #[snafu(display("HTTP request error: {}", source))]
     Request {
         source: clients::tower::RequestError,
@@ -20,21 +18,13 @@ pub enum Error {
         source: clients::tower::ResponseError<RestJsonError>,
     },
     #[snafu(display("Invalid cr field : {}", field))]
-    InvalidCRField {
-        field: String,
-    },
-    Generic {
-        message: String,
-    },
+    InvalidCRField { field: String },
+    #[snafu(display("{}", message))]
+    Generic { message: String },
     #[snafu(display("CRD merge failed"))]
-    CrdMergeError {
-        source: MergeError,
-    },
+    CrdMergeError { source: MergeError },
     #[snafu(display("{} for CRD : {}", field, name))]
-    CrdFieldMissing {
-        name: String,
-        field: String,
-    },
+    CrdFieldMissing { name: String, field: String },
 }
 
 impl From<clients::tower::Error<RestJsonError>> for Error {

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -60,7 +60,20 @@ fn error_policy(_object: Arc<DiskPool>, error: &Error, _ctx: Arc<OperatorContext
 #[tracing::instrument(fields(name = %dsp.spec.node(), status = ?dsp.status) skip(dsp, ctx))]
 async fn reconcile(dsp: Arc<DiskPool>, ctx: Arc<OperatorContext>) -> Result<Action, Error> {
     let dsp = ctx.upsert(ctx.clone(), dsp).await;
-    let _ = dsp.finalizer().await;
+
+    let is_deleted = matches!(
+        dsp.status,
+        Some(DiskPoolStatus {
+            cr_state: CrPoolState::Deleted,
+            ..
+        })
+    );
+
+    // Skip the finalizer hook when the CR is in Deleted state — the pool spec
+    // is already gone and we want to strip the finalizer, not re-add it.
+    if !is_deleted {
+        let _ = dsp.finalizer().await;
+    }
 
     if !ctx.inventory_contains(dsp.name_any()).await {
         return Ok(Action::await_change());
@@ -79,6 +92,15 @@ async fn reconcile(dsp: Arc<DiskPool>, ctx: Arc<OperatorContext>) -> Result<Acti
             cr_state: CrPoolState::Terminating,
             ..
         }) => dsp.pool_check().await,
+        Some(DiskPoolStatus {
+            cr_state: CrPoolState::Deleted,
+            ..
+        }) => {
+            // Pool spec was removed from the control plane. The CR is orphaned.
+            // Strip the finalizer so the user can delete the CR without the
+            // operator needing to intervene.
+            dsp.strip_finalizer().await
+        }
         // We use this state to indicate it's a new CRD however, we could (and
         // perhaps should) use the finalizer callback.
         None => dsp.init_cr().await,


### PR DESCRIPTION
Changes:
- Adds a new state 'Deleted' to the CRD for DiskPool
- Adds Pool delete (with purge options) functionality to DiskPool CR delete reconciliation
- Adds code to deserialize openebs.io/delete-opts from the DiskPool CR annotation
- Adds tests for pool delete option handling behaviour
- Adds guiding error messages for purge failures