### PR TITLE
feat(plugin): add app-nodes subcommand to rest-plugin

### DIFF
--- a/control-plane/plugin/src/lib.rs
+++ b/control-plane/plugin/src/lib.rs
@@ -15,10 +15,10 @@ use crate::{
         RebuildHistory, ReplicaTopology, Scale,
     },
     resources::{
-        blockdevice, cordon, drain, node, pool, snapshot, volume, volume::VolumeTopologiesArgs,
-        ClearErrors, CordonResources, DeleteArgs, DeleteResources, DrainResources, ExpandResources,
-        GetCordonArgs, GetDrainArgs, GetResources, ScaleResources, SetPropertyResources,
-        SetVolumeProperties, UnCordonResources,
+        app_node, blockdevice, cordon, drain, node, pool, snapshot, volume,
+        volume::VolumeTopologiesArgs, ClearErrors, CordonResources, DeleteArgs, DeleteResources,
+        DrainResources, ExpandResources, GetCordonArgs, GetDrainArgs, GetResources, ScaleResources,
+        SetPropertyResources, SetVolumeProperties, UnCordonResources,
     },
 };
 
@@ -185,6 +185,10 @@ impl ExecuteOperation for GetResources {
             GetResources::Nodes(args) => node::Nodes::list(args, &cli_args.output).await,
             GetResources::Node(args) => {
                 node::Node::get(&args.node_id(), args, &cli_args.output).await
+            }
+            GetResources::AppNodes(args) => app_node::AppNodes::list(args, &cli_args.output).await,
+            GetResources::AppNode(args) => {
+                app_node::AppNode::get(&args.node_id, &cli_args.output).await
             }
             GetResources::BlockDevices(bdargs) => {
                 blockdevice::BlockDevice::get_blockdevices(

--- a/control-plane/plugin/src/resources/app_node.rs
+++ b/control-plane/plugin/src/resources/app_node.rs
@@ -1,0 +1,106 @@
+use crate::{
+    operations::{Get, ListWithArgs, PluginResult},
+    resources::{
+        utils,
+        utils::{optional_cell, CreateRow, GetHeaderRow},
+        Error, NodeId,
+    },
+    rest_wrapper::RestClient,
+};
+use async_trait::async_trait;
+use itertools::Itertools;
+use prettytable::Row;
+
+/// App-Nodes resource.
+#[derive(clap::Args, Debug)]
+pub struct AppNodes {}
+
+/// Arguments used when getting an application/csi node.
+#[derive(Debug, Clone, clap::Args)]
+pub struct GetAppNodeArgs {
+    /// Id of the application/csi node.
+    pub(crate) node_id: NodeId,
+}
+
+/// Arguments used when getting all application/csi node.
+#[derive(Debug, Clone, clap::Args)]
+pub struct GetAppNodesArgs {
+    /// Id of the application/csi node.
+    node_id: Option<NodeId>,
+}
+
+// CreateRows being trait for Node would create the rows from the list of
+// Nodes returned from REST call.
+impl CreateRow for openapi::models::AppNode {
+    fn row(&self) -> Row {
+        let labels = self.spec.labels.as_ref().map(|l| {
+            l.iter()
+                .map(|(key, value)| format!("{key}={value}"))
+                .join(",")
+        });
+        let state = self.state.as_ref();
+        row![
+            self.id,
+            state.map(|s| &s.endpoint).unwrap_or(&self.spec.endpoint),
+            state.map(|s| s.status).unwrap_or_default(),
+            optional_cell(labels),
+        ]
+    }
+}
+
+impl GetHeaderRow for openapi::models::AppNode {
+    fn get_header_row(&self) -> Row {
+        utils::APP_NODE_HEADERS.clone()
+    }
+}
+
+#[async_trait(?Send)]
+impl ListWithArgs for AppNodes {
+    type Args = GetAppNodesArgs;
+    async fn list(args: &GetAppNodesArgs, output: &utils::OutputFormat) -> PluginResult {
+        if let Some(node_id) = &args.node_id {
+            return AppNode::get(node_id, output).await;
+        }
+
+        let max_entries = 1024;
+        let mut app_nodes = Vec::with_capacity(max_entries as usize);
+        let client = RestClient::client().app_nodes_api();
+        let mut starting_token = Some(0);
+        while starting_token.is_some() {
+            match client.get_app_nodes(max_entries, starting_token).await {
+                Ok(nodes) => {
+                    let nodes = nodes.into_body();
+                    app_nodes.extend(nodes.entries);
+                    starting_token = nodes.next_token;
+                }
+                Err(source) => {
+                    return Err(Error::ListNodesError { source });
+                }
+            }
+        }
+
+        utils::print_table(output, app_nodes);
+        Ok(())
+    }
+}
+
+/// Node resource.
+#[derive(clap::Args, Debug)]
+pub struct AppNode {}
+
+#[async_trait(?Send)]
+impl Get for AppNode {
+    type ID = NodeId;
+    async fn get(id: &Self::ID, output: &utils::OutputFormat) -> PluginResult {
+        match RestClient::client().app_nodes_api().get_app_node(id).await {
+            Ok(node) => {
+                utils::print_table(output, node.into_body());
+                Ok(())
+            }
+            Err(source) => Err(Error::GetNodeError {
+                id: id.to_owned(),
+                source,
+            }),
+        }
+    }
+}

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -1,4 +1,5 @@
 use crate::resources::{
+    app_node::{GetAppNodeArgs, GetAppNodesArgs},
     blockdevice::BlockDeviceArgs,
     node::{DrainNodeArgs, GetNodeArgs, GetNodesArgs},
     pool::{GetPoolArgs, GetPoolsArgs},
@@ -6,6 +7,7 @@ use crate::resources::{
     volume::{VolumeTopologiesArgs, VolumeTopologyArgs, VolumesArgs},
 };
 
+pub mod app_node;
 pub mod blockdevice;
 pub mod cordon;
 pub mod drain;
@@ -61,6 +63,10 @@ pub enum GetResources {
     Nodes(GetNodesArgs),
     /// Get node with the given ID.
     Node(GetNodeArgs),
+    /// Get all nodes.
+    AppNodes(GetAppNodesArgs),
+    /// Get a given node.
+    AppNode(GetAppNodeArgs),
     /// Get BlockDevices present on the Node. Lists usable devices by default.
     /// Currently, disks having blobstore pools not created by control-plane are also shown as
     /// usable.

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -67,6 +67,7 @@ lazy_static! {
         "VOLUMES",
         "SNAPSHOTS"
     ];
+    pub static ref APP_NODE_HEADERS: Row = row!["ID", "ENDPOINT", "STATUS", "LABELS"];
     pub static ref REPLICA_TOPOLOGIES_PREFIX: Row = row!["VOLUME-ID"];
     pub static ref REPLICA_TOPOLOGY_HEADERS: Row = row![
         "REPLICA-ID",

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -5110,8 +5110,8 @@ components:
             Deemed Status of the app node.
           type: string
           enum:
-            - Online
             - Offline
+            - Online
       required:
         - id
         - endpoint

--- a/openapi/templates/default/model.mustache
+++ b/openapi/templates/default/model.mustache
@@ -119,6 +119,19 @@ pub enum {{{enumName}}} {
 {{/allowableValues}}
 }
 
+impl std::fmt::Display for {{{enumName}}} {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str_value = match self {
+            {{#allowableValues}}
+            {{#enumVars}}
+            Self::{{{name}}} => "{{{value}}}",
+            {{/enumVars}}
+            {{/allowableValues}}
+        };
+        write!(f, "{str_value}")
+    }
+}
+
 impl Default for {{{enumName}}} {
     fn default() -> Self {
         Self::{{#allowableValues}}{{#enumVars}}{{#-first}}{{{name}}}{{/-first}}{{/enumVars}}{{/allowableValues}}


### PR DESCRIPTION
    feat(plugin): add app-nodes subcommand to rest-plugin
    
    Displays the public api for AppNodes.
    
---

    refactor: generate display for openapi inline enums
    
    Implement Display for the inline enums, defined in the spec.

