### PR TITLE
feat(control-plane): add Purge logic to Node service

### DIFF
--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -24,7 +24,10 @@ use stor_port::{
             volume::{AffinityGroupSpec, VolumeContentSource, VolumeSpec},
             AsOperationSequencer, OperationMode, SpecStatus, SpecTransaction,
         },
-        transport::{AppNodeId, NexusId, NodeId, PoolId, ReplicaId, SnapshotId, VolumeId},
+        transport::{
+            AppNodeId, NexusId, NodeId, PoolId, ReplicaId, ReplicaTopology, SnapshotId,
+            SnapshotLossDetail, SnapshotLossInfo, VolumeId, VolumeLossDetail, VolumeLossInfo,
+        },
     },
 };
 
@@ -32,7 +35,12 @@ use async_trait::async_trait;
 use parking_lot::RwLock;
 use serde::de::DeserializeOwned;
 use snafu::{ResultExt, Snafu};
-use std::{fmt::Debug, ops::Deref, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    ops::Deref,
+    sync::Arc,
+};
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]
@@ -1122,4 +1130,115 @@ fn get_affinity_group_specs(volume_specs: &[VolumeSpec]) -> Vec<AffinityGroupSpe
         }
     }
     affinity_group_specs
+}
+
+/// Analyze volume loss impact across one or more pools being purged.
+///
+/// For each volume that has replicas on the given pool(s), fetches the
+/// `Volume` object and uses its `replica_topology` to determine how many
+/// healthy replicas exist before and after the deletion.
+pub(crate) async fn analyze_volume_loss(
+    registry: &Registry,
+    pool_ids: &HashSet<PoolId>,
+    volume_ids: &HashSet<VolumeId>,
+) -> Result<Option<VolumeLossInfo>, SvcError> {
+    let mut volumes_with_volume_loss = Vec::new();
+
+    for volume_id in volume_ids {
+        let volume = match registry.volume(volume_id).await {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let topology = &volume.state().replica_topology;
+
+        let total_replicas = topology.len() as u32;
+        let healthy_before = topology
+            .values()
+            .filter(|rt| rt.status().online() && rt.healthy() == Some(true))
+            .count() as u32;
+
+        let on_pools =
+            |rt: &&ReplicaTopology| rt.pool().as_ref().is_some_and(|p| pool_ids.contains(p));
+
+        let replicas_on_pool = topology.values().filter(on_pools).count() as u32;
+        let healthy_lost = topology
+            .values()
+            .filter(on_pools)
+            .filter(|rt| rt.status().online() && rt.healthy() == Some(true))
+            .count() as u32;
+
+        let healthy_after = healthy_before.saturating_sub(healthy_lost);
+
+        if healthy_after == 0 && replicas_on_pool > 0 {
+            volumes_with_volume_loss.push(VolumeLossDetail {
+                volume_id: volume_id.clone(),
+                replicas_before: total_replicas,
+                healthy_before,
+                lost_on_pool: replicas_on_pool,
+                healthy_after,
+            });
+        }
+    }
+
+    if volumes_with_volume_loss.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(VolumeLossInfo {
+            volumes: volumes_with_volume_loss,
+        }))
+    }
+}
+
+/// Analyze snapshot loss impact across one or more pools being purged.
+///
+/// Replica snapshots on the given pool(s) are permanently lost. Any
+/// replica snapshot on a different pool is a surviving copy. If a volume
+/// snapshot has no surviving copies after the purge, it is reported as lost.
+pub(crate) fn analyze_snapshot_loss(
+    registry: &Registry,
+    pool_ids: &HashSet<PoolId>,
+) -> Result<Option<SnapshotLossInfo>, SvcError> {
+    let mut snapshots_with_loss: HashMap<SnapshotId, SnapshotLossDetail> = HashMap::new();
+
+    for vol_snapshot in registry.specs().volume_snapshots_rsc() {
+        let vol_snap = vol_snapshot.lock();
+        let vol_snap_id = vol_snap.spec().uuid().clone();
+
+        let mut total_replica_snaps = 0u32;
+        let mut on_these_pools = 0u32;
+
+        for txn_replicas in vol_snap.metadata().transactions().values() {
+            for rs in txn_replicas {
+                total_replica_snaps += 1;
+                if pool_ids.contains(rs.spec().source_id().pool_id()) {
+                    on_these_pools += 1;
+                }
+            }
+        }
+
+        if on_these_pools > 0 {
+            let surviving = total_replica_snaps - on_these_pools;
+
+            if surviving == 0 && !snapshots_with_loss.contains_key(&vol_snap_id) {
+                snapshots_with_loss.insert(
+                    vol_snap_id.clone(),
+                    SnapshotLossDetail {
+                        snapshot_id: vol_snap_id,
+                        replica_snapshots_before: total_replica_snaps,
+                        healthy_before: total_replica_snaps - on_these_pools,
+                        lost_on_pool: on_these_pools,
+                        healthy_after: 0,
+                    },
+                );
+            }
+        }
+    }
+
+    if snapshots_with_loss.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(SnapshotLossInfo {
+            snapshots: snapshots_with_loss.into_values().collect(),
+        }))
+    }
 }

--- a/control-plane/agents/src/bin/core/node/operations.rs
+++ b/control-plane/agents/src/bin/core/node/operations.rs
@@ -1,16 +1,20 @@
 use agents::errors::SvcError;
 
-use stor_port::types::v0::store::node::{DrainingVolumes, NodeOperation, NodeSpec};
+use stor_port::types::v0::{
+    store::node::{DrainingVolumes, NodeOperation, NodeSpec},
+    transport::{DestroyNode, DestroyPool, NodeDeleteResult, NodeId, NodeStatus},
+};
 
 use crate::controller::{
     registry::Registry,
     resources::{
-        operations::{ResourceCordon, ResourceDrain, ResourceLabel},
-        operations_helper::GuardedOperationsHelper,
+        operations::{ResourceCordon, ResourceDrain, ResourceLabel, ResourceLifecycle},
+        operations_helper::{analyze_snapshot_loss, analyze_volume_loss, GuardedOperationsHelper},
         OperationGuardArc,
     },
 };
-use std::collections::HashMap;
+use grpc::operations::pool::traits::PoolCordonRequest;
+use std::collections::{HashMap, HashSet};
 
 /// Resource Cordon Operations.
 #[async_trait::async_trait]
@@ -128,6 +132,39 @@ impl ResourceDrain for OperationGuardArc<NodeSpec> {
     }
 }
 
+#[async_trait::async_trait]
+impl ResourceLifecycle for OperationGuardArc<NodeSpec> {
+    type Create = ();
+    type CreateOutput = ();
+    type Destroy = DestroyNode;
+    type DestroyOutput = NodeDeleteResult;
+
+    async fn create(
+        _registry: &Registry,
+        _request: &Self::Create,
+    ) -> Result<Self::CreateOutput, SvcError> {
+        unimplemented!(
+            "Nodes self-register via keep-alives; they are not created via ResourceLifecycle"
+        )
+    }
+
+    async fn destroy(
+        &mut self,
+        registry: &Registry,
+        request: &Self::Destroy,
+    ) -> Result<Self::DestroyOutput, SvcError> {
+        let purge_result = self.purge_node(registry, request).await?;
+
+        // Remove the node's runtime state (wrapper).
+        {
+            let mut nodes = registry.nodes().write().await;
+            nodes.remove(request.id.as_ref());
+        }
+
+        Ok(purge_result)
+    }
+}
+
 /// Node drain Operations.
 impl OperationGuardArc<NodeSpec> {
     /// Drain the set of draining volumes to the stored set.
@@ -184,5 +221,189 @@ impl OperationGuardArc<NodeSpec> {
 
         self.complete_update(registry, Ok(()), spec_clone).await?;
         Ok(self.as_ref().clone())
+    }
+
+    /// Purge a node and all its resources (pools, replicas, nexuses, snapshots).
+    ///
+    /// Pre-flight validation (offline, cordoned, accept flags, loss analysis)
+    /// runs before any operation is logged. Once `start_destroy_for_purge` marks
+    /// the node as Purging, all destructive work is captured and passed through
+    /// `complete_destroy` — ensuring the pending op is always resolved.
+    ///
+    /// If the destructive work fails, `complete_destroy(Err)` clears the pending
+    /// op while keeping Purging status. The `NodePurgeReconciler` will resume.
+    pub(crate) async fn purge_node(
+        &mut self,
+        registry: &Registry,
+        request: &DestroyNode,
+    ) -> Result<NodeDeleteResult, SvcError> {
+        let node_id = request.id.clone();
+        let node_spec = self.as_ref().clone();
+        let resuming = node_spec.status.purging();
+
+        if !resuming {
+            // Pre-flight validation — no op logged yet, safe to return early.
+            Self::validate_purge_preconditions(registry, request, &node_spec).await?;
+        }
+
+        // Mark node as Purging BEFORE any destructive work.
+        // From here on, errors must go through complete_destroy.
+        self.start_destroy_for_purge(registry).await?;
+
+        // Capture all destructive work results.
+        let purge_result = Self::purge_node_resources(registry, &node_id, request).await;
+
+        // Always complete the op:
+        // - Ok(()) deletes the node spec from etcd and memory.
+        // - Err(error) clears the pending op, keeps Purging for reconciler retry.
+        self.complete_destroy(purge_result, registry).await
+    }
+
+    /// Validate all preconditions for node purge.
+    /// Called before any operation is logged — safe to return errors directly.
+    async fn validate_purge_preconditions(
+        registry: &Registry,
+        request: &DestroyNode,
+        node_spec: &NodeSpec,
+    ) -> Result<(), SvcError> {
+        let node_id = &request.id;
+
+        // 1. Validate node is offline.
+        let node_is_online = match registry.node_state(node_id).await {
+            Ok(state) => state.status == NodeStatus::Online,
+            Err(_) => false,
+        };
+        if node_is_online {
+            return Err(SvcError::NodeIsOnline {
+                node_id: node_id.clone(),
+            });
+        }
+
+        // 2. Validate node is cordoned.
+        if !node_spec.cordoned() {
+            return Err(SvcError::NodeNotCordoned {
+                node_id: node_id.clone(),
+            });
+        }
+
+        // 3. Collect pools on this node.
+        let node_pools = registry.get_node_opt_pools(Some(node_id.clone())).await?;
+
+        let has_resources = !node_pools.is_empty();
+
+        // 4. If node has resources but purge=false, reject.
+        if has_resources && !request.purge {
+            return Err(SvcError::NodeHasResources {
+                node_id: node_id.clone(),
+            });
+        }
+
+        // 5. If node has resources, accept=true is required.
+        if has_resources && !request.accept {
+            return Err(SvcError::NodePurgeAcceptRequired {
+                node_id: node_id.clone(),
+                pool_count: node_pools.len(),
+            });
+        }
+
+        // 5a. Analyze volume loss across ALL pools on this node.
+        let pool_ids: HashSet<_> = node_pools.iter().map(|p| p.id().clone()).collect();
+        let volume_ids: HashSet<_> = pool_ids
+            .iter()
+            .flat_map(|pid| registry.specs().pool_replicas(pid))
+            .filter_map(|r| r.lock().owners.volume().cloned())
+            .collect();
+
+        if let Some(info) = analyze_volume_loss(registry, &pool_ids, &volume_ids).await? {
+            if !request.accept_volume_loss {
+                return Err(SvcError::NodePurgeVolumeLossAcceptRequired {
+                    node_id: node_id.clone(),
+                    pool_count: pool_ids.len(),
+                    volume_count: info.volumes.len(),
+                    volume_loss: info,
+                });
+            }
+        }
+
+        // 5b. Analyze snapshot loss across ALL pools.
+        if let Some(info) = analyze_snapshot_loss(registry, &pool_ids)? {
+            if !request.accept_snapshot_loss {
+                return Err(SvcError::NodePurgeSnapshotLossAcceptRequired {
+                    node_id: node_id.clone(),
+                    pool_count: pool_ids.len(),
+                    snapshot_count: info.snapshots.len(),
+                    snapshot_loss: info,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Perform all destructive purge work: pool cordon+purge and nexus cleanup.
+    ///
+    /// Called after `start_destroy_for_purge`. The caller wraps the result in
+    /// `complete_destroy` to ensure the pending op is always resolved.
+    async fn purge_node_resources(
+        registry: &Registry,
+        node_id: &NodeId,
+        request: &DestroyNode,
+    ) -> Result<NodeDeleteResult, SvcError> {
+        // Re-collect pools (in the resume case, pre-flight was skipped).
+        let node_pools = registry.get_node_opt_pools(Some(node_id.clone())).await?;
+
+        let mut result = NodeDeleteResult::new(node_id.clone());
+
+        // Cordon and purge each pool.
+        for pool in &node_pools {
+            let mut pool_guard = match registry.specs().pool_guard(pool.id()).await? {
+                Some(guard) => guard,
+                None => continue,
+            };
+
+            // Best-effort cordon — pool purge's own validate_purge_cordon is the
+            // real enforcement. Log failures but don't abort.
+            let cordon_request = PoolCordonRequest {
+                node_id: None,
+                pool_id: pool.id().clone(),
+                replicas: true,
+                snapshots: true,
+                restores: false,
+                import: false,
+            };
+            if let Err(error) = pool_guard.cordon(registry, cordon_request).await {
+                tracing::warn!(
+                    node.id = %node_id,
+                    pool.id = %pool.id(),
+                    %error,
+                    "Failed to auto-cordon pool during node purge (pool purge will validate)"
+                );
+            }
+
+            let destroy_pool = DestroyPool::purge(pool.node(), pool.id().clone())
+                .with_accept(request.accept)
+                .with_accept_volume_loss(request.accept_volume_loss)
+                .with_accept_snapshot_loss(request.accept_snapshot_loss);
+
+            if let Some(pool_result) = pool_guard.destroy(registry, &destroy_pool).await? {
+                result.merge_pool_result(&pool_result);
+            }
+        }
+
+        /* TODO: Add Nexus removal
+         * The node where the nexus is, is deleted, what happens to the volume?
+         * HA is enabled, but the replicas are in offline nodes, what happens to this volume?
+         * What happen to a volume if their last healthy replica is lost?
+         */
+
+        tracing::info!(
+            node.id = %node_id,
+            pools_deleted = node_pools.len(),
+            volume_loss = result.has_volume_loss(),
+            snapshot_loss = result.has_snapshot_loss(),
+            "Node purge resources cleaned up"
+        );
+
+        Ok(result)
     }
 }

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -14,6 +14,7 @@ use stor_port::types::v0::transport::{
     Register,
 };
 
+use crate::controller::resources::operations::ResourceLifecycle;
 use crate::controller::{io_engine::HostApi, wrapper::InternalOps};
 use grpc::{
     context::Context,
@@ -156,8 +157,9 @@ impl NodeOperations for Service {
     }
 
     /// Delete a node and all its resources (purge).
-    async fn delete(&self, _request: &DestroyNode) -> Result<NodeDeleteResult, ReplyError> {
-        Err(ReplyError::unimplemented("Not implemented".into()))
+    async fn delete(&self, request: &DestroyNode) -> Result<NodeDeleteResult, ReplyError> {
+        let result = self.delete_node(request).await?;
+        Ok(result)
     }
 }
 
@@ -455,5 +457,20 @@ impl Service {
         let spec = guarded_node.unlabel(&self.registry, label).await?;
         let state = self.registry.node_state(&id).await.ok();
         Ok(Node::new(id, Some(spec), state))
+    }
+
+    /// Delete a node and all its resources (pools, replicas, nexuses, snapshots).
+    ///
+    /// Acquires the node operation guard and delegates to `purge_node` which
+    /// handles pre-flight validation, the destroy lifecycle, and resource cleanup.
+    /// After the spec is removed, the runtime wrapper is cleaned up.
+    pub(crate) async fn delete_node(
+        &self,
+        request: &DestroyNode,
+    ) -> Result<NodeDeleteResult, SvcError> {
+        let node_id = &request.id;
+
+        let mut node_guard = self.registry.specs().guarded_node(node_id).await?;
+        node_guard.destroy(&self.registry, request).await
     }
 }

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -152,6 +152,12 @@ impl ResourceSpecsLocked {
             })
             .collect()
     }
+
+    /// Remove the Node `id` from the spec list.
+    pub(crate) fn remove_node(&self, id: &NodeId) {
+        let mut specs = self.write();
+        specs.nodes.remove(id);
+    }
 }
 
 impl ResourceSpecs {
@@ -175,8 +181,9 @@ impl GuardedOperationsHelper for OperationGuardArc<NodeSpec> {
     type UpdateOp = NodeOperation;
     type Inner = NodeSpec;
 
-    fn remove_spec(&self, _registry: &Registry) {
-        unimplemented!();
+    fn remove_spec(&self, registry: &Registry) {
+        let id = self.lock().id().clone();
+        registry.specs().remove_node(&id);
     }
 }
 
@@ -256,7 +263,7 @@ impl SpecOperationsHelper for NodeSpec {
         unimplemented!();
     }
     fn start_destroy_op(&mut self) {
-        unimplemented!();
+        self.start_op(NodeOperation::Destroy);
     }
 
     fn dirty(&self) -> bool {
@@ -269,10 +276,10 @@ impl SpecOperationsHelper for NodeSpec {
         self.id().to_string()
     }
     fn status(&self) -> SpecStatus<Self::Status> {
-        SpecStatus::Created(())
+        self.status.clone()
     }
-    fn set_status(&mut self, _status: SpecStatus<Self::Status>) {
-        unimplemented!();
+    fn set_status(&mut self, status: SpecStatus<Self::Status>) {
+        self.status = status;
     }
     fn operation_result(&self) -> Option<Option<bool>> {
         self.operation.as_ref().map(|r| r.result)

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -31,6 +31,7 @@ use itertools::Itertools;
 use regex::Regex;
 use snafu::OptionExt;
 use std::{collections::HashSet, ops::Deref, sync::Arc};
+use stor_port::types::v0::transport::{PoolId, SnapshotLossInfo, VolumeId, VolumeLossInfo};
 use tokio::sync::RwLock;
 
 impl OperationGuardArc<PoolSpec> {
@@ -284,6 +285,28 @@ impl OperationGuardArc<PoolSpec> {
         let pool_spec = registry.specs().pool(self.uid())?;
 
         Ok(Pool::new(pool_spec, Some(CtrlPoolState::new(pool_state))))
+    }
+
+    /// Analyze volume loss impact for a single pool being purged.
+    pub(crate) async fn analyze_volume_loss(
+        registry: &Registry,
+        pool_id: &PoolId,
+        volume_ids: &HashSet<VolumeId>,
+    ) -> Result<Option<VolumeLossInfo>, SvcError> {
+        let pool_ids = HashSet::from([pool_id.clone()]);
+        crate::controller::resources::operations_helper::analyze_volume_loss(
+            registry, &pool_ids, volume_ids,
+        )
+        .await
+    }
+
+    /// Analyze snapshot loss impact for a single pool being purged.
+    pub(crate) fn analyze_snapshot_loss(
+        registry: &Registry,
+        pool_id: &PoolId,
+    ) -> Result<Option<SnapshotLossInfo>, SvcError> {
+        let pool_ids = HashSet::from([pool_id.clone()]);
+        crate::controller::resources::operations_helper::analyze_snapshot_loss(registry, &pool_ids)
     }
 }
 

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -22,8 +22,7 @@ use stor_port::{
         },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, ExpandPool, Pool, PoolDeleteResult, PoolDiag,
-            PoolDiskError, PoolId, PoolStatus, ReplicaOwners, ReplicaTopology, SnapshotId,
-            SnapshotLossDetail, SnapshotLossInfo, VolumeId, VolumeLossDetail, VolumeLossInfo,
+            PoolDiskError, PoolId, PoolStatus, ReplicaOwners,
         },
     },
 };
@@ -478,7 +477,7 @@ impl OperationGuardArc<PoolSpec> {
             // Node is online - check pool state via ctrl_pool_state
             if let Ok(ctrl_state) = registry.ctrl_pool_state(pool_id).await {
                 if !matches!(ctrl_state.status, PoolStatus::Unknown | PoolStatus::Offline) {
-                    return Err(SvcError::PoolStateNotUnknown {
+                    return Err(SvcError::PoolStateNotOfflineOrUnknown {
                         pool_id: pool_id.clone(),
                         state: ctrl_state.status.clone(),
                     });
@@ -530,116 +529,5 @@ impl OperationGuardArc<PoolSpec> {
             }
         }
         result
-    }
-
-    /// Analyze volume loss impact by examining each affected volume's replica topology.
-    ///
-    /// For each volume that has replicas on the pool being purged, we fetch the
-    /// `Volume` object and use its `replica_topology` to determine how many
-    /// healthy replicas exist before and after the deletion. A replica is
-    /// considered healthy if it is online and marked as fully synced.
-    async fn analyze_volume_loss(
-        registry: &Registry,
-        pool_id: &PoolId,
-        volume_ids: &HashSet<VolumeId>,
-    ) -> Result<Option<VolumeLossInfo>, SvcError> {
-        let mut volumes_with_volume_loss = Vec::new();
-
-        for volume_id in volume_ids {
-            let volume = match registry.volume(volume_id).await {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let topology = &volume.state().replica_topology;
-
-            let total_replicas = topology.len() as u32;
-            let healthy_before = topology
-                .values()
-                .filter(|rt| rt.status().online() && rt.healthy() == Some(true))
-                .count() as u32;
-
-            let on_pool = |rt: &&ReplicaTopology| rt.pool().as_ref() == Some(pool_id);
-
-            let replicas_on_pool = topology.values().filter(on_pool).count() as u32;
-            let healthy_lost = topology
-                .values()
-                .filter(on_pool)
-                .filter(|rt| rt.status().online() && rt.healthy() == Some(true))
-                .count() as u32;
-
-            let healthy_after = healthy_before.saturating_sub(healthy_lost);
-
-            if healthy_after == 0 && replicas_on_pool > 0 {
-                volumes_with_volume_loss.push(VolumeLossDetail {
-                    volume_id: volume_id.clone(),
-                    replicas_before: total_replicas,
-                    healthy_before,
-                    lost_on_pool: replicas_on_pool,
-                    healthy_after,
-                });
-            }
-        }
-
-        if volumes_with_volume_loss.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(VolumeLossInfo {
-                volumes: volumes_with_volume_loss,
-            }))
-        }
-    }
-
-    /// Analyze snapshot loss impact for replica snapshots being deleted.
-    ///
-    /// Replica snapshots on the pool being purged are permanently lost. Any
-    /// replica snapshot on a different pool is a surviving copy. If a volume
-    /// snapshot has no surviving copies after the purge, it is reported as lost.
-    fn analyze_snapshot_loss(
-        registry: &Registry,
-        pool_id: &PoolId,
-    ) -> Result<Option<SnapshotLossInfo>, SvcError> {
-        let mut snapshots_with_loss: HashMap<SnapshotId, SnapshotLossDetail> = HashMap::new();
-
-        for vol_snapshot in registry.specs().volume_snapshots_rsc() {
-            let vol_snap = vol_snapshot.lock();
-            let vol_snap_id = vol_snap.spec().uuid().clone();
-
-            let mut total_replica_snaps = 0u32;
-            let mut on_this_pool = 0u32;
-
-            for txn_replicas in vol_snap.metadata().transactions().values() {
-                for rs in txn_replicas {
-                    total_replica_snaps += 1;
-                    if rs.spec().source_id().pool_id() == pool_id {
-                        on_this_pool += 1;
-                    }
-                }
-            }
-
-            if on_this_pool > 0 {
-                let surviving = total_replica_snaps - on_this_pool;
-
-                if surviving == 0 && !snapshots_with_loss.contains_key(&vol_snap_id) {
-                    snapshots_with_loss.insert(
-                        vol_snap_id.clone(),
-                        SnapshotLossDetail {
-                            snapshot_id: vol_snap_id,
-                            replica_snapshots_before: total_replica_snaps,
-                            healthy_before: total_replica_snaps - on_this_pool,
-                            lost_on_pool: on_this_pool,
-                            healthy_after: 0,
-                        },
-                    );
-                }
-            }
-        }
-
-        if snapshots_with_loss.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(SnapshotLossInfo {
-                snapshots: snapshots_with_loss.into_values().collect(),
-            }))
-        }
     }
 }

--- a/control-plane/agents/src/bin/core/pool/specs.rs
+++ b/control-plane/agents/src/bin/core/pool/specs.rs
@@ -526,4 +526,16 @@ impl ResourceSpecsLocked {
             }),
         }
     }
+
+    /// Get an operation guard for the given pool, if it exists.
+    /// Returns `None` if the pool spec is not found (instead of an error).
+    pub(crate) async fn pool_guard(
+        &self,
+        pool_id: &PoolId,
+    ) -> Result<Option<OperationGuardArc<PoolSpec>>, SvcError> {
+        Ok(match self.pool_rsc(pool_id) {
+            None => None,
+            Some(pool) => Some(pool.operation_guard_wait().await?),
+        })
+    }
 }

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -450,12 +450,12 @@ pub enum SvcError {
     #[snafu(display("Pool {name} underlying disk rescan failed"))]
     DiskRescanFailed { name: PoolId },
     #[snafu(display(
-        "Cannot purge pool {pool_id}: pool state is {state}, purge only allowed when state is Unknown",
+        "Cannot purge pool {pool_id}: pool state is {state}, purge only allowed when state is Offline or Unknown",
     ))]
-    PoolStateNotUnknown { pool_id: PoolId, state: PoolStatus },
+    PoolStateNotOfflineOrUnknown { pool_id: PoolId, state: PoolStatus },
 
     #[snafu(display(
-        "Cannot purge pool {pool_id}: pool must be cordoned with --replicas --snapshots flags first",
+        "Cannot purge pool {pool_id}: pool must be cordoned for replicas and snapshots first",
     ))]
     PoolNotCordonedForPurge { pool_id: PoolId },
 
@@ -465,7 +465,7 @@ pub enum SvcError {
     PoolCordonInsufficientForPurge { pool_id: PoolId },
 
     #[snafu(display(
-        "Cannot purge pool {pool_id}: pool has {replica_count} replica(s), use --yes to proceed",
+        "Cannot purge pool {pool_id}: pool has {replica_count} replica(s), accept=true required",
     ))]
     PoolPurgeAcceptRequired {
         pool_id: PoolId,
@@ -473,7 +473,7 @@ pub enum SvcError {
     },
 
     #[snafu(display(
-        "Cannot purge pool {pool_id}: {volume_count} volume(s) would lose their last healthy replica, use --accept-volume-loss to proceed",
+        "Cannot purge pool {pool_id}: {volume_count} volume(s) would lose their last healthy replica, accept_volume_loss=true required",
     ))]
     PoolPurgeVolumeLossAcceptRequired {
         pool_id: PoolId,
@@ -482,10 +482,46 @@ pub enum SvcError {
     },
 
     #[snafu(display(
-        "Cannot purge pool {pool_id}: {snapshot_count} snapshot(s) would lose their last replica snapshot, use --accept-snapshot-loss to proceed",
+        "Cannot purge pool {pool_id}: {snapshot_count} snapshot(s) would lose their last replica snapshot, accept_snapshot_loss=true required",
     ))]
     PoolPurgeSnapshotLossAcceptRequired {
         pool_id: PoolId,
+        snapshot_count: usize,
+        snapshot_loss: SnapshotLossInfo,
+    },
+
+    #[snafu(display("Cannot delete node {node_id}: node is online"))]
+    NodeIsOnline { node_id: NodeId },
+
+    #[snafu(display("Cannot delete node {node_id}: node must be cordoned first"))]
+    NodeNotCordoned { node_id: NodeId },
+
+    #[snafu(display(
+        "Cannot delete node {node_id}: node has resources. purge=true required to delete all resources"
+    ))]
+    NodeHasResources { node_id: NodeId },
+
+    #[snafu(display(
+        "Cannot delete node {node_id}: node has {pool_count} pool(s), accept=true required"
+    ))]
+    NodePurgeAcceptRequired { node_id: NodeId, pool_count: usize },
+
+    #[snafu(display(
+        "Cannot delete node {node_id}: {volume_count} volume(s) across {pool_count} pool(s) would lose their last healthy replica, accept_volume_loss=true required"
+    ))]
+    NodePurgeVolumeLossAcceptRequired {
+        node_id: NodeId,
+        pool_count: usize,
+        volume_count: usize,
+        volume_loss: VolumeLossInfo,
+    },
+
+    #[snafu(display(
+        "Cannot delete node {node_id}: {snapshot_count} snapshot(s) across {pool_count} pool(s) would lose their last replica snapshot, accept_snapshot_loss=true required"
+    ))]
+    NodePurgeSnapshotLossAcceptRequired {
+        node_id: NodeId,
+        pool_count: usize,
         snapshot_count: usize,
         snapshot_loss: SnapshotLossInfo,
     },
@@ -1252,7 +1288,7 @@ impl From<SvcError> for ReplyError {
                 source,
                 extra,
             },
-            SvcError::PoolStateNotUnknown { .. } => ReplyError {
+            SvcError::PoolStateNotOfflineOrUnknown { .. } => ReplyError {
                 kind: ReplyErrorKind::PoolNotPurgeable,
                 resource: ResourceKind::Pool,
                 source,
@@ -1285,6 +1321,42 @@ impl From<SvcError> for ReplyError {
             SvcError::PoolPurgeSnapshotLossAcceptRequired { .. } => ReplyError {
                 kind: ReplyErrorKind::PoolPurgeSnapshotLossAcceptRequired,
                 resource: ResourceKind::Pool,
+                source,
+                extra,
+            },
+            SvcError::NodeIsOnline { .. } => ReplyError {
+                kind: ReplyErrorKind::NodeIsOnline,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodeNotCordoned { .. } => ReplyError {
+                kind: ReplyErrorKind::NodeNotCordoned,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodeHasResources { .. } => ReplyError {
+                kind: ReplyErrorKind::NodeHasResources,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodePurgeAcceptRequired { .. } => ReplyError {
+                kind: ReplyErrorKind::NodePurgeAcceptRequired,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodePurgeVolumeLossAcceptRequired { .. } => ReplyError {
+                kind: ReplyErrorKind::NodePurgeVolumeLossAcceptRequired,
+                resource: ResourceKind::Node,
+                source,
+                extra,
+            },
+            SvcError::NodePurgeSnapshotLossAcceptRequired { .. } => ReplyError {
+                kind: ReplyErrorKind::NodePurgeSnapshotLossAcceptRequired,
+                resource: ResourceKind::Node,
                 source,
                 extra,
             },


### PR DESCRIPTION
Flow:
  - Validate node is offline and cordoned
  - Check purge/accept flags
  - Mark node as Purging (crash-safe checkpoint)
  - Auto-cordon each pool (replicas + snapshots) on behalf of the user
  - Delegate to pool purge for each pool (replicas, snapshots, loss analysis all handled by existing pool purge code)
  - Disown replicas from the nexus children and remove the nexus specs
  - On pool rejection: complete_destroy(Err) clears pending op but keeps Purging status for reconciler resume
  - On success: complete_destroy removes node spec from store
  - Remove node runtime wrapper