### PR TITLE
feat: add simple backoff to failed pool imports

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/pool/mod.rs
@@ -145,6 +145,10 @@ async fn missing_pool_state_reconciler(
             Ok(Ok(node)) => node,
         };
 
+        if !pool.as_ref().can_retry_import() {
+            return PollResult::Ok(PollerState::Idle);
+        }
+
         if !pool.probe(&pool_spec, &node).await? {
             // if probing fails, there's no point in trying to import
             return PollResult::Ok(PollerState::Idle);

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -20,9 +20,9 @@ use stor_port::{
             replica::{PoolRef, ReplicaSpec},
         },
         transport::{
-            CreatePool, CtrlPoolState, DestroyReplica, GetBlockDevices, ImportPool, NodeId,
-            NodeStatus, Pool, PoolDeviceUri, PoolDiag, PoolDiskError, PoolError, PoolErrorCode,
-            PoolState, PoolStatus, ReplicaOwners,
+            CreatePool, CtrlPoolState, DestroyReplica, GetBlockDevices, ImportBackoff, ImportPool,
+            NodeId, NodeStatus, Pool, PoolDeviceUri, PoolDiag, PoolDiskError, PoolError,
+            PoolErrorCode, PoolState, PoolStatus, ReplicaOwners,
         },
     },
 };
@@ -114,9 +114,9 @@ impl OperationGuardArc<PoolSpec> {
         let mut pool = self.lock();
         let Some(ref mut diag) = &mut pool.metadata.runtime.diag else {
             pool.metadata.runtime.diag = Some(PoolDiag {
-                import_errors: vec![],
                 error: Some(error),
                 status,
+                ..Default::default()
             });
             return;
         };
@@ -227,6 +227,7 @@ impl OperationGuardArc<PoolSpec> {
                     }],
                     status: PoolStatus::Offline,
                     error: Some(error),
+                    import: ImportBackoff::new(&spec.metadata.runtime, registry.reconcile_period()),
                 });
             }
         }

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -96,6 +96,7 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
                         }],
                         status: PoolStatus::Unknown,
                         error: Some(error),
+                        ..Default::default()
                     });
                 }
             }
@@ -318,9 +319,9 @@ impl OperationGuardArc<PoolSpec> {
                         tonic::Code::Cancelled | tonic::Code::Aborted => {
                             if let Some(error) = Self::pool_import_error(&error) {
                                 self.lock().metadata.runtime.diag = Some(PoolDiag {
-                                    import_errors: vec![],
                                     status: PoolStatus::Unknown,
                                     error: Some(error),
+                                    ..Default::default()
                                 });
                             }
                             Err(error)

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -925,6 +925,8 @@ async fn reconciler_missing_pool_state() {
     let error = pool_diag.import_errors.first().unwrap();
     assert_eq!(error.error.code, PoolErrorCode::InvalidSuperBlock);
 
+    cluster.composer().kill(maya.as_str()).await.unwrap();
+
     // move original disk back and now import should succeed!
     drop(new_disk);
     disk.rename(POOL_FILE_NAME).unwrap();

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -476,6 +476,7 @@ impl From<pool::PoolDiag> for PoolDiag {
         Self {
             status: diag.status().into(),
             error: diag.error.into_opt(),
+            import: Default::default(),
             import_errors: diag.import_errors.into_iter().map(import_error).collect(),
         }
     }

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -315,6 +315,15 @@ impl PoolSpec {
             None => false,
         }
     }
+
+    /// May retry the pool import.
+    /// Otherwise, try again next time.
+    pub fn can_retry_import(&self) -> bool {
+        let Some(diag) = &self.metadata.runtime.diag else {
+            return true;
+        };
+        diag.import.retriable()
+    }
 }
 
 impl From<&PoolSpec> for ImportPool {

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 use crate::{
-    types::v0::store::pool::{Encryption, EncryptionSecret, PoolLabel, PoolSpec, PoolUSpec},
+    types::v0::store::pool::{
+        Encryption, EncryptionSecret, PoolLabel, PoolRuntimeMetadata, PoolSpec, PoolUSpec,
+    },
     IntoOption,
 };
 use serde::{Deserialize, Serialize};
@@ -155,6 +157,9 @@ pub struct PoolDiskError {
 pub struct PoolDiag {
     /// Errors encountered when trying to import the pool.
     pub import_errors: Vec<PoolDiskError>,
+    /// Information about import timings.
+    #[serde(skip)]
+    pub import: ImportBackoff,
     /// Inferred error of the pool, if any.
     #[serde(skip)]
     pub error: Option<PoolError>,
@@ -168,6 +173,46 @@ impl PoolDiag {
         Self {
             status: state.status.clone(),
             ..self
+        }
+    }
+}
+
+/// Pool import backoff.
+/// Used to avoid thrashing the logs.
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct ImportBackoff {
+    pub retries: u64,
+    pub next_retry: Option<std::time::SystemTime>,
+}
+impl ImportBackoff {
+    /// We may retry the import at this time.
+    pub fn retriable(&self) -> bool {
+        let Some(next_retry) = &self.next_retry else {
+            return true;
+        };
+        next_retry <= &std::time::SystemTime::now()
+    }
+    /// Create a new ImportBackoff.
+    pub fn new(old: &PoolRuntimeMetadata, gc_period: std::time::Duration) -> Self {
+        const MAX_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+        let retries = match &old.diag {
+            Some(diag) => diag.import.retries + 1,
+            None => 0,
+        };
+
+        let cooldown = if retries < 5 {
+            gc_period
+        } else if retries < 10 {
+            gc_period * retries as u32
+        } else {
+            gc_period * 10 * (retries - 9) as u32
+        }
+        .min(MAX_COOLDOWN);
+
+        Self {
+            retries,
+            next_retry: std::time::SystemTime::now().checked_add(cooldown),
         }
     }
 }

--- a/deployer/src/infra/jaeger.rs
+++ b/deployer/src/infra/jaeger.rs
@@ -47,6 +47,7 @@ impl ComponentAction for Jaeger {
                 }
             }
             .with_portmap("4317", "4317")
+            .with_env("GOMAXPROCS", "2")
             .with_env("COLLECTOR_OTLP_ENABLED", "true");
 
             if cfg.container_exists("elastic") {

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -273,15 +273,19 @@ impl Cluster {
         let start = std::time::Instant::now();
         let mut seen_status = None;
         loop {
-            let node = node_cli
+            let result = node_cli
                 .get(Filter::Node(node_id.clone()), true, None)
-                .await
-                .expect("To get node object");
-            if let Some(node) = node.0.first() {
-                if node.state().map(|n| &n.status) == Some(&status) {
-                    return Ok(());
+                .await;
+            match result {
+                Ok(nodes) => {
+                    if let Some(node) = nodes.0.first() {
+                        if node.state().map(|n| &n.status) == Some(&status) {
+                            return Ok(());
+                        }
+                        seen_status = node.state().map(|n| n.status);
+                    }
                 }
-                seen_status = node.state().map(|n| n.status);
+                Err(error) => tracing::error!(%error, "Failed to fetch node"),
             }
             if std::time::Instant::now() > (start + timeout) {
                 break;


### PR DESCRIPTION
    feat: add simple backoff to failed pool imports
    
    Avoids retrying pool import too often, especially if t here's something
    bad with the backend.
    
    Ideally this should be solved entirely by the proving, but as of now the
    probing doesn't do superblock probing...
    
---

    test: fix race condition on missing pool reconciler
    
    Kill the io-engine container to ensure there's no race between
    restoring the correct backend disk and checking for pool status.
    
---

    chore: limit GOMAXPROCS for jaeger
    
    Limit the memory used during tests.
