### PR TITLE
ci: don't comment from crd wf on fork PRs

### DIFF
--- a/.github/workflows/crds.yaml
+++ b/.github/workflows/crds.yaml
@@ -68,6 +68,7 @@ jobs:
           echo "Validation successful: No breaking changes detected."
 
       - name: Check changed files before commenting
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
         id: changes
         uses: dorny/paths-filter@v3
         with:
@@ -76,7 +77,7 @@ jobs:
               - 'k8s/**'
 
       - name: Add PR comment to update snapshot if required
-        if: ${{ success() && github.event_name == 'pull_request' && steps.changes.outputs.crd == 'true' }}
+        if: ${{ success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && steps.changes.outputs.crd == 'true' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- When PRs are raised from fork, the crds workflow fails.

Ref:- #1100 