### PR TITLE
deployer: csi-node-2 as a qemu vm for rwx testing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ __pycache__
 /ci-report/
 pytest.log
 /bundle
+/deployer/misc/rwx-vm/nixos.qcow2
+/deployer/misc/rwx-vm/result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,7 @@ dependencies = [
  "grpc",
  "humantime",
  "hyper-util",
+ "nix",
  "paste",
  "reqwest",
  "rpc",

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -8,6 +8,7 @@ mod garbage_collection;
 mod helpers;
 mod hotspare;
 mod resize;
+mod rwx;
 mod snapshot;
 mod snapshot_clone;
 mod switchover;

--- a/control-plane/agents/src/bin/core/tests/volume/rwx.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/rwx.rs
@@ -1,0 +1,107 @@
+#![cfg(test)]
+
+use deployer_cluster::{Cluster, ClusterBuilder};
+use grpc::operations::volume::traits::VolumeOperations;
+use std::{collections::HashMap, time::Duration};
+use stor_port::types::v0::transport::{
+    CreateVolume, PublishVolume, VolumeAccessMode, VolumeId, VolumeShareProtocol,
+};
+
+#[tokio::test]
+async fn rwx() {
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_io_engines(2)
+        .with_tmpfs_pool(100 * 1024 * 1024)
+        .with_cache_period("1s")
+        .with_reconcile_period(Duration::from_secs(1), Duration::from_secs(1))
+        .with_csi(false, true)
+        .with_agents(vec!["Core", "HaNode", "HaCluster"])
+        .with_rwx_vm(true)
+        .with_app_nodes(2)
+        .build()
+        .await
+        .unwrap();
+
+    test_migrate(&cluster).await;
+}
+
+#[tracing::instrument(skip(cluster))]
+async fn test_migrate(cluster: &Cluster) {
+    tracing::info!("Migrating...");
+
+    let volume_client = cluster.grpc_client().volume();
+    let volume = volume_client
+        .create(
+            &CreateVolume {
+                uuid: VolumeId::try_from("ec4e66fd-3b33-4439-b504-d49aba53da26").unwrap(),
+                size: 5242880,
+                replicas: 2,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // source VM
+    let vm_1 = cluster.csi_node(0);
+    let volume = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![vm_1.to_string()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    tracing::info!("Staging volume to {vm_1}");
+    let mut node_1 = cluster.csi_node_client(0).await.unwrap();
+    node_1
+        .node_stage_volume_(&volume, HashMap::default())
+        .await
+        .unwrap();
+
+    // destination VM
+    let vm_2 = cluster.csi_node(1);
+    let volume = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec![vm_1.to_string(), vm_2.to_string()],
+                access_mode: VolumeAccessMode::MultiNodeMultiWriter,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    tracing::info!("Staging volume to {vm_2}");
+    let mut node_2 = cluster.csi_node_client_tcp().await.unwrap();
+    node_2
+        .node_stage_volume_(&volume, HashMap::default())
+        .await
+        .unwrap();
+
+    // live migration starts
+
+    // todo: simulate node restarts, split-brain....
+
+    // live migration completes
+
+    // disconnect source node...
+    node_1.node_unstage_volume_(&volume).await.unwrap();
+
+    // todo: some disruption on destination node
+
+    // disconnect destination node
+    node_2.node_unstage_volume_(&volume).await.unwrap();
+}

--- a/control-plane/agents/src/bin/ha/node/detector.rs
+++ b/control-plane/agents/src/bin/ha/node/detector.rs
@@ -297,7 +297,7 @@ impl PathFailureDetector {
                     && (subsystem.hostnqn.starts_with(&host_nqn_prefix) || !in_deployer)
                 {
                     // todo: would we ever see non-mayastor subsystems here?
-                    // tracing::trace!(subsystem.hostnqn, "Ignoring subsystem");
+                    tracing::trace!(subsystem.hostnqn, gen_hostnqn, "Ignoring subsystem");
                     continue;
                 }
                 match subsystem.state.as_str() {

--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -54,6 +54,10 @@ struct Cli {
     #[clap(long, default_value_t = DEFAULT_NODE_AGENT_SERVER_PORT)]
     grpc_port: u16,
 
+    /// Reports this endpoint.
+    #[clap(long)]
+    fake_grpc_endpoint: Option<SocketAddr>,
+
     /// Add process service tags to the traces.
     #[clap(short, long, env = "TRACING_TAGS", value_delimiter=',', value_parser = utils::tracing_telemetry::parse_key_value)]
     tracing_tags: Vec<KeyValue>,
@@ -136,6 +140,17 @@ impl Cli {
             std::net::SocketAddr::new(self.grpc_ip, self.grpc_port)
         }
     }
+
+    fn reported_grpc_endpoint(&self) -> SocketAddr {
+        #[allow(deprecated)]
+        if let Some(endpoint) = &self.fake_grpc_endpoint {
+            *endpoint
+        } else if let Some(deprecated_endpoint) = &self.deprecated_grpc_endpoint {
+            *deprecated_endpoint
+        } else {
+            std::net::SocketAddr::new(self.grpc_ip, self.grpc_port)
+        }
+    }
 }
 
 #[tokio::main]
@@ -167,7 +182,10 @@ async fn main() -> anyhow::Result<()> {
 
     if let Err(error) = cluster_agent_client()
         .register(
-            &NodeAgentInfo::new(cli_args.node_name.clone(), cli_args.grpc_endpoint()),
+            &NodeAgentInfo::new(
+                cli_args.node_name.clone(),
+                cli_args.reported_grpc_endpoint(),
+            ),
             None,
         )
         .await

--- a/control-plane/agents/src/bin/ha/node/reporter.rs
+++ b/control-plane/agents/src/bin/ha/node/reporter.rs
@@ -74,7 +74,7 @@ impl PathReporter {
             .into_iter()
             .map(FailedPath::new)
             .collect::<Vec<FailedPath>>();
-        let node_ep = Cli::args().grpc_endpoint();
+        let node_ep = Cli::args().reported_grpc_endpoint();
         let mut req = ReportFailedPaths::new(node_name.to_string(), failed_paths, node_ep);
 
         // Report all paths in a separate task, continue till transmission succeeds.

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -37,3 +37,4 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tower = { workspace = true, features = ["timeout", "util"] }
 events-api = { workspace = true }
 anyhow = { workspace = true }
+nix = { workspace = true }

--- a/deployer/misc/rwx-vm/csi-node-2.nix
+++ b/deployer/misc/rwx-vm/csi-node-2.nix
@@ -1,0 +1,79 @@
+{ config, pkgs, ... }:
+{
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+  boot.kernelModules = [ "nvme-tcp" ];
+
+  services.getty.autologinUser = "root";
+  users.users.root.initialPassword = "a";
+
+  # enable for ssh access
+  # services.openssh.enable = true;
+  services.openssh.settings.PermitRootLogin = "yes";
+  services.openssh.settings.PasswordAuthentication = true;
+
+  virtualisation.vmVariant = {
+    virtualisation = {
+      forwardPorts = [
+        # enable for ssh access
+        # { from = "host"; host.port = 2222; guest.port = 22; }
+
+        # csi-node binds on vm on port 50055, and host ip can be used on $host:50056
+        # 50055 cannot be used on the host, because the csi-node in docker, has its port mapped to host 50055
+        { from = "host"; host.port = 50056; guest.port = 50055; }
+        # csi-node proxy that converts http to unix socket
+        { from = "host"; host.port = 50059; guest.port = 50059; }
+        # agent-ha-node service (the cluster agent calls replace-path on this, via the host ip 10.1.0.1 on the docker network)
+        { from = "host"; host.port = 50070; guest.port = 50070; }
+      ];
+      memorySize = 512;
+
+      sharedDirectories = {
+        workspace = {
+          source = builtins.getEnv "WORKSPACE_ROOT";
+          target = "/workspace";
+        };
+      };
+    };
+
+    systemd.services = {
+      csi-node = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          # User environment file for custom setup, example:
+          # ARGS=--nvme-nr-io-queues 1 --node-name app-node-2 --csi-socket /var/tmp/csi-app-node-2.sock --grpc-endpoint [::]:50055
+          # EnvironmentFile = "/workspace/tmp/run/csi-node.env";
+          # ExecStart = "/workspace/target/debug/csi-node $ARGS";
+          ExecStart = "/workspace/target/debug/csi-node --nvme-nr-io-queues 1 --node-name app-node-2 --csi-socket /var/tmp/csi-app-node-2.sock --grpc-endpoint [::]:50055";
+        };
+      };
+      agent-ha-node = {
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "csi-node.service" ];
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        serviceConfig = {
+          ExecStart = "/workspace/target/debug/agent-ha-node -napp-node-2 -g[::]:50070 --csi-socket /var/tmp/csi-app-node-2.sock --cluster-agent https://10.1.0.1:11500 --fake-grpc-endpoint 10.1.0.1:50070";
+        };
+      };
+      # this is required to convert TCP into unix-socket which is what the csi node plugin listen on
+      csi-node-proxy = {
+        wantedBy = [ "multi-user.target" ];
+        after = [ "csi-node.service" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.socat}/bin/socat TCP-LISTEN:50059,fork UNIX-CONNECT:/var/tmp/csi-app-node-2.sock";
+          Restart = "always";
+        };
+      };
+    };
+  };
+
+  networking.firewall.enable = false;
+
+  environment.systemPackages = with pkgs; [
+    nvme-cli
+    iptables
+  ];
+
+  system.stateVersion = config.system.nixos.release;
+}

--- a/deployer/src/infra/agents/ha/node.rs
+++ b/deployer/src/infra/agents/ha/node.rs
@@ -2,8 +2,7 @@ use crate::infra::{
     async_trait, Builder, ComponentAction, ComposeTest, CsiNode, Error, HaNodeAgent, StartOptions,
 };
 use composer::{Binary, ContainerSpec};
-use std::convert::TryFrom;
-
+use std::str::FromStr;
 use tokio::time::{sleep, Duration};
 use tonic::transport::Endpoint;
 
@@ -51,19 +50,29 @@ impl ComponentAction for HaNodeAgent {
 
     async fn wait_on(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
         // Wait till node-agent's gRPC server is ready to server the request
-        loop {
-            match Endpoint::try_from(format!(
-                "https://{}:11600",
-                cfg.container_ip("agent-ha-node")
-            ))?
+        wait_on(&format!(
+            "https://{}:11600",
+            cfg.container_ip("agent-ha-node")
+        ))
+        .await?;
+
+        wait_on("https://10.1.0.1:11600").await?;
+
+        Ok(())
+    }
+}
+
+async fn wait_on(uri: &str) -> Result<(), Error> {
+    // Wait till node-agent's gRPC server is ready to server the request
+    loop {
+        match Endpoint::from_str(uri)?
             .connect_timeout(Duration::from_millis(100))
             .connect()
             .await
-            {
-                Ok(_) => break,
-                Err(_) => sleep(Duration::from_millis(25)).await,
-            }
+        {
+            Ok(_) => break,
+            Err(_) => sleep(Duration::from_millis(25)).await,
         }
-        Ok(())
     }
+    Ok(())
 }

--- a/deployer/src/infra/csi-driver/node.rs
+++ b/deployer/src/infra/csi-driver/node.rs
@@ -38,6 +38,9 @@ impl ComponentAction for CsiNode {
             }
 
             for i in 0..options.app_nodes() {
+                if Self::vm_node(i, options) {
+                    continue;
+                }
                 cfg = CsiNode::with_app_node(
                     i,
                     cfg,
@@ -63,6 +66,9 @@ impl ComponentAction for CsiNode {
             }
 
             for i in 0..options.app_nodes() {
+                if Self::vm_node(i, options) {
+                    continue;
+                }
                 cfg.start(&Self::container_name(i)).await?;
             }
         }
@@ -85,6 +91,10 @@ impl ComponentAction for CsiNode {
         }
 
         for i in 0..options.app_nodes() {
+            if Self::vm_node(i, options) {
+                CsiNode::wait_node_vm().await?;
+                continue;
+            }
             CsiNode::wait_app_node(i).await?;
         }
 
@@ -143,6 +153,9 @@ impl CsiNode {
             options.csi_node_rest,
             options.io_engine_cores,
         )
+    }
+    fn vm_node(index: u32, option: &StartOptions) -> bool {
+        index == 1 && option.rwx_vm
     }
     fn with_node(
         container_name: &str,
@@ -233,6 +246,34 @@ impl CsiNode {
         let mut client = IdentityClient::new(channel);
 
         // Step 2: Make sure we can perform a successful RPC call.
+        loop {
+            match client
+                .get_plugin_info(GetPluginInfoRequest::default())
+                .await
+            {
+                Ok(_) => break,
+                Err(_) => sleep(Duration::from_millis(25)).await,
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn wait_node_vm() -> Result<(), Error> {
+        // Step 1: Wait till CSI node's gRPC server is registered and is ready
+        // to serve API requests.
+        let endpoint = Endpoint::try_from("http://127.0.0.1:50059")?
+            .connect_timeout(Duration::from_millis(150));
+
+        let channel = loop {
+            match endpoint.connect().await {
+                Ok(channel) => break channel,
+                Err(_) => sleep(Duration::from_millis(25)).await,
+            }
+        };
+
+        // Step 2: Make sure we can perform a successful RPC call.
+        let mut client = IdentityClient::new(channel);
         loop {
             match client
                 .get_plugin_info(GetPluginInfoRequest::default())

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -11,6 +11,7 @@ mod jaeger;
 mod kibana;
 pub mod nats;
 mod rest;
+mod rwx_vm;
 
 use super::StartOptions;
 use async_trait::async_trait;
@@ -441,6 +442,7 @@ impl_component! {
     Dns,            0,
     Etcd,           0,
     FioSpdk,        0,
+    RwxVm,          0,
     Elastic,        1,
     Kibana,         1,
     CoreAgent,      2,

--- a/deployer/src/infra/rwx_vm.rs
+++ b/deployer/src/infra/rwx_vm.rs
@@ -1,0 +1,93 @@
+use std::os::unix::process::CommandExt;
+
+use crate::infra::{
+    async_trait, Builder, ComponentAction, ComposeTest, Error, RwxVm, StartOptions,
+};
+
+macro_rules! ws_path {
+    ($p:literal) => {
+        concat!(env!("WORKSPACE_ROOT"), $p)
+    };
+    () => {
+        env!("WORKSPACE_ROOT")
+    };
+}
+const RWX_VM: &str = ws_path!("/deployer/misc/rwx-vm");
+const RWX_VM_NIX: &str = ws_path!("/deployer/misc/rwx-vm/csi-node-2.nix");
+
+fn is_nixos() -> bool {
+    // todo: any advantage is using nixos-rebuild?
+    match std::fs::read_to_string("/etc/os-release") {
+        Ok(contents) => contents.contains("ID=nixos"),
+        Err(_) => false,
+    }
+}
+
+#[async_trait]
+impl ComponentAction for RwxVm {
+    fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
+        if !options.rwx_vm {
+            return Ok(cfg);
+        }
+
+        let status = if is_nixos() {
+            std::process::Command::new("nixos-rebuild")
+                .arg("build-vm")
+                .arg("-I")
+                .arg(format!("nixos-config={RWX_VM_NIX}"))
+                .current_dir(RWX_VM)
+                .env("WORKSPACE_ROOT", ws_path!())
+                .status()?
+        } else {
+            std::process::Command::new("nix")
+                .arg("build")
+                .arg("-f")
+                .arg("<nixpkgs/nixos>")
+                .arg("-I")
+                .arg(format!("nixos-config={RWX_VM_NIX}"))
+                .arg("config.system.build.vm")
+                .arg("--extra-experimental-features")
+                .arg("nix-command")
+                .arg("--out-link")
+                .arg(format!("{RWX_VM}/result"))
+                .env("WORKSPACE_ROOT", ws_path!())
+                .status()?
+        };
+        if !status.success() {
+            return Err(
+                std::io::Error::other(format!("Failed to build the rwx vm: {status:?}")).into(),
+            );
+        }
+
+        Ok(cfg)
+    }
+    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+        if !options.rwx_vm {
+            return Ok(());
+        }
+
+        let mut cmd = std::process::Command::new("./result/bin/run-nixos-vm");
+        cmd.arg("-nographic")
+            .current_dir(RWX_VM)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+
+        if cfg.clean() {
+            unsafe {
+                cmd.pre_exec(|| {
+                    // When parent dies, send SIGTERM to this process
+                    nix::libc::prctl(nix::libc::PR_SET_PDEATHSIG, nix::libc::SIGTERM);
+                    Ok(())
+                })
+            };
+        }
+        cmd.spawn()?;
+
+        Ok(())
+    }
+    async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+        // we let the csi-node-2 and agent-ha-node-2 do the waiting
+        Ok(())
+    }
+}

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -490,6 +490,11 @@ impl StartOptions {
         self
     }
     #[must_use]
+    pub fn with_app_nodes(mut self, nodes: u32) -> Self {
+        self.app_nodes = Some(nodes);
+        self
+    }
+    #[must_use]
     pub fn with_csi_registration(mut self, opt: bool) -> Self {
         self.enable_app_node_registration = opt;
         self

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -116,6 +116,10 @@ pub struct StartOptions {
     #[clap(long, requires = "csi_node")]
     pub app_nodes: Option<u32>,
 
+    /// Deploy a nix-vm running both csi-node-2 and agent-ha-node-2.
+    #[clap(long)]
+    pub rwx_vm: bool,
+
     /// Run csi-node instances on io-engine nodes.
     #[clap(short, long, requires = "csi_node")]
     pub local_nodes: bool,
@@ -492,6 +496,11 @@ impl StartOptions {
     #[must_use]
     pub fn with_app_nodes(mut self, nodes: u32) -> Self {
         self.app_nodes = Some(nodes);
+        self
+    }
+    #[must_use]
+    pub fn with_rwx_vm(mut self, rwx_vm: bool) -> Self {
+        self.rwx_vm = rwx_vm;
         self
     }
     #[must_use]

--- a/scripts/rust/deployer-cleanup.sh
+++ b/scripts/rust/deployer-cleanup.sh
@@ -26,6 +26,22 @@ cleanup_ws_tmp() {
   return 0
 }
 
+cleanup_rwx_vm() {
+  # The VM disk path relative to workspace
+  local qcow2="$(realpath "$ROOT_DIR/deployer/misc/rwx-vm/nixos.qcow2")"
+
+  pids=$(ps aux | grep qemu-system | grep "file=$qcow2" | grep -v grep | awk '{print $2}')
+  if [ -z "$pids" ]; then
+      echo "No QEMU processes found using $qcow2"
+      return 0
+  fi
+  echo "Found QEMU processes: $pids"
+
+  for pid in $pids; do
+     kill "$pid" || kill -9 "$pid" || :
+  done
+}
+
 $SUDO $(which nvme) disconnect-all
 "$ROOT_DIR"/target/debug/deployer stop
 
@@ -39,3 +55,4 @@ for n in $(docker network ls --filter "label=io.composer.test.name" --format '{{
 done
 
 cleanup_ws_tmp
+cleanup_rwx_vm

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -1002,6 +1002,12 @@ impl ClusterBuilder {
         self.opts = self.opts.with_app_nodes(nodes);
         self
     }
+    /// Run RWX vm for csi-node-2.
+    #[must_use]
+    pub fn with_rwx_vm(mut self, rwx_vm: bool) -> Self {
+        self.opts = self.opts.with_rwx_vm(rwx_vm);
+        self
+    }
     /// Specify whether csi node registration should be enabled.
     #[must_use]
     pub fn with_csi_registration(mut self, opt: bool) -> Self {

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -373,6 +373,21 @@ impl Cluster {
         Ok(CsiNodeClient { csi, internal })
     }
 
+    /// Return a grpc handle to the csi-node plugin via TCP.
+    /// This is useful when unix socket cannot be used directly.
+    pub async fn csi_node_client_tcp(&self) -> Result<CsiNodeClient, Error> {
+        let csi_endpoint = "127.0.0.1";
+        let csi =
+            rpc::csi::node_client::NodeClient::connect(format!("http://{csi_endpoint}:50059"))
+                .await?;
+        let internal = csi_driver::node::internal::node_plugin_client::NodePluginClient::connect(
+            format!("http://{csi_endpoint}:50056"),
+        )
+        .await?;
+
+        Ok(CsiNodeClient { csi, internal })
+    }
+
     /// Return a grpc handle to the csi-controller.
     pub async fn csi_controller_client(&self) -> Result<CsiControllerClient, Error> {
         let endpoint = tonic::transport::Endpoint::try_from("http://[::]")?
@@ -981,6 +996,12 @@ impl ClusterBuilder {
         self.opts = self.opts.with_csi(controller, node);
         self
     }
+    /// Specify which csi components should be enabled.
+    #[must_use]
+    pub fn with_app_nodes(mut self, nodes: u32) -> Self {
+        self.opts = self.opts.with_app_nodes(nodes);
+        self
+    }
     /// Specify whether csi node registration should be enabled.
     #[must_use]
     pub fn with_csi_registration(mut self, opt: bool) -> Self {
@@ -1265,14 +1286,33 @@ impl CsiNodeClient {
         volume: &Volume,
         publish_context: HashMap<String, String>,
     ) -> Result<NodeStageVolumeResponse, Error> {
+        let uuid = &volume.spec.uuid;
+        let uri = &volume.state.target.as_ref().unwrap().device_uri;
+        self.node_stage_volume_inner(uuid, uri, publish_context)
+            .await
+    }
+    /// Similar to [`node_stage_volume`] but with the internal volume type.
+    pub async fn node_stage_volume_(
+        &mut self,
+        volume: &transport::Volume,
+        publish_context: HashMap<String, String>,
+    ) -> Result<NodeStageVolumeResponse, Error> {
+        let uuid = volume.uuid();
+        let uri = volume.state().target.unwrap().device_uri;
+        self.node_stage_volume_inner(uuid, uri, publish_context)
+            .await
+    }
+    async fn node_stage_volume_inner(
+        &mut self,
+        uuid: &impl ToString,
+        uri: impl Into<String>,
+        publish_context: HashMap<String, String>,
+    ) -> Result<NodeStageVolumeResponse, Error> {
         let mut context = std::collections::HashMap::new();
-        context.insert(
-            "uri".into(),
-            volume.state.target.as_ref().unwrap().device_uri.to_string(),
-        );
+        context.insert("uri".into(), uri.into());
         context.extend(publish_context);
         let request = rpc::csi::NodeStageVolumeRequest {
-            volume_id: volume.spec.uuid.to_string(),
+            volume_id: uuid.to_string(),
             publish_context: context,
             staging_target_path: "unused".to_string(),
             volume_capability: Some(rpc::csi::VolumeCapability {
@@ -1339,6 +1379,19 @@ impl CsiNodeClient {
         let request = rpc::csi::NodeUnstageVolumeRequest {
             volume_id: volume.spec.uuid.to_string(),
             staging_target_path: format!("/var/tmp/staging/mount/{}", volume.spec.uuid),
+        };
+        let response = self.csi.node_unstage_volume(request).await?;
+        Ok(response.into_inner())
+    }
+    /// Similar to [`node_unstage_volume`] but with the internal volume type.
+    pub async fn node_unstage_volume_(
+        &mut self,
+        volume: &transport::Volume,
+    ) -> Result<NodeUnstageVolumeResponse, Error> {
+        let uuid = volume.uuid();
+        let request = rpc::csi::NodeUnstageVolumeRequest {
+            volume_id: uuid.to_string(),
+            staging_target_path: format!("/var/tmp/staging/mount/{uuid}"),
         };
         let response = self.csi.node_unstage_volume(request).await?;
         Ok(response.into_inner())


### PR DESCRIPTION
    test(rwx): add basic live migration simulation
    
    Create and stage volume in csi-node-1.
    
    Then we modify volume to RWX by publishing and then staging
    to csi-node-2 (which is the qemu vm).
    
    todo: add some testing while both are connected
    
    Then we unstage from csi-node-1.
    
    todo: add some testing when only csi-node-2 is connected.
    
    Then we unstage from csi-node-2.
    
---

    feat(deployer): csi-node-2 as a qemu vm
    
    Adds --rwx-vm option to the deployer which deploys csi-node-2 and
    agent-ha-node-2 as systemd services inside a vm.
    
    If clean is set then we ensure vm teardown by using libc::PR_SET_PDEATHSIG.
    The deployer cleanup script also looks up and kills should these leak.
    
    The agent-ha-node and csi-node deployer components will attempt to
    wait for the services to be ready.
    This allows us to use this within a deployer-cluster test.
    
---

    test: add nix-vm for running as csi-node-2
    
    Define a vm with nvme-tcp, csi-node and agent-ha-node as systemd services.
    This can be used to simulate csi-node/ha-node combo running on the same node.
    
    This will be used by the rwx tests as we need the csi-node-2 to run in a different
    kernel than csi-node-1.
    
    This approach is fairly strict, with a bunch of hard-coded ports which is far from
    ideal.
    It should however be sufficient since we only intend to use this for the rwx test
    case, ensuring multiple connected hosts don't get broken.
    This also allows us to test temporary connection issues using iptables ie.
    
    To build and run the vm:
    1. cd deployer/misc/rwx-vm
    WORKSPACE_ROOT=$src
    on nixos:
    nixos-rebuild build-vm -I nixos-config=./csi-node-2.nix
    non non-nixos:
    nix-build -f '<nixpkgs/nixos>' -I nixos-config=./csi-node-2.nix config.system.build.vm
    --extra-experimental-features nix-command
    2. ./result/bin/run-nixos-vm -nographic
    
    The workspace root is required because that's how we can access the csi-node and
    agent-ha-node binaries.
    
---

    test: add csi-node tcp connection and stage with gRPC types
    
    Allows staging a volume via TCP.
    This will be required for upcoming changes where we can't use the
    unix socket directly, and have to go via trampoline.
    
    Also allow staging using the internal service types.
    
---

    test: add fake agent-ha-node endpoint reporting
    
    Useful for testing where the reply back from the cluster agent has to
    go via another endpoint.
    
    This will be useful for the coming test changes for rwx.
