### PR TITLE
feat(control-plane): integrate node purge rest API with core gRPC

### DIFF
--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -1,3 +1,4 @@
+use super::RECONCILE_TIMEOUT_SECS;
 use crate::volume::helpers::wait_node_online;
 use deployer_cluster::{Cluster, ClusterBuilder, FindVolumeRequest};
 use grpc::operations::{
@@ -676,29 +677,43 @@ async fn snapshot_upgrade() {
         .expect_err("No rebuild on older version!");
     assert_eq!(error.kind, ReplyErrorKind::FailedPrecondition);
 
+    // Replace node 0 with its idle replacement (registers under same CP node ID).
+    // replace_node waits for Offline, ensuring the old process releases hugepages.
     cluster
         .replace_node(cluster.node(0), cluster.node(2))
         .await
         .unwrap();
     cluster.wait_pool_online(cluster.pool(0, 0)).await.unwrap();
+
+    // Replace node 1.
     cluster
         .replace_node(cluster.node(1), cluster.node(3))
         .await
         .unwrap();
     cluster.wait_pool_online(cluster.pool(1, 0)).await.unwrap();
 
-    tokio::time::sleep(gc_period * 5).await;
-
-    let _volume = vol_cli
-        .set_replica(
-            &SetVolumeReplica {
-                uuid: volume_1.uuid().clone(),
-                replicas: 2,
-            },
-            None,
-        )
-        .await
-        .expect("After upgrade this should work!");
+    // Wait for set_replica to succeed — the reconciler needs time to process
+    // the node upgrades and rebuild volume state after replacement.
+    let timeout = Duration::from_secs(RECONCILE_TIMEOUT_SECS);
+    let start = std::time::Instant::now();
+    let _volume = loop {
+        match vol_cli
+            .set_replica(
+                &SetVolumeReplica {
+                    uuid: volume_1.uuid().clone(),
+                    replicas: 2,
+                },
+                None,
+            )
+            .await
+        {
+            Ok(v) => break v,
+            Err(_) if std::time::Instant::now() < start + timeout => {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+            Err(e) => panic!("set_replica should succeed after upgrade: {e}"),
+        }
+    };
 
     vol_cli
         .create_snapshot(

--- a/control-plane/grpc/src/operations/node/server.rs
+++ b/control-plane/grpc/src/operations/node/server.rs
@@ -2,7 +2,7 @@ use crate::{
     blockdevice::{get_block_devices_reply, GetBlockDevicesReply, GetBlockDevicesRequest},
     node,
     node::{
-        cordon_node_reply, drain_node_reply, get_nodes_reply, label_node_reply,
+        cordon_node_reply, delete_node_reply, drain_node_reply, get_nodes_reply, label_node_reply,
         node_grpc_server::{NodeGrpc, NodeGrpcServer},
         uncordon_node_reply, unlabel_node_reply, CordonNodeReply, CordonNodeRequest,
         DeleteNodeReply, DeleteNodeRequest, DrainNodeReply, DrainNodeRequest, GetNodesReply,
@@ -12,6 +12,7 @@ use crate::{
     operations::node::traits::NodeOperations,
 };
 use std::sync::Arc;
+use stor_port::types::v0::transport::DestroyNode;
 use tonic::{Request, Response};
 
 /// gRPC Node Server
@@ -164,8 +165,17 @@ impl NodeGrpc for NodeServer {
 
     async fn delete_node(
         &self,
-        _request: tonic::Request<DeleteNodeRequest>,
+        request: tonic::Request<DeleteNodeRequest>,
     ) -> Result<tonic::Response<DeleteNodeReply>, tonic::Status> {
-        Err(tonic::Status::unimplemented("Not yet implemented"))
+        let req: DeleteNodeRequest = request.into_inner();
+        let destroy: DestroyNode = req.into();
+        match self.service.delete(&destroy).await {
+            Ok(result) => Ok(Response::new(DeleteNodeReply {
+                reply: Some(delete_node_reply::Reply::Result(result.into())),
+            })),
+            Err(err) => Ok(Response::new(DeleteNodeReply {
+                reply: Some(delete_node_reply::Reply::Error(err.into())),
+            })),
+        }
     }
 }

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -23,6 +23,20 @@ impl apis::actix_server::Nodes for RestApi {
         Ok(result.into())
     }
 
+    async fn delete_node_cordon(
+        Path((id, label)): Path<(String, String)>,
+    ) -> Result<models::Node, RestError<RestJsonError>> {
+        let node = client().uncordon(id.into(), label).await?;
+        Ok(node.into())
+    }
+
+    async fn delete_node_label(
+        Path((id, label_key)): Path<(String, String)>,
+    ) -> Result<models::Node, RestError<RestJsonError>> {
+        let node = client().unlabel(id.into(), label_key).await?;
+        Ok(node.into())
+    }
+
     async fn get_node(Path(id): Path<String>) -> Result<models::Node, RestError<RestJsonError>> {
         let node = node(
             id.clone(),
@@ -59,13 +73,6 @@ impl apis::actix_server::Nodes for RestApi {
         Ok(node.into())
     }
 
-    async fn delete_node_cordon(
-        Path((id, label)): Path<(String, String)>,
-    ) -> Result<models::Node, RestError<RestJsonError>> {
-        let node = client().uncordon(id.into(), label).await?;
-        Ok(node.into())
-    }
-
     async fn put_node_drain(
         Path((id, label)): Path<(String, String)>,
     ) -> Result<models::Node, RestError<RestJsonError>> {
@@ -81,13 +88,6 @@ impl apis::actix_server::Nodes for RestApi {
         let node = client()
             .label(id.into(), [(key, value)].into(), overwrite)
             .await?;
-        Ok(node.into())
-    }
-
-    async fn delete_node_label(
-        Path((id, label_key)): Path<(String, String)>,
-    ) -> Result<models::Node, RestError<RestJsonError>> {
-        let node = client().unlabel(id.into(), label_key).await?;
         Ok(node.into())
     }
 }

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -1,7 +1,6 @@
 use super::*;
 use grpc::operations::node::traits::NodeOperations;
-// use rest_client::versions::v0::models::NodeDeleteResult;
-// use stor_port::types::v0::transport::DestroyNode;
+use stor_port::types::v0::transport::DestroyNode;
 
 fn client() -> impl NodeOperations {
     core_grpc().node()
@@ -10,19 +9,18 @@ fn client() -> impl NodeOperations {
 #[async_trait::async_trait]
 impl apis::actix_server::Nodes for RestApi {
     async fn del_node(
-        Path(_id): Path<String>,
+        Path(id): Path<String>,
         Body(body): Body<Option<models::DeleteNodeBody>>,
     ) -> Result<models::NodeDeleteResult, RestError<RestJsonError>> {
-        let _body = body.unwrap_or_default();
-        // let request = DestroyNode::new(id.into())
-        //     .with_purge(body.purge.unwrap_or(false))
-        //     .with_accept(body.accept.unwrap_or(false))
-        //     .with_accept_volume_loss(body.accept_volume_loss.unwrap_or(false))
-        //     .with_accept_snapshot_loss(body.accept_snapshot_loss.unwrap_or(false));
+        let body = body.unwrap_or_default();
+        let request = DestroyNode::new(id.into())
+            .with_purge(body.purge.unwrap_or(false))
+            .with_accept(body.accept.unwrap_or(false))
+            .with_accept_volume_loss(body.accept_volume_loss.unwrap_or(false))
+            .with_accept_snapshot_loss(body.accept_snapshot_loss.unwrap_or(false));
 
-        // let result = client().delete(&request).await?;
-        // Ok(result.into())
-        Ok(models::NodeDeleteResult::default())
+        let result = client().delete(&request).await?;
+        Ok(result.into())
     }
 
     async fn get_node(Path(id): Path<String>) -> Result<models::Node, RestError<RestJsonError>> {


### PR DESCRIPTION
feat(control-plane): integrate node purge rest API with core gRPC

This ties the REST code for node delete with the gRPC interface for the same
on the agent-core.

---

refactor(rest): arrange actix_server::Nodes impl fn. in the same order as trait

---

test: fix snapshot_upgrade test to use wait loop

The snapshot_upgrade test uses a sleep when waiting for a node state change,
this change uses a busy loop to check for the desired node state, instead of
sleeping and hoping for the best.