### PR TITLE
fix(csi): return FailedPrecondition instead of NotFound on freeze failure

### DIFF
--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -988,7 +988,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                     match issue_fs_freeze(app_node_endpoint.clone(), volume_uuid.to_string()).await
                     {
                         Err(error) if error.code() == Code::NotFound => {
-                            Err(Status::not_found(format!(
+                            Err(Status::failed_precondition(format!(
                                 "Failed to freeze volume {volume_uuid}, filesystem volume is not attached"
                             )))
                         }


### PR DESCRIPTION
## Summary

When `CreateSnapshot` fails because the source volume is not attached/staged, the CSI controller returns gRPC `NotFound`. While `NotFound` is treated as a final error per CSI spec, `FailedPrecondition` is more semantically correct, the operation cannot proceed in the current state of the resource (volume is not staged), but the resource itself exists.

## Changes

- Return `Status::failed_precondition` instead of `Status::not_found` when `issue_fs_freeze` fails because the volume is not attached
- The error message remains unchanged

## Why FailedPrecondition

- The volume exists (so `NotFound` is misleading)
- The freeze cannot proceed because the volume is not in a publishable/staged state — this is a precondition failure
- Makes it clearer to users and CSI consumers that the snapshot can be retried after publishing/staging the volume
- Both error codes are treated as final (non-retriable) by the external-snapshotter sidecar, so retry behavior is preserved

Fixes: https://github.com/openebs/mayastor/issues/1978
