### PR TITLE
feat(grpc): add node purge gRPC changes

### DIFF
--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -10,7 +10,8 @@ use crate::controller::{
 };
 use agents::errors::SvcError;
 use stor_port::types::v0::transport::{
-    Deregister, Filter, Node, NodeId, NodeState, NodeStatus, Register,
+    Deregister, DestroyNode, Filter, Node, NodeDeleteResult, NodeId, NodeState, NodeStatus,
+    Register,
 };
 
 use crate::controller::{io_engine::HostApi, wrapper::InternalOps};
@@ -152,6 +153,11 @@ impl NodeOperations for Service {
         }
         let node = self.unlabel(id, label_key).await?;
         Ok(node)
+    }
+
+    /// Delete a node and all its resources (purge).
+    async fn delete(&self, _request: &DestroyNode) -> Result<NodeDeleteResult, ReplyError> {
+        Err(ReplyError::unimplemented("Not implemented".into()))
     }
 }
 

--- a/control-plane/grpc/proto/v1/misc/common.proto
+++ b/control-plane/grpc/proto/v1/misc/common.proto
@@ -82,6 +82,12 @@ enum ReplyErrorKind {
   PoolPurgeAcceptRequired = 40;
   PoolPurgeVolumeLossAcceptRequired = 41;
   PoolPurgeSnapshotLossAcceptRequired = 42;
+  NodeIsOnline = 43;
+  NodeNotCordoned = 44;
+  NodeHasResources = 45;
+  NodePurgeAcceptRequired = 46;
+  NodePurgeVolumeLossAcceptRequired = 47;
+  NodePurgeSnapshotLossAcceptRequired = 48;
 }
 
 // ResourceKind for the resource which has undergone this error

--- a/control-plane/grpc/proto/v1/node/target_node.proto
+++ b/control-plane/grpc/proto/v1/node/target_node.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "v1/misc/common.proto";
 import "v1/blockdevice/blockdevice.proto";
+import "v1/pool/pool.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -184,6 +185,35 @@ message UnlabelNodeReply {
   }
 }
 
+message DeleteNodeRequest {
+  // Node identification
+  string node_id = 1;
+  // Purge node and all its resources without contacting io-engine
+  bool purge = 2;
+  // Accept deletion of resources (pools, replicas, nexuses, snapshots)
+  bool accept = 3;
+  // Accept volume loss (last healthy replica)
+  bool accept_volume_loss = 4;
+  // Accept snapshot loss (last replica snapshot)
+  bool accept_snapshot_loss = 5;
+}
+
+message NodeDeleteResult {
+  // The deleted node ID
+  string node_id = 1;
+  // Volumes that lost their last healthy replica
+  repeated pool.VolumeLossDetail volume_loss = 2;
+  // Snapshots that lost their last replica snapshot
+  repeated pool.SnapshotLossDetail snapshot_loss = 3;
+}
+
+message DeleteNodeReply {
+  oneof reply {
+    NodeDeleteResult result = 1;
+    common.ReplyError error = 2;
+  }
+}
+
 service NodeGrpc {
   rpc GetNodes (GetNodesRequest) returns (GetNodesReply) {}
   rpc GetBlockDevices (blockdevice.GetBlockDevicesRequest) returns (blockdevice.GetBlockDevicesReply) {}
@@ -193,4 +223,5 @@ service NodeGrpc {
   rpc DrainNode (DrainNodeRequest) returns (DrainNodeReply) {}
   rpc LabelNode (LabelNodeRequest) returns (LabelNodeReply) {}
   rpc UnlabelNode (UnlabelNodeRequest) returns (UnlabelNodeReply) {}
+  rpc DeleteNode (DeleteNodeRequest) returns (DeleteNodeReply) {}
 }

--- a/control-plane/grpc/src/misc/traits.rs
+++ b/control-plane/grpc/src/misc/traits.rs
@@ -117,6 +117,16 @@ impl From<ReplyErrorKind> for common::ReplyErrorKind {
             ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired => {
                 Self::PoolPurgeSnapshotLossAcceptRequired
             }
+            ReplyErrorKind::NodeIsOnline => Self::NodeIsOnline,
+            ReplyErrorKind::NodeNotCordoned => Self::NodeNotCordoned,
+            ReplyErrorKind::NodeHasResources => Self::NodeHasResources,
+            ReplyErrorKind::NodePurgeAcceptRequired => Self::NodePurgeAcceptRequired,
+            ReplyErrorKind::NodePurgeVolumeLossAcceptRequired => {
+                Self::NodePurgeVolumeLossAcceptRequired
+            }
+            ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired => {
+                Self::NodePurgeSnapshotLossAcceptRequired
+            }
         }
     }
 }
@@ -170,6 +180,16 @@ impl From<common::ReplyErrorKind> for ReplyErrorKind {
             }
             common::ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired => {
                 Self::PoolPurgeSnapshotLossAcceptRequired
+            }
+            common::ReplyErrorKind::NodeIsOnline => Self::NodeIsOnline,
+            common::ReplyErrorKind::NodeNotCordoned => Self::NodeNotCordoned,
+            common::ReplyErrorKind::NodeHasResources => Self::NodeHasResources,
+            common::ReplyErrorKind::NodePurgeAcceptRequired => Self::NodePurgeAcceptRequired,
+            common::ReplyErrorKind::NodePurgeVolumeLossAcceptRequired => {
+                Self::NodePurgeVolumeLossAcceptRequired
+            }
+            common::ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired => {
+                Self::NodePurgeSnapshotLossAcceptRequired
             }
         }
     }

--- a/control-plane/grpc/src/operations/node/client.rs
+++ b/control-plane/grpc/src/operations/node/client.rs
@@ -16,7 +16,7 @@ use stor_port::{
         v0::{BlockDevices, Nodes},
         ReplyError, ResourceKind, TimeoutOptions,
     },
-    types::v0::transport::{Filter, MessageIdVs, Node, NodeId},
+    types::v0::transport::{DestroyNode, Filter, MessageIdVs, Node, NodeDeleteResult, NodeId},
 };
 use tonic::transport::Uri;
 
@@ -177,6 +177,19 @@ impl NodeOperations for NodeClient {
                 unlabel_node_reply::Reply::Node(node) => Ok(Node::try_from(node)?),
                 unlabel_node_reply::Reply::Error(err) => Err(err.into()),
             },
+            None => Err(ReplyError::invalid_response(ResourceKind::Node)),
+        }
+    }
+
+    #[tracing::instrument(name = "NodeClient::delete", level = "debug", skip(self), err)]
+    async fn delete(&self, request: &DestroyNode) -> Result<NodeDeleteResult, ReplyError> {
+        let req = crate::node::DeleteNodeRequest::from(request.clone());
+        let response = self.client().delete_node(req).await?.into_inner();
+        match response.reply {
+            Some(crate::node::delete_node_reply::Reply::Result(result)) => {
+                Ok(NodeDeleteResult::try_from(result)?)
+            }
+            Some(crate::node::delete_node_reply::Reply::Error(err)) => Err(err.into()),
             None => Err(ReplyError::invalid_response(ResourceKind::Node)),
         }
     }

--- a/control-plane/grpc/src/operations/node/server.rs
+++ b/control-plane/grpc/src/operations/node/server.rs
@@ -5,9 +5,9 @@ use crate::{
         cordon_node_reply, drain_node_reply, get_nodes_reply, label_node_reply,
         node_grpc_server::{NodeGrpc, NodeGrpcServer},
         uncordon_node_reply, unlabel_node_reply, CordonNodeReply, CordonNodeRequest,
-        DrainNodeReply, DrainNodeRequest, GetNodesReply, GetNodesRequest, LabelNodeReply,
-        LabelNodeRequest, ProbeRequest, ProbeResponse, UncordonNodeReply, UncordonNodeRequest,
-        UnlabelNodeReply, UnlabelNodeRequest,
+        DeleteNodeReply, DeleteNodeRequest, DrainNodeReply, DrainNodeRequest, GetNodesReply,
+        GetNodesRequest, LabelNodeReply, LabelNodeRequest, ProbeRequest, ProbeResponse,
+        UncordonNodeReply, UncordonNodeRequest, UnlabelNodeReply, UnlabelNodeRequest,
     },
     operations::node::traits::NodeOperations,
 };
@@ -160,5 +160,12 @@ impl NodeGrpc for NodeServer {
                 reply: Some(unlabel_node_reply::Reply::Error(err.into())),
             })),
         }
+    }
+
+    async fn delete_node(
+        &self,
+        _request: tonic::Request<DeleteNodeRequest>,
+    ) -> Result<tonic::Response<DeleteNodeReply>, tonic::Status> {
+        Err(tonic::Status::unimplemented("Not yet implemented"))
     }
 }

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -1,6 +1,6 @@
 use crate::{
     blockdevice, blockdevice::GetBlockDevicesRequest, context::Context, node,
-    node::get_nodes_request,
+    node::get_nodes_request, pool,
 };
 use std::{collections::HashMap, convert::TryFrom, str::FromStr};
 use stor_port::{
@@ -11,8 +11,9 @@ use stor_port::{
     types::v0::{
         store::node::{CordonDrainState, CordonedState, DrainState, NodeSpec},
         transport::{
-            BlockDevice, Filesystem, Filter, GetBlockDevices, Node, NodeId, NodeState, NodeStatus,
-            Partition,
+            BlockDevice, DestroyNode, Filesystem, Filter, GetBlockDevices, Node, NodeDeleteResult,
+            NodeId, NodeState, NodeStatus, Partition, SnapshotLossDetail, SnapshotLossInfo,
+            VolumeLossDetail, VolumeLossInfo,
         },
     },
     TryIntoOption,
@@ -51,6 +52,8 @@ pub trait NodeOperations: Send + Sync {
     ) -> Result<Node, ReplyError>;
     /// Remove label from the a given node.
     async fn unlabel(&self, id: NodeId, label: String) -> Result<Node, ReplyError>;
+    /// Delete a node and all its resources (purge). Always returns `NodeDeleteResult`.
+    async fn delete(&self, request: &DestroyNode) -> Result<NodeDeleteResult, ReplyError>;
 }
 
 impl TryFrom<node::Node> for Node {
@@ -425,6 +428,106 @@ impl From<BlockDevices> for blockdevice::BlockDevices {
                 .into_iter()
                 .map(|bd| bd.into())
                 .collect(),
+        }
+    }
+}
+
+impl From<NodeDeleteResult> for node::NodeDeleteResult {
+    fn from(result: NodeDeleteResult) -> Self {
+        Self {
+            node_id: result.node_id.to_string(),
+            volume_loss: result
+                .volume_loss
+                .volumes
+                .into_iter()
+                .map(|v| pool::VolumeLossDetail {
+                    volume_id: v.volume_id.to_string(),
+                    replicas_before: v.replicas_before,
+                    healthy_before: v.healthy_before,
+                    lost_on_pool: v.lost_on_pool,
+                    healthy_after: v.healthy_after,
+                })
+                .collect(),
+            snapshot_loss: result
+                .snapshot_loss
+                .snapshots
+                .into_iter()
+                .map(|s| pool::SnapshotLossDetail {
+                    snapshot_id: s.snapshot_id.to_string(),
+                    replica_snapshots_before: s.replica_snapshots_before,
+                    healthy_before: s.healthy_before,
+                    lost_on_pool: s.lost_on_pool,
+                    healthy_after: s.healthy_after,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<node::NodeDeleteResult> for NodeDeleteResult {
+    type Error = ReplyError;
+
+    fn try_from(result: node::NodeDeleteResult) -> Result<Self, Self::Error> {
+        let mut volumes = Vec::new();
+        for v in result.volume_loss {
+            let volume_id = uuid::Uuid::parse_str(&v.volume_id).map_err(|_| {
+                ReplyError::invalid_argument(ResourceKind::Volume, "volume_id", v.volume_id.clone())
+            })?;
+            volumes.push(VolumeLossDetail {
+                volume_id: volume_id.into(),
+                replicas_before: v.replicas_before,
+                healthy_before: v.healthy_before,
+                lost_on_pool: v.lost_on_pool,
+                healthy_after: v.healthy_after,
+            });
+        }
+
+        let mut snapshots = Vec::new();
+        for s in result.snapshot_loss {
+            let snapshot_id = uuid::Uuid::parse_str(&s.snapshot_id).map_err(|_| {
+                ReplyError::invalid_argument(
+                    ResourceKind::VolumeSnapshot,
+                    "snapshot_id",
+                    s.snapshot_id.clone(),
+                )
+            })?;
+            snapshots.push(SnapshotLossDetail {
+                snapshot_id: snapshot_id.into(),
+                replica_snapshots_before: s.replica_snapshots_before,
+                healthy_before: s.healthy_before,
+                lost_on_pool: s.lost_on_pool,
+                healthy_after: s.healthy_after,
+            });
+        }
+
+        Ok(NodeDeleteResult {
+            node_id: result.node_id.into(),
+            volume_loss: VolumeLossInfo { volumes },
+            snapshot_loss: SnapshotLossInfo { snapshots },
+        })
+    }
+}
+
+impl From<DestroyNode> for node::DeleteNodeRequest {
+    fn from(request: DestroyNode) -> Self {
+        Self {
+            node_id: request.id.to_string(),
+            purge: request.purge,
+            accept: request.accept,
+            accept_volume_loss: request.accept_volume_loss,
+            accept_snapshot_loss: request.accept_snapshot_loss,
+        }
+    }
+}
+
+impl From<node::DeleteNodeRequest> for DestroyNode {
+    fn from(request: node::DeleteNodeRequest) -> Self {
+        Self {
+            id: request.node_id.into(),
+            purge: request.purge,
+            accept: request.accept,
+            accept_volume_loss: request.accept_volume_loss,
+            accept_snapshot_loss: request.accept_snapshot_loss,
         }
     }
 }

--- a/control-plane/stor-port/src/transport_api/mod.rs
+++ b/control-plane/stor-port/src/transport_api/mod.rs
@@ -201,7 +201,13 @@ impl From<ReplyError> for tonic::Status {
             | ReplyErrorKind::PoolCordonInsufficient
             | ReplyErrorKind::PoolPurgeAcceptRequired
             | ReplyErrorKind::PoolPurgeVolumeLossAcceptRequired
-            | ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired => {
+            | ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired
+            | ReplyErrorKind::NodeIsOnline
+            | ReplyErrorKind::NodeNotCordoned
+            | ReplyErrorKind::NodeHasResources
+            | ReplyErrorKind::NodePurgeAcceptRequired
+            | ReplyErrorKind::NodePurgeVolumeLossAcceptRequired
+            | ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired => {
                 tonic::Status::failed_precondition(error.full_string())
             }
             ReplyErrorKind::FailedPersist => {
@@ -461,6 +467,12 @@ pub enum ReplyErrorKind {
     PoolPurgeAcceptRequired,
     PoolPurgeVolumeLossAcceptRequired,
     PoolPurgeSnapshotLossAcceptRequired,
+    NodeIsOnline,
+    NodeNotCordoned,
+    NodeHasResources,
+    NodePurgeAcceptRequired,
+    NodePurgeVolumeLossAcceptRequired,
+    NodePurgeSnapshotLossAcceptRequired,
 }
 
 impl From<tonic::Code> for ReplyErrorKind {

--- a/control-plane/stor-port/src/types/mod.rs
+++ b/control-plane/stor-port/src/types/mod.rs
@@ -188,6 +188,32 @@ impl From<ReplyError> for RestError<RestJsonError> {
                     RestJsonError::new(details, message, Kind::PoolPurgeSnapshotLossAcceptRequired);
                 (StatusCode::PRECONDITION_FAILED, error)
             }
+            ReplyErrorKind::NodeIsOnline => {
+                let error = RestJsonError::new(details, message, Kind::NodeIsOnline);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodeNotCordoned => {
+                let error = RestJsonError::new(details, message, Kind::NodeNotCordoned);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodeHasResources => {
+                let error = RestJsonError::new(details, message, Kind::NodeHasResources);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodePurgeAcceptRequired => {
+                let error = RestJsonError::new(details, message, Kind::NodePurgeAcceptRequired);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodePurgeVolumeLossAcceptRequired => {
+                let error =
+                    RestJsonError::new(details, message, Kind::NodePurgeVolumeLossAcceptRequired);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
+            ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired => {
+                let error =
+                    RestJsonError::new(details, message, Kind::NodePurgeSnapshotLossAcceptRequired);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
         };
 
         RestError::new(status, error)

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -4,7 +4,7 @@ use crate::{
         openapi::models,
         store::{
             definitions::{ObjectKey, StorableObject, StorableObjectType},
-            AsOperationSequencer, OperationSequence, SpecTransaction,
+            AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
         },
         transport::{self, HostNqn, NodeBugFix, NodeBugFixes, NodeFeatures, NodeId, VolumeId},
     },
@@ -159,6 +159,11 @@ pub struct NodeState {
     pub node: transport::NodeState,
 }
 
+/// Default status for NodeSpec when deserializing old entries without a status field.
+fn default_node_spec_status() -> SpecStatus<()> {
+    SpecStatus::Created(())
+}
+
 /// Node spec data, including the cordon/drain state.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct NodeSpec {
@@ -186,6 +191,9 @@ pub struct NodeSpec {
     /// Record of the operation in progress.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operation: Option<NodeOperationState>,
+    /// Spec status (Created, Deleting, Purging, Deleted).
+    #[serde(default = "default_node_spec_status")]
+    pub status: SpecStatus<()>,
     /// Features exposed by the io-engine.
     #[serde(skip_serializing_if = "Option::is_none")]
     features: Option<NodeFeatures>,
@@ -224,6 +232,7 @@ impl NodeSpec {
             draining_timestamp: None,
             sequencer: OperationSequence::new(),
             operation: None,
+            status: SpecStatus::Created(()),
             features,
             bugfixes,
             version,
@@ -637,6 +646,7 @@ pub enum NodeOperation {
     SetDrained(),
     Label(NodeLabelOp),
     Unlabel(NodeUnLabelOp),
+    Destroy,
 }
 
 /// Parameter for adding node labels.
@@ -705,6 +715,9 @@ impl SpecTransaction<NodeOperation> for NodeSpec {
                 NodeOperation::Unlabel(NodeUnLabelOp { label_key }) => {
                     self.unlabel(&label_key);
                 }
+                NodeOperation::Destroy => {
+                    // Destroy is committed by remove_spec / complete_destroy.
+                }
             }
         }
         self.clear_op();
@@ -738,6 +751,7 @@ impl SpecTransaction<NodeOperation> for NodeSpec {
             NodeOperation::SetDrained() => (false, true),
             NodeOperation::Label(_) => (false, true),
             NodeOperation::Unlabel(_) => (false, true),
+            NodeOperation::Destroy => (true, true),
         }
     }
 

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -277,6 +277,155 @@ impl From<Register> for NodeState {
     }
 }
 
+/// Destroy Node Request.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DestroyNode {
+    /// Id of the node to delete.
+    pub id: NodeId,
+    /// Purge node and all its resources without contacting io-engine.
+    #[serde(default)]
+    pub purge: bool,
+    /// Accept deletion when node has resources (pools, replicas, nexuses).
+    #[serde(default)]
+    pub accept: bool,
+    /// Accept volume loss (last healthy replica for volumes).
+    #[serde(default)]
+    pub accept_volume_loss: bool,
+    /// Accept snapshot loss (last replica snapshot for snapshots).
+    #[serde(default)]
+    pub accept_snapshot_loss: bool,
+}
+
+impl DestroyNode {
+    /// Create a new DestroyNode request.
+    pub fn new(id: NodeId) -> Self {
+        Self {
+            id,
+            purge: false,
+            accept: false,
+            accept_volume_loss: false,
+            accept_snapshot_loss: false,
+        }
+    }
+
+    /// Create a purge request for the given node.
+    pub fn purge(id: NodeId) -> Self {
+        Self {
+            id,
+            purge: true,
+            accept: false,
+            accept_volume_loss: false,
+            accept_snapshot_loss: false,
+        }
+    }
+
+    /// Set purge option.
+    pub fn with_purge(mut self, purge: bool) -> Self {
+        self.purge = purge;
+        self
+    }
+
+    /// Set accept option.
+    pub fn with_accept(mut self, accept: bool) -> Self {
+        self.accept = accept;
+        self
+    }
+
+    /// Set accept_volume_loss option.
+    pub fn with_accept_volume_loss(mut self, accept_volume_loss: bool) -> Self {
+        self.accept_volume_loss = accept_volume_loss;
+        self
+    }
+
+    /// Set accept_snapshot_loss option.
+    pub fn with_accept_snapshot_loss(mut self, accept_snapshot_loss: bool) -> Self {
+        self.accept_snapshot_loss = accept_snapshot_loss;
+        self
+    }
+}
+
+/// Result of a node purge operation.
+///
+/// Always returned by node delete (purge) operations. The `volume_loss` and `snapshot_loss`
+/// fields are always present — empty lists indicate no loss occurred.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct NodeDeleteResult {
+    /// The deleted node ID.
+    pub node_id: NodeId,
+    /// Information about volumes that lost healthy replicas.
+    pub volume_loss: VolumeLossInfo,
+    /// Information about snapshots that lost replica snapshots.
+    pub snapshot_loss: SnapshotLossInfo,
+}
+
+impl NodeDeleteResult {
+    /// Create a new result for a node purge with no data or snapshot loss.
+    pub fn new(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            volume_loss: VolumeLossInfo::default(),
+            snapshot_loss: SnapshotLossInfo::default(),
+        }
+    }
+
+    /// Check if any data loss occurred.
+    pub fn has_volume_loss(&self) -> bool {
+        !self.volume_loss.volumes.is_empty()
+    }
+
+    /// Check if any snapshot loss occurred.
+    pub fn has_snapshot_loss(&self) -> bool {
+        !self.snapshot_loss.snapshots.is_empty()
+    }
+
+    /// Merge volume and snapshot loss from a pool delete result.
+    pub fn merge_pool_result(&mut self, pool_result: &super::PoolDeleteResult) {
+        self.volume_loss
+            .volumes
+            .extend(pool_result.volume_loss.volumes.iter().cloned());
+        self.snapshot_loss
+            .snapshots
+            .extend(pool_result.snapshot_loss.snapshots.iter().cloned());
+    }
+}
+
+impl From<NodeDeleteResult> for models::NodeDeleteResult {
+    fn from(src: NodeDeleteResult) -> Self {
+        models::NodeDeleteResult {
+            node_id: src.node_id.to_string(),
+            volume_loss: models::VolumeLossInfo {
+                volumes: src
+                    .volume_loss
+                    .volumes
+                    .into_iter()
+                    .map(|v| models::VolumeLossDetail {
+                        volume_id: v.volume_id.to_string(),
+                        replicas_before: v.replicas_before,
+                        healthy_before: v.healthy_before,
+                        lost_on_pool: v.lost_on_pool,
+                        healthy_after: v.healthy_after,
+                    })
+                    .collect(),
+            },
+            snapshot_loss: models::SnapshotLossInfo {
+                snapshots: src
+                    .snapshot_loss
+                    .snapshots
+                    .into_iter()
+                    .map(|s| models::SnapshotLossDetail {
+                        snapshot_id: s.snapshot_id.to_string(),
+                        replica_snapshots_before: s.replica_snapshots_before,
+                        healthy_before: s.healthy_before,
+                        lost_on_pool: s.lost_on_pool,
+                        healthy_after: s.healthy_after,
+                    })
+                    .collect(),
+            },
+        }
+    }
+}
+
 rpc_impl_string_id!(NodeId, "ID of a node");
 
 impl From<NodeState> for models::NodeState {


### PR DESCRIPTION
This change adds the gRPC protobuf changes to accomodate the Node Delete request from
Mayastor REST on the to agent-core. Adds types DeleteNodeRequest, NodeDeleteResult, DeleteNodeReply.
Also adds error variants NodeIsOnline, NodeNotCordoned, NodeHasResources, NodePurgeAcceptRequired,
NodePurgeVolumeLossAcceptRequired and NodePurgeSnapshotLossAcceptRequired.