### PR TITLE
feat(core): add configurable pool import timeout for large pools

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/snap_rebuild.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/snap_rebuild.rs
@@ -131,7 +131,7 @@ mod test {
             lock,
             &cluster.node(0),
             cluster.node_socket(0),
-            &NodeCommsTimeout::new(one_s, one_s, false),
+            &NodeCommsTimeout::new(one_s, one_s, false, None),
             None,
             ApiVersion::V1,
             false,

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -54,6 +54,13 @@ pub(crate) struct CliArgs {
     #[clap(long, default_value = "15m")]
     pub(crate) pool_async_creat_tmo: humantime::Duration,
 
+    /// The gRPC timeout for pool import operations.
+    /// Large pools with many volumes may take longer than the default 60s to
+    /// import after an io-engine restart. Set this to accommodate the expected
+    /// import time for your largest pool.
+    #[clap(long, env = "POOL_IMPORT_TIMEOUT")]
+    pub(crate) pool_import_timeout: Option<humantime::Duration>,
+
     /// Disable partial rebuild for volume targets.
     #[clap(long, env = "DISABLE_PARTIAL_REBUILD")]
     pub(crate) disable_partial_rebuild: bool,

--- a/control-plane/agents/src/bin/core/node/mod.rs
+++ b/control-plane/agents/src/bin/core/node/mod.rs
@@ -35,6 +35,8 @@ async fn create_node_service<S>(builder: &Service<S>) -> service::Service {
     let request = CliArgs::args().request_timeout.into();
     let connect = CliArgs::args().connect_timeout.into();
     let no_min = CliArgs::args().no_min_timeouts;
+    let pool_import_timeout = CliArgs::args().pool_import_timeout.map(Into::into);
 
-    service::Service::new(registry.clone(), deadline, request, connect, no_min).await
+    service::Service::new(registry.clone(), deadline, request, connect, no_min, pool_import_timeout)
+        .await
 }

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -60,6 +60,7 @@ impl NodeCommsTimeout {
         connect: std::time::Duration,
         request: std::time::Duration,
         no_min: bool,
+        pool_import_timeout: Option<std::time::Duration>,
     ) -> Self {
         let opts = TimeoutOptions::new()
             .with_req_timeout(request)
@@ -67,7 +68,11 @@ impl NodeCommsTimeout {
             .with_min_req_timeout(if no_min {
                 None
             } else {
-                TimeoutOptions::default().request_min_timeout().cloned()
+                let mut min = stor_port::transport_api::RequestMinTimeout::default();
+                if let Some(timeout) = pool_import_timeout {
+                    min = min.with_pool_import_timeout(timeout);
+                }
+                Some(min)
             });
 
         Self { opts }
@@ -197,12 +202,13 @@ impl Service {
         request: std::time::Duration,
         connect: std::time::Duration,
         no_min: bool,
+        pool_import_timeout: Option<std::time::Duration>,
     ) -> Self {
         let sim_socket = Self::sim_socket(&registry);
         let service = Self {
             registry,
             deadline,
-            comms_timeouts: NodeCommsTimeout::new(connect, request, no_min),
+            comms_timeouts: NodeCommsTimeout::new(connect, request, no_min, pool_import_timeout),
             sim_socket,
         };
         // attempt to reload the node state based on the specification

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -143,6 +143,7 @@ impl NodeWrapper {
                 std::time::Duration::from_secs(1),
                 std::time::Duration::from_secs(1),
                 false,
+                None,
             ),
             states: ResourceStatesLocked::new(),
             num_rebuilds: Arc::new(RwLock::new(0)),
@@ -383,6 +384,7 @@ impl NodeWrapper {
             self.comms_timeouts.connect(),
             self.comms_timeouts.connect(),
             true,
+            None,
         );
 
         let client = self.grpc_client_timeout(timeouts).await?;
@@ -402,6 +404,7 @@ impl NodeWrapper {
             self.comms_timeouts.connect(),
             self.comms_timeouts.connect(),
             true,
+            None,
         );
 
         // Set the api version to latest and make a call

--- a/control-plane/grpc/src/context.rs
+++ b/control-plane/grpc/src/context.rs
@@ -69,14 +69,22 @@ pub fn timeout_grpc(op_id: MessageId, timeout_opts: TimeoutOptions) -> Duration 
                 MessageIdVs::DestroyReplicaSnapshot => min_timeouts.replica_snapshot(),
 
                 MessageIdVs::CreatePool => min_timeouts.pool(),
-                MessageIdVs::ImportPool => min_timeouts.pool() * 3,
+                MessageIdVs::ImportPool => min_timeouts.pool_import(),
                 MessageIdVs::DestroyPool => min_timeouts.pool(),
 
                 MessageIdVs::ReplacePathInfo => min_timeouts.nvme_reconnect(),
                 _ => base,
             },
         };
-        let timeout = Duration::max(base, op_timeout).min(Duration::from_secs(59));
+        let timeout = Duration::max(base, op_timeout);
+        // Apply the 59s cap only when the operation's minimum timeout fits within it.
+        // Operations like nvme_reconnect (62s) and explicitly configured pool_import
+        // intentionally exceed this cap and should not be clamped.
+        let timeout = if op_timeout > Duration::from_secs(59) {
+            timeout
+        } else {
+            timeout.min(Duration::from_secs(59))
+        };
         match timeout_opts.client() {
             // the rest server should have some slack to allow for the CoreAgent to timeout first.
             ClientId::RestServer => timeout + Duration::from_secs(1),
@@ -208,5 +216,61 @@ impl<C: Clone> Client<C> {
     /// Returns a new client.
     pub(crate) fn client(&self) -> C {
         self.client.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stor_port::transport_api::RequestMinTimeout;
+
+    fn opts_with_base(secs: u64) -> TimeoutOptions {
+        TimeoutOptions::new()
+            .with_req_timeout(Duration::from_secs(secs))
+            .with_min_req_timeout(Some(RequestMinTimeout::default()))
+    }
+
+    #[test]
+    fn import_pool_default_timeout_not_capped() {
+        let opts = opts_with_base(5);
+        let timeout = timeout_grpc(MessageId::v0(MessageIdVs::ImportPool), opts);
+        // Default: pool(20s) * 3 = 60s, not capped because op_timeout > 59s
+        assert_eq!(timeout, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn create_pool_timeout_is_capped() {
+        // base=120s exceeds pool(20s), but 120s is capped at 59s
+        let opts = opts_with_base(120);
+        let timeout = timeout_grpc(MessageId::v0(MessageIdVs::CreatePool), opts);
+        assert_eq!(timeout, Duration::from_secs(59));
+    }
+
+    #[test]
+    fn nvme_reconnect_not_capped() {
+        // nvme_reconnect default is 62s, which should NOT be capped at 59s
+        let opts = opts_with_base(5);
+        let timeout = timeout_grpc(MessageId::v0(MessageIdVs::ReplacePathInfo), opts);
+        assert_eq!(timeout, Duration::from_secs(62));
+    }
+
+    #[test]
+    fn import_pool_explicit_timeout_not_capped() {
+        let min = RequestMinTimeout::default()
+            .with_pool_import_timeout(Duration::from_secs(300));
+        let opts = TimeoutOptions::new()
+            .with_req_timeout(Duration::from_secs(5))
+            .with_min_req_timeout(Some(min));
+        let timeout = timeout_grpc(MessageId::v0(MessageIdVs::ImportPool), opts);
+        assert_eq!(timeout, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn no_min_timeouts_uses_base() {
+        let opts = TimeoutOptions::new()
+            .with_req_timeout(Duration::from_secs(120))
+            .with_min_req_timeout(None);
+        let timeout = timeout_grpc(MessageId::v0(MessageIdVs::ImportPool), opts);
+        assert_eq!(timeout, Duration::from_secs(120));
     }
 }

--- a/control-plane/stor-port/src/transport_api/mod.rs
+++ b/control-plane/stor-port/src/transport_api/mod.rs
@@ -539,6 +539,7 @@ pub struct RequestMinTimeout {
     replica_snapshot: Duration,
     nexus: Duration,
     pool: Duration,
+    pool_import: Option<Duration>,
     nexus_shutdown: Duration,
     nexus_snapshot: Duration,
     nvme_reconnect: Duration,
@@ -551,6 +552,7 @@ impl Default for RequestMinTimeout {
             replica_snapshot: Duration::from_secs(10),
             nexus: Duration::from_secs(30),
             pool: Duration::from_secs(20),
+            pool_import: None,
             nexus_shutdown: Duration::from_secs(15),
             nexus_snapshot: Duration::from_secs(30),
             nvme_reconnect: Duration::from_secs(62),
@@ -582,6 +584,16 @@ impl RequestMinTimeout {
     /// Minimum timeout for a pool operation.
     pub fn pool(&self) -> Duration {
         self.pool
+    }
+    /// Minimum timeout for a pool import operation.
+    /// Falls back to `pool * 3` when not explicitly configured.
+    pub fn pool_import(&self) -> Duration {
+        self.pool_import.unwrap_or(self.pool * 3)
+    }
+    /// Set an explicit timeout for pool import operations.
+    pub fn with_pool_import_timeout(mut self, timeout: Duration) -> Self {
+        self.pool_import = Some(timeout);
+        self
     }
     /// Minimum timeout for nexus shutdown.
     pub fn nexus_shutdown(&self) -> Duration {


### PR DESCRIPTION
## Summary

When an io-engine pod restarts, agent-core re-imports disk pools via ImportPool gRPC. On large pools (e.g. ~200 TiB with many lvols), the SPDK blobstore metadata scan can exceed 60s, hitting the hardcoded timeout cap and causing an infinite timeout-retry loop.

This PR:

- Fixes the 59s hard cap in `timeout_grpc()` so operations whose minimum timeout intentionally exceeds 59s are no longer silently clamped (also fixes `nvme_reconnect` at 62s being capped to 59s)
- Adds a `--pool-import-timeout` CLI arg (env: `POOL_IMPORT_TIMEOUT`) to set an explicit timeout for pool import operations

When `--pool-import-timeout` is not specified, behavior is unchanged.

## Motivation

We run a ~200 TiB Mayastor disk pool across 2 storage nodes. After an io-engine crash, the pool import consistently exceeded the 59s gRPC timeout. Agent-core retried every 10s, flooding the freshly restarted io-engine with import + nexus + replica requests, preventing the import from ever completing. The pool was stuck in Unknown state indefinitely.

## Architectural Safety

### The 59s cap change is conservative

The cap logic changes from unconditional `.min(59s)` to conditional: only operations whose `op_timeout <= 59s` are still capped. This affects exactly two operations today:

- **ImportPool** (default 60s): goes from 59s to 60s -- a 1s increase that matches the originally intended `pool * 3` calculation
- **nvme_reconnect** (default 62s): goes from 59s to 62s -- this was always a bug; the 62s value was explicitly chosen but silently clamped

All other operations (replica, nexus, pool create/destroy, snapshots) have `op_timeout <= 30s` and remain capped at 59s exactly as before.

### The 60s tonic channel timeout is NOT affected

Pool import flows through `GrpcContext` (`client.rs:56-63`), which creates its own `tonic::transport::Endpoint` with `.timeout(timeout)` set to the result of `timeout_grpc()`. The separate 60s hardcoded channel timeout in `Context::endpoint()` (line 145) is only used by the rest-server/csi-to-core-agent path and is not involved.

### Node operation serialization

Node operations are serialized via `Arc<Mutex>` per node (`GrpcClientLocked`). A longer pool import timeout means other operations on that node queue behind it longer. This is acceptable: during pool import, the pool is in Unknown state, so nexus/replica operations targeting that pool would fail regardless. Letting the import complete is strictly better than the current behavior of timing out and retrying in a 10s loop indefinitely.

### No impact on reconciler behavior

The pool reconciler continues to retry imports every reconciliation cycle (default 10s). The only difference is that each attempt now has enough time to succeed on large pools, breaking the infinite timeout-retry loop.

## Changes

| File | Change |
|------|--------|
| `grpc/src/context.rs` | Fix 59s cap, use `pool_import()`, add 5 unit tests |
| `stor-port/src/transport_api/mod.rs` | Add `pool_import` field, accessor, builder |
| `agents/src/bin/core/main.rs` | Add `--pool-import-timeout` CLI arg |
| `agents/src/bin/core/node/mod.rs` | Thread new arg |
| `agents/src/bin/core/node/service.rs` | Wire to `RequestMinTimeout` |
| `agents/src/bin/core/node/wrapper.rs` | Update `NodeCommsTimeout::new()` call sites |
| `agents/.../snap_rebuild.rs` | Update `NodeCommsTimeout::new()` call site |

## Backward Compatibility

- Default behavior is preserved when `--pool-import-timeout` is not set
- The only side effect is `nvme_reconnect` (62s) is no longer capped to 59s, which was always a bug
- `--no-min-timeouts` continues to bypass all operation-specific timeouts

## Test plan

- [x] Unit tests for `timeout_grpc()` covering cap behavior (5 tests)
- [x] `cargo check -p agents --bin core` passes
- [ ] Manual: set `--pool-import-timeout=300s`, verify import uses 300s