### PR TITLE
cherry pick fixes from release/2.11

### DIFF
--- a/control-plane/csi-driver/src/bin/node/format.rs
+++ b/control-plane/csi-driver/src/bin/node/format.rs
@@ -18,8 +18,13 @@ pub(crate) async fn prepare_device(
 
     let fs_ops = fstype.fs_ops()?;
 
-    if let Ok(fs) = fs {
-        debug!("Found existing filesystem ({}) on device {}", fs, device);
+    if let Ok(ref found_fs) = fs {
+        debug!("Found existing filesystem ({found_fs}) on device {device}");
+        if found_fs != fstype.as_ref() {
+            return Err(format!(
+                "device {device} has filesystem {found_fs} but {fstype} was requested; cross-filesystem restores are not supported"
+            ));
+        }
         if let Some(fs_id) = fs_id {
             debug!("Attempting to set uuid for filesystem {fs_id}, device: {device}");
             fs_ops

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -80,6 +80,12 @@ let
   release_build = { "release" = true; "debug" = false; };
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ../../../Cargo.lock;
+    # Use static.crates.io (CDN) instead of crates.io/api to avoid the 1 req/sec
+    # rate limit on the API servers, which currently returns intermittent 403s.
+    # See https://github.com/rust-lang/crates.io/issues/13482
+    extraRegistries = {
+      "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
+    };
   };
 in
 let


### PR DESCRIPTION
- Use static.crates.io (CDN) instead of crates.io/api to avoid the 1 req/sec rate limit on the API servers, which currently returns intermittent 403s.
- Fail fs ops if the existing fs is different from requested