### PR TITLE
fix(reconciler): resize undersized replicas before retrying nexus resize

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -36,7 +36,8 @@ use stor_port::{
         },
         transport::{
             Child, ChildUri, CreateNexus, Nexus, NexusChildActionContext, NexusShareProtocol,
-            NexusStatus, NodeStatus, ReplicaId, ResizeNexus, ShareNexus, UnshareNexus,
+            NexusStatus, NodeStatus, ReplicaId, ResizeNexus, ResizeReplica, ShareNexus,
+            UnshareNexus,
         },
     },
 };
@@ -670,6 +671,45 @@ pub(super) async fn fixup_nexus_size(
     // Nexus's size doesn't need any fixup.
     if nexus.as_ref().size == required_size {
         return PollResult::Ok(PollerState::Idle);
+    }
+
+    // Ensure all nexus children (replicas) are at the required size before attempting
+    // nexus resize. Only resize replicas that are actual nexus children — disconnected
+    // volume replicas are handled separately by other reconcilers.
+    for child in nexus
+        .as_ref()
+        .children
+        .iter()
+        .filter_map(|c| c.as_replica_ref())
+    {
+        // Spec size only updates on successful resize, so if it's already at
+        // required size we can skip this child entirely.
+        let Some(rsc) = registry.specs().replica_rsc(child.uuid()) else {
+            continue;
+        };
+        if rsc.lock().size >= required_size {
+            continue;
+        }
+        let mut replica = registry.specs().replica(child.uuid()).await?;
+        let state = registry.replica(child.uuid()).await?;
+        nexus.info(&format!(
+            "Child replica {} is undersized (spec {}B < {}B), resizing before nexus resize",
+            child.uuid(),
+            replica.as_ref().size,
+            required_size
+        ));
+        replica
+            .resize(
+                registry,
+                &ResizeReplica::new(
+                    &state.node,
+                    replica.as_ref().pool_name(),
+                    None,
+                    child.uuid(),
+                    required_size,
+                ),
+            )
+            .await?;
     }
 
     let nexus_state = registry.nexus(nexus.as_ref().uid()).await?;


### PR DESCRIPTION
When a volume resize partially succeeds (some replicas expand, one fails), the nexus reconciler (fixup_nexus_size) retries only the nexus resize which always fails because an undersized child replica blocks it. This creates an infinite retry loop with no self-healing.

This fix adds a replica size check before the nexus resize attempt. If any replica is below the volume spec size, it is resized first. This mirrors the inverse logic already present in the garbage collector (which shrinks over-expanded replicas).

## Problem

Issue described at [#1989](https://github.com/openebs/mayastor/issues/1989) 
When a volume resize partially succeeds (2/3 replicas expand, 1 fails due to transient gRPC error), the volume spec is committed at the new size. The reconciler then retries `resize_nexus` every 5 minutes, which always fails with:

  Child nvmf://... of nexus ... is too small: size = 314572800 x 512, required = 524288000 x 512

No `resize_replica` is ever re-attempted for the stuck replica.

  ## Fix
Before calling `resize_nexus`, iterate over volume replicas and expand any that are undersized. This uses the same pattern as the garbage collector (`volume/garbage_collector.rs`) which already handles the inverse case (shrinking over-expanded replicas).

  ## Testing
  - [x] - nix-shell --run "cargo build --bins" 
  - [x] - nix-shell --run "cargo check -p agents"
  - [ ] -  nix-shell --run "cargo test -p agents -- volume::resize --test-threads=1" - will rely on CI
  - [ ] - Existing tests in agents already cover resize, but I can add dedicated tests if required