### PR TITLE
feat: add offline node delete

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/node/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/node/mod.rs
@@ -1,12 +1,17 @@
 mod nexus;
+mod purge;
 mod snapshot;
 
 use crate::controller::{
-    reconciler::node::{nexus::NodeNexusReconciler, snapshot::NodeSnapshotGarbageCollector},
+    reconciler::node::{
+        nexus::NodeNexusReconciler, purge::NodePurgeReconciler,
+        snapshot::NodeSnapshotGarbageCollector,
+    },
     task_poller::{PollContext, PollPeriods, PollResult, PollTimer, TaskPoller},
 };
 
-/// Node reconciler loop which moves nexuses from draining nodes.
+/// Node reconciler loop which moves nexuses from draining nodes
+/// and resumes interrupted node purge operations.
 #[derive(Debug)]
 pub(crate) struct NodeReconciler {
     counter: PollTimer,
@@ -20,6 +25,7 @@ impl NodeReconciler {
             poll_targets: vec![
                 Box::new(NodeNexusReconciler::new()),
                 Box::new(NodeSnapshotGarbageCollector::new()),
+                Box::new(NodePurgeReconciler::new()),
             ],
         }
     }

--- a/control-plane/agents/src/bin/core/controller/reconciler/node/purge.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/node/purge.rs
@@ -1,0 +1,74 @@
+use crate::controller::{
+    resources::{operations::ResourceLifecycle, OperationGuardArc, ResourceUid},
+    task_poller::{PollContext, PollResult, PollTimer, PollerState, TaskPoller},
+};
+use stor_port::types::v0::{store::node::NodeSpec, transport::DestroyNode};
+
+/// Node purge reconciler — resumes interrupted node purge operations.
+///
+/// When a node delete (purge) is interrupted mid-way (e.g. control-plane restart),
+/// the node spec remains in `Purging` state. This reconciler detects such nodes
+/// and resumes the purge with all accepts set to true (matching the pool purge
+/// reconciler pattern).
+#[derive(Debug)]
+pub(super) struct NodePurgeReconciler {
+    counter: PollTimer,
+}
+
+impl NodePurgeReconciler {
+    /// Return a new `Self`.
+    pub(super) fn new() -> Self {
+        Self {
+            counter: PollTimer::from(1),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for NodePurgeReconciler {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        let nodes = context.specs().nodes();
+        let mut results = Vec::with_capacity(nodes.len());
+
+        for node in nodes {
+            if !node.status.purging() {
+                continue;
+            }
+            let mut node_guard = context.registry().specs().guarded_node(node.id()).await?;
+            results.push(resume_node_purge(context, &mut node_guard).await);
+        }
+        Self::squash_results(results)
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        self.counter.poll()
+    }
+}
+
+/// Resume an interrupted node purge.
+///
+/// The node is already in Purging state. `purge_node` detects the resume case,
+/// skips pre-flight validation, and re-runs the destroy lifecycle with all
+/// accepts set to true.
+#[tracing::instrument(skip_all, level = "trace", fields(node.id = %node_guard.uid(), request.reconcile = true))]
+async fn resume_node_purge(
+    context: &PollContext,
+    node_guard: &mut OperationGuardArc<NodeSpec>,
+) -> PollResult {
+    let node_id = node_guard.uid().clone();
+
+    // Build a request with all accepts=true — validation was already done
+    // on the original request before the crash.
+    let request = DestroyNode::purge(node_id.clone())
+        .with_accept(true)
+        .with_accept_volume_loss(true)
+        .with_accept_snapshot_loss(true);
+
+    node_guard.destroy(context.registry(), &request).await?;
+
+    tracing::info!(
+        node.id = %node_id,
+        "Purging node reconciled successfully"
+    );
+    PollResult::Ok(PollerState::Idle)
+}

--- a/control-plane/agents/src/bin/core/controller/reconciler/persistent_store.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/persistent_store.rs
@@ -28,8 +28,15 @@ impl TaskPoller for PersistentStoreReconciler {
             let dirty_snapshots = specs
                 .reconcile_dirty_volume_snapshots(context.registry())
                 .await;
+            let dirty_nodes = specs.reconcile_dirty_nodes(context.registry()).await;
 
-            if dirty_nexuses || dirty_replicas || dirty_volumes || dirty_pools || dirty_snapshots {
+            if dirty_nexuses
+                || dirty_replicas
+                || dirty_volumes
+                || dirty_pools
+                || dirty_snapshots
+                || dirty_nodes
+            {
                 return PollResult::Ok(PollerState::Busy);
             }
         }

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -24,7 +24,10 @@ use stor_port::{
             volume::{AffinityGroupSpec, VolumeContentSource, VolumeSpec},
             AsOperationSequencer, OperationMode, SpecStatus, SpecTransaction,
         },
-        transport::{AppNodeId, NexusId, NodeId, PoolId, ReplicaId, SnapshotId, VolumeId},
+        transport::{
+            AppNodeId, NexusId, NodeId, PoolId, ReplicaId, ReplicaTopology, SnapshotId,
+            SnapshotLossDetail, SnapshotLossInfo, VolumeId, VolumeLossDetail, VolumeLossInfo,
+        },
     },
 };
 
@@ -32,7 +35,12 @@ use async_trait::async_trait;
 use parking_lot::RwLock;
 use serde::de::DeserializeOwned;
 use snafu::{ResultExt, Snafu};
-use std::{fmt::Debug, ops::Deref, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    ops::Deref,
+    sync::Arc,
+};
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]
@@ -1122,4 +1130,115 @@ fn get_affinity_group_specs(volume_specs: &[VolumeSpec]) -> Vec<AffinityGroupSpe
         }
     }
     affinity_group_specs
+}
+
+/// Analyze volume loss impact across one or more pools being purged.
+///
+/// For each volume that has replicas on the given pool(s), fetches the
+/// `Volume` object and uses its `replica_topology` to determine how many
+/// healthy replicas exist before and after the deletion.
+pub(crate) async fn analyze_volume_loss(
+    registry: &Registry,
+    pool_ids: &HashSet<PoolId>,
+    volume_ids: &HashSet<VolumeId>,
+) -> Result<Option<VolumeLossInfo>, SvcError> {
+    let mut volumes_with_volume_loss = Vec::new();
+
+    for volume_id in volume_ids {
+        let volume = match registry.volume(volume_id).await {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let topology = &volume.state().replica_topology;
+
+        let total_replicas = topology.len() as u32;
+        let healthy_before = topology
+            .values()
+            .filter(|rt| rt.status().online() && rt.healthy() == Some(true))
+            .count() as u32;
+
+        let on_pools =
+            |rt: &&ReplicaTopology| rt.pool().as_ref().is_some_and(|p| pool_ids.contains(p));
+
+        let replicas_on_pool = topology.values().filter(on_pools).count() as u32;
+        let healthy_lost = topology
+            .values()
+            .filter(on_pools)
+            .filter(|rt| rt.status().online() && rt.healthy() == Some(true))
+            .count() as u32;
+
+        let healthy_after = healthy_before.saturating_sub(healthy_lost);
+
+        if healthy_after == 0 && replicas_on_pool > 0 {
+            volumes_with_volume_loss.push(VolumeLossDetail {
+                volume_id: volume_id.clone(),
+                replicas_before: total_replicas,
+                healthy_before,
+                lost_on_pool: replicas_on_pool,
+                healthy_after,
+            });
+        }
+    }
+
+    if volumes_with_volume_loss.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(VolumeLossInfo {
+            volumes: volumes_with_volume_loss,
+        }))
+    }
+}
+
+/// Analyze snapshot loss impact across one or more pools being purged.
+///
+/// Replica snapshots on the given pool(s) are permanently lost. Any
+/// replica snapshot on a different pool is a surviving copy. If a volume
+/// snapshot has no surviving copies after the purge, it is reported as lost.
+pub(crate) fn analyze_snapshot_loss(
+    registry: &Registry,
+    pool_ids: &HashSet<PoolId>,
+) -> Result<Option<SnapshotLossInfo>, SvcError> {
+    let mut snapshots_with_loss: HashMap<SnapshotId, SnapshotLossDetail> = HashMap::new();
+
+    for vol_snapshot in registry.specs().volume_snapshots_rsc() {
+        let vol_snap = vol_snapshot.lock();
+        let vol_snap_id = vol_snap.spec().uuid().clone();
+
+        let mut total_replica_snaps = 0u32;
+        let mut on_these_pools = 0u32;
+
+        for txn_replicas in vol_snap.metadata().transactions().values() {
+            for rs in txn_replicas {
+                total_replica_snaps += 1;
+                if pool_ids.contains(rs.spec().source_id().pool_id()) {
+                    on_these_pools += 1;
+                }
+            }
+        }
+
+        if on_these_pools > 0 {
+            let surviving = total_replica_snaps - on_these_pools;
+
+            if surviving == 0 && !snapshots_with_loss.contains_key(&vol_snap_id) {
+                snapshots_with_loss.insert(
+                    vol_snap_id.clone(),
+                    SnapshotLossDetail {
+                        snapshot_id: vol_snap_id,
+                        replica_snapshots_before: total_replica_snaps,
+                        healthy_before: total_replica_snaps - on_these_pools,
+                        lost_on_pool: on_these_pools,
+                        healthy_after: 0,
+                    },
+                );
+            }
+        }
+    }
+
+    if snapshots_with_loss.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(SnapshotLossInfo {
+            snapshots: snapshots_with_loss.into_values().collect(),
+        }))
+    }
 }

--- a/control-plane/agents/src/bin/core/node/operations.rs
+++ b/control-plane/agents/src/bin/core/node/operations.rs
@@ -1,16 +1,20 @@
 use agents::errors::SvcError;
 
-use stor_port::types::v0::store::node::{DrainingVolumes, NodeOperation, NodeSpec};
+use stor_port::types::v0::{
+    store::node::{DrainingVolumes, NodeOperation, NodeSpec},
+    transport::{DestroyNode, DestroyPool, NodeDeleteResult, NodeId, NodeStatus},
+};
 
 use crate::controller::{
     registry::Registry,
     resources::{
-        operations::{ResourceCordon, ResourceDrain, ResourceLabel},
-        operations_helper::GuardedOperationsHelper,
+        operations::{ResourceCordon, ResourceDrain, ResourceLabel, ResourceLifecycle},
+        operations_helper::{analyze_snapshot_loss, analyze_volume_loss, GuardedOperationsHelper},
         OperationGuardArc,
     },
 };
-use std::collections::HashMap;
+use grpc::operations::pool::traits::PoolCordonRequest;
+use std::collections::{HashMap, HashSet};
 
 /// Resource Cordon Operations.
 #[async_trait::async_trait]
@@ -128,6 +132,39 @@ impl ResourceDrain for OperationGuardArc<NodeSpec> {
     }
 }
 
+#[async_trait::async_trait]
+impl ResourceLifecycle for OperationGuardArc<NodeSpec> {
+    type Create = ();
+    type CreateOutput = ();
+    type Destroy = DestroyNode;
+    type DestroyOutput = NodeDeleteResult;
+
+    async fn create(
+        _registry: &Registry,
+        _request: &Self::Create,
+    ) -> Result<Self::CreateOutput, SvcError> {
+        unimplemented!(
+            "Nodes self-register via keep-alives; they are not created via ResourceLifecycle"
+        )
+    }
+
+    async fn destroy(
+        &mut self,
+        registry: &Registry,
+        request: &Self::Destroy,
+    ) -> Result<Self::DestroyOutput, SvcError> {
+        let purge_result = self.purge_node(registry, request).await?;
+
+        // Remove the node's runtime state (wrapper).
+        {
+            let mut nodes = registry.nodes().write().await;
+            nodes.remove(request.id.as_ref());
+        }
+
+        Ok(purge_result)
+    }
+}
+
 /// Node drain Operations.
 impl OperationGuardArc<NodeSpec> {
     /// Drain the set of draining volumes to the stored set.
@@ -184,5 +221,189 @@ impl OperationGuardArc<NodeSpec> {
 
         self.complete_update(registry, Ok(()), spec_clone).await?;
         Ok(self.as_ref().clone())
+    }
+
+    /// Purge a node and all its resources (pools, replicas, nexuses, snapshots).
+    ///
+    /// Pre-flight validation (offline, cordoned, accept flags, loss analysis)
+    /// runs before any operation is logged. Once `start_destroy_for_purge` marks
+    /// the node as Purging, all destructive work is captured and passed through
+    /// `complete_destroy` — ensuring the pending op is always resolved.
+    ///
+    /// If the destructive work fails, `complete_destroy(Err)` clears the pending
+    /// op while keeping Purging status. The `NodePurgeReconciler` will resume.
+    pub(crate) async fn purge_node(
+        &mut self,
+        registry: &Registry,
+        request: &DestroyNode,
+    ) -> Result<NodeDeleteResult, SvcError> {
+        let node_id = request.id.clone();
+        let node_spec = self.as_ref().clone();
+        let resuming = node_spec.status.purging();
+
+        if !resuming {
+            // Pre-flight validation — no op logged yet, safe to return early.
+            Self::validate_purge_preconditions(registry, request, &node_spec).await?;
+        }
+
+        // Mark node as Purging BEFORE any destructive work.
+        // From here on, errors must go through complete_destroy.
+        self.start_destroy_for_purge(registry).await?;
+
+        // Capture all destructive work results.
+        let purge_result = Self::purge_node_resources(registry, &node_id, request).await;
+
+        // Always complete the op:
+        // - Ok(()) deletes the node spec from etcd and memory.
+        // - Err(error) clears the pending op, keeps Purging for reconciler retry.
+        self.complete_destroy(purge_result, registry).await
+    }
+
+    /// Validate all preconditions for node purge.
+    /// Called before any operation is logged — safe to return errors directly.
+    async fn validate_purge_preconditions(
+        registry: &Registry,
+        request: &DestroyNode,
+        node_spec: &NodeSpec,
+    ) -> Result<(), SvcError> {
+        let node_id = &request.id;
+
+        // 1. Validate node is offline.
+        let node_is_online = match registry.node_state(node_id).await {
+            Ok(state) => state.status == NodeStatus::Online,
+            Err(_) => false,
+        };
+        if node_is_online {
+            return Err(SvcError::NodeIsOnline {
+                node_id: node_id.clone(),
+            });
+        }
+
+        // 2. Validate node is cordoned.
+        if !node_spec.cordoned() {
+            return Err(SvcError::NodeNotCordoned {
+                node_id: node_id.clone(),
+            });
+        }
+
+        // 3. Collect pools on this node.
+        let node_pools = registry.get_node_opt_pools(Some(node_id.clone())).await?;
+
+        let has_resources = !node_pools.is_empty();
+
+        // 4. If node has resources but purge=false, reject.
+        if has_resources && !request.purge {
+            return Err(SvcError::NodeHasResources {
+                node_id: node_id.clone(),
+            });
+        }
+
+        // 5. If node has resources, accept=true is required.
+        if has_resources && !request.accept {
+            return Err(SvcError::NodePurgeAcceptRequired {
+                node_id: node_id.clone(),
+                pool_count: node_pools.len(),
+            });
+        }
+
+        // 5a. Analyze volume loss across ALL pools on this node.
+        let pool_ids: HashSet<_> = node_pools.iter().map(|p| p.id().clone()).collect();
+        let volume_ids: HashSet<_> = pool_ids
+            .iter()
+            .flat_map(|pid| registry.specs().pool_replicas(pid))
+            .filter_map(|r| r.lock().owners.volume().cloned())
+            .collect();
+
+        if let Some(info) = analyze_volume_loss(registry, &pool_ids, &volume_ids).await? {
+            if !request.accept_volume_loss {
+                return Err(SvcError::NodePurgeVolumeLossAcceptRequired {
+                    node_id: node_id.clone(),
+                    pool_count: pool_ids.len(),
+                    volume_count: info.volumes.len(),
+                    volume_loss: info,
+                });
+            }
+        }
+
+        // 5b. Analyze snapshot loss across ALL pools.
+        if let Some(info) = analyze_snapshot_loss(registry, &pool_ids)? {
+            if !request.accept_snapshot_loss {
+                return Err(SvcError::NodePurgeSnapshotLossAcceptRequired {
+                    node_id: node_id.clone(),
+                    pool_count: pool_ids.len(),
+                    snapshot_count: info.snapshots.len(),
+                    snapshot_loss: info,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Perform all destructive purge work: pool cordon+purge and nexus cleanup.
+    ///
+    /// Called after `start_destroy_for_purge`. The caller wraps the result in
+    /// `complete_destroy` to ensure the pending op is always resolved.
+    async fn purge_node_resources(
+        registry: &Registry,
+        node_id: &NodeId,
+        request: &DestroyNode,
+    ) -> Result<NodeDeleteResult, SvcError> {
+        // Re-collect pools (in the resume case, pre-flight was skipped).
+        let node_pools = registry.get_node_opt_pools(Some(node_id.clone())).await?;
+
+        let mut result = NodeDeleteResult::new(node_id.clone());
+
+        // Cordon and purge each pool.
+        for pool in &node_pools {
+            let mut pool_guard = match registry.specs().pool_guard(pool.id()).await? {
+                Some(guard) => guard,
+                None => continue,
+            };
+
+            // Best-effort cordon — pool purge's own validate_purge_cordon is the
+            // real enforcement. Log failures but don't abort.
+            let cordon_request = PoolCordonRequest {
+                node_id: None,
+                pool_id: pool.id().clone(),
+                replicas: true,
+                snapshots: true,
+                restores: false,
+                import: false,
+            };
+            if let Err(error) = pool_guard.cordon(registry, cordon_request).await {
+                tracing::warn!(
+                    node.id = %node_id,
+                    pool.id = %pool.id(),
+                    %error,
+                    "Failed to auto-cordon pool during node purge (pool purge will validate)"
+                );
+            }
+
+            let destroy_pool = DestroyPool::purge(pool.node(), pool.id().clone())
+                .with_accept(request.accept)
+                .with_accept_volume_loss(request.accept_volume_loss)
+                .with_accept_snapshot_loss(request.accept_snapshot_loss);
+
+            if let Some(pool_result) = pool_guard.destroy(registry, &destroy_pool).await? {
+                result.merge_pool_result(&pool_result);
+            }
+        }
+
+        /* TODO: Add Nexus removal
+         * The node where the nexus is, is deleted, what happens to the volume?
+         * HA is enabled, but the replicas are in offline nodes, what happens to this volume?
+         * What happen to a volume if their last healthy replica is lost?
+         */
+
+        tracing::info!(
+            node.id = %node_id,
+            pools_deleted = node_pools.len(),
+            volume_loss = result.has_volume_loss(),
+            snapshot_loss = result.has_snapshot_loss(),
+            "Node purge resources cleaned up"
+        );
+
+        Ok(result)
     }
 }

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -10,9 +10,11 @@ use crate::controller::{
 };
 use agents::errors::SvcError;
 use stor_port::types::v0::transport::{
-    Deregister, Filter, Node, NodeId, NodeState, NodeStatus, Register,
+    Deregister, DestroyNode, Filter, Node, NodeDeleteResult, NodeId, NodeState, NodeStatus,
+    Register,
 };
 
+use crate::controller::resources::operations::ResourceLifecycle;
 use crate::controller::{io_engine::HostApi, wrapper::InternalOps};
 use grpc::{
     context::Context,
@@ -152,6 +154,12 @@ impl NodeOperations for Service {
         }
         let node = self.unlabel(id, label_key).await?;
         Ok(node)
+    }
+
+    /// Delete a node and all its resources (purge).
+    async fn delete(&self, request: &DestroyNode) -> Result<NodeDeleteResult, ReplyError> {
+        let result = self.delete_node(request).await?;
+        Ok(result)
     }
 }
 
@@ -449,5 +457,20 @@ impl Service {
         let spec = guarded_node.unlabel(&self.registry, label).await?;
         let state = self.registry.node_state(&id).await.ok();
         Ok(Node::new(id, Some(spec), state))
+    }
+
+    /// Delete a node and all its resources (pools, replicas, nexuses, snapshots).
+    ///
+    /// Acquires the node operation guard and delegates to `purge_node` which
+    /// handles pre-flight validation, the destroy lifecycle, and resource cleanup.
+    /// After the spec is removed, the runtime wrapper is cleaned up.
+    pub(crate) async fn delete_node(
+        &self,
+        request: &DestroyNode,
+    ) -> Result<NodeDeleteResult, SvcError> {
+        let node_id = &request.id;
+
+        let mut node_guard = self.registry.specs().guarded_node(node_id).await?;
+        node_guard.destroy(&self.registry, request).await
     }
 }

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -137,6 +137,28 @@ impl ResourceSpecsLocked {
             .collect()
     }
 
+    /// Worker that reconciles dirty NodeSpec's with the persistent store.
+    /// This is useful when node operations are performed but we fail to
+    /// update the spec with the persistent store.
+    pub(crate) async fn reconcile_dirty_nodes(&self, registry: &Registry) -> bool {
+        let mut pending_ops = false;
+
+        let nodes = self.nodes_rsc();
+        for node in nodes {
+            // Skip nodes with no pending operation to avoid unnecessary guard
+            // acquisition. This keeps the reconciler low-cost for healthy nodes.
+            if !node.lock().has_pending_op() {
+                continue;
+            }
+            if let Ok(mut guard) = node.operation_guard() {
+                if !guard.handle_incomplete_ops(registry).await {
+                    pending_ops = true;
+                }
+            }
+        }
+        pending_ops
+    }
+
     /// Get all cordoned nodes.
     pub(crate) fn cordoned_nodes(&self) -> Vec<NodeSpec> {
         self.read()
@@ -151,6 +173,12 @@ impl ResourceSpecsLocked {
                 }
             })
             .collect()
+    }
+
+    /// Remove the Node `id` from the spec list.
+    pub(crate) fn remove_node(&self, id: &NodeId) {
+        let mut specs = self.write();
+        specs.nodes.remove(id);
     }
 }
 
@@ -175,8 +203,9 @@ impl GuardedOperationsHelper for OperationGuardArc<NodeSpec> {
     type UpdateOp = NodeOperation;
     type Inner = NodeSpec;
 
-    fn remove_spec(&self, _registry: &Registry) {
-        unimplemented!();
+    fn remove_spec(&self, registry: &Registry) {
+        let id = self.lock().id().clone();
+        registry.specs().remove_node(&id);
     }
 }
 
@@ -256,7 +285,7 @@ impl SpecOperationsHelper for NodeSpec {
         unimplemented!();
     }
     fn start_destroy_op(&mut self) {
-        unimplemented!();
+        self.start_op(NodeOperation::Destroy);
     }
 
     fn dirty(&self) -> bool {
@@ -269,10 +298,10 @@ impl SpecOperationsHelper for NodeSpec {
         self.id().to_string()
     }
     fn status(&self) -> SpecStatus<Self::Status> {
-        SpecStatus::Created(())
+        self.status.clone()
     }
-    fn set_status(&mut self, _status: SpecStatus<Self::Status>) {
-        unimplemented!();
+    fn set_status(&mut self, status: SpecStatus<Self::Status>) {
+        self.status = status;
     }
     fn operation_result(&self) -> Option<Option<bool>> {
         self.operation.as_ref().map(|r| r.result)

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -31,6 +31,7 @@ use itertools::Itertools;
 use regex::Regex;
 use snafu::OptionExt;
 use std::{collections::HashSet, ops::Deref, sync::Arc};
+use stor_port::types::v0::transport::{PoolId, SnapshotLossInfo, VolumeId, VolumeLossInfo};
 use tokio::sync::RwLock;
 
 impl OperationGuardArc<PoolSpec> {
@@ -283,6 +284,28 @@ impl OperationGuardArc<PoolSpec> {
         let pool_spec = registry.specs().pool(self.uid())?;
 
         Ok(Pool::new(pool_spec, Some(CtrlPoolState::new(pool_state))))
+    }
+
+    /// Analyze volume loss impact for a single pool being purged.
+    pub(crate) async fn analyze_volume_loss(
+        registry: &Registry,
+        pool_id: &PoolId,
+        volume_ids: &HashSet<VolumeId>,
+    ) -> Result<Option<VolumeLossInfo>, SvcError> {
+        let pool_ids = HashSet::from([pool_id.clone()]);
+        crate::controller::resources::operations_helper::analyze_volume_loss(
+            registry, &pool_ids, volume_ids,
+        )
+        .await
+    }
+
+    /// Analyze snapshot loss impact for a single pool being purged.
+    pub(crate) fn analyze_snapshot_loss(
+        registry: &Registry,
+        pool_id: &PoolId,
+    ) -> Result<Option<SnapshotLossInfo>, SvcError> {
+        let pool_ids = HashSet::from([pool_id.clone()]);
+        crate::controller::resources::operations_helper::analyze_snapshot_loss(registry, &pool_ids)
     }
 }
 

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -22,8 +22,7 @@ use stor_port::{
         },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, ExpandPool, Pool, PoolDeleteResult, PoolDiag,
-            PoolDiskError, PoolId, PoolStatus, ReplicaOwners, ReplicaTopology, SnapshotId,
-            SnapshotLossDetail, SnapshotLossInfo, VolumeId, VolumeLossDetail, VolumeLossInfo,
+            PoolDiskError, PoolId, PoolStatus, ReplicaOwners,
         },
     },
 };
@@ -477,7 +476,7 @@ impl OperationGuardArc<PoolSpec> {
             // Node is online - check pool state via ctrl_pool_state
             if let Ok(ctrl_state) = registry.ctrl_pool_state(pool_id).await {
                 if !matches!(ctrl_state.status, PoolStatus::Unknown | PoolStatus::Offline) {
-                    return Err(SvcError::PoolStateNotUnknown {
+                    return Err(SvcError::PoolStateNotOfflineOrUnknown {
                         pool_id: pool_id.clone(),
                         state: ctrl_state.status.clone(),
                     });
@@ -529,116 +528,5 @@ impl OperationGuardArc<PoolSpec> {
             }
         }
         result
-    }
-
-    /// Analyze volume loss impact by examining each affected volume's replica topology.
-    ///
-    /// For each volume that has replicas on the pool being purged, we fetch the
-    /// `Volume` object and use its `replica_topology` to determine how many
-    /// healthy replicas exist before and after the deletion. A replica is
-    /// considered healthy if it is online and marked as fully synced.
-    async fn analyze_volume_loss(
-        registry: &Registry,
-        pool_id: &PoolId,
-        volume_ids: &HashSet<VolumeId>,
-    ) -> Result<Option<VolumeLossInfo>, SvcError> {
-        let mut volumes_with_volume_loss = Vec::new();
-
-        for volume_id in volume_ids {
-            let volume = match registry.volume(volume_id).await {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let topology = &volume.state().replica_topology;
-
-            let total_replicas = topology.len() as u32;
-            let healthy_before = topology
-                .values()
-                .filter(|rt| rt.status().online() && rt.healthy() == Some(true))
-                .count() as u32;
-
-            let on_pool = |rt: &&ReplicaTopology| rt.pool().as_ref() == Some(pool_id);
-
-            let replicas_on_pool = topology.values().filter(on_pool).count() as u32;
-            let healthy_lost = topology
-                .values()
-                .filter(on_pool)
-                .filter(|rt| rt.status().online() && rt.healthy() == Some(true))
-                .count() as u32;
-
-            let healthy_after = healthy_before.saturating_sub(healthy_lost);
-
-            if healthy_after == 0 && replicas_on_pool > 0 {
-                volumes_with_volume_loss.push(VolumeLossDetail {
-                    volume_id: volume_id.clone(),
-                    replicas_before: total_replicas,
-                    healthy_before,
-                    lost_on_pool: replicas_on_pool,
-                    healthy_after,
-                });
-            }
-        }
-
-        if volumes_with_volume_loss.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(VolumeLossInfo {
-                volumes: volumes_with_volume_loss,
-            }))
-        }
-    }
-
-    /// Analyze snapshot loss impact for replica snapshots being deleted.
-    ///
-    /// Replica snapshots on the pool being purged are permanently lost. Any
-    /// replica snapshot on a different pool is a surviving copy. If a volume
-    /// snapshot has no surviving copies after the purge, it is reported as lost.
-    fn analyze_snapshot_loss(
-        registry: &Registry,
-        pool_id: &PoolId,
-    ) -> Result<Option<SnapshotLossInfo>, SvcError> {
-        let mut snapshots_with_loss: HashMap<SnapshotId, SnapshotLossDetail> = HashMap::new();
-
-        for vol_snapshot in registry.specs().volume_snapshots_rsc() {
-            let vol_snap = vol_snapshot.lock();
-            let vol_snap_id = vol_snap.spec().uuid().clone();
-
-            let mut total_replica_snaps = 0u32;
-            let mut on_this_pool = 0u32;
-
-            for txn_replicas in vol_snap.metadata().transactions().values() {
-                for rs in txn_replicas {
-                    total_replica_snaps += 1;
-                    if rs.spec().source_id().pool_id() == pool_id {
-                        on_this_pool += 1;
-                    }
-                }
-            }
-
-            if on_this_pool > 0 {
-                let surviving = total_replica_snaps - on_this_pool;
-
-                if surviving == 0 && !snapshots_with_loss.contains_key(&vol_snap_id) {
-                    snapshots_with_loss.insert(
-                        vol_snap_id.clone(),
-                        SnapshotLossDetail {
-                            snapshot_id: vol_snap_id,
-                            replica_snapshots_before: total_replica_snaps,
-                            healthy_before: total_replica_snaps - on_this_pool,
-                            lost_on_pool: on_this_pool,
-                            healthy_after: 0,
-                        },
-                    );
-                }
-            }
-        }
-
-        if snapshots_with_loss.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(SnapshotLossInfo {
-                snapshots: snapshots_with_loss.into_values().collect(),
-            }))
-        }
     }
 }

--- a/control-plane/agents/src/bin/core/pool/specs.rs
+++ b/control-plane/agents/src/bin/core/pool/specs.rs
@@ -526,4 +526,16 @@ impl ResourceSpecsLocked {
             }),
         }
     }
+
+    /// Get an operation guard for the given pool, if it exists.
+    /// Returns `None` if the pool spec is not found (instead of an error).
+    pub(crate) async fn pool_guard(
+        &self,
+        pool_id: &PoolId,
+    ) -> Result<Option<OperationGuardArc<PoolSpec>>, SvcError> {
+        Ok(match self.pool_rsc(pool_id) {
+            None => None,
+            Some(pool) => Some(pool.operation_guard_wait().await?),
+        })
+    }
 }

--- a/control-plane/agents/src/bin/core/tests/node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/node/mod.rs
@@ -1,3 +1,5 @@
+mod purge;
+
 use deployer_cluster::ClusterBuilder;
 use grpc::operations::node::traits::NodeOperations;
 use std::time::Duration;

--- a/control-plane/agents/src/bin/core/tests/node/purge.rs
+++ b/control-plane/agents/src/bin/core/tests/node/purge.rs
@@ -1,0 +1,553 @@
+use deployer_cluster::{Cluster, ClusterBuilder};
+use grpc::operations::{
+    node::traits::NodeOperations, pool::traits::PoolOperations, replica::traits::ReplicaOperations,
+    volume::traits::VolumeOperations,
+};
+use std::collections::HashMap;
+use std::time::Duration;
+use stor_port::{
+    pstor::{etcd::Etcd, StoreObj},
+    transport_api::{ReplyErrorKind, ResourceKind},
+    types::v0::{
+        openapi::models,
+        store::{
+            node::{NodeOperation, NodeOperationState, NodeSpec, NodeSpecKey},
+            SpecStatus,
+        },
+        transport::{
+            CreatePool, CreateVolume, DestroyNode, DestroyVolume, Filter, NodeId, NodeStatus,
+            PoolId, PublishVolume, Topology, VolumeAccessMode, VolumeId,
+        },
+    },
+};
+
+const NODE_OFFLINE_TIMEOUT: Duration = Duration::from_secs(10);
+const VOLUME_SIZE: u64 = 5242880;
+
+/// All node purge tests share a single cluster to avoid repeated spinup costs.
+#[tokio::test]
+async fn node_purge() {
+    let cluster = ClusterBuilder::builder()
+        .with_rest(false)
+        .with_agents(vec!["core"])
+        .with_io_engines(2)
+        .with_pools(1)
+        .with_cache_period("100ms")
+        .with_node_deadline("100ms")
+        .with_reconcile_period(Duration::from_millis(100), Duration::from_millis(100))
+        .build()
+        .await
+        .unwrap();
+
+    let node_client = cluster.grpc_client().node();
+    let pool_client = cluster.grpc_client().pool();
+    let volume_client = cluster.grpc_client().volume();
+    let replica_client = cluster.grpc_client().replica();
+    let node_id = cluster.node(0);
+    // Create a volume with 1 replica pinned to node 0 so that Phase 4's
+    // purge_succeeds_with_volume_loss reliably reports healthy_after=0
+    let vol_id = VolumeId::new();
+    volume_client
+        .create(
+            &CreateVolume {
+                uuid: vol_id.clone(),
+                size: VOLUME_SIZE,
+                replicas: 1,
+                topology: Some(Topology::from(models::Topology::new_all(
+                    Some(models::NodeTopology::explicit(
+                        models::ExplicitNodeTopology::new(
+                            vec![node_id.to_string()],
+                            Vec::<String>::new(),
+                        ),
+                    )),
+                    None,
+                ))),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    volume_client
+        .publish(
+            &PublishVolume {
+                uuid: vol_id.clone(),
+                target_node: Some(node_id.clone()),
+                share: None,
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .expect("Initial volume should publish on node 0");
+
+    // Verify the replica exists.
+    let replicas = replica_client
+        .get(Filter::Volume(vol_id.clone()), None)
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!replicas.is_empty(), "Volume should have a replica");
+
+    // --- Phase 1: Node online ---
+    purge_rejected_node_online(&node_client, &node_id).await;
+
+    // --- Phase 2: Node offline, not cordoned ---
+    cluster.composer().stop("io-engine-1").await.unwrap();
+    cluster
+        .wait_node_status_tmo(cluster.node(0), NodeStatus::Offline, NODE_OFFLINE_TIMEOUT)
+        .await
+        .expect("Node should go offline");
+
+    purge_rejected_not_cordoned(&node_client, &node_id).await;
+
+    // Cordon node for remaining tests.
+    node_client
+        .cordon(node_id.clone(), "offline-delete".to_string())
+        .await
+        .unwrap();
+
+    // --- Phase 3: Node offline, cordoned — missing flags ---
+    purge_rejected_no_purge_flag(&node_client, &node_id).await;
+    purge_rejected_without_accept(&node_client, &node_id).await;
+    purge_rejected_volume_loss_without_accept(&node_client, &node_id).await;
+
+    // --- Phase 4: Purge succeeds with all flags ---
+    // Node delete will cordon pools automatically on behalf of the user.
+    purge_succeeds_with_volume_loss(&node_client, &pool_client, &node_id, &vol_id).await;
+
+    // --- Phase 5: Reconciler resumes interrupted purge ---
+    purge_reconciler_resumes_interrupted(&cluster).await;
+}
+
+/// Purge must be rejected when the node is online.
+async fn purge_rejected_node_online(node_client: &dyn NodeOperations, node_id: &NodeId) {
+    let request = DestroyNode::purge(node_id.clone())
+        .with_accept(true)
+        .with_accept_volume_loss(true)
+        .with_accept_snapshot_loss(true);
+    let err = node_client
+        .delete(&request)
+        .await
+        .expect_err("Purge should be rejected for online node");
+
+    assert_eq!(err.kind, ReplyErrorKind::NodeIsOnline);
+    assert_eq!(err.resource, ResourceKind::Node);
+}
+
+/// Purge must be rejected when the node is not cordoned.
+async fn purge_rejected_not_cordoned(node_client: &dyn NodeOperations, node_id: &NodeId) {
+    let request = DestroyNode::purge(node_id.clone())
+        .with_accept(true)
+        .with_accept_volume_loss(true)
+        .with_accept_snapshot_loss(true);
+    let err = node_client
+        .delete(&request)
+        .await
+        .expect_err("Purge should be rejected for uncordoned node");
+
+    assert_eq!(err.kind, ReplyErrorKind::NodeNotCordoned);
+    assert_eq!(err.resource, ResourceKind::Node);
+}
+
+/// Purge must be rejected when node has resources but purge=false.
+async fn purge_rejected_no_purge_flag(node_client: &dyn NodeOperations, node_id: &NodeId) {
+    // purge defaults to false.
+    let request = DestroyNode::new(node_id.clone()).with_accept(true);
+    let err = node_client
+        .delete(&request)
+        .await
+        .expect_err("Delete should be rejected without purge flag");
+
+    assert_eq!(err.kind, ReplyErrorKind::NodeHasResources);
+    assert_eq!(err.resource, ResourceKind::Node);
+}
+
+/// Purge must be rejected when node has pools but accept=false.
+async fn purge_rejected_without_accept(node_client: &dyn NodeOperations, node_id: &NodeId) {
+    // accept defaults to false.
+    let request = DestroyNode::purge(node_id.clone());
+    let err = node_client
+        .delete(&request)
+        .await
+        .expect_err("Purge should be rejected without accept");
+
+    assert_eq!(err.kind, ReplyErrorKind::NodePurgeAcceptRequired);
+    assert_eq!(err.resource, ResourceKind::Node);
+}
+
+/// Purge must be rejected when volume loss would occur but accept_volume_loss=false.
+/// Node delete pre-flight scans all pools and reports aggregate volume loss.
+async fn purge_rejected_volume_loss_without_accept(
+    node_client: &dyn NodeOperations,
+    node_id: &NodeId,
+) {
+    let request = DestroyNode::purge(node_id.clone()).with_accept(true);
+    // accept_volume_loss defaults to false.
+    let err = node_client
+        .delete(&request)
+        .await
+        .expect_err("Purge should be rejected without volume loss accept");
+
+    assert_eq!(err.kind, ReplyErrorKind::NodePurgeVolumeLossAcceptRequired);
+    assert_eq!(err.resource, ResourceKind::Node);
+}
+
+/// Purge succeeds when all flags are provided, reports volume loss.
+async fn purge_succeeds_with_volume_loss(
+    node_client: &dyn NodeOperations,
+    pool_client: &dyn PoolOperations,
+    node_id: &NodeId,
+    volume_id: &VolumeId,
+) {
+    let request = DestroyNode::purge(node_id.clone())
+        .with_accept(true)
+        .with_accept_volume_loss(true)
+        .with_accept_snapshot_loss(true);
+
+    let result = node_client
+        .delete(&request)
+        .await
+        .expect("Purge should succeed with all flags");
+
+    assert_eq!(&result.node_id, node_id);
+    assert!(
+        !result.volume_loss.volumes.is_empty(),
+        "Should report volume loss"
+    );
+    assert_eq!(result.volume_loss.volumes.len(), 1);
+    assert_eq!(result.volume_loss.volumes[0].volume_id, *volume_id);
+    assert_eq!(result.volume_loss.volumes[0].healthy_after, 0);
+
+    // Verify node spec is gone.
+    let timeout = Duration::from_secs(5);
+    let start = std::time::Instant::now();
+    loop {
+        let nodes = node_client
+            .get(Filter::Node(node_id.clone()), false, None)
+            .await;
+        match nodes {
+            Err(e) if e.kind == ReplyErrorKind::NotFound => break,
+            _ => {}
+        }
+        assert!(
+            start.elapsed() < timeout,
+            "Timed out waiting for node spec to be removed"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Verify the purged node's pool is gone. Node 1's pool is still alive
+    // (it was never part of the purge), so we filter by node rather than
+    // expecting an empty global list.
+    let pools = pool_client
+        .get(Filter::Node(node_id.clone()), None)
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(
+        pools.is_empty(),
+        "All pools on the purged node should be gone"
+    );
+}
+
+/// Simulate a crash after the node is marked Purging but before pools are
+/// deleted. Write the Purging state directly to etcd, restart core, and verify
+/// the reconciler resumes and completes the purge.
+async fn purge_reconciler_resumes_interrupted(cluster: &Cluster) {
+    let node_client = cluster.grpc_client().node();
+    let pool_client = cluster.grpc_client().pool();
+    let volume_client = cluster.grpc_client().volume();
+    let replica_client = cluster.grpc_client().replica();
+    let node_id = cluster.node(0);
+    // Node 1 remains online throughout all phases and retains its auto-created
+    // pool from cluster startup; it is the survivor node for the 2-replica volume.
+    let node1_id = cluster.node(1);
+
+    // 1. Bring io-engine back online.
+    //    After Phase 4 purged the node, the spec is gone. The io-engine must
+    //    re-register to create a new NodeSpec, so we poll for it instead of
+    //    using wait_node_status_tmo (which panics on NotFound).
+    cluster.composer().start("io-engine-1").await.unwrap();
+    let timeout = NODE_OFFLINE_TIMEOUT;
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(nodes) = node_client
+            .get(Filter::Node(node_id.clone()), false, None)
+            .await
+        {
+            if nodes
+                .0
+                .first()
+                .and_then(|n| n.state())
+                .map(|s| s.status == NodeStatus::Online)
+                .unwrap_or(false)
+            {
+                break;
+            }
+        }
+        assert!(
+            start.elapsed() < timeout,
+            "Timed out waiting for node to re-register and come online"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // 2. Create a pool and volume.
+    let pool_id: PoolId = "resume-purge-pool".into();
+    pool_client
+        .create(
+            &CreatePool {
+                node: node_id.clone(),
+                id: pool_id.clone(),
+                disks: vec!["malloc:///resume_disk?size_mb=100".into()],
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .expect("Pool creation should succeed");
+
+    // 1-replica volume pinned to node 0 — fully lost when node 0 is purged.
+    let vol_id = VolumeId::new();
+    volume_client
+        .create(
+            &CreateVolume {
+                uuid: vol_id.clone(),
+                size: VOLUME_SIZE,
+                replicas: 1,
+                topology: Some(Topology::from(models::Topology::new_all(
+                    Some(models::NodeTopology::explicit(
+                        models::ExplicitNodeTopology::new(
+                            vec![node_id.to_string()],
+                            Vec::<String>::new(),
+                        ),
+                    )),
+                    None,
+                ))),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .expect("Volume creation should succeed");
+
+    volume_client
+        .publish(
+            &PublishVolume {
+                uuid: vol_id.clone(),
+                target_node: Some(node_id.clone()),
+                share: None,
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .expect("1-replica volume should publish on node 0");
+
+    // Verify replica landed on our pool.
+    let replicas = replica_client
+        .get(Filter::Volume(vol_id.clone()), None)
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!replicas.is_empty(), "Volume should have a replica");
+    assert_eq!(
+        replicas[0].pool_id, pool_id,
+        "Replica should be on the new pool"
+    );
+
+    // 2-replica volume spanning both nodes — one replica survives on node 1
+    // after the purge, so the volume spec persists in a degraded state.
+    let vol_id_2r = VolumeId::new();
+    volume_client
+        .create(
+            &CreateVolume {
+                uuid: vol_id_2r.clone(),
+                size: VOLUME_SIZE,
+                replicas: 2,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .expect("2-replica volume creation should succeed");
+
+    volume_client
+        .publish(
+            &PublishVolume {
+                uuid: vol_id_2r.clone(),
+                target_node: Some(node_id.clone()),
+                share: None,
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .expect("2-replica volume should publish on node 0");
+
+    let replicas_2r = replica_client
+        .get(Filter::Volume(vol_id_2r.clone()), None)
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        replicas_2r.len(),
+        2,
+        "2-replica volume should have 2 replicas"
+    );
+    assert!(
+        replicas_2r.iter().any(|r| r.node == node_id),
+        "One replica should be on node 0 (the node being purged)"
+    );
+    assert!(
+        replicas_2r.iter().any(|r| r.node == node1_id),
+        "One replica should be on node 1 (the survivor node)"
+    );
+
+    // 3. Stop node so it goes offline.
+    cluster.composer().stop("io-engine-1").await.unwrap();
+    cluster
+        .wait_node_status_tmo(cluster.node(0), NodeStatus::Offline, NODE_OFFLINE_TIMEOUT)
+        .await
+        .expect("Node should go offline");
+
+    // Cordon the node.
+    node_client
+        .cordon(node_id.clone(), "reconciler-test".to_string())
+        .await
+        .unwrap();
+
+    // 4. Simulate crash after start_destroy_for_purge: write Purging state + Destroy op to etcd.
+    //    The reconciler will cordon pools automatically when resuming.
+    let mut etcd = Etcd::new("0.0.0.0:2379")
+        .await
+        .expect("Failed to connect to etcd");
+    let (mut node_spec, _): (NodeSpec, i64) = etcd
+        .get_obj(&NodeSpecKey::from(&node_id))
+        .await
+        .expect("Node spec should exist in etcd");
+
+    node_spec.status = SpecStatus::Purging;
+    node_spec.operation = Some(NodeOperationState {
+        operation: NodeOperation::Destroy,
+        result: None,
+    });
+    etcd.put_obj(&node_spec)
+        .await
+        .expect("Failed to write Purging node spec to etcd");
+
+    // 5. Restart core agent — reconciler should detect Purging and resume the purge.
+    cluster
+        .restart_core_with_liveness(None)
+        .await
+        .expect("Core agent should restart and become live");
+
+    // 6. Wait for the reconciler to complete the purge (node spec gone).
+    let timeout = Duration::from_secs(5);
+    let start = std::time::Instant::now();
+    loop {
+        let nodes = node_client
+            .get(Filter::Node(node_id.clone()), false, None)
+            .await;
+        match nodes {
+            Err(e) if e.kind == ReplyErrorKind::NotFound => break,
+            _ => {}
+        }
+        assert!(
+            start.elapsed() < timeout,
+            "Timed out waiting for reconciler to complete node purge"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // 7. Pool is gone — either NotFound or an empty list; anything else is a bug.
+    match pool_client.get(Filter::Pool(pool_id.clone()), None).await {
+        Ok(p) => assert!(
+            p.into_inner().is_empty(),
+            "Pool should be gone after node purge"
+        ),
+        Err(e) if e.kind == ReplyErrorKind::NotFound => {}
+        Err(e) => panic!("Unexpected error checking pool after purge: {e:?}"),
+    }
+
+    // 8. Replicas of the 1-replica volume are gone — same contract.
+    match replica_client
+        .get(Filter::Volume(vol_id.clone()), None)
+        .await
+    {
+        Ok(r) => assert!(
+            r.into_inner().is_empty(),
+            "Replicas should be gone after node purge"
+        ),
+        Err(e) if e.kind == ReplyErrorKind::NotFound => {}
+        Err(e) => panic!("Unexpected error checking replicas after purge: {e:?}"),
+    }
+
+    // 9. Verify the 2-replica volume still exists and has exactly one surviving
+    //    replica on node 1. The volume spec is NOT deleted by the purge because
+    //    healthy_after=1 — it stays degraded until the user removes it.
+    let surviving = replica_client
+        .get(Filter::Volume(vol_id_2r.clone()), None)
+        .await
+        .expect("2-replica volume replicas should be queryable after purge")
+        .into_inner();
+    assert_eq!(
+        surviving.len(),
+        1,
+        "Exactly one replica should survive on node 1"
+    );
+    assert_eq!(
+        surviving[0].node, node1_id,
+        "Surviving replica must be on node 1, not the purged node"
+    );
+
+    volume_client
+        .get(Filter::Volume(vol_id_2r.clone()), false, None, None)
+        .await
+        .expect("2-replica volume spec should still exist after partial purge");
+
+    // 10. Clean up: destroy both volumes.
+    //     vol_id has no replicas left — pure spec deletion, no io-engine RPC.
+    //     vol_id_2r has one replica on node 1 — the destroy will tear it down.
+    volume_client
+        .destroy(
+            &DestroyVolume {
+                uuid: vol_id.clone(),
+            },
+            None,
+        )
+        .await
+        .expect("1-replica volume destroy should succeed after all replicas are gone");
+
+    let err = volume_client
+        .get(Filter::Volume(vol_id.clone()), false, None, None)
+        .await
+        .expect_err("1-replica volume should be NotFound after destroy");
+    assert_eq!(err.kind, ReplyErrorKind::NotFound);
+    assert_eq!(err.resource, ResourceKind::Volume);
+
+    volume_client
+        .destroy(
+            &DestroyVolume {
+                uuid: vol_id_2r.clone(),
+            },
+            None,
+        )
+        .await
+        .expect("2-replica volume destroy should succeed");
+
+    let err = volume_client
+        .get(Filter::Volume(vol_id_2r.clone()), false, None, None)
+        .await
+        .expect_err("2-replica volume should be NotFound after destroy");
+    assert_eq!(err.kind, ReplyErrorKind::NotFound);
+    assert_eq!(err.resource, ResourceKind::Volume);
+}

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -450,12 +450,12 @@ pub enum SvcError {
     #[snafu(display("Pool {name} underlying disk rescan failed"))]
     DiskRescanFailed { name: PoolId },
     #[snafu(display(
-        "Cannot purge pool {pool_id}: pool state is {state}, purge only allowed when state is Unknown",
+        "Cannot purge pool {pool_id}: pool state is {state}, purge only allowed when state is Offline or Unknown",
     ))]
-    PoolStateNotUnknown { pool_id: PoolId, state: PoolStatus },
+    PoolStateNotOfflineOrUnknown { pool_id: PoolId, state: PoolStatus },
 
     #[snafu(display(
-        "Cannot purge pool {pool_id}: pool must be cordoned with --replicas --snapshots flags first",
+        "Cannot purge pool {pool_id}: pool must be cordoned for replicas and snapshots first",
     ))]
     PoolNotCordonedForPurge { pool_id: PoolId },
 
@@ -465,7 +465,7 @@ pub enum SvcError {
     PoolCordonInsufficientForPurge { pool_id: PoolId },
 
     #[snafu(display(
-        "Cannot purge pool {pool_id}: pool has {replica_count} replica(s), use --yes to proceed",
+        "Cannot purge pool {pool_id}: pool has {replica_count} replica(s), accept=true required",
     ))]
     PoolPurgeAcceptRequired {
         pool_id: PoolId,
@@ -473,7 +473,7 @@ pub enum SvcError {
     },
 
     #[snafu(display(
-        "Cannot purge pool {pool_id}: {volume_count} volume(s) would lose their last healthy replica, use --accept-volume-loss to proceed",
+        "Cannot purge pool {pool_id}: {volume_count} volume(s) would lose their last healthy replica, accept_volume_loss=true required",
     ))]
     PoolPurgeVolumeLossAcceptRequired {
         pool_id: PoolId,
@@ -482,10 +482,46 @@ pub enum SvcError {
     },
 
     #[snafu(display(
-        "Cannot purge pool {pool_id}: {snapshot_count} snapshot(s) would lose their last replica snapshot, use --accept-snapshot-loss to proceed",
+        "Cannot purge pool {pool_id}: {snapshot_count} snapshot(s) would lose their last replica snapshot, accept_snapshot_loss=true required",
     ))]
     PoolPurgeSnapshotLossAcceptRequired {
         pool_id: PoolId,
+        snapshot_count: usize,
+        snapshot_loss: SnapshotLossInfo,
+    },
+
+    #[snafu(display("Cannot delete node {node_id}: node is online"))]
+    NodeIsOnline { node_id: NodeId },
+
+    #[snafu(display("Cannot delete node {node_id}: node must be cordoned first"))]
+    NodeNotCordoned { node_id: NodeId },
+
+    #[snafu(display(
+        "Cannot delete node {node_id}: node has resources. purge=true required to delete all resources"
+    ))]
+    NodeHasResources { node_id: NodeId },
+
+    #[snafu(display(
+        "Cannot delete node {node_id}: node has {pool_count} pool(s), accept=true required"
+    ))]
+    NodePurgeAcceptRequired { node_id: NodeId, pool_count: usize },
+
+    #[snafu(display(
+        "Cannot delete node {node_id}: {volume_count} volume(s) across {pool_count} pool(s) would lose their last healthy replica, accept_volume_loss=true required"
+    ))]
+    NodePurgeVolumeLossAcceptRequired {
+        node_id: NodeId,
+        pool_count: usize,
+        volume_count: usize,
+        volume_loss: VolumeLossInfo,
+    },
+
+    #[snafu(display(
+        "Cannot delete node {node_id}: {snapshot_count} snapshot(s) across {pool_count} pool(s) would lose their last replica snapshot, accept_snapshot_loss=true required"
+    ))]
+    NodePurgeSnapshotLossAcceptRequired {
+        node_id: NodeId,
+        pool_count: usize,
         snapshot_count: usize,
         snapshot_loss: SnapshotLossInfo,
     },
@@ -1252,7 +1288,7 @@ impl From<SvcError> for ReplyError {
                 source,
                 extra,
             },
-            SvcError::PoolStateNotUnknown { .. } => ReplyError {
+            SvcError::PoolStateNotOfflineOrUnknown { .. } => ReplyError {
                 kind: ReplyErrorKind::PoolNotPurgeable,
                 resource: ResourceKind::Pool,
                 source,
@@ -1285,6 +1321,42 @@ impl From<SvcError> for ReplyError {
             SvcError::PoolPurgeSnapshotLossAcceptRequired { .. } => ReplyError {
                 kind: ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired,
                 resource: ResourceKind::Pool,
+                source,
+                extra,
+            },
+            SvcError::NodeIsOnline { .. } => ReplyError {
+                kind: ReplyErrorKind::NodeIsOnline,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodeNotCordoned { .. } => ReplyError {
+                kind: ReplyErrorKind::NodeNotCordoned,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodeHasResources { .. } => ReplyError {
+                kind: ReplyErrorKind::NodeHasResources,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodePurgeAcceptRequired { .. } => ReplyError {
+                kind: ReplyErrorKind::NodePurgeAcceptRequired,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodePurgeVolumeLossAcceptRequired { .. } => ReplyError {
+                kind: ReplyErrorKind::NodePurgeVolumeLossAcceptRequired,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodePurgeSnapshotLossAcceptRequired { .. } => ReplyError {
+                kind: ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired,
+                resource: ResourceKind::Node,
                 source,
                 extra,
             },

--- a/control-plane/grpc/proto/v1/misc/common.proto
+++ b/control-plane/grpc/proto/v1/misc/common.proto
@@ -82,6 +82,12 @@ enum ReplyErrorKind {
   PoolPurgeAcceptRequired = 40;
   PoolPurgeVolumeLossAcceptRequired = 41;
   PoolPurgeSnapshotLossAcceptRequired = 42;
+  NodeIsOnline = 43;
+  NodeNotCordoned = 44;
+  NodeHasResources = 45;
+  NodePurgeAcceptRequired = 46;
+  NodePurgeVolumeLossAcceptRequired = 47;
+  NodePurgeSnapshotLossAcceptRequired = 48;
 }
 
 // ResourceKind for the resource which has undergone this error

--- a/control-plane/grpc/proto/v1/node/target_node.proto
+++ b/control-plane/grpc/proto/v1/node/target_node.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "v1/misc/common.proto";
 import "v1/blockdevice/blockdevice.proto";
+import "v1/pool/pool.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -184,6 +185,35 @@ message UnlabelNodeReply {
   }
 }
 
+message DeleteNodeRequest {
+  // Node identification
+  string node_id = 1;
+  // Purge node and all its resources without contacting io-engine
+  bool purge = 2;
+  // Accept deletion of resources (pools, replicas, nexuses, snapshots)
+  bool accept = 3;
+  // Accept volume loss (last healthy replica)
+  bool accept_volume_loss = 4;
+  // Accept snapshot loss (last replica snapshot)
+  bool accept_snapshot_loss = 5;
+}
+
+message NodeDeleteResult {
+  // The deleted node ID
+  string node_id = 1;
+  // Volumes that lost their last healthy replica
+  repeated pool.VolumeLossDetail volume_loss = 2;
+  // Snapshots that lost their last replica snapshot
+  repeated pool.SnapshotLossDetail snapshot_loss = 3;
+}
+
+message DeleteNodeReply {
+  oneof reply {
+    NodeDeleteResult result = 1;
+    common.ReplyError error = 2;
+  }
+}
+
 service NodeGrpc {
   rpc GetNodes (GetNodesRequest) returns (GetNodesReply) {}
   rpc GetBlockDevices (blockdevice.GetBlockDevicesRequest) returns (blockdevice.GetBlockDevicesReply) {}
@@ -193,4 +223,5 @@ service NodeGrpc {
   rpc DrainNode (DrainNodeRequest) returns (DrainNodeReply) {}
   rpc LabelNode (LabelNodeRequest) returns (LabelNodeReply) {}
   rpc UnlabelNode (UnlabelNodeRequest) returns (UnlabelNodeReply) {}
+  rpc DeleteNode (DeleteNodeRequest) returns (DeleteNodeReply) {}
 }

--- a/control-plane/grpc/src/misc/traits.rs
+++ b/control-plane/grpc/src/misc/traits.rs
@@ -117,6 +117,16 @@ impl From<ReplyErrorKind> for common::ReplyErrorKind {
             ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired => {
                 Self::PoolPurgeSnapshotLossAcceptRequired
             }
+            ReplyErrorKind::NodeIsOnline => Self::NodeIsOnline,
+            ReplyErrorKind::NodeNotCordoned => Self::NodeNotCordoned,
+            ReplyErrorKind::NodeHasResources => Self::NodeHasResources,
+            ReplyErrorKind::NodePurgeAcceptRequired => Self::NodePurgeAcceptRequired,
+            ReplyErrorKind::NodePurgeVolumeLossAcceptRequired => {
+                Self::NodePurgeVolumeLossAcceptRequired
+            }
+            ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired => {
+                Self::NodePurgeSnapshotLossAcceptRequired
+            }
         }
     }
 }
@@ -170,6 +180,16 @@ impl From<common::ReplyErrorKind> for ReplyErrorKind {
             }
             common::ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired => {
                 Self::PoolPurgeSnapshotLossAcceptRequired
+            }
+            common::ReplyErrorKind::NodeIsOnline => Self::NodeIsOnline,
+            common::ReplyErrorKind::NodeNotCordoned => Self::NodeNotCordoned,
+            common::ReplyErrorKind::NodeHasResources => Self::NodeHasResources,
+            common::ReplyErrorKind::NodePurgeAcceptRequired => Self::NodePurgeAcceptRequired,
+            common::ReplyErrorKind::NodePurgeVolumeLossAcceptRequired => {
+                Self::NodePurgeVolumeLossAcceptRequired
+            }
+            common::ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired => {
+                Self::NodePurgeSnapshotLossAcceptRequired
             }
         }
     }

--- a/control-plane/grpc/src/operations/node/client.rs
+++ b/control-plane/grpc/src/operations/node/client.rs
@@ -16,7 +16,7 @@ use stor_port::{
         v0::{BlockDevices, Nodes},
         ReplyError, ResourceKind, TimeoutOptions,
     },
-    types::v0::transport::{Filter, MessageIdVs, Node, NodeId},
+    types::v0::transport::{DestroyNode, Filter, MessageIdVs, Node, NodeDeleteResult, NodeId},
 };
 use tonic::transport::Uri;
 
@@ -177,6 +177,19 @@ impl NodeOperations for NodeClient {
                 unlabel_node_reply::Reply::Node(node) => Ok(Node::try_from(node)?),
                 unlabel_node_reply::Reply::Error(err) => Err(err.into()),
             },
+            None => Err(ReplyError::invalid_response(ResourceKind::Node)),
+        }
+    }
+
+    #[tracing::instrument(name = "NodeClient::delete", level = "debug", skip(self), err)]
+    async fn delete(&self, request: &DestroyNode) -> Result<NodeDeleteResult, ReplyError> {
+        let req = crate::node::DeleteNodeRequest::from(request.clone());
+        let response = self.client().delete_node(req).await?.into_inner();
+        match response.reply {
+            Some(crate::node::delete_node_reply::Reply::Result(result)) => {
+                Ok(NodeDeleteResult::try_from(result)?)
+            }
+            Some(crate::node::delete_node_reply::Reply::Error(err)) => Err(err.into()),
             None => Err(ReplyError::invalid_response(ResourceKind::Node)),
         }
     }

--- a/control-plane/grpc/src/operations/node/server.rs
+++ b/control-plane/grpc/src/operations/node/server.rs
@@ -2,16 +2,17 @@ use crate::{
     blockdevice::{get_block_devices_reply, GetBlockDevicesReply, GetBlockDevicesRequest},
     node,
     node::{
-        cordon_node_reply, drain_node_reply, get_nodes_reply, label_node_reply,
+        cordon_node_reply, delete_node_reply, drain_node_reply, get_nodes_reply, label_node_reply,
         node_grpc_server::{NodeGrpc, NodeGrpcServer},
         uncordon_node_reply, unlabel_node_reply, CordonNodeReply, CordonNodeRequest,
-        DrainNodeReply, DrainNodeRequest, GetNodesReply, GetNodesRequest, LabelNodeReply,
-        LabelNodeRequest, ProbeRequest, ProbeResponse, UncordonNodeReply, UncordonNodeRequest,
-        UnlabelNodeReply, UnlabelNodeRequest,
+        DeleteNodeReply, DeleteNodeRequest, DrainNodeReply, DrainNodeRequest, GetNodesReply,
+        GetNodesRequest, LabelNodeReply, LabelNodeRequest, ProbeRequest, ProbeResponse,
+        UncordonNodeReply, UncordonNodeRequest, UnlabelNodeReply, UnlabelNodeRequest,
     },
     operations::node::traits::NodeOperations,
 };
 use std::sync::Arc;
+use stor_port::types::v0::transport::DestroyNode;
 use tonic::{Request, Response};
 
 /// gRPC Node Server
@@ -158,6 +159,22 @@ impl NodeGrpc for NodeServer {
             })),
             Err(err) => Ok(Response::new(UnlabelNodeReply {
                 reply: Some(unlabel_node_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn delete_node(
+        &self,
+        request: tonic::Request<DeleteNodeRequest>,
+    ) -> Result<tonic::Response<DeleteNodeReply>, tonic::Status> {
+        let req: DeleteNodeRequest = request.into_inner();
+        let destroy: DestroyNode = req.into();
+        match self.service.delete(&destroy).await {
+            Ok(result) => Ok(Response::new(DeleteNodeReply {
+                reply: Some(delete_node_reply::Reply::Result(result.into())),
+            })),
+            Err(err) => Ok(Response::new(DeleteNodeReply {
+                reply: Some(delete_node_reply::Reply::Error(err.into())),
             })),
         }
     }

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -1,6 +1,6 @@
 use crate::{
     blockdevice, blockdevice::GetBlockDevicesRequest, context::Context, node,
-    node::get_nodes_request,
+    node::get_nodes_request, pool,
 };
 use std::{collections::HashMap, convert::TryFrom, str::FromStr};
 use stor_port::{
@@ -11,8 +11,9 @@ use stor_port::{
     types::v0::{
         store::node::{CordonDrainState, CordonedState, DrainState, NodeSpec},
         transport::{
-            BlockDevice, Filesystem, Filter, GetBlockDevices, Node, NodeId, NodeState, NodeStatus,
-            Partition,
+            BlockDevice, DestroyNode, Filesystem, Filter, GetBlockDevices, Node, NodeDeleteResult,
+            NodeId, NodeState, NodeStatus, Partition, SnapshotLossDetail, SnapshotLossInfo,
+            VolumeLossDetail, VolumeLossInfo,
         },
     },
     TryIntoOption,
@@ -51,6 +52,8 @@ pub trait NodeOperations: Send + Sync {
     ) -> Result<Node, ReplyError>;
     /// Remove label from the a given node.
     async fn unlabel(&self, id: NodeId, label: String) -> Result<Node, ReplyError>;
+    /// Delete a node and all its resources (purge). Always returns `NodeDeleteResult`.
+    async fn delete(&self, request: &DestroyNode) -> Result<NodeDeleteResult, ReplyError>;
 }
 
 impl TryFrom<node::Node> for Node {
@@ -425,6 +428,106 @@ impl From<BlockDevices> for blockdevice::BlockDevices {
                 .into_iter()
                 .map(|bd| bd.into())
                 .collect(),
+        }
+    }
+}
+
+impl From<NodeDeleteResult> for node::NodeDeleteResult {
+    fn from(result: NodeDeleteResult) -> Self {
+        Self {
+            node_id: result.node_id.to_string(),
+            volume_loss: result
+                .volume_loss
+                .volumes
+                .into_iter()
+                .map(|v| pool::VolumeLossDetail {
+                    volume_id: v.volume_id.to_string(),
+                    replicas_before: v.replicas_before,
+                    healthy_before: v.healthy_before,
+                    lost_on_pool: v.lost_on_pool,
+                    healthy_after: v.healthy_after,
+                })
+                .collect(),
+            snapshot_loss: result
+                .snapshot_loss
+                .snapshots
+                .into_iter()
+                .map(|s| pool::SnapshotLossDetail {
+                    snapshot_id: s.snapshot_id.to_string(),
+                    replica_snapshots_before: s.replica_snapshots_before,
+                    healthy_before: s.healthy_before,
+                    lost_on_pool: s.lost_on_pool,
+                    healthy_after: s.healthy_after,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<node::NodeDeleteResult> for NodeDeleteResult {
+    type Error = ReplyError;
+
+    fn try_from(result: node::NodeDeleteResult) -> Result<Self, Self::Error> {
+        let mut volumes = Vec::new();
+        for v in result.volume_loss {
+            let volume_id = uuid::Uuid::parse_str(&v.volume_id).map_err(|_| {
+                ReplyError::invalid_argument(ResourceKind::Volume, "volume_id", v.volume_id.clone())
+            })?;
+            volumes.push(VolumeLossDetail {
+                volume_id: volume_id.into(),
+                replicas_before: v.replicas_before,
+                healthy_before: v.healthy_before,
+                lost_on_pool: v.lost_on_pool,
+                healthy_after: v.healthy_after,
+            });
+        }
+
+        let mut snapshots = Vec::new();
+        for s in result.snapshot_loss {
+            let snapshot_id = uuid::Uuid::parse_str(&s.snapshot_id).map_err(|_| {
+                ReplyError::invalid_argument(
+                    ResourceKind::VolumeSnapshot,
+                    "snapshot_id",
+                    s.snapshot_id.clone(),
+                )
+            })?;
+            snapshots.push(SnapshotLossDetail {
+                snapshot_id: snapshot_id.into(),
+                replica_snapshots_before: s.replica_snapshots_before,
+                healthy_before: s.healthy_before,
+                lost_on_pool: s.lost_on_pool,
+                healthy_after: s.healthy_after,
+            });
+        }
+
+        Ok(NodeDeleteResult {
+            node_id: result.node_id.into(),
+            volume_loss: VolumeLossInfo { volumes },
+            snapshot_loss: SnapshotLossInfo { snapshots },
+        })
+    }
+}
+
+impl From<DestroyNode> for node::DeleteNodeRequest {
+    fn from(request: DestroyNode) -> Self {
+        Self {
+            node_id: request.id.to_string(),
+            purge: request.purge,
+            accept: request.accept,
+            accept_volume_loss: request.accept_volume_loss,
+            accept_snapshot_loss: request.accept_snapshot_loss,
+        }
+    }
+}
+
+impl From<node::DeleteNodeRequest> for DestroyNode {
+    fn from(request: node::DeleteNodeRequest) -> Self {
+        Self {
+            id: request.node_id.into(),
+            purge: request.purge,
+            accept: request.accept,
+            accept_volume_loss: request.accept_volume_loss,
+            accept_snapshot_loss: request.accept_snapshot_loss,
         }
     }
 }

--- a/control-plane/plugin/src/lib.rs
+++ b/control-plane/plugin/src/lib.rs
@@ -336,6 +336,9 @@ impl ExecuteOperation for DeleteArgs {
                     DeleteResources::Pool(args) => {
                         pool::Pool::del(args, self.ignore_not_found, &cli_args.output).await
                     }
+                    DeleteResources::Node(args) => {
+                        node::Node::del(args, self.ignore_not_found, &cli_args.output).await
+                    }
                     DeleteResources::Volume { id } => {
                         volume::Volume::del(id, self.ignore_not_found, &cli_args.output).await
                     }

--- a/control-plane/plugin/src/resources/error.rs
+++ b/control-plane/plugin/src/resources/error.rs
@@ -71,6 +71,11 @@ pub enum Error {
         id: String,
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,
     },
+    #[snafu(display("Failed to delete node {id}. Error {source}"))]
+    DeleteNodeError {
+        id: String,
+        source: openapi::tower::client::Error<openapi::models::RestJsonError>,
+    },
     /// Error when get pool request fails.
     #[snafu(display("No state for pool {id}. Please verify if node is online"))]
     PoolStateError { id: String },

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -251,6 +251,8 @@ pub struct DeleteArgs {
 pub enum DeleteResources {
     /// Deletes the specified pool resource.
     Pool(pool::DeletePoolArgs),
+    /// Deletes the specified node and all its resources (purge).
+    Node(node::DeleteNodeArgs),
     /// Deletes the specified volume resource.
     Volume {
         /// The id of the volume to delete.

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -1,5 +1,5 @@
 use crate::{
-    operations::{Cordoning, Drain, GetWithArgs, Label, ListWithArgs, PluginResult},
+    operations::{Cordoning, Delete, Drain, GetWithArgs, Label, ListWithArgs, PluginResult},
     resources::{
         error::{Error, LabelAssignSnafu, OpError, TopologyError},
         utils::{
@@ -11,7 +11,7 @@ use crate::{
     rest_wrapper::RestClient,
 };
 use async_trait::async_trait;
-use openapi::{apis::StatusCode, models::CordonDrainState};
+use openapi::{apis::StatusCode, models, models::CordonDrainState};
 use prettytable::{Cell, Row};
 use serde::Serialize;
 use snafu::ResultExt;
@@ -762,5 +762,116 @@ impl Label for Node {
             }
         }
         Ok(())
+    }
+}
+
+/// Arguments for deleting a node.
+#[derive(Debug, Clone, clap::Args)]
+pub struct DeleteNodeArgs {
+    /// Id of the node to delete.
+    node_id: NodeId,
+
+    /// Purge node and all its resources without contacting io-engine.{n}
+    /// Use this when the node is permanently offline or decommissioned.
+    /// Requires the node to be offline and cordoned.
+    #[arg(long)]
+    purge: bool,
+
+    /// Accept both volume loss and snapshot loss.
+    /// Shorthand for --accept-volume-loss --accept-snapshot-loss.
+    #[arg(long)]
+    accept_data_loss: bool,
+
+    /// Accept volume loss for volumes losing their last healthy replica.
+    /// Required when --purge would cause volume data loss.
+    #[arg(long)]
+    accept_volume_loss: bool,
+
+    /// Accept snapshot loss for snapshots losing their last replica snapshot.
+    /// Required when --purge would cause snapshot loss.
+    #[arg(long)]
+    accept_snapshot_loss: bool,
+}
+
+#[async_trait(?Send)]
+impl Delete for Node {
+    type ID = DeleteNodeArgs;
+
+    async fn del(id: &Self::ID, _ignore_not_found: bool, output: &OutputFormat) -> PluginResult {
+        // --accept-data-loss is shorthand for both volume and snapshot loss.
+        let accept_volume_loss = id.accept_volume_loss || id.accept_data_loss;
+        let accept_snapshot_loss = id.accept_snapshot_loss || id.accept_data_loss;
+        let body = openapi::models::DeleteNodeBody {
+            purge: Some(id.purge),
+            accept: Some(true),
+            accept_volume_loss: Some(accept_volume_loss),
+            accept_snapshot_loss: Some(accept_snapshot_loss),
+        };
+
+        match RestClient::client()
+            .nodes_api()
+            .del_node(&id.node_id, Some(body))
+            .await
+        {
+            Ok(response) => {
+                utils::print_table(output, response.into_body());
+                Ok(())
+            }
+            Err(source) => {
+                // Translate core agent errors into user-friendly messages with CLI flags.
+                use openapi::models::rest_json_error::Kind;
+                if let Some(kind) = source.error_body().map(|b| b.kind) {
+                    let hint = match kind {
+                        Kind::NodeIsOnline => {
+                            Some("Node is online. Only offline nodes can be deleted.")
+                        }
+                        Kind::NodeNotCordoned => {
+                            Some("Node must be cordoned first. Use: kubectl mayastor cordon node <id> <label>")
+                        }
+                        Kind::NodeHasResources => {
+                            Some("Node has resources. Use --purge to force-remove the node and all its resources.")
+                        }
+                        Kind::NodePurgeAcceptRequired => {
+                            Some("Node has pools with data. Confirm with --yes to proceed.")
+                        }
+                        Kind::NodePurgeVolumeLossAcceptRequired => {
+                            Some("Volumes would lose their last healthy replica. Use --accept-volume-loss or --accept-data-loss to proceed.")
+                        }
+                        Kind::NodePurgeSnapshotLossAcceptRequired => {
+                            Some("Snapshots would lose their last replica snapshot. Use --accept-snapshot-loss or --accept-data-loss to proceed.")
+                        }
+                        _ => None,
+                    };
+                    if let Some(hint) = hint {
+                        eprintln!("{hint}");
+                    }
+                }
+                Err(Error::DeleteNodeError {
+                    id: id.node_id.clone(),
+                    source,
+                })
+            }
+        }
+    }
+}
+
+impl GetHeaderRow for models::NodeDeleteResult {
+    fn get_header_row(&self) -> Row {
+        row!["NODE", "VOLUME_LOSS", "SNAPSHOT_LOSS"]
+    }
+}
+
+impl CreateRow for models::NodeDeleteResult {
+    fn row(&self) -> Row {
+        let volume_loss = optional_cell(
+            (!self.volume_loss.volumes.is_empty())
+                .then(|| format!("{} volume(s)", self.volume_loss.volumes.len())),
+        );
+        let snapshot_loss = optional_cell(
+            (!self.snapshot_loss.snapshots.is_empty())
+                .then(|| format!("{} snapshot(s)", self.snapshot_loss.snapshots.len())),
+        );
+
+        row![self.node_id, volume_loss, snapshot_loss]
     }
 }

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -777,6 +777,11 @@ pub struct DeleteNodeArgs {
     #[arg(long)]
     purge: bool,
 
+    /// Show what would happen if this node is purged, without actually deleting.
+    /// Displays node status, cordon state, per-pool replica counts, and affected volumes.
+    #[arg(long)]
+    pub show_impact: bool,
+
     /// Accept both volume loss and snapshot loss.
     /// Shorthand for --accept-volume-loss --accept-snapshot-loss.
     #[arg(long)]
@@ -798,6 +803,11 @@ impl Delete for Node {
     type ID = DeleteNodeArgs;
 
     async fn del(id: &Self::ID, _ignore_not_found: bool, output: &OutputFormat) -> PluginResult {
+        // If --show-impact is set, show purge impact analysis and return without deleting.
+        if id.show_impact {
+            return Node::show_impact_analysis(&id.node_id, output).await;
+        }
+
         // --accept-data-loss is shorthand for both volume and snapshot loss.
         let accept_volume_loss = id.accept_volume_loss || id.accept_data_loss;
         let accept_snapshot_loss = id.accept_snapshot_loss || id.accept_data_loss;
@@ -873,5 +883,194 @@ impl CreateRow for models::NodeDeleteResult {
         );
 
         row![self.node_id, volume_loss, snapshot_loss]
+    }
+}
+
+/// Per-pool impact detail within a node purge.
+#[derive(Serialize, Debug, Clone)]
+pub struct PoolImpact {
+    /// The pool being analyzed.
+    pub pool_id: String,
+    /// Current runtime status of the pool.
+    pub status: models::PoolStatus,
+    /// Number of replicas residing on this pool.
+    pub replica_count: usize,
+    /// Volumes affected by purging this pool.
+    pub affected_volumes: Vec<super::VolumeId>,
+}
+
+/// Impact analysis for a node purge operation.
+///
+/// Shown when using `--show-impact` to preview what would happen before
+/// actually purging the node and all its pools.
+#[derive(Serialize, Debug, Clone)]
+pub struct NodePurgeImpact {
+    /// The node being analyzed.
+    pub node_id: NodeId,
+    /// Deemed status of the node (Online, Offline, Unknown).
+    pub status: models::NodeStatus,
+    /// Whether the node is cordoned.
+    pub cordoned: bool,
+    /// Per-pool impact breakdown.
+    pub pools: Vec<PoolImpact>,
+    /// Total number of replicas across all pools on this node.
+    pub total_replicas: usize,
+    /// Total unique volumes affected across all pools.
+    pub total_affected_volumes: usize,
+    /// Whether the node meets all preconditions for purge:
+    /// node is offline and cordoned.
+    pub ready_for_purge: bool,
+}
+
+impl GetHeaderRow for NodePurgeImpact {
+    fn get_header_row(&self) -> Row {
+        row![
+            "NODE",
+            "STATUS",
+            "CORDONED",
+            "POOLS",
+            "TOTAL_REPLICAS",
+            "AFFECTED_VOLUMES",
+            "READY",
+        ]
+    }
+}
+
+impl CreateRow for NodePurgeImpact {
+    fn row(&self) -> Row {
+        row![
+            self.node_id,
+            self.status,
+            self.cordoned,
+            self.pools.len(),
+            self.total_replicas,
+            self.total_affected_volumes,
+            self.ready_for_purge,
+        ]
+    }
+}
+
+impl GetHeaderRow for PoolImpact {
+    fn get_header_row(&self) -> Row {
+        row!["POOL", "STATUS", "REPLICAS", "AFFECTED_VOLUMES"]
+    }
+}
+
+impl CreateRow for PoolImpact {
+    fn row(&self) -> Row {
+        row![
+            self.pool_id,
+            self.status,
+            self.replica_count,
+            optional_cell((!self.affected_volumes.is_empty()).then(|| {
+                self.affected_volumes
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })),
+        ]
+    }
+}
+
+impl Node {
+    /// Show what would happen if this node is purged.
+    async fn show_impact_analysis(node_id: &NodeId, output: &OutputFormat) -> PluginResult {
+        // Get node info.
+        let node = match RestClient::client().nodes_api().get_node(node_id).await {
+            Ok(n) => n.into_body(),
+            Err(e) => {
+                return Err(Error::GetNodeError {
+                    id: node_id.to_string(),
+                    source: e,
+                });
+            }
+        };
+
+        let status = node.status.unwrap_or(models::NodeStatus::Unknown);
+        let cordoned = node
+            .spec
+            .as_ref()
+            .and_then(|s| s.cordondrainstate.as_ref())
+            .is_some();
+
+        // Get pools on this node.
+        let node_pools = RestClient::client()
+            .pools_api()
+            .get_node_pools(node_id)
+            .await
+            .map(|r| r.into_body())
+            .unwrap_or_default();
+
+        // Get all volumes for cross-referencing replica topology.
+        let volumes = RestClient::client()
+            .volumes_api()
+            .get_volumes(0, None, None)
+            .await
+            .map(|r| r.into_body().entries)
+            .unwrap_or_default();
+
+        let mut pool_impacts = Vec::new();
+        let mut all_affected_volumes: std::collections::HashSet<super::VolumeId> =
+            std::collections::HashSet::new();
+        let mut total_replicas = 0usize;
+
+        for pool in &node_pools {
+            let pool_id = pool.spec.as_ref().map(|s| s.id.clone()).unwrap_or_default();
+
+            let pool_status = pool
+                .state
+                .as_ref()
+                .map(|s| s.status)
+                .unwrap_or(models::PoolStatus::Unknown);
+
+            let mut replica_count = 0usize;
+            let mut affected_volumes: Vec<super::VolumeId> = Vec::new();
+
+            for volume in &volumes {
+                for topo in volume.state.replica_topology.values() {
+                    if topo.pool.as_deref() == Some(pool_id.as_str()) {
+                        replica_count += 1;
+                        if !affected_volumes.contains(&volume.spec.uuid) {
+                            affected_volumes.push(volume.spec.uuid);
+                        }
+                        all_affected_volumes.insert(volume.spec.uuid);
+                    }
+                }
+            }
+
+            total_replicas += replica_count;
+
+            pool_impacts.push(PoolImpact {
+                pool_id,
+                status: pool_status,
+                replica_count,
+                affected_volumes,
+            });
+        }
+
+        let ready_for_purge = status == models::NodeStatus::Offline && cordoned;
+
+        let impact = NodePurgeImpact {
+            node_id: node_id.clone(),
+            status,
+            cordoned,
+            pools: pool_impacts.clone(),
+            total_replicas,
+            total_affected_volumes: all_affected_volumes.len(),
+            ready_for_purge,
+        };
+
+        // Print node-level summary.
+        print_table(output, impact);
+
+        // Print per-pool breakdown if there are pools.
+        if !pool_impacts.is_empty() {
+            println!();
+            println!("Per-pool breakdown:");
+            print_table(output, pool_impacts);
+        }
+
+        Ok(())
     }
 }

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -341,7 +341,7 @@ impl GetWithArgs for Pool {
 #[derive(Debug, Clone, clap::Args)]
 pub struct DeletePoolArgs {
     /// Id of the pool to delete.
-    pool_id: PoolId,
+    pub pool_id: PoolId,
 
     /// Purge pool without contacting io-engine.{n}
     /// Use this when the pool's node is offline or the pool state is Unknown.
@@ -409,6 +409,35 @@ impl Delete for Pool {
                 // Handle not found with ignore flag
                 if ignore_not_found && source.status() == Some(StatusCode::NOT_FOUND) {
                     return Ok(());
+                }
+
+                // Translate core agent errors into user-friendly messages with CLI flags.
+                use openapi::models::rest_json_error::Kind;
+                if let Some(kind) = source.error_body().map(|b| b.kind) {
+                    let hint = match kind {
+                        Kind::PoolNotPurgeable => {
+                            Some("Pool state is not Unknown. Only pools with Unknown state (offline node) can be purged.")
+                        }
+                        Kind::PoolNotCordoned => {
+                            Some("Pool must be cordoned first. Use: kubectl mayastor cordon pool <id> --replicas --snapshots")
+                        }
+                        Kind::PoolCordonInsufficient => {
+                            Some("Pool cordon must block both replicas and snapshots. Use: kubectl mayastor cordon pool <id> --replicas --snapshots")
+                        }
+                        Kind::PoolPurgeAcceptRequired => {
+                            Some("Pool has replicas. Confirm with --yes to proceed.")
+                        }
+                        Kind::PoolPurgeVolumeLossAcceptRequired => {
+                            Some("Volumes would lose their last healthy replica. Use --accept-volume-loss or --accept-data-loss to proceed.")
+                        }
+                        Kind::PoolPurgeSnapshotLossAcceptRequired => {
+                            Some("Snapshots would lose their last replica snapshot. Use --accept-snapshot-loss or --accept-data-loss to proceed.")
+                        }
+                        _ => None,
+                    };
+                    if let Some(hint) = hint {
+                        eprintln!("{hint}");
+                    }
                 }
 
                 Err(Error::DeletePoolError {

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -233,6 +233,35 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: [ ]
+    delete:
+      tags:
+        - Nodes
+      operationId: del_node
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteNodeBody'
+      responses:
+        '200':
+          description: Node purged successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeDeleteResult'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
   '/nodes/{id}/cordon/{label}':
     put:
       tags:
@@ -2795,6 +2824,52 @@ components:
         - healthyBefore
         - lostOnPool
         - healthyAfter
+
+    DeleteNodeBody:
+      description: Request body for node deletion
+      type: object
+      properties:
+        purge:
+          description: |
+            Force removal of node and all its resources without contacting io-engine.
+            Requires node to be offline and cordoned.
+          type: boolean
+          default: false
+        accept:
+          description: Accept deletion when node has resources (pools, replicas, nexuses)
+          type: boolean
+          default: false
+        acceptVolumeLoss:
+          description: |
+            Accept volume loss. Required when purge would cause volumes
+            to lose their last healthy replica.
+          type: boolean
+          default: false
+        acceptSnapshotLoss:
+          description: |
+            Accept snapshot loss. Required when purge would cause
+            snapshots to lose their last replica snapshot.
+          type: boolean
+          default: false
+
+    NodeDeleteResult:
+      description: Result of a node delete operation
+      type: object
+      properties:
+        nodeId:
+          description: The deleted node identifier
+          type: string
+        volumeLoss:
+          description: Information about volumes that lost healthy replicas
+          $ref: '#/components/schemas/VolumeLossInfo'
+        snapshotLoss:
+          description: Information about snapshots that lost replica snapshots
+          $ref: '#/components/schemas/SnapshotLossInfo'
+      required:
+        - nodeId
+        - volumeLoss
+        - snapshotLoss
+
     CreateReplicaBody:
       example:
         size: 80241024
@@ -3801,6 +3876,12 @@ components:
             - PoolPurgeAcceptRequired
             - PoolPurgeVolumeLossAcceptRequired
             - PoolPurgeSnapshotLossAcceptRequired
+            - NodeIsOnline
+            - NodeNotCordoned
+            - NodeHasResources
+            - NodePurgeAcceptRequired
+            - NodePurgeVolumeLossAcceptRequired
+            - NodePurgeSnapshotLossAcceptRequired
       required:
         - details
         - kind

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -1,5 +1,6 @@
 use super::*;
 use grpc::operations::node::traits::NodeOperations;
+use stor_port::types::v0::transport::DestroyNode;
 
 fn client() -> impl NodeOperations {
     core_grpc().node()
@@ -7,6 +8,21 @@ fn client() -> impl NodeOperations {
 
 #[async_trait::async_trait]
 impl apis::actix_server::Nodes for RestApi {
+    async fn del_node(
+        Path(id): Path<String>,
+        Body(body): Body<Option<models::DeleteNodeBody>>,
+    ) -> Result<models::NodeDeleteResult, RestError<RestJsonError>> {
+        let body = body.unwrap_or_default();
+        let request = DestroyNode::new(id.into())
+            .with_purge(body.purge.unwrap_or(false))
+            .with_accept(body.accept.unwrap_or(false))
+            .with_accept_volume_loss(body.accept_volume_loss.unwrap_or(false))
+            .with_accept_snapshot_loss(body.accept_snapshot_loss.unwrap_or(false));
+
+        let result = client().delete(&request).await?;
+        Ok(result.into())
+    }
+
     async fn get_node(Path(id): Path<String>) -> Result<models::Node, RestError<RestJsonError>> {
         let node = node(
             id.clone(),

--- a/control-plane/stor-port/src/transport_api/mod.rs
+++ b/control-plane/stor-port/src/transport_api/mod.rs
@@ -201,7 +201,13 @@ impl From<ReplyError> for tonic::Status {
             | ReplyErrorKind::PoolCordonInsufficient
             | ReplyErrorKind::PoolPurgeAcceptRequired
             | ReplyErrorKind::PoolPurgeVolumeLossAcceptRequired
-            | ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired => {
+            | ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired
+            | ReplyErrorKind::NodeIsOnline
+            | ReplyErrorKind::NodeNotCordoned
+            | ReplyErrorKind::NodeHasResources
+            | ReplyErrorKind::NodePurgeAcceptRequired
+            | ReplyErrorKind::NodePurgeVolumeLossAcceptRequired
+            | ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired => {
                 tonic::Status::failed_precondition(error.full_string())
             }
             ReplyErrorKind::FailedPersist => {
@@ -461,6 +467,12 @@ pub enum ReplyErrorKind {
     PoolPurgeAcceptRequired,
     PoolPurgeVolumeLossAcceptRequired,
     PoolPurgeSnapshotLossAcceptRequired,
+    NodeIsOnline,
+    NodeNotCordoned,
+    NodeHasResources,
+    NodePurgeAcceptRequired,
+    NodePurgeVolumeLossAcceptRequired,
+    NodePurgeSnapshotLossAcceptRequired,
 }
 
 impl From<tonic::Code> for ReplyErrorKind {

--- a/control-plane/stor-port/src/types/mod.rs
+++ b/control-plane/stor-port/src/types/mod.rs
@@ -188,6 +188,32 @@ impl From<ReplyError> for RestError<RestJsonError> {
                     RestJsonError::new(details, message, Kind::PoolPurgeSnapshotLossAcceptRequired);
                 (StatusCode::PRECONDITION_FAILED, error)
             }
+            ReplyErrorKind::NodeIsOnline => {
+                let error = RestJsonError::new(details, message, Kind::NodeIsOnline);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodeNotCordoned => {
+                let error = RestJsonError::new(details, message, Kind::NodeNotCordoned);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodeHasResources => {
+                let error = RestJsonError::new(details, message, Kind::NodeHasResources);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodePurgeAcceptRequired => {
+                let error = RestJsonError::new(details, message, Kind::NodePurgeAcceptRequired);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodePurgeVolumeLossAcceptRequired => {
+                let error =
+                    RestJsonError::new(details, message, Kind::NodePurgeVolumeLossAcceptRequired);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired => {
+                let error =
+                    RestJsonError::new(details, message, Kind::NodePurgeSnapshotLossAcceptRequired);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
         };
 
         RestError::new(status, error)

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -4,7 +4,7 @@ use crate::{
         openapi::models,
         store::{
             definitions::{ObjectKey, StorableObject, StorableObjectType},
-            AsOperationSequencer, OperationSequence, SpecTransaction,
+            AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
         },
         transport::{self, HostNqn, NodeBugFix, NodeBugFixes, NodeFeatures, NodeId, VolumeId},
     },
@@ -159,6 +159,11 @@ pub struct NodeState {
     pub node: transport::NodeState,
 }
 
+/// Default status for NodeSpec when deserializing old entries without a status field.
+fn default_node_spec_status() -> SpecStatus<()> {
+    SpecStatus::Created(())
+}
+
 /// Node spec data, including the cordon/drain state.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct NodeSpec {
@@ -186,6 +191,9 @@ pub struct NodeSpec {
     /// Record of the operation in progress.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operation: Option<NodeOperationState>,
+    /// Spec status (Created, Deleting, Purging, Deleted).
+    #[serde(default = "default_node_spec_status")]
+    pub status: SpecStatus<()>,
     /// Features exposed by the io-engine.
     #[serde(skip_serializing_if = "Option::is_none")]
     features: Option<NodeFeatures>,
@@ -224,6 +232,7 @@ impl NodeSpec {
             draining_timestamp: None,
             sequencer: OperationSequence::new(),
             operation: None,
+            status: SpecStatus::Created(()),
             features,
             bugfixes,
             version,
@@ -637,6 +646,7 @@ pub enum NodeOperation {
     SetDrained(),
     Label(NodeLabelOp),
     Unlabel(NodeUnLabelOp),
+    Destroy,
 }
 
 /// Parameter for adding node labels.
@@ -705,6 +715,9 @@ impl SpecTransaction<NodeOperation> for NodeSpec {
                 NodeOperation::Unlabel(NodeUnLabelOp { label_key }) => {
                     self.unlabel(&label_key);
                 }
+                NodeOperation::Destroy => {
+                    // Destroy is committed by remove_spec / complete_destroy.
+                }
             }
         }
         self.clear_op();
@@ -738,6 +751,7 @@ impl SpecTransaction<NodeOperation> for NodeSpec {
             NodeOperation::SetDrained() => (false, true),
             NodeOperation::Label(_) => (false, true),
             NodeOperation::Unlabel(_) => (false, true),
+            NodeOperation::Destroy => (true, true),
         }
     }
 

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -277,6 +277,155 @@ impl From<Register> for NodeState {
     }
 }
 
+/// Destroy Node Request.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DestroyNode {
+    /// Id of the node to delete.
+    pub id: NodeId,
+    /// Purge node and all its resources without contacting io-engine.
+    #[serde(default)]
+    pub purge: bool,
+    /// Accept deletion when node has resources (pools, replicas, nexuses).
+    #[serde(default)]
+    pub accept: bool,
+    /// Accept volume loss (last healthy replica for volumes).
+    #[serde(default)]
+    pub accept_volume_loss: bool,
+    /// Accept snapshot loss (last replica snapshot for snapshots).
+    #[serde(default)]
+    pub accept_snapshot_loss: bool,
+}
+
+impl DestroyNode {
+    /// Create a new DestroyNode request.
+    pub fn new(id: NodeId) -> Self {
+        Self {
+            id,
+            purge: false,
+            accept: false,
+            accept_volume_loss: false,
+            accept_snapshot_loss: false,
+        }
+    }
+
+    /// Create a purge request for the given node.
+    pub fn purge(id: NodeId) -> Self {
+        Self {
+            id,
+            purge: true,
+            accept: false,
+            accept_volume_loss: false,
+            accept_snapshot_loss: false,
+        }
+    }
+
+    /// Set purge option.
+    pub fn with_purge(mut self, purge: bool) -> Self {
+        self.purge = purge;
+        self
+    }
+
+    /// Set accept option.
+    pub fn with_accept(mut self, accept: bool) -> Self {
+        self.accept = accept;
+        self
+    }
+
+    /// Set accept_volume_loss option.
+    pub fn with_accept_volume_loss(mut self, accept_volume_loss: bool) -> Self {
+        self.accept_volume_loss = accept_volume_loss;
+        self
+    }
+
+    /// Set accept_snapshot_loss option.
+    pub fn with_accept_snapshot_loss(mut self, accept_snapshot_loss: bool) -> Self {
+        self.accept_snapshot_loss = accept_snapshot_loss;
+        self
+    }
+}
+
+/// Result of a node purge operation.
+///
+/// Always returned by node delete (purge) operations. The `volume_loss` and `snapshot_loss`
+/// fields are always present — empty lists indicate no loss occurred.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct NodeDeleteResult {
+    /// The deleted node ID.
+    pub node_id: NodeId,
+    /// Information about volumes that lost healthy replicas.
+    pub volume_loss: VolumeLossInfo,
+    /// Information about snapshots that lost replica snapshots.
+    pub snapshot_loss: SnapshotLossInfo,
+}
+
+impl NodeDeleteResult {
+    /// Create a new result for a node purge with no data or snapshot loss.
+    pub fn new(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            volume_loss: VolumeLossInfo::default(),
+            snapshot_loss: SnapshotLossInfo::default(),
+        }
+    }
+
+    /// Check if any data loss occurred.
+    pub fn has_volume_loss(&self) -> bool {
+        !self.volume_loss.volumes.is_empty()
+    }
+
+    /// Check if any snapshot loss occurred.
+    pub fn has_snapshot_loss(&self) -> bool {
+        !self.snapshot_loss.snapshots.is_empty()
+    }
+
+    /// Merge volume and snapshot loss from a pool delete result.
+    pub fn merge_pool_result(&mut self, pool_result: &super::PoolDeleteResult) {
+        self.volume_loss
+            .volumes
+            .extend(pool_result.volume_loss.volumes.iter().cloned());
+        self.snapshot_loss
+            .snapshots
+            .extend(pool_result.snapshot_loss.snapshots.iter().cloned());
+    }
+}
+
+impl From<NodeDeleteResult> for models::NodeDeleteResult {
+    fn from(src: NodeDeleteResult) -> Self {
+        models::NodeDeleteResult {
+            node_id: src.node_id.to_string(),
+            volume_loss: models::VolumeLossInfo {
+                volumes: src
+                    .volume_loss
+                    .volumes
+                    .into_iter()
+                    .map(|v| models::VolumeLossDetail {
+                        volume_id: v.volume_id.to_string(),
+                        replicas_before: v.replicas_before,
+                        healthy_before: v.healthy_before,
+                        lost_on_pool: v.lost_on_pool,
+                        healthy_after: v.healthy_after,
+                    })
+                    .collect(),
+            },
+            snapshot_loss: models::SnapshotLossInfo {
+                snapshots: src
+                    .snapshot_loss
+                    .snapshots
+                    .into_iter()
+                    .map(|s| models::SnapshotLossDetail {
+                        snapshot_id: s.snapshot_id.to_string(),
+                        replica_snapshots_before: s.replica_snapshots_before,
+                        healthy_before: s.healthy_before,
+                        lost_on_pool: s.lost_on_pool,
+                        healthy_after: s.healthy_after,
+                    })
+                    .collect(),
+            },
+        }
+    }
+}
+
 rpc_impl_string_id!(NodeId, "ID of a node");
 
 impl From<NodeState> for models::NodeState {


### PR DESCRIPTION
Add DELETE /v0/nodes/{node_id} API for removing offline nodes and all
their resources (pools, replicas, nexuses, snapshots) without contacting
io-engine. Follows the pool purge pattern across all layers.

API:
  DELETE /v0/nodes/{id} with body {purge, accept, acceptVolumeLoss,
  acceptSnapshotLoss} returns NodeDeleteResult with aggregated volume
  and snapshot loss information.

CLI:
  kubectl mayastor delete node <id> --purge [--accept-data-loss]
  --accept-data-loss is shorthand for --accept-volume-loss
  --accept-snapshot-loss. The --yes prompt maps to accept=true.

Flow:
  1. Validate node is offline and cordoned
  2. Check purge/accept flags
  3. Mark node as Purging (crash-safe checkpoint)
  4. Auto-cordon each pool (replicas + snapshots) on behalf of the user
  5. Delegate to pool purge for each pool (replicas, snapshots, loss
     analysis all handled by existing pool purge code)
  6. On pool rejection: complete_destroy(Err) clears pending op but
     keeps Purging status for reconciler resume
  7. On success: complete_destroy removes node spec from store
  8. Remove node runtime wrapper

Crash recovery:
  - NodePurgeReconciler detects SpecStatus::Purging on startup, resumes
    with all accepts=true (validation was done before Purging was set)
  - PersistentStoreReconciler clears stale pending ops first
  - Individual pool crashes handled by existing pool purge reconciler

-------------------------

CLI:
  Add --show-impact to dry-run Node Purge