### PR TITLE
fix: don't schedule on critical pools

### DIFF
--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/pool.rs
@@ -90,9 +90,10 @@ impl PoolBaseFilters {
             false => item.pool.free_space() > request.size,
         }
     }
-    /// Should only attempt to use usable (not faulted) pools.
+    /// Should only attempt to use usable (not faulted) pools, and with no critical alerts.
     pub(crate) fn usable(_: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
-        item.pool.status != PoolStatus::Faulted && item.pool.status != PoolStatus::Unknown
+        !matches!(item.pool.status, PoolStatus::Faulted | PoolStatus::Unknown)
+            && !item.pool.is_critical()
     }
 
     /// Should only attempt to use uncordoned pools.

--- a/control-plane/agents/src/bin/core/pool/wrapper.rs
+++ b/control-plane/agents/src/bin/core/pool/wrapper.rs
@@ -1,6 +1,8 @@
 use stor_port::types::v0::{
     store::replica::PoolRef,
-    transport::{CtrlPoolState, PoolState, PoolStatus, Protocol, Replica, ReplicaId},
+    transport::{
+        CtrlPoolState, PoolAlertStatus, PoolState, PoolStatus, Protocol, Replica, ReplicaId,
+    },
 };
 
 use std::{cmp::Ordering, ops::Deref};
@@ -145,6 +147,13 @@ impl PoolWrapper {
             replica.share = *share;
             replica.uri = uri.to_string();
         }
+    }
+    /// Check if the pool has alert status critical.
+    pub(crate) fn is_critical(&self) -> bool {
+        self.errors
+            .as_ref()
+            .map(|e| e.alerts.status == PoolAlertStatus::Critical)
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
Don't try to schedule on critical pools, since we don't expect a good outcome anyway.

Much more than this will be needed, as we should not even try to issue any I/O.
Data-plane itself should also avoid any gRPC timing out when it knows the pool is stalled anyway..