### PR TITLE
test(rwx): add ha event and run fio

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,18 +17,18 @@ repos:
         args: [ "--spec-changes" ]
         pass_filenames: false
         language: system
-      - id: rust-lint
-        name: Rust lint
-        description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
-        entry: nix-shell --pure --run './scripts/rust/linter.sh clippy'
-        pass_filenames: false
-        types: [ file, rust ]
-        language: system
       - id: rust-style
         name: Rust style
         description: Run cargo fmt on files included in the commit. rustfmt should be installed before-hand.
         entry: nix-shell --pure --run './scripts/rust/linter.sh fmt'
         exclude: openapi/
+        pass_filenames: false
+        types: [ file, rust ]
+        language: system
+      - id: rust-lint
+        name: Rust lint
+        description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
+        entry: nix-shell --pure --run './scripts/rust/linter.sh clippy'
         pass_filenames: false
         types: [ file, rust ]
         language: system

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -14,8 +14,9 @@ use stor_port::types::v0::transport::{
     Register,
 };
 
-use crate::controller::resources::operations::ResourceLifecycle;
-use crate::controller::{io_engine::HostApi, wrapper::InternalOps};
+use crate::controller::{
+    io_engine::HostApi, resources::operations::ResourceLifecycle, wrapper::InternalOps,
+};
 use grpc::{
     context::Context,
     operations::{

--- a/control-plane/agents/src/bin/core/tests/node/purge.rs
+++ b/control-plane/agents/src/bin/core/tests/node/purge.rs
@@ -3,8 +3,7 @@ use grpc::operations::{
     node::traits::NodeOperations, pool::traits::PoolOperations, replica::traits::ReplicaOperations,
     volume::traits::VolumeOperations,
 };
-use std::collections::HashMap;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 use stor_port::{
     pstor::{etcd::Etcd, StoreObj},
     transport_api::{ReplyErrorKind, ResourceKind},

--- a/control-plane/agents/src/bin/core/tests/snapshot/fs_cons_snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/snapshot/fs_cons_snapshot.rs
@@ -1,8 +1,7 @@
 #![cfg(test)]
 
 use deployer_cluster::{Cluster, ClusterBuilder};
-use std::collections::HashMap;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 use stor_port::types::v0::openapi::models;
 
 struct DeviceDisconnect(nvmeadm::NvmeTarget);

--- a/control-plane/agents/src/bin/core/tests/volume/format_options.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/format_options.rs
@@ -1,8 +1,7 @@
 #![cfg(test)]
 
 use deployer_cluster::ClusterBuilder;
-use stor_port::types::v0::openapi::models;
-use stor_port::types::v0::transport::VolumeId;
+use stor_port::types::v0::{openapi::models, transport::VolumeId};
 
 use std::{collections::HashMap, time::Duration};
 

--- a/control-plane/agents/src/bin/core/tests/volume/helpers.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/helpers.rs
@@ -197,3 +197,34 @@ pub(crate) async fn wait_till_volume_status(
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
+
+/// Wait for a volume to reach the provided status with timeout.
+pub(crate) async fn wait_volume_target_node(
+    cluster: &Cluster,
+    uid: &Uuid,
+    node: &NodeId,
+    timeout: Duration,
+) -> Result<(), String> {
+    let start = std::time::Instant::now();
+    loop {
+        let mut curr_node = None;
+        let volume = cluster
+            .rest_v00()
+            .volumes_api()
+            .get_volume(uid)
+            .await
+            .unwrap();
+        if let Some(nexus) = volume.state.target {
+            if nexus.node.as_str() == node.as_str() {
+                return Ok(());
+            }
+            curr_node = Some(nexus.node);
+        }
+        if std::time::Instant::now() > (start + timeout) {
+            let error =
+                format!("Timeout wait_volume_target_node ('{node}'), current: '{curr_node:?}'");
+            return Err(error);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/control-plane/agents/src/bin/core/tests/volume/rwx.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/rwx.rs
@@ -1,11 +1,13 @@
 #![cfg(test)]
 
-use deployer_cluster::{Cluster, ClusterBuilder};
+use crate::volume::helpers::wait_volume_target_node;
+use deployer_cluster::{Cluster, ClusterBuilder, CsiNodeClient, FindVolumeRequest};
 use grpc::operations::volume::traits::VolumeOperations;
 use std::{collections::HashMap, time::Duration};
 use stor_port::types::v0::transport::{
-    CreateVolume, PublishVolume, VolumeAccessMode, VolumeId, VolumeShareProtocol,
+    CreateVolume, PublishVolume, Volume, VolumeAccessMode, VolumeId, VolumeShareProtocol,
 };
+use uuid::Uuid;
 
 #[tokio::test]
 async fn rwx() {
@@ -43,16 +45,20 @@ async fn test_migrate(cluster: &Cluster) {
         )
         .await
         .unwrap();
+    let context = HashMap::from([
+        ("nvmeReconnectDelay".into(), "1".into()),
+        ("nvmeKeepAliveTmo".into(), "1".into()),
+    ]);
 
     // source VM
-    let vm_1 = cluster.csi_node(0);
+    let vm_1 = cluster.csi_node(1);
     let volume = volume_client
         .publish(
             &PublishVolume {
                 uuid: volume.spec().uuid.clone(),
-                target_node: None,
+                target_node: Some(cluster.node(0)),
                 share: Some(VolumeShareProtocol::Nvmf),
-                publish_context: HashMap::new(),
+                publish_context: context.clone(),
                 frontend_nodes: vec![vm_1.to_string()],
                 access_mode: VolumeAccessMode::SingleNodeWriter,
             },
@@ -61,21 +67,25 @@ async fn test_migrate(cluster: &Cluster) {
         .await
         .unwrap();
     tracing::info!("Staging volume to {vm_1}");
-    let mut node_1 = cluster.csi_node_client(0).await.unwrap();
+    let target = volume.state().target.unwrap().node;
+    let next_target = cluster.node(1);
+    assert_ne!(target, next_target);
+
+    let mut node_1 = cluster.csi_node_client_tcp().await.unwrap();
     node_1
-        .node_stage_volume_(&volume, HashMap::default())
+        .node_stage_volume_(&volume, context.clone())
         .await
         .unwrap();
 
     // destination VM
-    let vm_2 = cluster.csi_node(1);
+    let vm_2 = cluster.csi_node(0);
     let volume = volume_client
         .publish(
             &PublishVolume {
                 uuid: volume.spec().uuid.clone(),
                 target_node: None,
                 share: Some(VolumeShareProtocol::Nvmf),
-                publish_context: HashMap::new(),
+                publish_context: context.clone(),
                 frontend_nodes: vec![vm_1.to_string(), vm_2.to_string()],
                 access_mode: VolumeAccessMode::MultiNodeMultiWriter,
             },
@@ -85,23 +95,124 @@ async fn test_migrate(cluster: &Cluster) {
         .unwrap();
 
     tracing::info!("Staging volume to {vm_2}");
-    let mut node_2 = cluster.csi_node_client_tcp().await.unwrap();
-    node_2
-        .node_stage_volume_(&volume, HashMap::default())
-        .await
-        .unwrap();
+    let mut node_2 = cluster.csi_node_client(0).await.unwrap();
+    node_2.node_stage_volume_(&volume, context).await.unwrap();
 
     // live migration starts
 
-    // todo: simulate node restarts, split-brain....
+    // workload is ongoing...
+    let (s, r) = tokio::sync::oneshot::channel::<()>();
+    let join = run_fio_vol(cluster, volume.uuid(), &mut node_2, r).await;
 
-    // live migration completes
+    // Simulate target node loss
+    tracing::info!("Simulating node loss by stopping {target}");
+    cluster.composer().stop(&target).await.unwrap();
+    tracing::info!("Waiting for volume target to switch from {target} to {next_target}");
+    wait_volume_target_node(
+        cluster,
+        volume.uuid(),
+        &next_target,
+        Duration::from_secs(10),
+    )
+    .await
+    .unwrap();
+    tracing::info!("Volume target switched from {target} to {next_target}");
 
-    // disconnect source node...
-    node_1.node_unstage_volume_(&volume).await.unwrap();
+    // todo: simulate split-brain....
 
-    // todo: some disruption on destination node
+    // live migration completes, remove vm_1
+    tracing::info!("Waiting for volume unstage from vm_1");
+    wait_unstage(&mut node_1, &volume).await.unwrap();
+    tracing::info!("Volume unstaged from vm_1");
+
+    drop(s);
+    let code = join.await.unwrap();
+
+    tracing::info!("Fio completed with {code:?}");
+
+    assert_eq!(code, Some(0));
 
     // disconnect destination node
     node_2.node_unstage_volume_(&volume).await.unwrap();
+}
+
+async fn wait_unstage(
+    node: &mut CsiNodeClient,
+    volume: &Volume,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = std::time::Instant::now();
+
+    let mut result = node.node_unstage_volume_(volume).await.map(drop);
+
+    while start.elapsed() < Duration::from_secs(10) {
+        result = node.node_unstage_volume_(volume).await.map(drop);
+        if result.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    result
+}
+
+async fn run_fio_vol(
+    cluster: &Cluster,
+    volume: &Uuid,
+    node: &mut CsiNodeClient,
+    mut stop: tokio::sync::oneshot::Receiver<()>,
+) -> tokio::task::JoinHandle<Option<i64>> {
+    let fio_builder = |device: &str| {
+        let filename = format!("--filename={device}");
+        vec![
+            "fio",
+            "--direct=1",
+            "--ioengine=libaio",
+            "--bs=4k",
+            "--iodepth=16",
+            "--loops=1",
+            "--numjobs=1",
+            "--name=fio",
+            "--readwrite=randwrite",
+            "--verify=crc32",
+            filename.as_str(),
+        ]
+        .into_iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+    };
+
+    let response = node
+        .internal()
+        .find_volume(FindVolumeRequest {
+            volume_id: volume.to_string(),
+        })
+        .await
+        .unwrap();
+
+    let device_path = response.into_inner().device_path;
+    let device_path = device_path.trim_end();
+    let fio_cmd = fio_builder(device_path);
+    let fio_cmdline = fio_cmd
+        .iter()
+        .fold(String::new(), |acc, next| format!("{acc} {next}"));
+    let composer = cluster.composer().clone();
+    let name = node.name().to_string();
+
+    println!("STEP: spawn fio in container");
+    tokio::spawn(async move {
+        use tokio::sync::oneshot::error::TryRecvError;
+        loop {
+            tracing::info!("Running fio: {fio_cmdline}");
+            let (code, out) = composer.exec(&name, fio_cmd.clone()).await.unwrap();
+            println!("{fio_cmdline}: {out}, code: {code:?}");
+            if code != Some(0) {
+                return code;
+            }
+            assert_eq!(code, Some(0));
+
+            if stop.try_recv().is_ok() || matches!(stop.try_recv(), Err(TryRecvError::Closed)) {
+                break code;
+            }
+        }
+    })
 }

--- a/control-plane/agents/src/bin/core/volume/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/volume/operations_helper.rs
@@ -31,8 +31,10 @@ use stor_port::{
             nexus_child::NexusChild,
             nexus_persistence::VolumeHealthPrefix,
             replica::ReplicaSpec,
-            volume::RepublishOperation,
-            volume::{FrontendConfig, TargetConfig, VolumeOperation, VolumeSpec, VolumeTarget},
+            volume::{
+                FrontendConfig, RepublishOperation, TargetConfig, VolumeOperation, VolumeSpec,
+                VolumeTarget,
+            },
         },
         transport::{
             CreateNexus, CreateReplica, Nexus, NexusId, NexusNvmePreemption, NexusNvmfConfig,

--- a/control-plane/csi-driver/src/bin/node/config.rs
+++ b/control-plane/csi-driver/src/bin/node/config.rs
@@ -18,6 +18,10 @@ pub fn nvme_keep_alive_tmo() -> String {
 pub fn nvme_ctrl_loss_tmo() -> String {
     Parameters::NvmeCtrlLossTmo.as_ref().to_kebab_case()
 }
+/// Command line arg name for `Parameters::NvmeReconnectDelay`.
+pub fn nvme_reconnect_delay() -> String {
+    Parameters::NvmeReconnectDelay.as_ref().to_kebab_case()
+}
 /// Command line arg name for `Parameters::NvmeIoTimeout`.
 pub fn nvme_io_tmo() -> String {
     Parameters::NvmeIoTimeout.as_ref().to_kebab_case()
@@ -45,6 +49,8 @@ pub(crate) struct NvmeConfig {
     nr_io_queues: Option<u32>,
     /// Default value for `ctrl_loss_tmo` when not specified via the volume parameters (sc).
     ctrl_loss_tmo: Option<u32>,
+    /// Default value for `reconnect_delay` when not specified via the volume parameters (sc).
+    reconnect_delay: Option<u32>,
     keep_alive_tmo: Option<u32>,
     /// Default value for `io_tmo` when not specified via the volume parameters (sc).
     io_tmo: Option<humantime::Duration>,
@@ -53,12 +59,14 @@ impl NvmeConfig {
     fn new(
         nr_io_queues: Option<u32>,
         ctrl_loss_tmo: Option<u32>,
+        reconnect_delay: Option<u32>,
         keep_alive_tmo: Option<u32>,
         io_tmo: Option<humantime::Duration>,
     ) -> Self {
         Self {
             nr_io_queues,
             ctrl_loss_tmo,
+            reconnect_delay,
             keep_alive_tmo,
             io_tmo,
         }
@@ -71,6 +79,11 @@ impl NvmeConfig {
     /// Used to setup the max number of reconnects until the initiator gives up.
     pub(crate) fn ctrl_loss_tmo(&self) -> Option<u32> {
         self.ctrl_loss_tmo
+    }
+    /// The `reconnect_delay` value.
+    /// Used to space out initiator reconnection attempts.
+    pub(crate) fn reconnect_delay(&self) -> Option<u32> {
+        self.reconnect_delay
     }
     /// The keep-alive timeout.
     pub(crate) fn keep_alive_tmo(&self) -> Option<u32> {
@@ -114,6 +127,14 @@ impl TryFrom<NvmeArgValues> for NvmeConfig {
                 error
             )
         })?;
+        let reconnect_delay =
+            Parameters::reconnect_delay(src.0.get(Parameters::NvmeReconnectDelay.as_ref()))
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "Invalid value for {}, error = {error}",
+                        Parameters::NvmeReconnectDelay.as_ref(),
+                    )
+                })?;
         let keep_alive_tmo = Parameters::keep_alive_tmo(
             src.0.get(Parameters::NvmeKeepAliveTmo.as_ref()),
         )
@@ -137,6 +158,7 @@ impl TryFrom<NvmeArgValues> for NvmeConfig {
         Ok(Self::new(
             nvme_nr_ioq,
             ctrl_loss_tmo,
+            reconnect_delay,
             keep_alive_tmo,
             nvme_io_tmo,
         ))
@@ -154,6 +176,7 @@ impl TryFrom<NvmeParseParams<'_>> for NvmeArgValues {
         }
         let mut us = Self::default();
         add_param(&value, &mut us, Parameters::NvmeCtrlLossTmo.as_ref());
+        add_param(&value, &mut us, Parameters::NvmeReconnectDelay.as_ref());
         add_param(&value, &mut us, Parameters::NvmeKeepAliveTmo.as_ref());
         Ok(us)
     }
@@ -176,6 +199,12 @@ impl TryFrom<&ArgMatches> for NvmeArgValues {
         if let Some(value) = matches.get_one::<String>(&nvme_ctrl_loss_tmo()) {
             map.0
                 .insert(Parameters::NvmeCtrlLossTmo.to_string(), value.to_string());
+        }
+        if let Some(value) = matches.get_one::<String>(&nvme_reconnect_delay()) {
+            map.0.insert(
+                Parameters::NvmeReconnectDelay.to_string(),
+                value.to_string(),
+            );
         }
 
         if let Some(value) = matches.get_one::<String>(&nvme_keep_alive_tmo()) {

--- a/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
@@ -39,6 +39,7 @@ pub(super) struct NvmfAttach {
     io_tmo: Option<u32>,
     nr_io_queues: Option<u32>,
     ctrl_loss_tmo: Option<u32>,
+    reconnect_delay: Option<u32>,
     keep_alive_tmo: Option<u32>,
     hostnqn: Option<String>,
     warn_bad: std::sync::atomic::AtomicBool,
@@ -55,6 +56,7 @@ impl NvmfAttach {
         nr_io_queues: Option<u32>,
         io_tmo: Option<humantime::Duration>,
         ctrl_loss_tmo: Option<u32>,
+        reconnect_delay: Option<u32>,
         keep_alive_tmo: Option<u32>,
         hostnqn: Option<String>,
     ) -> NvmfAttach {
@@ -67,6 +69,7 @@ impl NvmfAttach {
             io_tmo: io_tmo.map(|io_tmo| io_tmo.as_secs().try_into().unwrap_or(u32::MAX)),
             nr_io_queues,
             ctrl_loss_tmo,
+            reconnect_delay,
             keep_alive_tmo,
             hostnqn,
             warn_bad: std::sync::atomic::AtomicBool::new(true),
@@ -119,6 +122,7 @@ impl TryFrom<&Url> for NvmfAttach {
 
         let nr_io_queues = config().nvme().nr_io_queues();
         let ctrl_loss_tmo = config().nvme().ctrl_loss_tmo();
+        let reconnect_delay = config().nvme().reconnect_delay();
         let keep_alive_tmo = config().nvme().keep_alive_tmo();
         let io_tmo = config().nvme().io_tmo();
 
@@ -136,6 +140,7 @@ impl TryFrom<&Url> for NvmfAttach {
             nr_io_queues,
             io_tmo,
             ctrl_loss_tmo,
+            reconnect_delay,
             keep_alive_tmo,
             hostnqn,
         ))
@@ -164,6 +169,9 @@ impl Attach for NvmfAttach {
         if let Some(keep_alive_tmo) = nvme_config.keep_alive_tmo() {
             self.keep_alive_tmo = Some(keep_alive_tmo);
         }
+        if let Some(reconnect_delay) = nvme_config.reconnect_delay() {
+            self.reconnect_delay = Some(reconnect_delay);
+        }
         if self.io_tmo.is_none() {
             if let Some(io_tmo) = publish_context.io_timeout() {
                 self.io_tmo = Some(*io_tmo);
@@ -188,15 +196,15 @@ impl Attach for NvmfAttach {
             Err(NvmeError::SubsystemNotFound { .. }) => {
                 // The default reconnect delay in linux kernel is set to 10s. Use the
                 // same default value unless the timeout is less or equal to 10.
-                let reconnect_delay = match self.io_tmo {
-                    Some(io_timeout) => {
+                let reconnect_delay = match (self.io_tmo, self.reconnect_delay) {
+                    (Some(io_timeout), None) => {
                         if io_timeout <= 10 {
                             Some(1)
                         } else {
                             Some(10)
                         }
                     }
-                    None => None,
+                    _else => self.reconnect_delay,
                 };
                 let ca = ConnectArgsBuilder::default()
                     .traddr(&self.host)

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -143,6 +143,13 @@ pub(super) async fn main() -> anyhow::Result<()> {
                 .help("Sets the nvme-ctrl-loss-tmo parameter when connecting to a volume target. (May be overridden through the storage class)")
         )
         .arg(
+            Arg::new(crate::config::nvme_reconnect_delay())
+                .long(crate::config::nvme_reconnect_delay())
+                .value_name("NUMBER")
+                .required(false)
+                .help("Sets the nvme-reconnect-delay parameter when connecting to a volume target. (May be overridden through the storage class)")
+        )
+        .arg(
             Arg::new(crate::config::nvme_keep_alive_tmo())
                 .long(crate::config::nvme_keep_alive_tmo())
                 .value_name("NUMBER")

--- a/control-plane/csi-driver/src/context.rs
+++ b/control-plane/csi-driver/src/context.rs
@@ -40,6 +40,7 @@ pub enum Parameters {
     NvmeIoTimeout,
     NvmeNrIoQueues,
     NvmeCtrlLossTmo,
+    NvmeReconnectDelay,
     NvmeKeepAliveTmo,
     #[strum(serialize = "repl")]
     ReplicaCount,
@@ -186,6 +187,10 @@ impl Parameters {
     }
     /// Parse the value for `Self::NvmeCtrlLossTmo`.
     pub fn ctrl_loss_tmo(value: Option<&String>) -> Result<Option<u32>, ParseIntError> {
+        Self::parse_u32(value)
+    }
+    /// Parse the value for `Self::NvmeReconnectDelay`.
+    pub fn reconnect_delay(value: Option<&String>) -> Result<Option<u32>, ParseIntError> {
         Self::parse_u32(value)
     }
     /// Parse the value for `Self::NvmeNrIoQueues`.

--- a/control-plane/csi-driver/src/context.rs
+++ b/control-plane/csi-driver/src/context.rs
@@ -1,7 +1,9 @@
 use crate::filesystem::FileSystem;
 use k8s_openapi::api::core::v1::PersistentVolumeClaim;
-use kube::api::{Patch, PatchParams};
-use kube::{Api, Client};
+use kube::{
+    api::{Patch, PatchParams},
+    Api, Client,
+};
 use parse_size::parse_size;
 use regex::Regex;
 use std::{
@@ -10,11 +12,9 @@ use std::{
     num::ParseIntError,
     str::{FromStr, ParseBoolError},
 };
-use stor_port::platform;
-use stor_port::types::v0::openapi::models::VolumeShareProtocol;
+use stor_port::{platform, types::v0::openapi::models::VolumeShareProtocol};
 use strum_macros::{AsRefStr, Display, EnumString};
-use tracing::log::warn;
-use tracing::{debug, trace};
+use tracing::{debug, log::warn, trace};
 use utils::K8S_STS_PVC_NAMING_REGEX;
 
 use uuid::{Error as UuidError, Uuid};

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -8,8 +8,7 @@ use crate::{
     },
 };
 use prost::UnknownEnumValue;
-use std::ops::Deref;
-use std::{collections::HashMap, convert::TryFrom};
+use std::{collections::HashMap, convert::TryFrom, ops::Deref};
 use stor_port::{
     transport_api::{v0::Pools, ReplyError, ResourceKind},
     types::v0::{

--- a/control-plane/rest/service/src/v0/pools.rs
+++ b/control-plane/rest/service/src/v0/pools.rs
@@ -5,10 +5,12 @@ use grpc::operations::pool::traits::{
 use openapi::apis::pools_api::actix::server::{delNodePoolResponse, delPoolResponse};
 use rest_client::versions::v0::{apis::Uuid, models::PoolClearErr};
 use std::collections::HashMap;
-use stor_port::types::v0::openapi;
 use stor_port::{
     transport_api::{ReplyError, ReplyErrorKind, ResourceKind},
-    types::v0::transport::{DestroyPool, ExpandPool, Filter, UnlabelPool},
+    types::v0::{
+        openapi,
+        transport::{DestroyPool, ExpandPool, Filter, UnlabelPool},
+    },
 };
 
 fn client() -> impl PoolOperations {

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -11,24 +11,24 @@ pub use stor_port::{
         },
         store::pool::PoolLabel,
         transport::{
-            AddNexusChild, BlockDevice, Child, ChildUri, CreateNexus, CreatePool, CreateReplica,
-            CreateVolume, DestroyNexus, DestroyPool, DestroyReplica, DestroyVolume, Filter,
-            GetBlockDevices, JsonGrpcRequest, LabelPool, Nexus, NexusId, NexusShareProtocol, Node,
-            NodeId, Pool, PoolDeviceUri, PoolId, Protocol, RemoveNexusChild, Replica, ReplicaId,
-            ReplicaShareProtocol, ShareNexus, ShareReplica, Specs, Topology, UnshareNexus,
-            UnshareReplica, VolumeId, VolumeLabels, VolumePolicy, VolumeProperty, Watch,
-            WatchCallback, WatchResourceId,
+            AddNexusChild, AffinityGroup, BlockDevice, Child, ChildUri, CreateNexus, CreatePool,
+            CreateReplica, CreateSnapshotVolume, CreateVolume, DestroyNexus, DestroyPool,
+            DestroyReplica, DestroyVolume, Filter, GetBlockDevices, HostNqn, HostNqnParseError,
+            JsonGrpcRequest, LabelPool, Nexus, NexusId, NexusShareProtocol, Node, NodeId, Pool,
+            PoolDeviceUri, PoolId, Protocol, RemoveNexusChild, Replica, ReplicaId,
+            ReplicaShareProtocol, ShareNexus, ShareReplica, SnapshotId, Specs, Topology,
+            UnshareNexus, UnshareReplica, VolumeId, VolumeLabels, VolumePolicy, VolumeProperty,
+            Watch, WatchCallback, WatchResourceId,
         },
-        transport::{AffinityGroup, CreateSnapshotVolume, HostNqn, HostNqnParseError, SnapshotId},
     },
     IntoOption, IntoVec,
 };
 
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
+    fmt::Debug,
 };
 use stor_port::TryIntoOption;
 

--- a/scripts/rust/linter.sh
+++ b/scripts/rust/linter.sh
@@ -3,6 +3,7 @@
 set -e
 
 FMT_ERROR=
+FMT_OPTS=${FMT_OPTS:-"--config imports_granularity=Crate"}
 
 OP="${1:-}"
 
@@ -18,9 +19,9 @@ cargo fmt -- --version
 cargo clippy -- --version
 
 if [ -z "$OP" ] || [  "$OP" = "fmt" ]; then
-  cargo fmt --all --check || FMT_ERROR=$?
+  cargo fmt --all --check -- $FMT_OPTS || FMT_ERROR=$?
   if [ -n "$FMT_ERROR" ]; then
-    cargo fmt --all
+    cargo fmt --all -- $FMT_OPTS
   fi
 fi
 

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -370,7 +370,11 @@ impl Cluster {
         )
         .await?;
 
-        Ok(CsiNodeClient { csi, internal })
+        Ok(CsiNodeClient {
+            csi,
+            internal,
+            name: CsiNode::container_name(index),
+        })
     }
 
     /// Return a grpc handle to the csi-node plugin via TCP.
@@ -385,7 +389,11 @@ impl Cluster {
         )
         .await?;
 
-        Ok(CsiNodeClient { csi, internal })
+        Ok(CsiNodeClient {
+            csi,
+            internal,
+            name: CsiNode::container_name(1),
+        })
     }
 
     /// Return a grpc handle to the csi-controller.
@@ -1270,8 +1278,13 @@ pub struct CsiNodeClient {
     csi: csi_driver::csi::node_client::NodeClient<tonic::transport::Channel>,
     internal:
         csi_driver::node::internal::node_plugin_client::NodePluginClient<tonic::transport::Channel>,
+    name: String,
 }
 impl CsiNodeClient {
+    /// Get the csi node name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
     /// Get a mutable reference to the node-plugin csi client.
     pub fn csi(
         &mut self,

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -83,25 +83,68 @@ pub fn default_options() -> StartOptions {
         .with_env_tags(vec!["CARGO_PKG_NAME"])
 }
 
-/// A wrapper over the composer utility meant to ensure termination in the
-/// correct order.
-/// todo: I suspect this is not working because composer itself is being created
-///  with cleaning enabled, so this won't actually work as expected!
-pub struct ComposeTestNt {
+struct ComposeTestFlags {
     logs_on_panic: bool,
     clean: bool,
     allow_clean_on_panic: bool,
+}
+impl ComposeTestFlags {
+    fn override_flags(flag: &mut bool, flag_name: &str) {
+        let key = format!("COMPOSE_{}", flag_name.to_ascii_uppercase());
+        if let Some(val) = std::env::var_os(&key) {
+            let clean = match val.to_str().unwrap_or_default() {
+                "true" => true,
+                "false" => false,
+                _ => return,
+            };
+            if clean != *flag {
+                tracing::warn!(
+                    "env::{} => Overriding the {} flag to {}",
+                    key,
+                    flag_name,
+                    clean
+                );
+                *flag = clean;
+            }
+        }
+    }
+    /// override clean flags with environment variable
+    /// useful for testing without having to change the code
+    fn override_debug_flags(&mut self) {
+        Self::override_flags(&mut self.clean, "clean");
+        Self::override_flags(&mut self.allow_clean_on_panic, "allow_clean_on_panic");
+        Self::override_flags(&mut self.logs_on_panic, "logs_on_panic");
+    }
+}
+/// A wrapper over the composer utility meant to ensure termination in the
+/// correct order.
+/// todo: add shutdown order!
+pub struct ComposeTestNt {
+    flags: ComposeTestFlags,
     composer: ComposeTest,
+    name: String,
     shutdown_order: Vec<Vec<String>>,
 }
 impl ComposeTestNt {
     async fn new(composer: Builder) -> Result<Self, Error> {
-        let composer = composer.build().await?;
-        Ok(Self {
+        let mut flags = ComposeTestFlags {
             logs_on_panic: composer.logs_on_panic(),
             clean: composer.clean(),
-            allow_clean_on_panic: composer.clean_on_panic(),
+            allow_clean_on_panic: false,
+        };
+        flags.override_debug_flags();
+        let name = composer.get_name();
+        let mut composer = composer
+            .with_clean(false)
+            .with_clean_on_panic(false)
+            .with_logs(false)
+            .build()
+            .await?;
+        composer.clear_logs_on_panic();
+        Ok(Self {
+            flags,
             composer,
+            name,
             shutdown_order: vec![],
         })
     }
@@ -114,47 +157,53 @@ impl Deref for ComposeTestNt {
 }
 impl Drop for ComposeTestNt {
     fn drop(&mut self) {
-        if std::thread::panicking() && self.logs_on_panic {
+        use std::process::Command;
+
+        if std::thread::panicking() && self.flags.logs_on_panic {
             self.print_all_logs();
         }
 
-        if self.clean && (!std::thread::panicking() || self.allow_clean_on_panic) {
-            let sh = self.shutdown_order.drain(..);
-            sh.into_iter().for_each(|c| {
-                c.into_iter()
-                    .map(|c| {
-                        std::thread::spawn(move || {
-                            std::process::Command::new("docker")
-                                .args(["kill", "-s", "term", c.as_str()])
-                                .output()
-                                .unwrap();
+        if self.flags.clean && (!std::thread::panicking() || self.flags.allow_clean_on_panic) {
+            let containers = self.composer.containers();
+            let container_names = containers.keys().map(|k| k.as_str());
+
+            // todo: shutdown order not in-place at the moment
+            if !self.shutdown_order.is_empty() {
+                let sh = self.shutdown_order.drain(..);
+                sh.into_iter().for_each(|c| {
+                    c.into_iter()
+                        .map(|c| {
+                            std::thread::spawn(move || {
+                                Command::new("docker")
+                                    .args(["kill", "-s", "term", c.as_str()])
+                                    .output()
+                                    .unwrap();
+                            })
                         })
-                    })
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                    .for_each(|h| {
-                        h.join().ok();
-                    });
-            });
-            self.composer
-                .containers()
-                .keys()
-                .map(|k| {
-                    let name = k.clone();
-                    std::thread::spawn(move || {
-                        std::process::Command::new("docker")
-                            .args(["kill", "-s", "term", name.as_str()])
-                            .output()
-                            .unwrap();
-                    })
-                })
-                .collect::<Vec<_>>()
-                .into_iter()
-                .for_each(|h| {
-                    h.join().ok();
+                        .collect::<Vec<_>>()
+                        .into_iter()
+                        .for_each(|h| {
+                            h.join().ok();
+                        });
                 });
+            } else {
+                // Kill with SIGTERM to allow for some cleanup
+                let cmd = vec!["kill", "-s", "term"]
+                    .into_iter()
+                    .chain(container_names.clone());
+                Command::new("docker").args(cmd).output().unwrap();
+            }
+
+            // Remove (killing with force if not already stopped)
+            let cmd = vec!["rm", "-vf"].into_iter().chain(container_names.clone());
+            Command::new("docker").args(cmd).output().unwrap();
+
+            // Finally remove the network, leaving no traces of our composer
+            Command::new("docker")
+                .args(["network", "rm", self.name.as_str()])
+                .output()
+                .unwrap();
         }
-        self.composer.clear_logs_on_panic();
     }
 }
 
@@ -1255,13 +1304,7 @@ impl Pool {
         match &self.disk {
             PoolDisk::Malloc(size) => {
                 let size = size / (1024 * 1024);
-                format!(
-                    "malloc:///disk{}?size_mb={}&uuid={}",
-                    self.index,
-                    size,
-                    transport::PoolId::new()
-                )
-                .into()
+                format!("malloc:///disk{}?size={}MiB", self.index, size).into()
             }
             PoolDisk::Uri(uri) => uri.into(),
             PoolDisk::Tmp(disk) => disk.uri().into(),


### PR DESCRIPTION
    ci: log container errors before tearing them down
    
    On the deployer tests we have a wrapper over the composer library.
    
    Sometimes we pass the composer to other threads, and it may end up
    tearing down ahead of time, in a racy manner.
    
    This should also fix the missing container logs in these kinds of
    tests, as we see sometimes in CI, we now have the root cause!
    
---

    test(rwx): add ha event and run fio
    
    Adds a failover event by shutting down the target node.
    This should trigger a failover, and the volume target should then
    be moved to another available node.
    
---

    feat(csi/node): add support for reconnect-delay configuration
    
    This is mostly useful for testing, though it could be used to speed up
    retries in a cluster.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
