### PR TITLE
feat(core): offline rebuild for unpublished degraded volumes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/offline_rebuild.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/offline_rebuild.rs
@@ -1,16 +1,25 @@
 use crate::controller::{
     reconciler::{PollContext, TaskPoller},
-    resources::{operations_helper::OperationSequenceGuard, ResourceMutex},
+    resources::{
+        operations::ResourcePublishing, operations_helper::OperationSequenceGuard,
+        OperationGuardArc, ResourceMutex,
+    },
     task_poller::{PollResult, PollerState},
 };
 
-use stor_port::types::v0::{store::volume::VolumeSpec, transport::VolumeStatus};
+use stor_port::types::v0::{
+    store::volume::VolumeSpec,
+    transport::{PublishVolume, UnpublishVolume, VolumeState, VolumeStatus},
+};
 
-/// Offline Volume Rebuild reconciler.
+/// Offline Volume Rebuild.
 ///
-/// Detects unpublished volumes whose replicas have become unhealthy and would
-/// benefit from a rebuild. Iteration 1 only logs eligible candidates; the
-/// actual rebuild action is added in a follow-up iteration.
+/// Detects unpublished volumes whose replicas have become unhealthy and
+/// creates a temporary non-shared nexus so the existing rebuild engine
+/// can restore them. Once rebuild completes, tears the nexus down.
+///
+/// The per-volume grace-period state lives on `VolumeMetadata.runtime` so it
+/// gets cleaned up automatically when the volume is deleted.
 ///
 /// See `designs/replicated-pv/mayastor/offline-volume-rebuild.md` for the
 /// full design.
@@ -41,32 +50,161 @@ impl TaskPoller for OfflineRebuildReconciler {
 
 #[tracing::instrument(
     level = "debug",
-    skip(context, volume_spec),
+    skip_all,
     fields(volume.uuid = %volume_spec.uuid(), request.reconcile = true)
 )]
 async fn offline_rebuild_reconcile(
     volume_spec: &mut ResourceMutex<VolumeSpec>,
     context: &PollContext,
 ) -> PollResult {
-    let volume = match volume_spec.operation_guard() {
+    let mut volume = match volume_spec.operation_guard() {
         Ok(guard) => guard,
         Err(_) => return PollResult::Ok(PollerState::Busy),
     };
 
-    if !volume.as_ref().policy.self_heal
-        || !volume.as_ref().status.created()
-        || volume.as_ref().target().is_some()
-    {
+    if !volume.as_ref().policy.self_heal || !volume.as_ref().status.created() {
         return PollResult::Ok(PollerState::Idle);
     }
 
-    let volume_state = context.registry().volume_state(volume.uuid()).await?;
-    if volume_state.status == VolumeStatus::Degraded {
-        tracing::debug!(
-            volume.uuid = %volume.uuid(),
-            "Unpublished volume is Degraded; eligible for offline rebuild"
-        );
+    // Early bails that don't need the volume state: a real (shared) publish is
+    // not our concern, and a never-published volume has no data to rebuild.
+    let has_offline_rebuild_target = match volume.as_ref().target() {
+        Some(target) => {
+            if target.protocol().is_some() {
+                return PollResult::Ok(PollerState::Idle);
+            }
+            true
+        }
+        None => {
+            if volume.as_ref().health_info_id().is_none() {
+                return PollResult::Ok(PollerState::Idle);
+            }
+            false
+        }
+    };
+
+    // Must use the health-aware state: for an unpublished volume the plain
+    // volume_state() derives status from the replica spec count (unchanged when a
+    // node dies), so it reports Online and we'd never detect the degradation.
+    // volume_state_health() factors in actual online replica health.
+    let volume_state = context
+        .registry()
+        .volume_state_health(volume.uuid())
+        .await?;
+
+    if has_offline_rebuild_target {
+        return teardown_if_rebuilt(&mut volume, &volume_state, context).await;
     }
 
+    // Volume is unpublished with prior health info. Wait for it to actually be
+    // Degraded, then enforce the grace period before initiating rebuild.
+    if volume_state.status != VolumeStatus::Degraded {
+        volume.lock().metadata.clear_offline_rebuild_degraded();
+        return PollResult::Ok(PollerState::Idle);
+    }
+
+    let degraded_for = volume.lock().metadata.offline_rebuild_degraded();
+    let grace_period = context.registry().offline_rebuild_grace_period();
+    if degraded_for < grace_period {
+        tracing::debug!(
+            volume.uuid = %volume.uuid(),
+            remaining = ?grace_period.saturating_sub(degraded_for),
+            "Offline rebuild waiting for grace period"
+        );
+        return PollResult::Ok(PollerState::Busy);
+    }
+
+    initiate_offline_rebuild(&mut volume, context).await
+}
+
+/// Creates a non-shared nexus for the volume so the existing rebuild engine
+/// (HotSpareReconciler) can restore faulted replicas.
+async fn initiate_offline_rebuild(
+    volume: &mut OperationGuardArc<VolumeSpec>,
+    context: &PollContext,
+) -> PollResult {
+    let registry = context.registry();
+
+    // Respect the system-wide rebuild concurrency limit.
+    if registry.rebuild_allowed().await.is_err() {
+        tracing::debug!(
+            volume.uuid = %volume.uuid(),
+            "Offline rebuild deferred: max concurrent rebuilds reached"
+        );
+        return PollResult::Ok(PollerState::Busy);
+    }
+
+    tracing::info!(
+        volume.uuid = %volume.uuid(),
+        "Initiating offline rebuild: creating non-shared nexus"
+    );
+
+    let request = PublishVolume::new(
+        volume.uuid().clone(),
+        None, // auto-select target node (prefers node with healthy replica)
+        None, // share = None → nexus won't be shared
+        Default::default(),
+        vec![],
+        Default::default(),
+    );
+
+    match volume.publish(registry, &request).await {
+        Ok(_) => {
+            tracing::info!(
+                volume.uuid = %volume.uuid(),
+                "Offline rebuild nexus created; HotSpareReconciler will handle the rebuild"
+            );
+            volume.lock().metadata.clear_offline_rebuild_degraded();
+            PollResult::Ok(PollerState::Idle)
+        }
+        Err(error) => {
+            tracing::warn!(
+                volume.uuid = %volume.uuid(),
+                %error,
+                "Failed to create offline rebuild nexus"
+            );
+            PollResult::Ok(PollerState::Idle)
+        }
+    }
+}
+
+/// Tears down the temporary nexus once the volume is fully rebuilt. For any
+/// other state we wait — a stuck or transiently-unavailable nexus is left in
+/// place so we don't churn (creating and destroying repeatedly) or accidentally
+/// tear down a healthy in-progress rebuild during a brief node blip.
+async fn teardown_if_rebuilt(
+    volume: &mut OperationGuardArc<VolumeSpec>,
+    volume_state: &VolumeState,
+    context: &PollContext,
+) -> PollResult {
+    if volume_state.status == VolumeStatus::Online {
+        tracing::info!(
+            volume.uuid = %volume.uuid(),
+            "Offline rebuild complete; tearing down temporary nexus"
+        );
+
+        let request = UnpublishVolume::new(volume.uuid(), false, vec![]);
+        match volume.unpublish(context.registry(), &request).await {
+            Ok(_) => {
+                tracing::info!(
+                    volume.uuid = %volume.uuid(),
+                    "Temporary nexus destroyed; volume returned to unpublished state"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    volume.uuid = %volume.uuid(),
+                    %error,
+                    "Failed to tear down offline rebuild nexus"
+                );
+            }
+        }
+        return PollResult::Ok(PollerState::Idle);
+    }
+
+    // Only `Online` is a clean enough signal to tear the nexus down. Anything
+    // else (Degraded mid-rebuild, transient state during a node blip, etc.)
+    // we wait on — tearing down would either churn against the grace timer
+    // or kill a healthy in-progress rebuild during a brief hiccup.
     PollResult::Ok(PollerState::Idle)
 }

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -128,6 +128,9 @@ pub(crate) struct RegistryInner<S: Store> {
     /// Enable the OfflineRebuildReconciler. Off by default until the
     /// feature is fully tested and ready for general use.
     offline_rebuild_enabled: bool,
+    /// Grace period before initiating an offline rebuild for a degraded
+    /// unpublished volume. Prevents unnecessary rebuilds for transient failures.
+    offline_rebuild_grace_period: std::time::Duration,
 }
 
 impl Registry {
@@ -160,6 +163,7 @@ impl Registry {
         deprecated_access_mode: bool,
         sim_args: Option<SimArgs>,
         offline_rebuild_enabled: bool,
+        offline_rebuild_grace_period: std::time::Duration,
     ) -> Result<Self, SvcError> {
         let store_endpoint = Self::format_store_endpoint(&store_url);
         tracing::info!("Connecting to persistent store at {}", store_endpoint);
@@ -225,6 +229,7 @@ impl Registry {
                 deprecated_access_mode,
                 sim_args,
                 offline_rebuild_enabled,
+                offline_rebuild_grace_period,
             }),
         };
         registry.init().await?;
@@ -363,6 +368,10 @@ impl Registry {
     /// Whether the OfflineRebuildReconciler is enabled.
     pub(crate) fn offline_rebuild_enabled(&self) -> bool {
         self.offline_rebuild_enabled
+    }
+    /// Grace period before initiating an offline rebuild.
+    pub(crate) fn offline_rebuild_grace_period(&self) -> std::time::Duration {
+        self.offline_rebuild_grace_period
     }
     /// Allow for this given time before assuming failure and allowing the pool to get deleted.
     pub(crate) fn pool_async_creat_tmo(&self) -> std::time::Duration {

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -48,10 +48,16 @@ pub(crate) struct CliArgs {
     pub(crate) faulted_child_wait_period: Option<humantime::Duration>,
 
     /// Enable the OfflineRebuildReconciler, which detects unpublished
-    /// volumes with degraded replicas and logs them as rebuild candidates.
-    /// Disabled by default; rebuild action is not yet implemented.
+    /// volumes with degraded replicas and rebuilds them automatically.
+    /// Disabled by default; opt in once the feature is fully tested.
     #[clap(long, env = "OFFLINE_REBUILD_ENABLED")]
     pub(crate) offline_rebuild_enabled: bool,
+
+    /// Grace period before initiating an offline rebuild for a degraded
+    /// unpublished volume. Prevents unnecessary rebuilds when a node is
+    /// temporarily unavailable.
+    #[clap(long, env = "OFFLINE_REBUILD_GRACE_PERIOD", default_value = "10m")]
+    pub(crate) offline_rebuild_grace_period: humantime::Duration,
 
     /// When the pool creation gRPC times out, the actual call in the io-engine
     /// may still progress.
@@ -295,6 +301,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         cli_args.deprecated_access_mode,
         sim_args,
         cli_args.offline_rebuild_enabled,
+        cli_args.offline_rebuild_grace_period.into(),
     )
     .await?;
 

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -7,6 +7,7 @@ mod format_options;
 mod garbage_collection;
 mod helpers;
 mod hotspare;
+mod offline_rebuild;
 mod resize;
 mod rwx;
 mod snapshot;

--- a/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
@@ -1,0 +1,164 @@
+#![cfg(test)]
+
+use super::helpers::wait_till_volume_status;
+use deployer_cluster::ClusterBuilder;
+use std::{collections::HashMap, time::Duration};
+use stor_port::types::v0::{
+    openapi::models::{self, VolumePolicy, VolumeStatus},
+    transport::VolumeId,
+};
+use uuid::Uuid;
+
+const RECONCILE_PERIOD_MS: u64 = 250;
+const GRACE_PERIOD_SECS: u64 = 2;
+const REBUILD_TIMEOUT_SECS: u64 = 30;
+
+/// Happy path: create a 2-replica volume, publish to establish health_info,
+/// unpublish, stop one io-engine node → volume becomes Degraded.
+/// With offline rebuild enabled, the reconciler creates a temp nexus,
+/// HotSpare rebuilds the replica, then the reconciler tears down the nexus.
+/// Final state: volume Online with no target (unpublished).
+#[tokio::test]
+async fn offline_rebuild_happy_path() {
+    let reconcile = Duration::from_millis(RECONCILE_PERIOD_MS);
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_io_engines(3)
+        .with_tmpfs_pool(52428800)
+        .with_cache_period("250ms")
+        .with_reconcile_period(reconcile, reconcile)
+        .with_options(|o| {
+            o.with_isolated_io_engine(true)
+                .with_agents_env("OFFLINE_REBUILD_ENABLED", "true")
+                .with_agents_env(
+                    "OFFLINE_REBUILD_GRACE_PERIOD",
+                    &format!("{GRACE_PERIOD_SECS}s"),
+                )
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let api_client = cluster.rest_v00();
+    let volume_api = api_client.volumes_api();
+
+    let volid = VolumeId::new();
+    let body = models::CreateVolumeBody::new(VolumePolicy::new(true), 2, 10485760u64, false, false);
+    let volume = volume_api.put_volume(&volid, body).await.unwrap();
+    let uid = volume.spec.uuid;
+
+    // Also provision a second volume that is never published. With no
+    // health_info_id the reconciler must never stand up a target for it, even
+    // while the first volume is actively being rebuilt.
+    let never_pub_id = VolumeId::new();
+    let never_pub_body =
+        models::CreateVolumeBody::new(VolumePolicy::new(true), 2, 10485760u64, false, false);
+    let never_pub = volume_api
+        .put_volume(&never_pub_id, never_pub_body)
+        .await
+        .unwrap();
+    let never_pub_uid = never_pub.spec.uuid;
+
+    // Publish to establish health_info_id (nexus info persisted to etcd).
+    let volume = volume_api
+        .put_volume_target(
+            &uid,
+            models::PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                cluster.node(0).to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+                None,
+            ),
+        )
+        .await
+        .expect("Should publish volume");
+
+    assert_eq!(volume.state.status, VolumeStatus::Online);
+
+    // Unpublish — volume returns to no-target state.
+    volume_api
+        .del_volume_target(&uid, None, None)
+        .await
+        .expect("Should unpublish volume");
+
+    let volume = volume_api.get_volume(&uid).await.unwrap();
+    assert!(
+        volume.state.target.is_none(),
+        "Volume should have no target after unpublish"
+    );
+
+    // Stop a node hosting a replica — makes volume Degraded.
+    let replicas = api_client.replicas_api().get_replicas().await.unwrap();
+    let victim_replica = replicas
+        .iter()
+        .find(|r| r.node != cluster.node(0).to_string())
+        .expect("Should have a replica on a non-target node");
+    let victim_node = victim_replica.node.clone();
+
+    cluster
+        .composer()
+        .stop(&victim_node)
+        .await
+        .expect("Should stop io-engine node");
+
+    // Wait for Degraded status.
+    wait_till_volume_status(
+        &cluster,
+        &uid,
+        VolumeStatus::Degraded,
+        Duration::from_secs(10),
+    )
+    .await
+    .expect("Volume should become Degraded");
+
+    // Now wait for grace period + rebuild time. The reconciler should:
+    // 1. Wait for grace period (GRACE_PERIOD_SECS)
+    // 2. Create temporary unshared nexus
+    // 3. HotSpare rebuilds replica onto remaining healthy node's pool
+    // 4. Volume goes Online
+    // 5. Reconciler tears down temporary nexus
+    //
+    // We wait for the volume to return to Online with no target.
+    let timeout = Duration::from_secs(GRACE_PERIOD_SECS + REBUILD_TIMEOUT_SECS);
+    wait_till_volume_online_no_target(&cluster, &uid, timeout)
+        .await
+        .expect("Volume should be Online with no target after offline rebuild");
+
+    // The never-published volume must still have no target — the reconciler
+    // skips it for lack of health_info_id.
+    let never_pub = volume_api.get_volume(&never_pub_uid).await.unwrap();
+    assert!(
+        never_pub.state.target.is_none(),
+        "Never-published volume must not be touched by the offline rebuild reconciler; got {:?}",
+        never_pub.state.target
+    );
+}
+
+/// Wait for volume to reach Online status with no target (nexus torn down).
+async fn wait_till_volume_online_no_target(
+    cluster: &deployer_cluster::Cluster,
+    volume: &Uuid,
+    timeout: Duration,
+) -> Result<(), String> {
+    let start = std::time::Instant::now();
+    loop {
+        let vol = cluster.rest_v00().volumes_api().get_volume(volume).await;
+
+        if let Ok(vol) = vol {
+            if vol.state.status == VolumeStatus::Online && vol.state.target.is_none() {
+                return Ok(());
+            }
+        }
+
+        if std::time::Instant::now() > (start + timeout) {
+            let vol = cluster.rest_v00().volumes_api().get_volume(volume).await;
+            return Err(format!(
+                "Timeout waiting for volume to be Online with no target. Current: {vol:?}"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -321,6 +321,16 @@ impl VolumeMetadata {
     pub fn set_data_loss_warned(&mut self) {
         self.runtime.set_data_loss_warned();
     }
+    /// How long the offline-rebuild reconciler has been seeing this volume as
+    /// Degraded. First call stamps `now` and returns `0`; later calls return
+    /// the elapsed duration since that stamp.
+    pub fn offline_rebuild_degraded(&mut self) -> std::time::Duration {
+        self.runtime.offline_rebuild_degraded()
+    }
+    /// Clear the offline-rebuild degraded mark.
+    pub fn clear_offline_rebuild_degraded(&mut self) {
+        self.runtime.clear_offline_rebuild_degraded();
+    }
 }
 
 /// Volume meta information.
@@ -339,6 +349,10 @@ pub struct VolumeRuntimeMetadata {
     /// Avoids flooding logs once-per-reconcile-tick when a published volume is
     /// stuck with zero replicas after a pool purge.
     data_loss_warned: bool,
+    /// First time the offline-rebuild reconciler observed this volume as
+    /// Degraded; used to enforce the grace period before starting a rebuild.
+    /// Tied to the volume's lifetime so it goes away when the volume is deleted.
+    offline_rebuild_degraded_since: Option<std::time::Instant>,
 }
 impl VolumeRuntimeMetadata {
     /// Check if there's any snapshot.
@@ -352,6 +366,20 @@ impl VolumeRuntimeMetadata {
     /// Mark the data-loss warning as emitted.
     pub fn set_data_loss_warned(&mut self) {
         self.data_loss_warned = true;
+    }
+    /// How long the offline-rebuild reconciler has been seeing this volume as
+    /// Degraded. The first call stamps `now`; subsequent calls return the
+    /// elapsed duration since that stamp. Use `clear_offline_rebuild_degraded`
+    /// to reset.
+    pub fn offline_rebuild_degraded(&mut self) -> std::time::Duration {
+        let now = std::time::Instant::now();
+        let first = *self.offline_rebuild_degraded_since.get_or_insert(now);
+        now.duration_since(first)
+    }
+    /// Clear the offline-rebuild degraded mark (e.g. when the volume is no
+    /// longer Degraded or rebuild has been initiated).
+    pub fn clear_offline_rebuild_degraded(&mut self) {
+        self.offline_rebuild_degraded_since = None;
     }
 }
 


### PR DESCRIPTION
Iteration 2 of offline volume rebuild ([openebs/openebs#4208](https://github.com/openebs/openebs/issues/4208)), builds on the detection-only reconciler from [#1103](https://github.com/openebs/mayastor-control-plane/pull/1103).

When an unpublished volume goes degraded, the reconciler now creates a temporary unshared nexus (target_config with `protocol: None`) after a grace period. That makes the volume look published to the existing HotSpareReconciler, which rebuilds the faulted replicas. Once the volume is Online again, the reconciler tears the nexus down and the volume returns to unpublished.

Key point: no rebuild logic is reimplemented, we lean on HotSpare. We just stand up and tear down the nexus.

New config: `--offline-rebuild-grace-period` (default 10m), behind the existing `--offline-rebuild-enabled` flag.

BDD tests cover happy path, feature-disabled, and never-published precondition.