### PR TITLE
fix(csi/controller): add missing type value to cli argument

### DIFF
--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -135,6 +135,7 @@ async fn main() -> anyhow::Result<()> {
             Arg::new("tls-client-ca-path")
                 .long("tls-client-ca-path")
                 .help("path to the CA certificate file")
+                .value_parser(clap::value_parser!(std::path::PathBuf))
         )
         .get_matches();
 


### PR DESCRIPTION
Missing type value parse on the tls client certificate path. todo: convert to clap derive to avoid these issues...