### PR TITLE
 feat: allow deleting snapshots from deleted pools

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -86,6 +86,7 @@ impl IoEngineToAgent for v0::Pool {
         transport::PoolState {
             node: Default::default(),
             id: self.name.clone().into(),
+            uuid: None,
             disks: self.disks.clone().into_vec(),
             status: self.state.into(),
             capacity: self.capacity,

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -1069,7 +1069,7 @@ impl From<rpc::v1::pool::ProbeDiskInfo> for ProbeDiskInfo {
                     RpcErrorCode::PciNotNvme => PoolErrorCode::PCINotNvme,
                     RpcErrorCode::InvalidDiskUri => PoolErrorCode::InvalidDiskUri,
                 },
-                msg: error.msg.unwrap_or_default(),
+                msg: error.msg,
             },
         });
         Self {

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -670,6 +670,7 @@ impl IoEngineToAgent for v1::pool::Pool {
         transport::PoolState {
             node: Default::default(),
             id: self.name.clone().into(),
+            uuid: self.uuid.clone().try_into().ok(),
             disks: self.disks.clone().into_vec(),
             capacity: self.capacity,
             used: self.used,

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -274,10 +274,7 @@ mod tests {
         cmp::Ordering,
         net::{IpAddr, Ipv4Addr},
     };
-    use stor_port::types::v0::{
-        store::pool::POOL_BS_CLUSTER_SIZE_DEFAULT,
-        transport::{NodeState, NodeStatus, PoolState, PoolStatus, Replica},
-    };
+    use stor_port::types::v0::transport::{NodeState, NodeStatus, PoolState, PoolStatus, Replica};
 
     fn make_node(name: &str) -> NodeWrapper {
         let state = NodeState::new(
@@ -307,13 +304,7 @@ mod tests {
             status: PoolStatus::Online,
             capacity,
             used,
-            committed: None,
-            encrypted: false,
-            cluster_size: POOL_BS_CLUSTER_SIZE_DEFAULT,
-            disk_capacity: None,
-            max_expandable_size: None,
-            disk_info: vec![],
-            errors: None,
+            ..Default::default()
         };
         let replica = Replica::default();
         let pool = PoolWrapper::new(

--- a/control-plane/agents/src/bin/core/pool/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/pool/operations_helper.rs
@@ -79,7 +79,7 @@ impl OperationGuardArc<PoolSpec> {
                 if node_guard.is_offline() {
                     self.mark_diag_error(PoolError {
                         code: PoolErrorCode::NodeIsOffline,
-                        msg: "".to_string(),
+                        msg: None,
                     });
                     return Ok(Err(node_guard.status()));
                 }
@@ -93,7 +93,7 @@ impl OperationGuardArc<PoolSpec> {
             if node.is_shutdown() {
                 self.mark_diag_error(PoolError {
                     code: PoolErrorCode::NodeIsOffline,
-                    msg: "".to_string(),
+                    msg: None,
                 });
                 return Ok(Err(NodeStatus::Offline));
             }
@@ -101,7 +101,7 @@ impl OperationGuardArc<PoolSpec> {
 
         self.mark_diag_error(PoolError {
             code: PoolErrorCode::NodeIsUnknown,
-            msg: "".to_string(),
+            msg: None,
         });
         Err(error)
     }
@@ -158,7 +158,7 @@ impl OperationGuardArc<PoolSpec> {
     pub(crate) fn mark_as_import_cordoned(&mut self) {
         let error = PoolError {
             code: PoolErrorCode::ImportDisabled,
-            msg: "".to_string(),
+            msg: None,
         };
         self.mark_diag(PoolStatus::Offline, error);
     }
@@ -267,7 +267,10 @@ impl OperationGuardArc<PoolSpec> {
             }
             _error => _error.to_string(),
         };
-        Some(PoolError { code, msg })
+        Some(PoolError {
+            code,
+            msg: Some(msg),
+        })
     }
 
     // todo: fit in a trait

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -12,9 +12,9 @@ use stor_port::{
     types::v0::{
         openapi::models,
         transport::{
-            CreateReplica, CreateVolume, DestroyPool, DestroyReplica, DestroyVolume, Filter,
-            PublishVolume, ReplicaId, SetVolumeReplica, SnapshotId, Volume, VolumeShareProtocol,
-            VolumeStatus,
+            CreatePool, CreateReplica, CreateVolume, DestroyPool, DestroyReplica, DestroyVolume,
+            Filter, LabelledTopology, NodeStatus, PoolTopology, PublishVolume, ReplicaId,
+            SetVolumeReplica, SnapshotId, Topology, Volume, VolumeShareProtocol, VolumeStatus,
         },
     },
 };
@@ -426,10 +426,25 @@ async fn unknown_snapshot_garbage_collector() {
     let cluster = ClusterBuilder::builder()
         .with_rest(false)
         .with_io_engines(1)
-        .with_pools(1)
         .with_cache_period("50ms")
         .with_reconcile_period(Duration::from_millis(50), Duration::from_millis(50))
         .build()
+        .await
+        .unwrap();
+
+    pool_uuid_changed(&cluster).await;
+
+    let pool_cli = cluster.grpc_client().pool();
+    pool_cli
+        .create(
+            &CreatePool {
+                node: cluster.node(0),
+                id: cluster.pool(0, 0),
+                disks: vec!["malloc:///xc?size=100MiB".into()],
+                ..Default::default()
+            },
+            None,
+        )
         .await
         .unwrap();
 
@@ -939,4 +954,116 @@ async fn run_fio_vol_verify(
         node.node_unstage_volume(&volume).await.unwrap();
         code
     })
+}
+
+async fn pool_uuid_changed(cluster: &Cluster) {
+    let pool_cli = cluster.grpc_client().pool();
+    let vol_cli = cluster.grpc_client().volume();
+
+    let pool_disk = "malloc:///xc?size=32MiB";
+    let labels = HashMap::from([("node".into(), "0".into())]);
+    let pool = pool_cli
+        .create(
+            &CreatePool {
+                node: cluster.node(0),
+                id: "pool-uuid-xc".into(),
+                disks: vec![pool_disk.into()],
+                labels: Some(labels.clone()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let volume = vol_cli
+        .create(
+            &CreateVolume {
+                uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd7b8".try_into().unwrap(),
+                size: 8 * 1024 * 1024,
+                replicas: 1,
+                thin: true,
+                topology: Some(Topology {
+                    node: None,
+                    pool: Some(PoolTopology::Labelled(LabelledTopology {
+                        inclusion: labels,
+                        ..Default::default()
+                    })),
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let replica_snapshot = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(volume.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    tracing::info!("Replica Snapshot: {replica_snapshot:?}");
+
+    // Get snapshot by source id and snapshot id.
+    let snaps = vol_cli
+        .get_snapshots(
+            Filter::VolumeSnapshot(
+                volume.uuid().clone(),
+                replica_snapshot.spec().snap_id.clone(),
+            ),
+            false,
+            None,
+            None,
+        )
+        .await
+        .expect("Error while listing snapshot...");
+
+    tracing::info!("List Snapshot by sourceid and snapid: {snaps:?}");
+
+    // Get snapshot by snapshot id.
+    let snaps = vol_cli
+        .get_snapshots(
+            Filter::Snapshot(replica_snapshot.spec().snap_id.clone()),
+            false,
+            None,
+            None,
+        )
+        .await
+        .expect("Error while listing snapshot...");
+
+    tracing::info!("List Snapshot by snapid: {snaps:?}");
+    assert!(!snaps.entries().is_empty());
+
+    cluster.composer().restart(&cluster.node(0)).await.unwrap();
+
+    cluster
+        .wait_node_status(cluster.node(0), NodeStatus::Online)
+        .await
+        .unwrap();
+
+    let error = vol_cli
+        .destroy_snapshot(&DestroyVolumeSnapshot::from(&replica_snapshot), None)
+        .await
+        .expect_err("Pool Offline");
+    assert_eq!(error.kind, ReplyErrorKind::Deleting);
+
+    let mut rpc = cluster.grpc_handle(&cluster.node(0)).await.unwrap();
+    rpc.create_pool(pool.id(), pool_disk).await.unwrap();
+
+    cluster.wait_pool_online(pool.id().clone()).await.unwrap();
+
+    if let Err(error) = vol_cli
+        .destroy_snapshot(&DestroyVolumeSnapshot::from(&replica_snapshot), None)
+        .await
+    {
+        assert_eq!(error.kind, ReplyErrorKind::NotFound);
+    }
+
+    tracing::info!("Deleted Snapshot: {}", replica_snapshot.spec().snap_id);
+
+    vol_cli.destroy(&volume, None).await.unwrap();
+    pool_cli.destroy(&pool, None).await.unwrap();
 }

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -475,14 +475,37 @@ impl OperationGuardArc<VolumeSnapshot> {
         let node_wrapper = registry.node_wrapper(&node_id).await?;
 
         // Execute the call for corresponding dataplane node.
-        node_wrapper
+        let Err(error) = node_wrapper
             .destroy_repl_snapshot(&DestroyReplicaSnapshot::new(
                 replica_snapshot.spec().uuid().clone(),
                 source.pool_uuid().clone(),
             ))
-            .await?;
+            .await
+        else {
+            return Ok(());
+        };
 
-        Ok(())
+        if error.tonic_code() == tonic::Code::NotFound {
+            return Ok(());
+        }
+
+        tracing::error!(%error, "Failed to destroy replica snapshot");
+
+        if error.tonic_code() == tonic::Code::FailedPrecondition {
+            if let Ok(pool) = registry.pool_wrapper(source.pool_id()).await {
+                let snap_pool = source.pool_uuid();
+                let snap_uid = replica_snapshot.spec().uuid();
+                match pool.uuid.as_ref() {
+                    Some(pool_uuid) if pool_uuid != source.pool_uuid() => {
+                        tracing::warn!("Forgetting about snapshot {snap_uid} since its pool {snap_pool} has been replaced with {pool_uuid}");
+                        return Ok(());
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Err(error)
     }
 
     async fn check_nodes_availability(&self, registry: &Registry) -> bool {
@@ -545,12 +568,13 @@ impl OperationGuardArc<VolumeSnapshot> {
     ) -> Vec<ReplicaSnapshot> {
         let mut failed = vec![];
         for snapshot in snapshots {
-            if let Err(err) = Self::destroy_replica_snapshot(registry, snapshot).await {
-                if err.tonic_code() != tonic::Code::NotFound {
-                    let mut snapshot = snapshot.clone();
-                    snapshot.set_status_deleting();
-                    failed.push(snapshot);
-                }
+            if Self::destroy_replica_snapshot(registry, snapshot)
+                .await
+                .is_err()
+            {
+                let mut snapshot = snapshot.clone();
+                snapshot.set_status_deleting();
+                failed.push(snapshot);
             }
         }
         failed

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -57,7 +57,7 @@ enum ProbeErrorCode {
 message ProbeError {
   ProbeErrorCode code = 1;
   // additional as human readable
-  string          msg = 2;
+  optional string msg = 2;
 }
 
 // An IoEngine Storage Pool

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -165,6 +165,7 @@ impl TryFrom<pool::PoolState> for PoolState {
         Ok(PoolState {
             node: pool_state.node_id.into(),
             id: pool_state.pool_id.into(),
+            uuid: None,
             disks: pool_state.disks_uri.iter().map(|i| i.into()).collect(),
             status: status.into(),
             capacity: pool_state.capacity,
@@ -587,6 +588,27 @@ pub trait DestroyPoolInfo: Sync + Send + std::fmt::Debug {
     fn accept_volume_loss(&self) -> bool;
     /// Accept snapshot loss (snapshots losing last replica snapshot).
     fn accept_snapshot_loss(&self) -> bool;
+}
+
+impl DestroyPoolInfo for Pool {
+    fn pool_id(&self) -> PoolId {
+        self.id().clone()
+    }
+    fn node_id(&self) -> NodeId {
+        self.node()
+    }
+    fn purge(&self) -> bool {
+        false
+    }
+    fn accept(&self) -> bool {
+        false
+    }
+    fn accept_volume_loss(&self) -> bool {
+        false
+    }
+    fn accept_snapshot_loss(&self) -> bool {
+        false
+    }
 }
 
 impl CreatePoolInfo for CreatePool {

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3514,7 +3514,6 @@ components:
         code:
           $ref: '#/components/schemas/PoolProbeErrorCode'
       required:
-        - message
         - code
     PoolProbeErrorCode:
       description: Pool Disk Probe Errors

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -592,6 +592,7 @@ impl From<&PoolSpec> for transport::PoolState {
         Self {
             node: pool.node.clone(),
             id: pool.id.clone(),
+            uuid: None,
             disks: pool.disks.clone(),
             status: transport::PoolStatus::Unknown,
             capacity: 0,

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -139,7 +139,7 @@ pub struct PoolError {
     /// Code of the encountered error.
     pub code: PoolErrorCode,
     /// Human-readable message.
-    pub msg: String,
+    pub msg: Option<String>,
 }
 
 /// Pool Disk Errors.

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -225,6 +225,8 @@ pub struct PoolState {
     pub node: NodeId,
     /// Id of the pool.
     pub id: PoolId,
+    /// Uuid of the pool.
+    pub uuid: Option<PoolUuid>,
     /// Absolute disk paths claimed by the pool.
     pub disks: Vec<PoolDeviceUri>,
     /// Current state of the pool.

--- a/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
+++ b/k8s/operators/src/pool/diskpool/crd/v1beta3.rs
@@ -629,7 +629,7 @@ impl From<openapi::models::PoolProbeError> for PoolError {
     fn from(value: openapi::models::PoolProbeError) -> Self {
         Self {
             code: value.code.into(),
-            message: Some(value.message),
+            message: value.message,
         }
     }
 }


### PR DESCRIPTION
    feat: allow deleting snapshots from deleted pools
    
    When users recreate pools manually and leave resources around its possible
    that the pool uuid will change, and so we'll reject snapshot deletion.
    
    In this case, we should accept the deletion and allow graceful cleanup.
    
---

    feat: add pool uuid to the transport types
    
    Note that we're not yet exposing this via the public interface nor the
    internal service though I think we should do that.
