### PR TITLE
build: use static CDN to pull crates

### DIFF
--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -80,6 +80,12 @@ let
   release_build = { "release" = true; "debug" = false; };
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ../../../Cargo.lock;
+    # Use static.crates.io (CDN) instead of crates.io/api to avoid the 1 req/sec
+    # rate limit on the API servers, which currently returns intermittent 403s.
+    # See https://github.com/rust-lang/crates.io/issues/13482
+    extraRegistries = {
+      "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
+    };
   };
 in
 let


### PR DESCRIPTION
Use static.crates.io (CDN) instead of crates.io/api to avoid the 1 req/sec rate limit on the API servers, which currently returns intermittent 403s.

This will likely require tweaks further down.