### PR TITLE
feat: add node resource tally

### DIFF
--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -88,7 +88,7 @@ pub(crate) struct RegistryInner<S: Store> {
     /// reconciliation period when work is pending.
     reconcile_period: std::time::Duration,
     /// The duration for which the reconciler waits for the replica to
-    /// to be healthy again before attempting to online the faulted child.
+    /// be healthy again before attempting to online the faulted child.
     faulted_child_wait_period: Option<std::time::Duration>,
     /// When the pool creation gRPC times out, the actual call in the io-engine
     /// may still progress.
@@ -119,8 +119,8 @@ pub(crate) struct RegistryInner<S: Store> {
     allow_non_persistent_devlinks: bool,
     /// Prefer encrypted pools for volume replicas.
     encrypted_pools_soft_scheduling: bool,
-    /// Blobstore cluster size(in bytes) required for pool creation and replica scheduling. This is
-    /// not per-pool.
+    /// Blobstore cluster size(in bytes) required for pool creation and replica scheduling.
+    /// This is not per-pool.
     pool_cluster_size: Option<u32>,
     deprecated_access_mode: bool,
     /// Running in simulation mode.

--- a/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
+++ b/control-plane/agents/src/bin/core/controller/resources/operations_helper.rs
@@ -996,11 +996,22 @@ impl ResourceSpecsLocked {
                 }
             }
         }
-        // add runtime information for pool replica/snapshot count
+        // add runtime information for node and pool replica/snapshot count
         for pool in self.read().pools.values() {
             let mut pool = pool.lock();
-            pool.metadata.runtime.replica_count = Some(self.calculate_repl_count(pool.id()));
-            pool.metadata.runtime.snapshot_count = Some(self.calculate_snap_count(pool.id()));
+
+            let replica_count = self.calculate_repl_count(pool.id());
+            let snapshot_count = self.calculate_snap_count(pool.id());
+            pool.metadata.runtime.replica_count = Some(replica_count);
+            pool.metadata.runtime.snapshot_count = Some(snapshot_count);
+
+            let Ok(node) = self.node_rsc(&pool.node) else {
+                continue;
+            };
+            let mut node = node.lock();
+            node.metadata.runtime.pool_count += 1;
+            node.metadata.runtime.replica_count += replica_count;
+            node.metadata.runtime.snapshot_count += snapshot_count;
         }
 
         // Remove all entries of v1 key prefix.

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -180,6 +180,64 @@ impl ResourceSpecsLocked {
         let mut specs = self.write();
         specs.nodes.remove(id);
     }
+
+    /// On replica creation, update the node's replica count.
+    pub(crate) fn node_on_repl_create(&self, node_id: &NodeId) {
+        let Ok(node) = self.node_rsc(node_id) else {
+            return;
+        };
+
+        let mut node = node.lock();
+        node.metadata.runtime.replica_count += 1;
+    }
+    /// On replica deletion, update the node's replica count.
+    pub(crate) fn node_on_repl_destroy(&self, node_id: &NodeId) {
+        let Ok(node) = self.node_rsc(node_id) else {
+            return;
+        };
+
+        let mut node = node.lock();
+        node.metadata.runtime.replica_count = node.metadata.runtime.replica_count.saturating_sub(1);
+    }
+
+    /// On replica snapshot creation, update the node's snapshot count.
+    pub(crate) fn node_on_snap_create(&self, node_id: &NodeId) {
+        let Ok(node) = self.node_rsc(node_id) else {
+            return;
+        };
+
+        let mut node = node.lock();
+        node.metadata.runtime.snapshot_count += 1;
+    }
+    /// On replica snapshot deletion, update the node's snapshot count.
+    pub(crate) fn node_on_snap_destroy(&self, node_id: &NodeId) {
+        let Ok(node) = self.node_rsc(node_id) else {
+            return;
+        };
+
+        let mut node = node.lock();
+        node.metadata.runtime.snapshot_count =
+            node.metadata.runtime.snapshot_count.saturating_sub(1);
+    }
+
+    /// On pool creation, update the node's pool count.
+    pub(crate) fn on_pool_create(&self, node_id: &NodeId) {
+        let Ok(node) = self.node_rsc(node_id) else {
+            return;
+        };
+
+        let mut node = node.lock();
+        node.metadata.runtime.pool_count += 1;
+    }
+    /// On pool deletion, update the node's pool count.
+    pub(crate) fn on_pool_destroy(&self, node_id: &NodeId) {
+        let Ok(node) = self.node_rsc(node_id) else {
+            return;
+        };
+
+        let mut node = node.lock();
+        node.metadata.runtime.pool_count = node.metadata.runtime.pool_count.saturating_sub(1);
+    }
 }
 
 impl ResourceSpecs {

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -116,6 +116,7 @@ impl ResourceLifecycle for OperationGuardArc<PoolSpec> {
         let mut state = pool.complete_create(result, registry, on_fail).await?;
         state.repl_count = Some(0);
         state.snap_count = Some(0);
+        registry.specs().on_pool_create(&state.node);
         let spec = pool.lock().clone();
         Ok(Pool::new(spec, Some(CtrlPoolState::new(state))))
     }
@@ -347,6 +348,7 @@ impl OperationGuardArc<PoolSpec> {
             Err(error) => Err(error),
         };
         self.complete_destroy(result, registry).await?;
+        registry.specs().on_pool_destroy(&request.node);
         Ok(None)
     }
 
@@ -444,6 +446,7 @@ impl OperationGuardArc<PoolSpec> {
 
         // 10. Complete the op.
         let result = self.complete_destroy(purge_result, registry).await?;
+        registry.specs().on_pool_destroy(node_id);
         Ok(Some(result))
     }
 

--- a/control-plane/agents/src/bin/core/pool/specs.rs
+++ b/control-plane/agents/src/bin/core/pool/specs.rs
@@ -582,13 +582,17 @@ impl ResourceSpecsLocked {
             return;
         };
 
-        let mut pool = pool.lock();
-        if let Some(count) = pool.metadata.runtime.replica_count.as_mut() {
-            *count += 1;
-        } else {
-            // this should only happen the first time
-            pool.metadata.runtime.replica_count = Some(self.calculate_repl_count(pool_id));
-        }
+        let node_id = {
+            let mut pool = pool.lock();
+            if let Some(count) = pool.metadata.runtime.replica_count.as_mut() {
+                *count += 1;
+            } else {
+                // this should only happen the first time
+                pool.metadata.runtime.replica_count = Some(self.calculate_repl_count(pool_id));
+            }
+            pool.node.clone()
+        };
+        self.node_on_repl_create(&node_id);
     }
     /// On replica deletion, update the pool's replica count.
     pub(crate) fn on_repl_destroy(&self, pool_id: &PoolId) {
@@ -596,12 +600,16 @@ impl ResourceSpecsLocked {
             return;
         };
 
-        let mut pool = pool.lock();
-        if let Some(count) = pool.metadata.runtime.replica_count.as_mut() {
-            *count = count.saturating_sub(1);
-        } else {
-            pool.metadata.runtime.replica_count = Some(self.calculate_repl_count(pool_id));
-        }
+        let node_id = {
+            let mut pool = pool.lock();
+            if let Some(count) = pool.metadata.runtime.replica_count.as_mut() {
+                *count = count.saturating_sub(1);
+            } else {
+                pool.metadata.runtime.replica_count = Some(self.calculate_repl_count(pool_id));
+            }
+            pool.node.clone()
+        };
+        self.node_on_repl_destroy(&node_id);
     }
 
     /// On replica snapshot creation, update the pool's snapshot count.
@@ -610,12 +618,16 @@ impl ResourceSpecsLocked {
             return;
         };
 
-        let mut pool = pool.lock();
-        if let Some(count) = pool.metadata.runtime.snapshot_count.as_mut() {
-            *count += 1;
-        } else {
-            pool.metadata.runtime.snapshot_count = Some(self.calculate_snap_count(pool_id));
-        }
+        let node_id = {
+            let mut pool = pool.lock();
+            if let Some(count) = pool.metadata.runtime.snapshot_count.as_mut() {
+                *count += 1;
+            } else {
+                pool.metadata.runtime.snapshot_count = Some(self.calculate_snap_count(pool_id));
+            }
+            pool.node.clone()
+        };
+        self.node_on_snap_create(&node_id);
     }
     /// On replica snapshot deletion, update the pool's snapshot count.
     pub(crate) fn on_snap_destroy(&self, pool_id: &PoolId) {
@@ -623,11 +635,15 @@ impl ResourceSpecsLocked {
             return;
         };
 
-        let mut pool = pool.lock();
-        if let Some(count) = pool.metadata.runtime.snapshot_count.as_mut() {
-            *count = count.saturating_sub(1);
-        } else {
-            pool.metadata.runtime.snapshot_count = Some(self.calculate_snap_count(pool_id));
-        }
+        let node_id = {
+            let mut pool = pool.lock();
+            if let Some(count) = pool.metadata.runtime.snapshot_count.as_mut() {
+                *count = count.saturating_sub(1);
+            } else {
+                pool.metadata.runtime.snapshot_count = Some(self.calculate_snap_count(pool_id));
+            }
+            pool.node.clone()
+        };
+        self.node_on_snap_destroy(&node_id);
     }
 }

--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -30,9 +30,9 @@ use stor_port::{
         },
         transport::{
             CreatePool, CreateReplica, DestroyPool, DestroyReplica, ExpandPool, Filter,
-            GetBlockDevices, GetSpecs, NexusId, NodeId, NodeStatus, PoolErrorCode, Protocol,
-            Replica, ReplicaId, ReplicaName, ReplicaOwners, ReplicaShareProtocol, ReplicaStatus,
-            ShareReplica, UnshareReplica, Volume, VolumeId,
+            GetBlockDevices, GetSpecs, NexusId, NodeId, NodeRscCounts, NodeStatus, PoolErrorCode,
+            Protocol, Replica, ReplicaId, ReplicaName, ReplicaOwners, ReplicaShareProtocol,
+            ReplicaStatus, ShareReplica, UnshareReplica, Volume, VolumeId,
         },
     },
 };
@@ -52,6 +52,15 @@ async fn pool() {
     let io_engine = cluster.node(0);
     let nodes = node_client.get(Filter::None, false, None).await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
+    let node = nodes.0.first().unwrap();
+    assert_eq!(
+        node.tallies(),
+        Some(&NodeRscCounts {
+            pool_count: 0,
+            replica_count: 0,
+            snapshot_count: 0,
+        })
+    );
 
     let pool = pool_client
         .create(
@@ -78,6 +87,16 @@ async fn pool() {
         pool.config.as_ref().unwrap().definition.snapshot_count,
         Some(0)
     );
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
+    let node = nodes.0.first().unwrap();
+    assert_eq!(
+        node.tallies(),
+        Some(&NodeRscCounts {
+            pool_count: 1,
+            replica_count: 0,
+            snapshot_count: 0,
+        })
+    );
 
     let _pool2 = pool_client
         .create(
@@ -96,6 +115,16 @@ async fn pool() {
         .unwrap();
 
     tracing::info!("Pools: {:?}", pool);
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
+    let node = nodes.0.first().unwrap();
+    assert_eq!(
+        node.tallies(),
+        Some(&NodeRscCounts {
+            pool_count: 2,
+            replica_count: 0,
+            snapshot_count: 0,
+        })
+    );
 
     let pools = pool_client.get(Filter::None, None).await.unwrap();
     tracing::info!("Pools: {:?}", pools);
@@ -135,6 +164,16 @@ async fn pool() {
     assert_eq!(
         pool.config.as_ref().unwrap().definition.snapshot_count,
         Some(0)
+    );
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
+    let node = nodes.0.first().unwrap();
+    assert_eq!(
+        node.tallies(),
+        Some(&NodeRscCounts {
+            pool_count: 2,
+            replica_count: 1,
+            snapshot_count: 0,
+        })
     );
 
     let replicas = rep_client.get(Filter::None, None).await.unwrap();
@@ -252,6 +291,16 @@ async fn pool() {
         pool.config.as_ref().unwrap().definition.snapshot_count,
         Some(0)
     );
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
+    let node = nodes.0.first().unwrap();
+    assert_eq!(
+        node.tallies(),
+        Some(&NodeRscCounts {
+            pool_count: 2,
+            replica_count: 0,
+            snapshot_count: 0,
+        })
+    );
 
     let error = rep_client
         .destroy(
@@ -298,6 +347,16 @@ async fn pool() {
         )
         .await
         .unwrap();
+    let nodes = node_client.get(Filter::None, false, None).await.unwrap();
+    let node = nodes.0.first().unwrap();
+    assert_eq!(
+        node.tallies(),
+        Some(&NodeRscCounts {
+            pool_count: 0,
+            replica_count: 0,
+            snapshot_count: 0,
+        })
+    );
 
     let error = rep_client
         .destroy(

--- a/control-plane/grpc/proto/v1/node/target_node.proto
+++ b/control-plane/grpc/proto/v1/node/target_node.proto
@@ -18,6 +18,25 @@ message Node {
   optional NodeState state = 3;
   // Perceived status of the node.
   optional NodeStatus status = 4;
+  // Node metadata.
+  optional Metadata meta = 5;
+}
+
+message Metadata {
+  ResourceTallies tallies = 1;
+}
+
+message ResourceTallies {
+  /// A tally of all pools configured to reside on this node.
+  uint64 pool_count = 1;
+  // A tally of all replicas configured to reside on this node.
+  // Note that this number may not match the volumes api, as it will include all replicas,
+  // configured to reside in the node, sometimes even the failed ones until such time they are deleted.
+  uint64 repl_count = 2;
+  // A tally of all snapshots configured to reside on this node.
+  // Note that this number may not match the volume-snapshots api, as it will include all snapshots,
+  // configured to reside in the node, sometimes even the failed ones until such time they are deleted.
+  uint64 snap_count = 3;
 }
 
 message NodeSpec {

--- a/control-plane/grpc/src/operations/node/traits.rs
+++ b/control-plane/grpc/src/operations/node/traits.rs
@@ -12,11 +12,11 @@ use stor_port::{
         store::node::{CordonDrainState, CordonedState, DrainState, NodeSpec},
         transport::{
             BlockDevice, DestroyNode, Filesystem, Filter, GetBlockDevices, Node, NodeDeleteResult,
-            NodeId, NodeState, NodeStatus, Partition, SnapshotLossDetail, SnapshotLossInfo,
-            VolumeLossDetail, VolumeLossInfo,
+            NodeId, NodeRscCounts, NodeState, NodeStatus, Partition, SnapshotLossDetail,
+            SnapshotLossInfo, VolumeLossDetail, VolumeLossInfo,
         },
     },
-    TryIntoOption,
+    IntoOption, TryIntoOption,
 };
 
 /// Trait implemented by services which support node operations.
@@ -132,11 +132,20 @@ impl TryFrom<node::Node> for Node {
             }
             None => None,
         };
-        Ok(Node::new(
-            node_grpc_type.node_id.into(),
-            node_spec,
-            node_state,
-        ))
+        Ok(
+            Node::new(node_grpc_type.node_id.into(), node_spec, node_state)
+                .with_rsc(node_grpc_type.meta.and_then(|m| m.tallies.into_opt())),
+        )
+    }
+}
+
+impl From<node::ResourceTallies> for NodeRscCounts {
+    fn from(value: node::ResourceTallies) -> Self {
+        Self {
+            pool_count: value.pool_count,
+            replica_count: value.repl_count,
+            snapshot_count: value.snap_count,
+        }
     }
 }
 
@@ -206,6 +215,13 @@ impl From<Node> for node::Node {
             spec: grpc_node_spec,
             state: grpc_node_state,
             status: Some(node::NodeStatus::from(types_v0_node.status()) as i32),
+            meta: types_v0_node.tallies().map(|c| node::Metadata {
+                tallies: Some(node::ResourceTallies {
+                    pool_count: c.pool_count,
+                    repl_count: c.replica_count,
+                    snap_count: c.snapshot_count,
+                }),
+            }),
         }
     }
 }

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -102,11 +102,15 @@ impl CreateRow for openapi::models::Node {
                 )
             }
         };
+        let tallies = self.meta.as_ref().map(|m| &m.tallies);
         row![
             self.id,
             state.grpc_endpoint,
             statuses,
-            optional_cell(state.version)
+            optional_cell(state.version),
+            optional_cell(tallies.map(|t| t.pool_count)),
+            optional_cell(tallies.map(|t| t.replica_count)),
+            optional_cell(tallies.map(|t| t.snapshot_count)),
         ]
     }
 }

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -58,7 +58,15 @@ lazy_static! {
         "VOLUMES",
         "SNAPSHOTS",
     ];
-    pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS", "VERSION"];
+    pub static ref NODE_HEADERS: Row = row![
+        "ID",
+        "GRPC ENDPOINT",
+        "STATUS",
+        "VERSION",
+        "POOLS",
+        "VOLUMES",
+        "SNAPSHOTS"
+    ];
     pub static ref REPLICA_TOPOLOGIES_PREFIX: Row = row!["VOLUME-ID"];
     pub static ref REPLICA_TOPOLOGY_HEADERS: Row = row![
         "REPLICA-ID",

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3444,12 +3444,42 @@ components:
           $ref: '#/components/schemas/NodeId'
         spec:
           $ref: '#/components/schemas/NodeSpec'
+        meta:
+          $ref: '#/components/schemas/NodeMeta'
         state:
           $ref: '#/components/schemas/NodeState'
         status:
           $ref: '#/components/schemas/NodeStatus'
       required:
         - id
+    NodeMeta:
+      description: Node metadata information
+      type: object
+      properties:
+        tallies:
+          $ref: '#/components/schemas/NodeRscTallies'
+      required:
+        - tallies
+    NodeRscTallies:
+      description: Node resource tallies
+      type: object
+      properties:
+        poolCount:
+          description: A tally of all pools configured on this node
+          type: integer
+          format: uint64
+        replicaCount:
+          description: A tally of all volume-replicas configured on this node
+          type: integer
+          format: uint64
+        snapshotCount:
+          description: A tally of all snapshots configured on this node
+          type: integer
+          format: uint64
+      required:
+        - poolCount
+        - replicaCount
+        - snapshotCount
     PoolStatus:
       description: current status of the pool
       type: string

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -100,6 +100,12 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
     let listed_node = client.nodes_api().get_node(io_engine1.as_str()).await;
     let listed_node = listed_node.unwrap();
     let version = listed_node.spec.as_ref().unwrap().version.clone();
+
+    let pools = client
+        .pools_api()
+        .get_node_pools(&io_engine1)
+        .await
+        .unwrap();
     let mut node = models::Node {
         id: io_engine1.to_string(),
         spec: Some(models::NodeSpec {
@@ -125,10 +131,15 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
             version,
         }),
         status: Some(models::NodeStatus::Online),
+        meta: Some(models::NodeMeta {
+            tallies: models::NodeRscTallies {
+                pool_count: pools.len() as u64,
+                ..Default::default()
+            },
+        }),
     };
     assert_eq!(listed_node, node);
 
-    let _ = client.pools_api().get_pools(None).await.unwrap();
     let pool = client
         .pools_api()
         .put_node_pool(
@@ -442,6 +453,18 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
     if let Some(ref mut spec) = node.spec {
         spec.shutdown = Some(true);
     }
+
+    let pools = client
+        .pools_api()
+        .get_node_pools(&io_engine1)
+        .await
+        .unwrap();
+    node.meta = Some(models::NodeMeta {
+        tallies: models::NodeRscTallies {
+            pool_count: pools.len() as u64,
+            ..Default::default()
+        },
+    });
     assert_eq!(
         client
             .nodes_api()

--- a/control-plane/stor-port/src/types/v0/store/node.rs
+++ b/control-plane/stor-port/src/types/v0/store/node.rs
@@ -206,6 +206,42 @@ pub struct NodeSpec {
     /// If the node has signaled shutdown by sending deregistration message.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     shutdown: bool,
+    /// Node metadata information.
+    #[serde(default, skip_serializing_if = "super::is_default")]
+    pub metadata: NodeMetadata,
+}
+
+/// Node meta information.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct NodeMetadata {
+    /// Persisted metadata information.
+    #[serde(default, skip_serializing_if = "super::is_default")]
+    pub persisted: NodePersistedMetadata,
+    /// Runtime information, useful to quick checks without having to read out from PSTOR
+    /// or any other control-plane related registry.
+    #[serde(skip)]
+    pub runtime: NodeRuntimeMetadata,
+}
+
+/// Node meta information.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct NodePersistedMetadata {}
+
+/// Runtime pool information.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NodeRuntimeMetadata {
+    /// How many replica volumes owned by pools in the node.
+    /// This value is re-generated from the replicas, and then keep track via create/destroy.
+    /// Note that this count may differ from expected, as it tracks resources in
+    /// created and deleting states
+    pub replica_count: u64,
+    /// How many replica snapshots owned by pools in the node.
+    /// This value is re-generated from the volume-snapshots, and then keep track via create/destroy.
+    /// Note that this count may differ from expected, as it tracks resources in
+    /// created and deleting states.
+    pub snapshot_count: u64,
+    /// How many pools are owned by the node.
+    pub pool_count: u64,
 }
 
 impl NodeSpec {
@@ -237,6 +273,7 @@ impl NodeSpec {
             bugfixes,
             version,
             shutdown,
+            metadata: NodeMetadata::default(),
         }
     }
 

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -72,14 +72,46 @@ impl GetNodes {
     }
 }
 
+/// User configuration with user specification and metadata information.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeConfig {
+    /// Specification of the node.
+    pub spec: NodeSpec,
+    /// Node resource counts.
+    pub resources: Option<NodeRscCounts>,
+}
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeRscCounts {
+    /// How many pools are owned by the node.
+    pub pool_count: u64,
+    /// How many replicas are owned by pools on the node.
+    pub replica_count: u64,
+    /// How many snapshots are owned by pools on the node.
+    pub snapshot_count: u64,
+}
+impl From<NodeSpec> for NodeConfig {
+    fn from(spec: NodeSpec) -> Self {
+        Self {
+            resources: Some(NodeRscCounts {
+                pool_count: spec.metadata.runtime.pool_count,
+                replica_count: spec.metadata.runtime.replica_count,
+                snapshot_count: spec.metadata.runtime.snapshot_count,
+            }),
+            spec,
+        }
+    }
+}
+
 /// Node information
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Node {
     /// Node identification
     id: NodeId,
-    /// Specification of the node.
-    spec: Option<NodeSpec>,
+    /// [`NodeConfig`].
+    config: Option<NodeConfig>,
     /// Runtime state of the node.
     state: Option<NodeState>,
 }
@@ -87,7 +119,11 @@ pub struct Node {
 impl Node {
     /// Get new `Self` from the given parameters
     pub fn new(id: NodeId, spec: Option<NodeSpec>, state: Option<NodeState>) -> Self {
-        Self { id, spec, state }
+        Self {
+            id,
+            config: spec.map(NodeConfig::from),
+            state,
+        }
     }
     /// Get the node id
     pub fn id(&self) -> &NodeId {
@@ -99,15 +135,22 @@ impl Node {
     pub fn status(&self) -> NodeStatus {
         match &self.state {
             Some(state) => state.status,
-            None => match &self.spec {
+            None => match self.spec() {
                 Some(spec) if spec.is_shutdown() => NodeStatus::Offline,
                 _ => NodeStatus::Unknown,
             },
         }
     }
+    pub fn take_config(&mut self) -> Option<NodeConfig> {
+        self.config.take()
+    }
     /// Get the node specification
     pub fn spec(&self) -> Option<&NodeSpec> {
-        self.spec.as_ref()
+        self.config.as_ref().map(|config| &config.spec)
+    }
+    /// Get the node specification
+    pub fn spec_mut(&mut self) -> Option<&mut NodeSpec> {
+        self.config.as_mut().map(|config| &mut config.spec)
     }
     /// Get the node runtime state
     pub fn state(&self) -> Option<&NodeState> {
@@ -115,7 +158,7 @@ impl Node {
     }
     /// Set the shutdown flag.
     pub fn with_shutdown(mut self, shutdown: bool) -> Self {
-        if let Some(ref mut spec) = self.spec {
+        if let Some(ref mut spec) = self.spec_mut() {
             spec.set_shutdown(shutdown);
         }
         self
@@ -123,11 +166,12 @@ impl Node {
 }
 
 impl From<Node> for models::Node {
-    fn from(src: Node) -> Self {
+    fn from(mut src: Node) -> Self {
         let status = src.status();
+        let config = src.take_config();
         Self::new_all(
             src.id,
-            src.spec.map(Into::into),
+            config.map(|n| n.spec.into()),
             src.state.map(Into::into),
             Some(status.into()),
         )

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -179,13 +179,29 @@ impl Node {
 impl From<Node> for models::Node {
     fn from(mut src: Node) -> Self {
         let status = src.status();
-        let config = src.take_config();
+        let (spec, meta) = match src.take_config() {
+            None => (None, None),
+            Some(config) => (Some(config.spec), config.resources),
+        };
         Self::new_all(
             src.id,
-            config.map(|n| n.spec.into()),
+            spec.map(Into::into),
+            meta.map(Into::into),
             src.state.map(Into::into),
             Some(status.into()),
         )
+    }
+}
+
+impl From<NodeRscCounts> for models::NodeMeta {
+    fn from(value: NodeRscCounts) -> Self {
+        Self {
+            tallies: models::NodeRscTallies {
+                pool_count: value.pool_count,
+                replica_count: value.replica_count,
+                snapshot_count: value.snapshot_count,
+            },
+        }
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -125,6 +125,13 @@ impl Node {
             state,
         }
     }
+    /// Add the given node resource tallies.
+    pub fn with_rsc(mut self, rsc: Option<NodeRscCounts>) -> Self {
+        if let Some(ref mut config) = self.config.as_mut() {
+            config.resources = rsc;
+        }
+        self
+    }
     /// Get the node id
     pub fn id(&self) -> &NodeId {
         &self.id
@@ -162,6 +169,10 @@ impl Node {
             spec.set_shutdown(shutdown);
         }
         self
+    }
+    /// Get a reference to the node resource counts.
+    pub fn tallies(&self) -> Option<&NodeRscCounts> {
+        self.config.as_ref().and_then(|c| c.resources.as_ref())
     }
 }
 


### PR DESCRIPTION
    feat: add resource tally to the rest-plugin for node objects
    
---

    feat: expose node resource tally on the public api
    
---

    feat: add node resource tallies to the internal service
    
---

    feat(agent/core): add replica and snapshot count to node
    
    Similar to the pool changes, keeps a tally of replica and snapshot count,
    and the pool count, but for the node.
    This will then be exposed by the internal and public api.