### PR TITLE
feat: expose pool replica and snapshot count

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/translation.rs
@@ -98,6 +98,8 @@ impl IoEngineToAgent for v0::Pool {
             max_expandable_size: None,
             disk_info: vec![],
             errors: None,
+            repl_count: None,
+            snap_count: None,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -689,6 +689,8 @@ impl IoEngineToAgent for v1::pool::Pool {
                 info.map(ExternalType).map(Into::into).collect::<Vec<_>>()
             },
             errors: self.errors.clone().map(ExternalType).into_opt(),
+            repl_count: None,
+            snap_count: None,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -996,6 +996,12 @@ impl ResourceSpecsLocked {
                 }
             }
         }
+        // add runtime information for pool replica/snapshot count
+        for pool in self.read().pools.values() {
+            let mut pool = pool.lock();
+            pool.metadata.runtime.replica_count = Some(self.calculate_repl_count(pool.id()));
+            pool.metadata.runtime.snapshot_count = Some(self.calculate_snap_count(pool.id()));
+        }
 
         // Remove all entries of v1 key prefix.
         store

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -314,6 +314,7 @@ mod tests {
                 .cycle()
                 .take(replicas)
                 .collect::<Vec<_>>(),
+            0,
         );
         PoolItem::new(node_state, pool, ag_replica_count, None)
     }

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -546,7 +546,11 @@ impl NodeWrapper {
                         }
                     })
                     .collect::<Vec<Replica>>();
-                PoolWrapper::new(pool_state.pool, replicas)
+                let snaps = resources
+                    .snapshot_states()
+                    .filter(|s| s.snapshot.pool_id() == pool_state.uid())
+                    .count();
+                PoolWrapper::new(pool_state.pool, replicas, snaps as u64)
             })
             .collect()
     }
@@ -574,7 +578,11 @@ impl NodeWrapper {
                         }
                     })
                     .collect();
-                Some(PoolWrapper::new(pool_state.pool, replicas))
+                let snaps = resources
+                    .snapshot_states()
+                    .filter(|s| s.snapshot.pool_id() == pool_state.uid())
+                    .count();
+                Some(PoolWrapper::new(pool_state.pool, replicas, snaps as u64))
             }
             None => None,
         }

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -112,7 +112,9 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
             }
         }
 
-        let state = pool.complete_create(result, registry, on_fail).await?;
+        let mut state = pool.complete_create(result, registry, on_fail).await?;
+        state.repl_count = Some(0);
+        state.snap_count = Some(0);
         let spec = pool.lock().clone();
         Ok(Pool::new(spec, Some(CtrlPoolState::new(state))))
     }

--- a/control-plane/agents/src/bin/core/pool/replica_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/replica_operations.rs
@@ -52,7 +52,9 @@ impl ResourceLifecycle for OperationGuardArc<ReplicaSpec> {
         let result = node.create_replica(request).await;
         let on_fail = OnCreateFail::eeinval_delete(&result);
 
-        replica.complete_create(result, registry, on_fail).await
+        let replica = replica.complete_create(result, registry, on_fail).await?;
+        specs.on_repl_create(&replica.pool_id);
+        Ok(replica)
     }
 
     async fn destroy(
@@ -95,7 +97,9 @@ impl ResourceLifecycle for Option<&mut OperationGuardArc<ReplicaSpec>> {
                 Err(error) if error.tonic_code() == tonic::Code::NotFound => Ok(()),
                 Err(error) => Err(error),
             };
-            replica.complete_destroy(result, registry).await
+            replica.complete_destroy(result, registry).await?;
+            registry.specs().on_repl_destroy(&request.pool_id);
+            Ok(())
         } else {
             node.destroy_replica(request).await
         }

--- a/control-plane/agents/src/bin/core/pool/specs.rs
+++ b/control-plane/agents/src/bin/core/pool/specs.rs
@@ -272,6 +272,31 @@ impl ResourceSpecs {
         }
         false
     }
+    /// Get a count of all volume replicas on the given pool.
+    fn pool_replica_count(&self, id: &PoolId) -> u64 {
+        self.replicas
+            .values()
+            .filter(|r| r.immutable_ref().pool_name() == id)
+            .count() as u64
+    }
+    /// Get a count of all volume snapshots on the given pool.
+    fn pool_snap_count(&self, id: &PoolId) -> u64 {
+        let mut snapshots = 0u64;
+        for snapshot in self.volume_snapshots.values() {
+            let snapshot = snapshot.lock();
+
+            let transactions = snapshot.metadata().transactions();
+            let this_pool = transactions
+                .values()
+                .flatten()
+                .any(|r| r.spec().source_id().pool_id() == id);
+
+            if this_pool {
+                snapshots += 1;
+            }
+        }
+        snapshots
+    }
     /// Get all replicas on the given pool.
     fn pool_replicas(&self, id: &PoolId) -> Vec<ResourceMutex<ReplicaSpec>> {
         self.replicas
@@ -448,6 +473,18 @@ impl ResourceSpecsLocked {
         let specs = self.read();
         specs.pool_replicas(id)
     }
+    /// Calculates the number of replicas owned by the pool by probing the entire list of
+    /// replicas which report the pool as their owner.
+    /// This is necessary when a pool is offline, and as such we can't use the runtime information.
+    pub(crate) fn calculate_repl_count(&self, id: &PoolId) -> u64 {
+        self.read().pool_replica_count(id)
+    }
+    /// Calculates the number of replicas owned by the pool by probing the entire list of
+    /// replicas which report the pool as their owner.
+    /// This is necessary when a pool is offline, and as such we can't use the runtime information.
+    pub(crate) fn calculate_snap_count(&self, id: &PoolId) -> u64 {
+        self.read().pool_snap_count(id)
+    }
     /// Check if the given pool `id` has any snapshots.
     fn pool_has_snapshots(&self, id: &PoolId) -> bool {
         let specs = self.read();
@@ -537,5 +574,60 @@ impl ResourceSpecsLocked {
             None => None,
             Some(pool) => Some(pool.operation_guard_wait().await?),
         })
+    }
+
+    /// On replica creation, update the pool's replica count.
+    pub(crate) fn on_repl_create(&self, pool_id: &PoolId) {
+        let Some(pool) = self.pool_rsc(pool_id) else {
+            return;
+        };
+
+        let mut pool = pool.lock();
+        if let Some(count) = pool.metadata.runtime.replica_count.as_mut() {
+            *count += 1;
+        } else {
+            // this should only happen the first time
+            pool.metadata.runtime.replica_count = Some(self.calculate_repl_count(pool_id));
+        }
+    }
+    /// On replica deletion, update the pool's replica count.
+    pub(crate) fn on_repl_destroy(&self, pool_id: &PoolId) {
+        let Some(pool) = self.pool_rsc(pool_id) else {
+            return;
+        };
+
+        let mut pool = pool.lock();
+        if let Some(count) = pool.metadata.runtime.replica_count.as_mut() {
+            *count = count.saturating_sub(1);
+        } else {
+            pool.metadata.runtime.replica_count = Some(self.calculate_repl_count(pool_id));
+        }
+    }
+
+    /// On replica snapshot creation, update the pool's snapshot count.
+    pub(crate) fn on_snap_create(&self, pool_id: &PoolId) {
+        let Some(pool) = self.pool_rsc(pool_id) else {
+            return;
+        };
+
+        let mut pool = pool.lock();
+        if let Some(count) = pool.metadata.runtime.snapshot_count.as_mut() {
+            *count += 1;
+        } else {
+            pool.metadata.runtime.snapshot_count = Some(self.calculate_snap_count(pool_id));
+        }
+    }
+    /// On replica snapshot deletion, update the pool's snapshot count.
+    pub(crate) fn on_snap_destroy(&self, pool_id: &PoolId) {
+        let Some(pool) = self.pool_rsc(pool_id) else {
+            return;
+        };
+
+        let mut pool = pool.lock();
+        if let Some(count) = pool.metadata.runtime.snapshot_count.as_mut() {
+            *count = count.saturating_sub(1);
+        } else {
+            pool.metadata.runtime.snapshot_count = Some(self.calculate_snap_count(pool_id));
+        }
     }
 }

--- a/control-plane/agents/src/bin/core/pool/wrapper.rs
+++ b/control-plane/agents/src/bin/core/pool/wrapper.rs
@@ -27,7 +27,7 @@ impl Deref for PoolWrapper {
 
 impl PoolWrapper {
     /// New Pool wrapper with the pool and replicas.
-    pub(crate) fn new(mut pool: PoolState, replicas: Vec<Replica>) -> Self {
+    pub(crate) fn new(mut pool: PoolState, replicas: Vec<Replica>, snapshot_count: u64) -> Self {
         let free_space = if pool.capacity >= pool.used {
             pool.capacity - pool.used
         } else {
@@ -45,6 +45,13 @@ impl PoolWrapper {
             pool.committed = Some(committed);
             committed
         });
+
+        if pool.repl_count.is_none() {
+            pool.repl_count = Some(replicas.len() as u64);
+        }
+        if pool.snap_count.is_none() {
+            pool.snap_count = Some(snapshot_count);
+        }
 
         Self {
             state: pool,

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -68,6 +68,17 @@ async fn pool() {
         )
         .await
         .unwrap();
+    assert_eq!(pool.state.as_ref().unwrap().repl_count, Some(0));
+    assert_eq!(pool.state.as_ref().unwrap().snap_count, Some(0));
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.replica_count,
+        Some(0)
+    );
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.snapshot_count,
+        Some(0)
+    );
+
     let _pool2 = pool_client
         .create(
             &CreatePool {
@@ -109,6 +120,22 @@ async fn pool() {
         .await
         .unwrap();
     tracing::info!("Replicas: {:?}", replica);
+    let pools = pool_client
+        .get(Filter::Pool(replica.pool_id.clone()), None)
+        .await
+        .unwrap()
+        .into_inner();
+    let pool = pools.first().unwrap();
+    assert_eq!(pool.state.as_ref().unwrap().repl_count, Some(1));
+    assert_eq!(pool.state.as_ref().unwrap().snap_count, Some(0));
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.replica_count,
+        Some(1)
+    );
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.snapshot_count,
+        Some(0)
+    );
 
     let replicas = rep_client.get(Filter::None, None).await.unwrap();
     tracing::info!("Replicas: {:?}", replicas);
@@ -209,6 +236,22 @@ async fn pool() {
         )
         .await
         .unwrap();
+    let pools = pool_client
+        .get(Filter::Pool(replica.pool_id.clone()), None)
+        .await
+        .unwrap()
+        .into_inner();
+    let pool = pools.first().unwrap();
+    assert_eq!(pool.state.as_ref().unwrap().repl_count, Some(0));
+    assert_eq!(pool.state.as_ref().unwrap().snap_count, Some(0));
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.replica_count,
+        Some(0)
+    );
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.snapshot_count,
+        Some(0)
+    );
 
     let error = rep_client
         .destroy(
@@ -920,7 +963,7 @@ async fn reconciler_missing_pool_state() {
     tracing::info!("Pools: {:?}", pools);
 
     let hpool = pools.0.first().unwrap();
-    let pool_diag = hpool.diag.as_ref().unwrap();
+    let pool_diag = hpool.diag().unwrap();
     assert_eq!(pool_diag.import_errors.len(), 1);
     let error = pool_diag.import_errors.first().unwrap();
     assert_eq!(error.error.code, PoolErrorCode::InvalidSuperBlock);
@@ -963,7 +1006,7 @@ async fn reconciler_missing_pool_state() {
     tracing::info!("Pools: {:?}", pools);
 
     let hpool = pools.0.first().unwrap();
-    let pool_diag = hpool.diag.as_ref().unwrap();
+    let pool_diag = hpool.diag().unwrap();
     assert_eq!(pool_diag.import_errors.len(), 1);
     let error = pool_diag.import_errors.first().unwrap();
     assert_eq!(error.error.code, PoolErrorCode::DiskNotFound);

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -32,6 +32,7 @@ async fn snapshot() {
         .unwrap();
 
     let vol_cli = cluster.grpc_client().volume();
+    let pool_cli = cluster.grpc_client().pool();
 
     let volume = vol_cli
         .create(
@@ -59,6 +60,22 @@ async fn snapshot() {
         .unwrap();
 
     tracing::info!("Replica Snapshot: {replica_snapshot:?}");
+    let pools = pool_cli
+        .get(Filter::Pool(cluster.pool(0, 0)), None)
+        .await
+        .unwrap()
+        .into_inner();
+    let pool = pools.first().unwrap();
+    assert_eq!(pool.state.as_ref().unwrap().repl_count, Some(1));
+    assert_eq!(pool.state.as_ref().unwrap().snap_count, Some(1));
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.replica_count,
+        Some(1)
+    );
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.snapshot_count,
+        Some(1)
+    );
 
     let volumes = vol_cli
         .get(Filter::Volume(volume.uuid().clone()), false, None, None)
@@ -105,6 +122,22 @@ async fn snapshot() {
         .unwrap();
 
     tracing::info!("Deleted Snapshot: {}", replica_snapshot.spec().snap_id);
+    let pools = pool_cli
+        .get(Filter::Pool(cluster.pool(0, 0)), None)
+        .await
+        .unwrap()
+        .into_inner();
+    let pool = pools.first().unwrap();
+    assert_eq!(pool.state.as_ref().unwrap().repl_count, Some(1));
+    assert_eq!(pool.state.as_ref().unwrap().snap_count, Some(0));
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.replica_count,
+        Some(1)
+    );
+    assert_eq!(
+        pool.config.as_ref().unwrap().definition.snapshot_count,
+        Some(0)
+    );
 
     assert!(!volume.spec().thin);
     assert!(volume.spec().as_thin(), "Volume should still be thin!");

--- a/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/snapshot_operations.rs
@@ -412,6 +412,7 @@ impl OperationGuardArc<VolumeSnapshot> {
                 ),
             )
             .await?;
+            registry.specs().on_snap_create(snapshot.pool_id());
 
             replica_snap.complete_vol(
                 snapshot.timestamp().into(),
@@ -444,6 +445,7 @@ impl OperationGuardArc<VolumeSnapshot> {
                     replica_params,
                 )))
                 .await?;
+            registry.specs().on_snap_create(response.pool_id());
             timestamp = response.timestamp();
             replica_snap.complete_vol(
                 timestamp.into(),
@@ -575,7 +577,11 @@ impl OperationGuardArc<VolumeSnapshot> {
                 let mut snapshot = snapshot.clone();
                 snapshot.set_status_deleting();
                 failed.push(snapshot);
+                continue;
             }
+            registry
+                .specs()
+                .on_snap_destroy(snapshot.spec().source_id().pool_id());
         }
         failed
     }

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -97,6 +97,14 @@ message Metadata {
   google.protobuf.StringValue uuid = 1;
   // spec status of the pool
   common.SpecStatus spec_status = 2;
+  // A tally of all replicas configured to reside on this pool.
+  // Note that this number may not match the volumes api, as it will include all replicas,
+  // configured to reside in the pool, sometimes even the failed ones until such time they are deleted.
+  optional uint64 repl_count = 3;
+  // A tally of all snapshots configured to reside on this pool.
+  // Note that this number may not match the volume-snapshots api, as it will include all snapshots,
+  // configured to reside in the pool, sometimes even the failed ones until such time they are deleted.
+  optional uint64 snap_count = 4;
 }
 
 // User specification of a pool.
@@ -147,6 +155,10 @@ message PoolState {
   repeated DiskInfo disk_info = 12;
   // Error information at the pool top-level.
   optional PoolErrors errors = 13;
+  // How many replicas in the pool.
+  optional uint64 repl_count = 14;
+  // How many replica-snapshots in the pool.
+  optional uint64 snap_count = 15;
 }
 
 // status of the pool

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -19,10 +19,10 @@ use stor_port::{
         },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, DiskInfo, ExpandPool, Filter, LabelPool,
-            NodeId, Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolDeleteResult, PoolDeviceUri,
-            PoolDiag, PoolDiskError, PoolError, PoolErrorCode, PoolErrorInfo, PoolId, PoolState,
-            PoolStatus, SnapshotLossDetail, SnapshotLossInfo, UnlabelPool, VolumeId,
-            VolumeLossDetail, VolumeLossInfo,
+            NodeId, Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolDef, PoolDeleteResult,
+            PoolDeviceUri, PoolDiag, PoolDiskError, PoolError, PoolErrorCode, PoolErrorInfo,
+            PoolId, PoolState, PoolStatus, SnapshotLossDetail, SnapshotLossInfo, UnlabelPool,
+            VolumeId, VolumeLossDetail, VolumeLossInfo,
         },
     },
     IntoOption, IntoVec,
@@ -211,7 +211,14 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
                     .unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
                 max_expansion: None,
             },
-            metadata: Default::default(),
+            metadata: PoolMetadata {
+                persisted: Default::default(),
+                runtime: PoolRuntimeMetadata {
+                    diag: None,
+                    replica_count: pool_meta.repl_count,
+                    snapshot_count: pool_meta.snap_count,
+                },
+            },
         })
     }
 }
@@ -238,6 +245,8 @@ impl TryFrom<pool::PoolState> for PoolState {
             max_expandable_size: pool_state.max_expandable_size,
             disk_info: pool_state.disk_info.into_vec(),
             errors: pool_state.errors.into_opt(),
+            repl_count: pool_state.repl_count,
+            snap_count: pool_state.snap_count,
         })
     }
 }
@@ -363,12 +372,7 @@ impl From<PoolAlertStatus> for pool::PoolAlertStatus {
 
 fn pool_with_diag(mut pool_spec: PoolSpec, diag: Option<pool::PoolDiag>) -> PoolSpec {
     if let Some(diag) = diag {
-        pool_spec.metadata = PoolMetadata {
-            persisted: Default::default(),
-            runtime: PoolRuntimeMetadata {
-                diag: Some(diag.into()),
-            },
-        };
+        pool_spec.metadata.runtime.diag = Some(diag.into());
     }
     pool_spec
 }
@@ -403,7 +407,18 @@ impl TryFrom<pool::Pool> for Pool {
 }
 
 impl From<PoolUSpec> for pool::PoolDefinition {
-    fn from(pool_spec: PoolUSpec) -> Self {
+    fn from(spec: PoolUSpec) -> Self {
+        PoolDef {
+            spec,
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl From<PoolDef> for pool::PoolDefinition {
+    fn from(pool_def: PoolDef) -> Self {
+        let pool_spec = pool_def.spec;
         let spec_status: common::SpecStatus = pool_spec.status.into();
         pool::PoolDefinition {
             spec: Some(pool::PoolSpec {
@@ -440,6 +455,8 @@ impl From<PoolUSpec> for pool::PoolDefinition {
             metadata: Some(pool::Metadata {
                 uuid: None,
                 spec_status: spec_status as i32,
+                repl_count: pool_def.replica_count,
+                snap_count: pool_def.snapshot_count,
             }),
         }
     }
@@ -461,6 +478,8 @@ impl From<PoolState> for pool::PoolState {
             max_expandable_size: pool_state.max_expandable_size,
             disk_info: pool_state.disk_info.into_vec(),
             errors: pool_state.errors.into_opt(),
+            repl_count: pool_state.repl_count,
+            snap_count: pool_state.snap_count,
         }
     }
 }
@@ -567,10 +586,15 @@ impl From<PoolError> for pool::ProbeError {
 
 impl From<Pool> for pool::Pool {
     fn from(pool: Pool) -> Self {
+        let state = pool.state;
+        let (def, diag) = match pool.config {
+            None => (None, None),
+            Some(cfg) => (Some(cfg.definition), cfg.diag),
+        };
         pool::Pool {
-            definition: pool.spec.map(|pool_spec| pool_spec.into()),
-            state: pool.state.map(|p| p.state).into_opt(),
-            diag: pool.diag.map(Into::into),
+            definition: def.into_opt(),
+            state: state.map(|p| p.state).into_opt(),
+            diag: diag.into_opt(),
         }
     }
 }

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -114,7 +114,19 @@ impl CreateRow for openapi::models::Pool {
             optional_cell(state.committed.map(::utils::bytes::into_human)),
             state.encrypted,
             optional_cell(state.disk_capacity.map(::utils::bytes::into_human)),
-            optional_cell(state.max_expandable_size.map(::utils::bytes::into_human))
+            optional_cell(state.max_expandable_size.map(::utils::bytes::into_human)),
+            optional_cell(
+                self.meta
+                    .as_ref()
+                    .and_then(|m| m.replica_count)
+                    .or(state.replica_count)
+            ),
+            optional_cell(
+                self.meta
+                    .as_ref()
+                    .and_then(|m| m.snapshot_count)
+                    .or(state.snapshot_count)
+            ),
         ]
     }
 }

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -54,7 +54,9 @@ lazy_static! {
         "COMMITTED",
         "ENCRYPTED",
         "DISK-CAPACITY",
-        "MAX-EXPANDABLE-SIZE"
+        "MAX-EXPANDABLE-SIZE",
+        "VOLUMES",
+        "SNAPSHOTS",
     ];
     pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS", "VERSION"];
     pub static ref REPLICA_TOPOLOGIES_PREFIX: Row = row!["VOLUME-ID"];

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3472,9 +3472,23 @@ components:
           $ref: '#/components/schemas/PoolState'
         diag:
           $ref: '#/components/schemas/PoolDiag'
+        meta:
+          $ref: '#/components/schemas/PoolMeta'
       required:
         - id
       minProperties: 2
+    PoolMeta:
+      description: Pool metadata information
+      type: object
+      properties:
+        replicaCount:
+          description: A tally of all volume-replicas configured on this pool
+          type: integer
+          format: uint64
+        snapshotCount:
+          description: A tally of all snapshots configured on this pool
+          type: integer
+          format: uint64
     PoolDiag:
       description: Pool diagnostic information
       type: object
@@ -3686,6 +3700,21 @@ components:
           format: uint64
         errorInfo:
           $ref: '#/components/schemas/PoolErrorInfo'
+        replicaCount:
+          description: -|
+            A tally of all replicas configured to reside on this pool.
+            As of today this can be correlated to the number of volumes hosted in the pool.
+            Note that this number may not match the volumes api, as it will include all replicas,
+            configured to reside in the pool, sometimes even the failed ones until such time they are deleted.
+          type: integer
+          format: uint64
+        snapshotCount:
+          description: -|
+            A tally of all snapshots configured to reside on this pool.
+            Note that this number may not match the volume-snapshots api, as it will include all snapshots,
+            configured to reside in the pool, sometimes even the failed ones until such time they are deleted.
+          type: integer
+          format: uint64
       required:
         - capacity
         - disks

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -149,8 +149,9 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
         models::Pool::new_all(
             "pooloop",
             models::PoolSpec::new_all(vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", None, &io_engine1, models::SpecStatus::Created, None, None, 4194304, None),
-            models::PoolState::new_all(100663296u64, vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::PoolStatus::Online, 0u64, 0, false, 4194304u64, 104857600u64 , Some(137271181312), error_info),
-            pool.diag.clone()
+            models::PoolState::new_all(100663296u64, vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &io_engine1, models::PoolStatus::Online, 0u64, 0, false, 4194304u64, 104857600u64 , Some(137271181312), error_info, Some(0), Some(0)),
+            pool.diag.clone(),
+            pool.meta.clone(),
         )
     );
 

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -74,7 +74,14 @@ impl From<&CreatePool> for PoolSpec {
                 cluster_size: request.cluster_size.unwrap_or(POOL_BS_CLUSTER_SIZE_DEFAULT),
                 max_expansion: request.max_expansion.clone(),
             },
-            metadata: PoolMetadata::default(),
+            metadata: PoolMetadata {
+                runtime: PoolRuntimeMetadata {
+                    snapshot_count: Some(0),
+                    replica_count: Some(0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
         }
     }
 }
@@ -197,6 +204,16 @@ pub struct PoolPersistedMetadata {}
 pub struct PoolRuntimeMetadata {
     /// Diagnostic info for the pool.
     pub diag: Option<PoolDiag>,
+    /// How many replica volumes owned by the pool.
+    /// This value is re-generated from the replicas, and then keep track via create/destroy.
+    /// Note that this count may differ from expected, as it tracks resources in
+    /// created and deleting states
+    pub replica_count: Option<u64>,
+    /// How many replica snapshots owned by the pool.
+    /// This value is re-generated from the volume-snapshots, and then keep track via create/destroy.
+    /// Note that this count may differ from expected, as it tracks resources in
+    /// created and deleting states.
+    pub snapshot_count: Option<u64>,
 }
 
 impl PoolSpec {
@@ -604,6 +621,8 @@ impl From<&PoolSpec> for transport::PoolState {
             max_expandable_size: None,
             disk_info: vec![],
             errors: None,
+            repl_count: pool.metadata.runtime.replica_count,
+            snap_count: pool.metadata.runtime.snapshot_count,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -274,6 +274,10 @@ pub struct PoolState {
     pub disk_info: Vec<DiskInfo>,
     /// Error information at the pool top-level.
     pub errors: Option<PoolErrorInfo>,
+    /// How many replicas exist in the pool.
+    pub repl_count: Option<u64>,
+    /// How many replica-snapshots exist in the pool.
+    pub snap_count: Option<u64>,
 }
 
 /// Pool information related to a specific disk.
@@ -367,6 +371,8 @@ impl From<CtrlPoolState> for models::PoolState {
             src.disk_capacity,
             src.max_expandable_size,
             src.errors.into_opt(),
+            src.repl_count,
+            src.snap_count,
         )
     }
 }
@@ -516,6 +522,49 @@ impl PartialOrd for PoolStatus {
     }
 }
 
+/// User configuration with user specification and metadata information.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PoolDef {
+    /// User specification for the pool.
+    pub spec: PoolUSpec,
+    /// How many replicas are owned by the pool.
+    pub replica_count: Option<u64>,
+    /// How many snapshots are owned by the pool.
+    pub snapshot_count: Option<u64>,
+}
+
+/// User configuration with user specification and metadata information.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PoolConfig {
+    /// Pool definition.
+    pub definition: PoolDef,
+    /// Health of the pool.
+    pub diag: Option<PoolDiag>,
+}
+impl PoolConfig {
+    fn with_state_diag(mut self, state: &CtrlPoolState) -> Self {
+        if let Some(ref mut diag) = self.diag {
+            diag.status = state.state.status.clone();
+        }
+        self
+    }
+}
+
+impl From<PoolSpec> for PoolConfig {
+    fn from(value: PoolSpec) -> Self {
+        Self {
+            definition: PoolDef {
+                spec: value.spec,
+                replica_count: value.metadata.runtime.replica_count,
+                snapshot_count: value.metadata.runtime.snapshot_count,
+            },
+            diag: value.metadata.runtime.diag,
+        }
+    }
+}
+
 /// A Storage Pool.
 /// It may have a spec which is the specification provided by the creator.
 /// It may have a state if such state is retrieved from a storage node.
@@ -524,12 +573,10 @@ impl PartialOrd for PoolStatus {
 pub struct Pool {
     /// Pool identification.
     id: PoolId,
-    /// Desired specification of the pool.
-    pub spec: Option<PoolUSpec>,
+    /// [`PoolConfig`].
+    pub config: Option<PoolConfig>,
     /// Runtime state of the pool.
     pub state: Option<CtrlPoolState>,
-    /// Health of the pool.
-    pub diag: Option<PoolDiag>,
 }
 
 impl Pool {
@@ -537,8 +584,7 @@ impl Pool {
     pub fn new(spec: PoolSpec, state: Option<CtrlPoolState>) -> Self {
         Self {
             id: spec.id.clone(),
-            diag: spec.metadata.runtime.diag.clone(),
-            spec: Some(spec.spec),
+            config: Some(PoolConfig::from(spec)),
             state,
         }
     }
@@ -546,8 +592,7 @@ impl Pool {
     pub fn from_spec(spec: PoolSpec) -> Self {
         Self {
             id: spec.id.clone(),
-            diag: spec.metadata.runtime.diag.clone(),
-            spec: Some(spec.spec),
+            config: Some(PoolConfig::from(spec)),
             state: None,
         }
     }
@@ -555,11 +600,7 @@ impl Pool {
     pub fn from_state(state: CtrlPoolState, spec: Option<PoolSpec>) -> Self {
         Self {
             id: state.id.clone(),
-            diag: spec
-                .as_ref()
-                .and_then(|spec| spec.metadata.runtime.diag.clone())
-                .map(|d| d.with_state(&state.state)),
-            spec: spec.map(|s| s.spec),
+            config: spec.map(|s| PoolConfig::from(s).with_state_diag(&state)),
             state: Some(state),
         }
     }
@@ -574,7 +615,11 @@ impl Pool {
     }
     /// Get the pool spec.
     pub fn spec(&self) -> Option<PoolUSpec> {
-        self.spec.clone()
+        Some(self.config.as_ref()?.definition.spec.clone())
+    }
+    /// Get the pool diagnostics.
+    pub fn diag(&self) -> Option<&PoolDiag> {
+        self.config.as_ref()?.diag.as_ref()
     }
     /// Get the pool identification.
     pub fn id(&self) -> &PoolId {
@@ -590,22 +635,35 @@ impl Pool {
     }
     /// Get the node identification.
     pub fn node(&self) -> NodeId {
-        match &self.spec {
+        match &self.config {
             // guaranteed that at either spec or state are defined
             // todo: use enum derivation
             None => self.state.as_ref().unwrap().node.clone(),
-            Some(spec) => spec.node.clone(),
+            Some(config) => config.definition.spec.node.clone(),
         }
     }
 }
 
 impl From<Pool> for models::Pool {
     fn from(src: Pool) -> Self {
+        let (def, diag) = match src.config {
+            None => (None, None),
+            Some(config) => (Some(config.definition), config.diag),
+        };
+        let (spec, meta) = match def {
+            None => (None, None),
+            Some(def) => {
+                let meta = models::PoolMeta::new_all(def.replica_count, def.snapshot_count);
+                (Some(def.spec), Some(meta))
+            }
+        };
+
         models::Pool::new_all(
             src.id,
-            src.spec.into_opt(),
+            spec.into_opt(),
             src.state.into_opt(),
-            src.diag.into_opt(),
+            diag.into_opt(),
+            meta,
         )
     }
 }


### PR DESCRIPTION
Exposes these counts from a pool, allowing for easily inspecting pool usage in terms of placement rather than just commitment/usage.

We expose both the state information, which is retrieved by counting
the replicas directly from the data-plane information and the spec
like information, which we retrieve from the pstor entries.
This latter is useful because it still allows us to gauge the pool
usage even when the node is offline for example.
