### PR TITLE
feat(rest): add openapi spec changes for node purge

### DIFF
--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -233,6 +233,35 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: [ ]
+    delete:
+      tags:
+        - Nodes
+      operationId: del_node
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteNodeBody'
+      responses:
+        '200':
+          description: Node purged successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeDeleteResult'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
   '/nodes/{id}/cordon/{label}':
     put:
       tags:
@@ -2795,6 +2824,52 @@ components:
         - healthyBefore
         - lostOnPool
         - healthyAfter
+
+    DeleteNodeBody:
+      description: Request body for node deletion
+      type: object
+      properties:
+        purge:
+          description: |
+            Force removal of node and all its resources without contacting io-engine.
+            Requires node to be offline and cordoned.
+          type: boolean
+          default: false
+        accept:
+          description: Accept deletion when node has resources (pools, replicas, nexuses)
+          type: boolean
+          default: false
+        acceptVolumeLoss:
+          description: |
+            Accept volume loss. Required when purge would cause volumes
+            to lose their last healthy replica.
+          type: boolean
+          default: false
+        acceptSnapshotLoss:
+          description: |
+            Accept snapshot loss. Required when purge would cause
+            snapshots to lose their last replica snapshot.
+          type: boolean
+          default: false
+
+    NodeDeleteResult:
+      description: Result of a node delete operation
+      type: object
+      properties:
+        nodeId:
+          description: The deleted node identifier
+          type: string
+        volumeLoss:
+          description: Information about volumes that lost healthy replicas
+          $ref: '#/components/schemas/VolumeLossInfo'
+        snapshotLoss:
+          description: Information about snapshots that lost replica snapshots
+          $ref: '#/components/schemas/SnapshotLossInfo'
+      required:
+        - nodeId
+        - volumeLoss
+        - snapshotLoss
+
     CreateReplicaBody:
       example:
         size: 80241024
@@ -3801,6 +3876,12 @@ components:
             - PoolPurgeAcceptRequired
             - PoolPurgeVolumeLossAcceptRequired
             - PoolPurgeSnapshotLossAcceptRequired
+            - NodeIsOnline
+            - NodeNotCordoned
+            - NodeHasResources
+            - NodePurgeAcceptRequired
+            - NodePurgeVolumeLossAcceptRequired
+            - NodePurgeSnapshotLossAcceptRequired
       required:
         - details
         - kind

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -1,5 +1,7 @@
 use super::*;
 use grpc::operations::node::traits::NodeOperations;
+// use rest_client::versions::v0::models::NodeDeleteResult;
+// use stor_port::types::v0::transport::DestroyNode;
 
 fn client() -> impl NodeOperations {
     core_grpc().node()
@@ -7,6 +9,22 @@ fn client() -> impl NodeOperations {
 
 #[async_trait::async_trait]
 impl apis::actix_server::Nodes for RestApi {
+    async fn del_node(
+        Path(_id): Path<String>,
+        Body(body): Body<Option<models::DeleteNodeBody>>,
+    ) -> Result<models::NodeDeleteResult, RestError<RestJsonError>> {
+        let _body = body.unwrap_or_default();
+        // let request = DestroyNode::new(id.into())
+        //     .with_purge(body.purge.unwrap_or(false))
+        //     .with_accept(body.accept.unwrap_or(false))
+        //     .with_accept_volume_loss(body.accept_volume_loss.unwrap_or(false))
+        //     .with_accept_snapshot_loss(body.accept_snapshot_loss.unwrap_or(false));
+
+        // let result = client().delete(&request).await?;
+        // Ok(result.into())
+        Ok(models::NodeDeleteResult::default())
+    }
+
     async fn get_node(Path(id): Path<String>) -> Result<models::Node, RestError<RestJsonError>> {
         let node = node(
             id.clone(),


### PR DESCRIPTION
Adds openapi types for the Mayastor REST API. Adds DeleteNodeBody, NodeDeleteResult. Also adds error variants:
- NodeIsOnline
- NodeNotCordoned
- NodeHasResources
- NodePurgeAcceptRequired
- NodePurgeVolumeLossAcceptRequired
- NodePurgeSnapshotLossAcceptRequired