### PR TITLE
build: remove openssl and ring dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,8 +131,6 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "futures-core",
- "http 0.2.12",
- "http 1.1.0",
  "impl-more",
  "pin-project-lite",
  "rustls-pki-types",
@@ -308,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -384,9 +382,9 @@ checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
 name = "async-broadcast"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -396,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3bdd6ea595b2ea504500a3566071beb81125fc15d40a6f6bffa43575f64152"
+checksum = "a798aab0c0203b31d67d501e5ed1f3ac6c36a329899ce47fc93c3bea53f3ae89"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -408,10 +406,10 @@ dependencies = [
  "nkeys",
  "nuid",
  "once_cell",
+ "pin-project",
  "portable-atomic",
  "rand",
  "regex",
- "ring",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile",
  "rustls-webpki",
@@ -424,6 +422,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "tokio-websockets",
  "tracing",
  "tryhard",
  "url",
@@ -475,64 +474,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "awc"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79049b2461279b886e46f1107efc347ebecc7b88d74d023dda010551a124967b"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-rt",
- "actix-service",
- "actix-tls",
- "actix-utils",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "cookie",
- "derive_more",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "itoa",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
-]
-
-[[package]]
 name = "aws-lc-rs"
-version = "1.10.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
- "mirai-annotations",
- "paste",
  "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.22.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
- "paste",
 ]
 
 [[package]]
@@ -788,10 +749,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -886,9 +848,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cmake"
-version = "0.1.51"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1477,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1488,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -1564,6 +1526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,21 +1561,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1762,10 +1715,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1870,30 +1821,6 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
-
-[[package]]
-name = "headers"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core",
- "http 1.1.0",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http 1.1.0",
-]
 
 [[package]]
 name = "heck"
@@ -2022,26 +1949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-http-proxy"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d06dbdfbacf34d996c6fb540a71a684a7aae9056c71951163af8a8a4c07b9a4"
-dependencies = [
- "bytes",
- "futures-util",
- "headers",
- "http 1.1.0",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "pin-project-lite",
- "rustls-native-certs 0.7.3",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-named-pipe"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,7 +1973,6 @@ dependencies = [
  "http 1.1.0",
  "hyper",
  "hyper-util",
- "log",
  "rustls",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
@@ -2085,22 +1991,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2506,16 +2396,18 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.0"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64 0.21.7",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
 ]
 
@@ -2586,8 +2478,6 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-http-proxy",
- "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
@@ -2595,8 +2485,6 @@ dependencies = [
  "kube-core",
  "pem",
  "rand",
- "rustls",
- "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -2898,12 +2786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2914,23 +2796,6 @@ name = "mutually_exclusive_features"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
-
-[[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "newline-converter"
@@ -3079,7 +2944,6 @@ version = "1.0.0"
 dependencies = [
  "actix-web",
  "async-trait",
- "awc",
  "dyn-clonable",
  "futures",
  "http-body",
@@ -3087,7 +2951,6 @@ dependencies = [
  "hyper",
  "hyper-body",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "opentelemetry",
  "opentelemetry-http",
@@ -3101,7 +2964,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tower 0.5.1",
  "tower-http",
  "tracing",
@@ -3109,33 +2971,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "webpki",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -3143,18 +2978,6 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -3322,20 +3145,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.7.14"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
- "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.14"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3343,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.14"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3356,11 +3178,10 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.14"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -3866,9 +3687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3951,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -3963,9 +3782,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4026,10 +3845,11 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -4044,10 +3864,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.217"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4628,16 +4457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4694,6 +4513,27 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "httparse",
+ "rand",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5099,12 +4939,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version-info"
 version = "0.1.0"
 dependencies = [
@@ -5221,13 +5055,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
+name = "webpki-roots"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "ring",
- "untrusted 0.9.0",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,16 +57,15 @@ nvmeadm = { path = "./utils/dependencies/nvmeadm" }
 sysfs = { path = "./utils/dependencies/sysfs" }
 composer = { path = "./utils/dependencies/composer", default-features = false }
 
-rustls = { version = "0.23.19", default-features = false }
+rustls = { version = "0.23.19", default-features = false, features = ["aws_lc_rs"] }
 rustls-pemfile = "2.2.0"
 webpki = "0.22.4"
 tokio-native-tls = "0.3.1"
 
 actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
 actix-service = "2.0.3"
-awc = { version = "3.5.1" }
 tinytemplate = "1.2.1"
-jsonwebtoken = "9.3.0"
+jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 
 tokio = { version = "1.45.1", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["net"] }
@@ -144,7 +143,6 @@ hyper = { version = "1.5.0", default-features = false, features = ["client", "ht
 hyper-body = { path = "./utils/hyper-body" }
 http-body-util = { version = "0.1.3", default-features = false }
 hyper-rustls = { version = "0.27.3", default-features = false }
-hyper-tls = { version = "0.6.0" }
 
 udev = "0.9.1"
 sys-mount = { version = "3.0.1", default-features = false }
@@ -157,7 +155,7 @@ flate2 = "1.0"
 tar = "0.4"
 
 k8s-openapi = { version = "0.22.0", default-features = false, features = ["v1_24", "schemars"] }
-kube = { version = "0.94.2", features = ["runtime", "derive"] }
+kube = { version = "0.94.2", default-features = false, features = ["runtime", "derive", "client"] }
 schemars = { version = "0.8.21" }
-async-nats = { version = "0.37.0", default-features = false }
+async-nats = { version = "0.39.0", default-features = false }
 etcd-client = "0.14.0"

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -439,6 +439,7 @@ impl From<ExternalType<v1::nexus::ChildStateReason>> for ChildStateReason {
             v1::nexus::ChildStateReason::NoSpace => Self::NoSpace,
             v1::nexus::ChildStateReason::TimedOut => Self::TimedOut,
             v1::nexus::ChildStateReason::AdminFailed => Self::AdminCommandFailed,
+            v1::nexus::ChildStateReason::HotRemoved => Self::HotRemoved,
         }
     }
 }

--- a/control-plane/grpc/proto/v1/nexus/nexus.proto
+++ b/control-plane/grpc/proto/v1/nexus/nexus.proto
@@ -85,6 +85,7 @@ enum ChildStateReason {
   CHILD_STATE_REASON_NO_SPACE = 9;        // child faulted because I/O operation failed with ENOSPC
   CHILD_STATE_REASON_TIMED_OUT = 10;      // child faulted because I/O operation failed with timeout
   CHILD_STATE_REASON_ADMIN_FAILED = 11;   // child faulted of an admin command failure
+  CHILD_STATE_REASON_HOT_REMOVED = 12;    // child hot-removed under the nexus (ie mistaken lvol destroy or pool hot-removal)
 }
 
 message NexusSpec {

--- a/control-plane/grpc/src/operations/nexus/traits.rs
+++ b/control-plane/grpc/src/operations/nexus/traits.rs
@@ -243,6 +243,7 @@ impl From<nexus::ChildStateReason> for ChildStateReason {
             nexus::ChildStateReason::NoSpace => Self::NoSpace,
             nexus::ChildStateReason::TimedOut => Self::TimedOut,
             nexus::ChildStateReason::AdminFailed => Self::AdminCommandFailed,
+            nexus::ChildStateReason::HotRemoved => Self::HotRemoved,
         }
     }
 }
@@ -266,6 +267,7 @@ impl From<&ChildStateReason> for nexus::ChildStateReason {
             ChildStateReason::IoError => Self::IoFailure,
             ChildStateReason::ByClient => Self::ByClient,
             ChildStateReason::AdminCommandFailed => Self::AdminFailed,
+            ChildStateReason::HotRemoved => Self::HotRemoved,
         }
     }
 }

--- a/control-plane/plugin/Cargo.toml
+++ b/control-plane/plugin/Cargo.toml
@@ -16,7 +16,6 @@ path = "./src/lib.rs"
 [features]
 default = ["rls"]
 rls = ["openapi/tower-client-rls"]
-tls = ["openapi/tower-client-tls"]
 
 [dependencies]
 tracing = { workspace = true }

--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -26,7 +26,7 @@ async fn main() {
     let cli_args = CliArgs::args();
     let _trace_flush = cli_args.args.init_tracing();
     if let Err(error) = cli_args.execute().await {
-        eprintln!("{error}");
+        eprintln!("{error:?}");
         std::process::exit(-1);
     }
 }

--- a/control-plane/plugin/src/rest_wrapper.rs
+++ b/control-plane/plugin/src/rest_wrapper.rs
@@ -32,10 +32,7 @@ impl RestClient {
             .with_tracing(tracing)
             .build_url(url)
             .map_err(|error| {
-                anyhow::anyhow!(
-                    "Failed to create openapi configuration, Error: '{:?}'",
-                    error
-                )
+                anyhow::anyhow!("Failed to create openapi configuration, Error: '{error:?}'")
             })?;
         Ok(Self {
             uri,

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -35,7 +35,7 @@ snafu = { workspace = true }
 url = { workspace = true }
 http = { workspace = true }
 tinytemplate = { workspace = true }
-jsonwebtoken = { workspace = true }
+jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 stor-port = { path = "../stor-port" }
 utils = { path = "../../utils/utils-lib" }
 humantime = { workspace = true }

--- a/control-plane/stor-port/src/types/v0/transport/child.rs
+++ b/control-plane/stor-port/src/types/v0/transport/child.rs
@@ -168,6 +168,8 @@ pub enum ChildStateReason {
     ByClient,
     /// Admin command failure.
     AdminCommandFailed,
+    /// Children was hot-removed (ie mistaken deletion or pool hot-removed due to disk failure).
+    HotRemoved,
 }
 
 impl From<&ChildStateReason> for Option<models::ChildStateReason> {

--- a/k8s/operators/Cargo.toml
+++ b/k8s/operators/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/lib.rs"
 default = ["rls", "bin"]
 bin = ["openapi", "utils", "anyhow", "chrono", "clap", "futures", "snafu", "tokio", "humantime", "tracing", "strum_macros", "strum"]
 rls = ["openapi/tower-client-rls"]
-tls = ["openapi/tower-client-tls"]
 
 [dependencies]
 # CRD

--- a/k8s/proxy/Cargo.toml
+++ b/k8s/proxy/Cargo.toml
@@ -9,7 +9,6 @@ description = "Kubernetes OpenApi Client via k8s-proxy"
 [features]
 default = ["rls"]
 rls = ["openapi/tower-client-rls"]
-tls = ["openapi/tower-client-tls"]
 
 [dependencies]
 kube-forward = { path = "../forward" }

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -4,7 +4,6 @@
 , lib
 , llvmPackages
 , makeRustPlatform
-, openssl
 , pkg-config
 , protobuf
 , sources
@@ -74,7 +73,7 @@ let
 
     inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE;
     nativeBuildInputs = [ clang pkg-config paperclip which git llvmPackages.bintools ];
-    buildInputs = [ llvmPackages.libclang protobuf openssl.dev systemdMinimal.dev utillinux.dev rdma-core ];
+    buildInputs = [ llvmPackages.libclang protobuf systemdMinimal.dev utillinux.dev rdma-core ];
     doCheck = false;
   };
   release_build = { "release" = true; "debug" = false; };

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -11,16 +11,12 @@ path = "src/lib.rs"
 [features]
 default = ["tower-client-rls", "tower-trace"]
 actix-server = ["actix"]
-actix-client = ["actix", "awc"]
 actix = ["actix-web", "rustls"]
-tower-client-rls = ["tower-client", "rustls_ring"]
-tower-client-tls = ["tower-client", "hyper_tls_feat"]
+tower-client-rls = ["tower-client", "rustls_aws_lc_rs"]
 tower-client = ["tower-hyper"]
 tower-hyper = ["hyper", "tower", "tower-http", "http-body", "futures", "pin-project", "tokio"]
-hyper_tls_feat = ["hyper-tls", "tokio-native-tls"]
-rustls_feat = ["rustls", "webpki", "hyper-rustls"]
+rustls_feat = ["rustls", "hyper-rustls"]
 rustls_aws_lc_rs = ["rustls_feat", "rustls/aws-lc-rs", "hyper-rustls/aws-lc-rs"]
-rustls_ring = ["rustls_feat", "rustls/ring", "hyper-rustls/ring"]
 tower-trace = ["opentelemetry-otlp", "opentelemetry_sdk", "tracing-opentelemetry", "opentelemetry", "opentelemetry-http", "tracing", "tracing-subscriber"]
 
 [dependencies]
@@ -36,7 +32,6 @@ serde_urlencoded = { workspace = true }
 # actix dependencies
 actix-web = { workspace = true, optional = true }
 
-awc = { workspace = true, optional = true }
 # tower and hyper dependencies
 hyper = { workspace = true, features = ["http1", "http2", "client"], optional = true }
 hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2", "tokio", "service"] }
@@ -52,10 +47,7 @@ hyper-body = { workspace = true }
 # SSL
 rustls = { workspace = true, default-features = false, optional = true }
 rustls-pemfile = { workspace = true }
-webpki = { workspace = true, optional = true }
 hyper-rustls = { workspace = true, default-features = false, features = ["rustls-native-certs"], optional = true }
-hyper-tls = { workspace = true, optional = true }
-tokio-native-tls = { workspace = true, optional = true }
 # tracing and telemetry
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }

--- a/openapi/templates/default/Cargo.mustache
+++ b/openapi/templates/default/Cargo.mustache
@@ -10,14 +10,12 @@ path = "src/lib.rs"
 [features]
 default = [ "tower-client-rls", "tower-trace" ]
 actix-server = [ "actix" ]
-actix-client = [ "actix", "actix-web-opentelemetry", "awc" ]
 actix = [ "actix-web", "rustls" ]
-tower-client-rls = [ "tower-client", "rustls_feat" ]
-tower-client-tls = [ "tower-client", "hyper_tls_feat" ]
+tower-client-rls = [ "tower-client", "rustls_aws_lc_rs" ]
 tower-client = [ "tower-hyper" ]
 tower-hyper = [ "hyper", "tower", "tower-http", "http-body", "futures", "pin-project", "tokio" ]
-hyper_tls_feat = [ "hyper-tls", "tokio-native-tls" ]
-rustls_feat = [ "rustls", "webpki", "hyper-rustls" ]
+rustls_feat = [ "rustls", "hyper-rustls" ]
+rustls_aws_lc_rs = ["rustls_feat", "rustls/aws-lc-rs", "hyper-rustls/aws-lc-rs"]
 tower-trace = [ "opentelemetry-jaeger", "tracing-opentelemetry", "opentelemetry", "opentelemetry-http", "tracing", "tracing-subscriber" ]
 
 [dependencies]
@@ -32,8 +30,6 @@ serde_urlencoded = "0.7"
 
 # actix dependencies
 actix-web = { version = "4.4.0", features = ["rustls-0_21"], optional = true }
-actix-web-opentelemetry = { version = "0.17.0", optional = true }
-awc = { version = "3.2.0", optional = true }
 
 # tower and hyper dependencies
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ], optional = true }
@@ -47,10 +43,7 @@ pin-project = { version = "1.1.3", optional = true }
 # SSL
 rustls = { version = "0.21.12", optional = true, features = [ "dangerous_configuration" ] }
 rustls-pemfile = "1.0.3"
-webpki = { version = "0.22.2", optional = true }
 hyper-rustls = { version = "0.24.1", optional = true }
-hyper-tls = { version = "0.5.0", optional = true }
-tokio-native-tls = { version = "0.3.1", optional = true }
 
 # tracing and telemetry
 opentelemetry-jaeger = { version = "0.21.0", features = ["rt-tokio-current-thread"], optional = true  }

--- a/openapi/templates/default/actix/mod.mustache
+++ b/openapi/templates/default/actix/mod.mustache
@@ -1,4 +1,2 @@
-#[cfg(feature = "actix-client")]
-pub mod client;
 #[cfg(feature = "actix-server")]
 pub mod server;

--- a/openapi/templates/default/lib.mustache
+++ b/openapi/templates/default/lib.mustache
@@ -16,9 +16,6 @@ pub mod tower {
 
 #[cfg(feature = "actix")]
 pub mod actix {
-    #[cfg(feature = "actix-client")]
-    pub use crate::clients::actix as client;
-
     #[cfg(feature = "actix-server")]
     pub use crate::apis::actix_server as server;
 }

--- a/openapi/templates/default/mod_clients.mustache
+++ b/openapi/templates/default/mod_clients.mustache
@@ -1,9 +1,2 @@
-#[cfg(feature = "actix-client")]
-pub mod actix;
 #[cfg(feature = "tower-client")]
 pub mod tower;
-
-// Enable once we move to rust-2021
-// #[cfg(all(feature = "tower-client-rls", feature = "tower-client-tls"))]
-// compile_error!("feature \"tower-client-rls\" and feature \"tower-client-tls\" cannot be enabled
-// at the same time");

--- a/openapi/templates/default/tower-hyper/client/configuration.mustache
+++ b/openapi/templates/default/tower-hyper/client/configuration.mustache
@@ -283,7 +283,6 @@ impl Configuration {
         trace_requests: bool,
         concurrency_limit: Option<usize>,
     ) -> Result<Self, Error> {
-        #[cfg(all(not(feature = "tower-client-tls"), feature = "tower-client-rls"))]
         let client = {
             match certificate {
                 None => {
@@ -327,46 +326,6 @@ impl Configuration {
                     http.enforce_http(false);
                     let connector =
                         hyper_rustls::HttpsConnector::from((http, std::sync::Arc::new(config)));
-                    url.set_scheme("https").ok();
-                    hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                        .build(connector)
-                }
-            }
-        };
-        #[cfg(feature = "tower-client-tls")]
-        let client = {
-            match certificate {
-                None => {
-                    let mut http = hyper_tls::HttpsConnector::new();
-                    if url.scheme() == "https" {
-                        http.https_only(true);
-                    }
-
-                    let tls = hyper_tls::native_tls::TlsConnector::builder()
-                        .danger_accept_invalid_certs(true)
-                        .build()
-                        .map_err(|_| Error::TlsConnector)?;
-                    let tls = tokio_native_tls::TlsConnector::from(tls);
-
-                    let connector = hyper_tls::HttpsConnector::from((http, tls));
-                    hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                        .build(connector)
-                }
-                Some(bytes) => {
-                    let certificate = hyper_tls::native_tls::Certificate::from_pem(bytes)
-                        .map_err(|_| Error::Certificate)?;
-
-                    let tls = hyper_tls::native_tls::TlsConnector::builder()
-                        .add_root_certificate(certificate)
-                        .danger_accept_invalid_hostnames(true)
-                        .disable_built_in_roots(true)
-                        .build()
-                        .map_err(|_| Error::TlsConnector)?;
-                    let tls = tokio_native_tls::TlsConnector::from(tls);
-
-                    let mut http = hyper_tls::HttpsConnector::new();
-                    http.https_only(true);
-                    let connector = hyper_tls::HttpsConnector::from((http, tls));
                     url.set_scheme("https").ok();
                     hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
                         .build(connector)
@@ -472,10 +431,9 @@ where
     }
 }
 
-#[cfg(all(feature = "tower-client-rls", not(feature = "tower-client-tls")))]
 #[derive(Debug)]
 struct NoCertificateVerification {}
-#[cfg(all(feature = "tower-client-rls", not(feature = "tower-client-tls")))]
+
 impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
     fn verify_server_cert(
         &self,

--- a/shell.nix
+++ b/shell.nix
@@ -40,7 +40,6 @@ mkShellNoCC {
     nixpkgs-fmt
     nix
     openapi-generator-cli
-    openssl
     pkg-config
     utillinux
     which

--- a/utils/utils-lib/Cargo.toml
+++ b/utils/utils-lib/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["rls-ring"]
+default = ["rls"]
 rls = ["event-publisher/rls-aws-lc-rs"]
-rls-ring = ["event-publisher/rls-ring"]
 
 [dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }


### PR DESCRIPTION
Drops hyper-client-tls feature and all related tls feats.
This was used to build the windows kubectl-client but the rls build
now works fine for windows targets, so let's drop it to avoid depending
on the openssl, and it's also good to keep things consistent across targets.

Also drops ring and favours aws-lc-rs. This will eventually make it easier
to use fips algorithms.
