### PR TITLE
build: update dependencies to pick up hot-remove changes

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,6 @@
 export default {
     rules: {
-        'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'example']],
+        'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test', 'example', 'security']],
         'code-review-rule': [2, 'always'],
         "body-max-line-length": [2, "always", 100],
         "footer-leading-blank": [1, "always"],

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -439,6 +439,7 @@ impl From<ExternalType<v1::nexus::ChildStateReason>> for ChildStateReason {
             v1::nexus::ChildStateReason::NoSpace => Self::NoSpace,
             v1::nexus::ChildStateReason::TimedOut => Self::TimedOut,
             v1::nexus::ChildStateReason::AdminFailed => Self::AdminCommandFailed,
+            v1::nexus::ChildStateReason::HotRemoved => Self::HotRemoved,
         }
     }
 }

--- a/control-plane/grpc/proto/v1/nexus/nexus.proto
+++ b/control-plane/grpc/proto/v1/nexus/nexus.proto
@@ -85,6 +85,7 @@ enum ChildStateReason {
   CHILD_STATE_REASON_NO_SPACE = 9;        // child faulted because I/O operation failed with ENOSPC
   CHILD_STATE_REASON_TIMED_OUT = 10;      // child faulted because I/O operation failed with timeout
   CHILD_STATE_REASON_ADMIN_FAILED = 11;   // child faulted of an admin command failure
+  CHILD_STATE_REASON_HOT_REMOVED = 12;    // child hot-removed under the nexus (ie mistaken lvol destroy or pool hot-removal)
 }
 
 message NexusSpec {

--- a/control-plane/grpc/src/operations/nexus/traits.rs
+++ b/control-plane/grpc/src/operations/nexus/traits.rs
@@ -243,6 +243,7 @@ impl From<nexus::ChildStateReason> for ChildStateReason {
             nexus::ChildStateReason::NoSpace => Self::NoSpace,
             nexus::ChildStateReason::TimedOut => Self::TimedOut,
             nexus::ChildStateReason::AdminFailed => Self::AdminCommandFailed,
+            nexus::ChildStateReason::HotRemoved => Self::HotRemoved,
         }
     }
 }
@@ -266,6 +267,7 @@ impl From<&ChildStateReason> for nexus::ChildStateReason {
             ChildStateReason::IoError => Self::IoFailure,
             ChildStateReason::ByClient => Self::ByClient,
             ChildStateReason::AdminCommandFailed => Self::AdminFailed,
+            ChildStateReason::HotRemoved => Self::HotRemoved,
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/child.rs
+++ b/control-plane/stor-port/src/types/v0/transport/child.rs
@@ -168,6 +168,8 @@ pub enum ChildStateReason {
     ByClient,
     /// Admin command failure.
     AdminCommandFailed,
+    /// The child was hot-removed (ie mistaken deletion or pool hot-removed due to disk failure).
+    HotRemoved,
 }
 
 impl From<&ChildStateReason> for Option<models::ChildStateReason> {

--- a/tests/bdd/requirements.txt
+++ b/tests/bdd/requirements.txt
@@ -1,10 +1,10 @@
 pytest-bdd==8.1.0
 python-dateutil==2.9.0
-retrying==1.4.1
-urllib3==2.5.0
+retrying==1.4.2
+urllib3==2.7.0
 docker==7.1.0
-asyncssh==2.21.0
+asyncssh==2.23.0
 python3-etcd3==0.13.0
-requests==2.32.4
-pytest==8.4.1
-pydantic==2.11.7
+requests==2.33.1
+pytest==9.0.3
+pydantic==2.13.4


### PR DESCRIPTION
Since we had to revert the changes, we lost the update for hot-remove, so adding that back in.