### PR TITLE
Pool delete fixes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/hot_spare.rs
@@ -267,6 +267,29 @@ async fn volume_replica_count_reconciler_traced(
 
     match current_replica_count.cmp(&required_replica_count) {
         Ordering::Less => {
+            // Guard: do not materialise a fresh, empty replica when the volume has
+            // already been published but currently has zero spec'd replicas.
+            //
+            // A volume that has never been published has no `health_info_id` and
+            // no data to lose, so a fresh replica there is correct.
+            if current_replica_count == 0 && volume.as_ref().health_info_id().is_some() {
+                // The reconciler cannot recover this volume on its own.
+                // Emit the warning exactly once per agent lifetime per volume to avoid flooding
+                // logs at the reconcile cadence.
+                if !volume.as_ref().data_loss_warned() {
+                    // Mark first, then log. The lock is dropped before the
+                    // tracing macro fires so the lock isn't held across logging.
+                    volume.lock().set_data_loss_warned();
+                    volume.warn_span(|| {
+                        tracing::warn!(
+                            "Volume has no remaining replicas; hot-spare will not create \
+                            additional replicas since no rebuild is possible"
+                        )
+                    });
+                }
+                return PollResult::Ok(PollerState::Idle);
+            }
+
             volume.warn_span(|| {
                 tracing::warn!(
                     "The volume has '{}' replica(s) but it should have '{}'",

--- a/control-plane/agents/src/bin/core/tests/pool/purge.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/purge.rs
@@ -3,7 +3,7 @@ use grpc::operations::{
     pool::traits::PoolOperations, replica::traits::ReplicaOperations,
     volume::traits::VolumeOperations,
 };
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 use stor_port::{
     pstor::{etcd::Etcd, StoreObj},
     transport_api::{ReplyErrorKind, ResourceKind},
@@ -13,7 +13,8 @@ use stor_port::{
             SpecStatus,
         },
         transport::{
-            CreatePool, CreateVolume, DestroyPool, Filter, NodeStatus, Pool, PoolId, VolumeId,
+            CreatePool, CreateVolume, DestroyPool, DestroyVolume, Filter, GetVolumes, NodeStatus,
+            Pool, PoolId, PublishVolume, VolumeAccessMode, VolumeId, VolumeStatus,
         },
     },
 };
@@ -29,8 +30,14 @@ async fn pool_purge() {
     let cluster = ClusterBuilder::builder()
         .with_rest(false)
         .with_agents(vec!["core"])
-        .with_io_engines(1)
-        .with_pools(2) // pool-1 for purge tests, pool-2 for normal delete
+        // Engine 1 is intentionally idle for phases 1-3 (no pools on it). The existing
+        // phases assume the volume replica goes on the engine being stopped, which is
+        // guaranteed when engine 1 has no pool to land on. Phase 4 then provisions a
+        // pool on engine 1 to act as the surviving online destination that the bug
+        // would write a stray replica to.
+        .with_io_engines(2)
+        .with_pool(0, "malloc:///disk1?size_mb=100")
+        .with_pool(0, "malloc:///disk2?size_mb=100")
         .with_cache_period("100ms")
         .with_node_deadline("100ms")
         .with_reconcile_period(Duration::from_millis(100), Duration::from_millis(100))
@@ -112,6 +119,10 @@ async fn pool_purge() {
 
     // --- Phase 3: reconciler resume after simulated crash ---
     purge_reconciler_resumes_interrupted(&cluster).await;
+
+    // --- Phase 4: regression — purging the last healthy replica must not silently
+    //     create a fresh empty replica on a surviving node.
+    purge_skips_replica_creation_on_last_healthy_loss(&cluster).await;
 }
 
 /// Purge must be rejected when the pool's node is online (state is not Unknown).
@@ -391,4 +402,242 @@ async fn purge_reconciler_resumes_interrupted(cluster: &Cluster) {
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+}
+
+/// Setup: starts the engine that was left stopped by Phase 3 and creates a fresh
+/// pool on each io-engine. A 1-replica volume is published on the node holding its
+/// replica, so:
+///   - the volume has `health_info_id` set (NexusInfo persisted to etcd),
+///   - both the replica and the nexus live on node-A,
+///   - node-B has a pool with free space — the candidate destination if the bug fires.
+///
+/// Sequence:
+///   1. Stop node-A. The nexus state can no longer be fetched, so `volume_state`
+///      (which `hot_spare_reconcile` calls without health info) returns `Unknown`.
+///   2. Cordon and purge the pool on node-A. The replica is destroyed (spec-only).
+///   3. Without the guard in `volume_replica_count_reconciler_traced`, the dispatch
+///      `Unknown -> hot_spare_nexus_reconcile -> volume_replica_count_reconciler`
+///      sees `0 < 1` replicas and creates a brand new empty replica on node-B,
+///      silently masking the data loss.
+///
+/// Expected with the fix:
+///   - No new replica appears on node-B.
+///   - The volume settles into a state without a healthy replica (Faulted/Unknown).
+async fn purge_skips_replica_creation_on_last_healthy_loss(cluster: &Cluster) {
+    let pool_client = cluster.grpc_client().pool();
+    let volume_client = cluster.grpc_client().volume();
+    let replica_client = cluster.grpc_client().replica();
+
+    // Phase 3 ends with io-engine-1 stopped and no pools anywhere. Bring it back so
+    // we have two engines to play with, then create a fresh pool on each.
+    cluster.composer().start("io-engine-1").await.unwrap();
+    cluster
+        .wait_node_status_tmo(cluster.node(0), NodeStatus::Online, NODE_OFFLINE_TIMEOUT)
+        .await
+        .expect("io-engine-1 should come online");
+
+    // Phases 1 and 3 leave behind volume specs with zero replicas (their pools were
+    // purged). Before we provision new pools, destroy them — otherwise the hot-spare
+    // reconciler will repopulate them on whichever pool we create first, which both
+    // pollutes the test and breaks the volume_loss accounting in the purge below
+    // (the analyzer would report multiple affected volumes).
+    let leftover = volume_client
+        .get(Filter::None, false, None, None)
+        .await
+        .expect("Should be able to list volumes")
+        .entries;
+    for vol in leftover {
+        let _ = volume_client
+            .destroy(&DestroyVolume::new(vol.uuid()), None)
+            .await;
+    }
+
+    let pool_a: PoolId = "data-loss-pool-a".into();
+    let pool_b: PoolId = "data-loss-pool-b".into();
+    pool_client
+        .create(
+            &CreatePool {
+                node: cluster.node(0),
+                id: pool_a.clone(),
+                disks: vec!["malloc:///data_loss_a?size_mb=100".into()],
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .expect("Pool A creation on io-engine-1 should succeed");
+    pool_client
+        .create(
+            &CreatePool {
+                node: cluster.node(1),
+                id: pool_b.clone(),
+                disks: vec!["malloc:///data_loss_b?size_mb=100".into()],
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .expect("Pool B creation on io-engine-2 should succeed");
+
+    // 1-replica volume; the replica lands on whichever pool the scheduler picks.
+    let vol_id = VolumeId::new();
+    volume_client
+        .create(
+            &CreateVolume {
+                uuid: vol_id.clone(),
+                size: VOLUME_SIZE,
+                replicas: 1,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .expect("Volume creation should succeed");
+
+    // Identify the replica's node — that's the pool we'll purge.
+    let replicas = replica_client
+        .get(Filter::Volume(vol_id.clone()), None)
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(replicas.len(), 1, "Volume should have a single replica");
+    let replica_node = replicas[0].node.clone();
+    let replica_pool: PoolId = replicas[0].pool_id.clone();
+    let surviving_node = if replica_node == cluster.node(0) {
+        cluster.node(1)
+    } else {
+        cluster.node(0)
+    };
+
+    // Publish on the replica's node so the nexus shares its fate when we stop the engine.
+    // This forces `volume_state` to see `target.is_some()` but fail to fetch nexus state,
+    // landing the volume in `Unknown` — the exact path the bug rides on.
+    volume_client
+        .publish(
+            &PublishVolume::new(
+                vol_id.clone(),
+                Some(replica_node.clone()),
+                None,
+                HashMap::new(),
+                vec![],
+                VolumeAccessMode::SingleNodeWriter,
+            ),
+            None,
+        )
+        .await
+        .expect("Volume should publish on the replica's node");
+
+    // Stop the io-engine holding the replica + nexus. NodeId stringifies to the same
+    // name as the composer container ("io-engine-N").
+    let engine_name = replica_node.to_string();
+    cluster
+        .composer()
+        .stop(&engine_name)
+        .await
+        .expect("Should stop io-engine");
+    cluster
+        .wait_node_status_tmo(
+            replica_node.clone(),
+            NodeStatus::Offline,
+            NODE_OFFLINE_TIMEOUT,
+        )
+        .await
+        .expect("Node should go offline");
+
+    // Cordon and purge.
+    pool_client
+        .cordon(PoolCordonRequest {
+            node_id: None,
+            pool_id: replica_pool.clone(),
+            replicas: true,
+            snapshots: true,
+            restores: false,
+            import: false,
+        })
+        .await
+        .expect("Cordon should succeed");
+
+    let destroy = DestroyPool::purge(replica_node.clone(), replica_pool.clone())
+        .with_accept(true)
+        .with_accept_volume_loss(true)
+        .with_accept_snapshot_loss(true);
+    let result = pool_client
+        .destroy(&destroy, None)
+        .await
+        .expect("Purge should succeed")
+        .expect("Purge should return a PoolDeleteResult");
+    assert_eq!(result.volume_loss.volumes.len(), 1);
+    assert_eq!(result.volume_loss.volumes[0].volume_id, vol_id);
+    assert_eq!(result.volume_loss.volumes[0].healthy_after, 0);
+
+    // Give the reconciler a generous window to misbehave. With reconcile_period at
+    // 100ms, this is ~30 ticks — plenty of opportunity for the buggy code path to
+    // kick in if the guard isn't there.
+    let observation_window = Duration::from_secs(3);
+    let start = std::time::Instant::now();
+    while std::time::Instant::now() < start + observation_window {
+        // Re-check on every tick: any replica appearing is an immediate failure,
+        // regardless of which pool it landed on. Catching it as soon as it appears
+        // keeps the failure log close to the cause.
+        let replicas = match replica_client
+            .get(Filter::Volume(vol_id.clone()), None)
+            .await
+        {
+            Ok(r) => r.into_inner(),
+            Err(e) if e.kind == ReplyErrorKind::NotFound => Vec::new(),
+            Err(e) => panic!("unexpected error querying replicas: {e:?}"),
+        };
+        assert!(
+            replicas.is_empty(),
+            "Reconciler created a new replica after the last healthy one was purged \
+             (replicas: {:?}). This is the data-loss-masking bug the guard prevents.",
+            replicas
+                .iter()
+                .map(|r| (r.node.clone(), r.pool_id.clone()))
+                .collect::<Vec<_>>()
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Sanity: the candidate destination pool is still present and could have received
+    // a replica — so the absence above isn't a placement failure, it's the guard
+    // correctly refusing to create.
+    let surviving_pools = pool_client
+        .get(Filter::Node(surviving_node.clone()), None)
+        .await
+        .expect("Should be able to list pools on the surviving node")
+        .into_inner();
+    assert!(
+        !surviving_pools.is_empty(),
+        "Surviving node should still have its pool — otherwise the no-replica result \
+         doesn't prove anything"
+    );
+
+    // The volume should report no healthy replica. Status check is a soft confirmation:
+    // depending on whether the nexus state is reachable through any path it may end up
+    // Faulted or Unknown, but never Online/Degraded.
+    let volume = volume_client
+        .get(GetVolumes::new(&vol_id).filter, false, None, None)
+        .await
+        .expect("Volume should still exist")
+        .entries
+        .into_iter()
+        .next()
+        .expect("Volume should be returned");
+    let status = volume.state().status;
+    assert!(
+        matches!(status, VolumeStatus::Faulted | VolumeStatus::Unknown),
+        "Volume should not appear healthy after losing its only replica, got: {status:?}"
+    );
+
+    // Replica spec count should be zero.
+    let final_replicas = match replica_client
+        .get(Filter::Volume(vol_id.clone()), None)
+        .await
+    {
+        Ok(r) => r.into_inner().len(),
+        Err(e) if e.kind == ReplyErrorKind::NotFound => 0,
+        Err(e) => panic!("unexpected error: {e:?}"),
+    };
+    assert_eq!(final_replicas, 0, "Volume should have no replicas");
 }

--- a/control-plane/plugin/src/resources/error.rs
+++ b/control-plane/plugin/src/resources/error.rs
@@ -66,10 +66,12 @@ pub enum Error {
         id: String,
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,
     },
-    #[snafu(display("Failed to delete pool {id}. Error {source}"))]
+    #[snafu(display("Failed to delete pool {id}. Error {source}{}", hint.as_deref().map(|h| format!("\nHint: {h}")).unwrap_or_default()))]
     DeletePoolError {
         id: String,
         source: openapi::tower::client::Error<openapi::models::RestJsonError>,
+        /// Optional contextual hint shown when the pool is already being deleted/purged.
+        hint: Option<String>,
     },
     #[snafu(display("Failed to delete node {id}. Error {source}"))]
     DeleteNodeError {

--- a/control-plane/plugin/src/resources/error.rs
+++ b/control-plane/plugin/src/resources/error.rs
@@ -234,13 +234,13 @@ pub enum PurgeReason {
     NodeHasResources,
     #[strum(to_string = "Node has pools with data. Confirm with --yes to proceed.")]
     NodePurgeAcceptRequired,
-    #[strum(
-        to_string = "Volumes would lose their last healthy replica. Use --accept-volume-loss or --accept-data-loss to proceed."
-    )]
+    #[strum(to_string = "Volumes would lose their last healthy replica. \
+                 Use --accept-volume-loss to proceed, or --accept-data-loss \
+                 to also accept snapshot loss in a single flag.")]
     NodePurgeVolumeLoss,
-    #[strum(
-        to_string = "Snapshots would lose their last replica snapshot. Use --accept-snapshot-loss or --accept-data-loss to proceed."
-    )]
+    #[strum(to_string = "Snapshots would lose their last replica snapshot. \
+                 Use --accept-snapshot-loss to proceed, or --accept-data-loss \
+                 to also accept volume loss in a single flag.")]
     NodePurgeSnapshotLoss,
     #[strum(
         to_string = "Pool state is not Offline or Unknown. Only pools with Offline or Unknown state can be purged."
@@ -256,13 +256,13 @@ pub enum PurgeReason {
     PoolCordonInsufficient,
     #[strum(to_string = "Pool has replicas. Confirm with --yes to proceed.")]
     PoolPurgeAcceptRequired,
-    #[strum(
-        to_string = "Volumes would lose their last healthy replica. Use --accept-volume-loss or --accept-data-loss to proceed."
-    )]
+    #[strum(to_string = "Volumes would lose their last healthy replica. \
+                 Use --accept-volume-loss to proceed, or --accept-data-loss \
+                 to also accept snapshot loss in a single flag.")]
     PoolPurgeVolumeLoss,
-    #[strum(
-        to_string = "Snapshots would lose their last replica snapshot. Use --accept-snapshot-loss or --accept-data-loss to proceed."
-    )]
+    #[strum(to_string = "Snapshots would lose their last replica snapshot. \
+                 Use --accept-snapshot-loss to proceed, or --accept-data-loss \
+                 to also accept volume loss in a single flag.")]
     PoolPurgeSnapshotLoss,
 }
 

--- a/control-plane/plugin/src/resources/pool.rs
+++ b/control-plane/plugin/src/resources/pool.rs
@@ -427,6 +427,7 @@ impl Delete for Pool {
                 match super::error::PurgeReason::from_api_error(&source) {
                     Some(reason) => Err(Error::Purge { reason }),
                     None => Err(Error::DeletePoolError {
+                        hint: pool_deletion_hint(&id.pool_id).await,
                         id: id.pool_id.to_string(),
                         source,
                     }),
@@ -434,6 +435,29 @@ impl Delete for Pool {
             }
         }
     }
+}
+
+/// GET the pool and, if its spec status is `Deleting` or `Purging`, return a hint
+/// message telling the user that the delete will be retried automatically.
+/// Returns `None` when the pool cannot be fetched or is not in a pending-deletion state.
+async fn pool_deletion_hint(pool_id: &PoolId) -> Option<String> {
+    let pool = RestClient::client()
+        .pools_api()
+        .get_pool(pool_id)
+        .await
+        .ok()?
+        .into_body();
+    let status = pool.spec?.status;
+    matches!(
+        status,
+        models::SpecStatus::Deleting | models::SpecStatus::Purging
+    )
+    .then(|| {
+        format!(
+            "Pool '{pool_id}' is currently in '{status}' state. \
+             This operation will be retried automatically."
+        )
+    })
 }
 
 impl GetHeaderRow for models::PoolDeleteResult {

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -313,6 +313,14 @@ impl VolumeMetadata {
     pub fn has_snapshots(&self) -> bool {
         self.runtime.has_snapshots()
     }
+    /// Check whether the data-loss warning has already been emitted (runtime only).
+    pub fn data_loss_warned(&self) -> bool {
+        self.runtime.data_loss_warned()
+    }
+    /// Mark the data-loss warning as emitted (runtime only).
+    pub fn set_data_loss_warned(&mut self) {
+        self.runtime.set_data_loss_warned();
+    }
 }
 
 /// Volume meta information.
@@ -328,11 +336,22 @@ pub struct VolumePersistedMetadata {
 pub struct VolumeRuntimeMetadata {
     /// Runtime list of all volume snapshots.
     snapshots: super::snapshots::volume::VolumeSnapshotList,
+    /// Avoids flooding logs once-per-reconcile-tick when a published volume is
+    /// stuck with zero replicas after a pool purge.
+    data_loss_warned: bool,
 }
 impl VolumeRuntimeMetadata {
     /// Check if there's any snapshot.
     pub fn has_snapshots(&self) -> bool {
         !self.snapshots.is_empty()
+    }
+    /// Check whether the data-loss warning has already been emitted.
+    pub fn data_loss_warned(&self) -> bool {
+        self.data_loss_warned
+    }
+    /// Mark the data-loss warning as emitted.
+    pub fn set_data_loss_warned(&mut self) {
+        self.data_loss_warned = true;
     }
 }
 
@@ -443,6 +462,16 @@ impl VolumeSpec {
     /// Check if there's any snapshot.
     pub fn has_snapshots(&self) -> bool {
         self.metadata.runtime.has_snapshots()
+    }
+    /// Check whether the data-loss warning has already been emitted for this volume.
+    /// Runtime only — resets on core agent restart.
+    pub fn data_loss_warned(&self) -> bool {
+        self.metadata.data_loss_warned()
+    }
+    /// Mark the data-loss warning as emitted for this volume.
+    /// Runtime only — resets on core agent restart.
+    pub fn set_data_loss_warned(&mut self) {
+        self.metadata.set_data_loss_warned();
     }
     /// Check if the volume behaves as thin provisioned.
     /// This can happen when a volume has snapshots.


### PR DESCRIPTION
fix(reconciler): don't create empty replicas for purged published volumes

Add a guard in volume_replica_count_reconciler_traced before the
Ordering::Less branch: skip replica creation when the volume has zero
spec'd replicas and was previously published (health_info_id is set).
Replica anti-affinity guarantees at most one replica per volume per
node, so a single purge can only ever drop the spec count by one — the
0 case is the only one this guard needs to cover. Higher Less arities
imply a surviving spec with rebuild source available, and the volume
would already be Faulted and dispatched away from this reconciler.

---

feat(plugin): hint on pool delete error when pool is already Deleting/Purging

If `del_pool` returns an error (other than NOT_FOUND), GET the pool and
check its spec status. If the pool is already in `Deleting` or `Purging`
state, attach a hint to the `DeletePoolError` telling the user that the
operation will be retried automatically.

The hint is appended to the existing error display as a `\nHint: ...`
line, so it is visible in all output modes without changing the error
type or any upstream handler.

---

refactor(plugin): clarify --accept-data-loss consequences in purge error hints

The volume-loss and snapshot-loss PurgeReason messages previously listed
--accept-volume-loss/--accept-snapshot-loss and --accept-data-loss as if
they were interchangeable. Clarify that --accept-data-loss is a combined
flag that accepts both losses, so users understand the broader consequence
before reaching for it.

---

test: check if no new replicas are created for faulted vols. of purged pools