### PR TITLE
refactor(rest): streamline TLS and JWT authentication across clients

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "nixEnvSelector.nixFile": "${workspaceRoot}/shell.nix"
+    "nixEnvSelector.nixFile": "${workspaceFolder}/shell.nix",
+    "nixEnvSelector.useFlakes": false
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,6 +2651,7 @@ dependencies = [
  "hyper-body",
  "k8s-openapi",
  "kube",
+ "openapi",
  "shutdown",
  "thiserror",
  "tokio",
@@ -3628,6 +3629,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3750,6 +3764,7 @@ dependencies = [
  "jsonwebtoken",
  "num_cpus",
  "once_cell",
+ "rcgen",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -3778,6 +3793,7 @@ dependencies = [
  "humantime",
  "inquire",
  "itertools 0.13.0",
+ "kube-proxy",
  "lazy_static",
  "once_cell",
  "openapi",
@@ -5583,6 +5599,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ rustls = { version = "0.23.19", default-features = false }
 rustls-pemfile = "2.2.0"
 webpki = "0.22.4"
 tokio-native-tls = "0.3.1"
+rcgen = "0.13"
 
 actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
 actix-service = "2.0.3"

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -2,7 +2,10 @@ use crate::CsiControllerConfig;
 use stor_port::types::v0::openapi::{
     client::Error,
     clients,
-    clients::tower::StatusCode,
+    clients::tower::{
+        configuration::{ClientSecurity, TlsMode},
+        StatusCode,
+    },
     models,
     models::{
         rest_json_error::Kind, AffinityGroup, AppNode, CreateVolumeBody, Node, NodeTopology, Pool,
@@ -124,57 +127,30 @@ impl RestApiClient {
         let url = clients::tower::Url::parse(endpoint)
             .map_err(|error| anyhow!("Invalid API endpoint URL {}: {:?}", endpoint, error))?;
         let concurrency_limit = cfg.create_volume_limit() * 2;
-        let ca_certificate_path = cfg.ca_certificate_path();
-        let cert = match ca_certificate_path {
-            Some(path) => {
-                let cert = std::fs::read(path).map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to create openapi configuration at path {}, Error: '{:?}'",
-                        path.display(),
-                        error
-                    )
-                })?;
-                Some(cert)
-            }
-            None => None,
-        };
-        let tower = match (url.scheme(), cert) {
-            ("https", Some(cert)) => clients::tower::Configuration::builder()
-                .with_timeout(Some(cfg.io_timeout()))
-                .with_concurrency_limit(Some(concurrency_limit))
-                .with_certificate(cert.as_slice())
-                .build_url(url)
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to create openapi configuration, Error: '{:?}'",
-                        error
-                    )
-                })?,
-            ("https", None) => {
-                anyhow::bail!("HTTPS endpoint requires a CA certificate path");
-            }
-            (_, Some(_path)) => {
-                anyhow::bail!("CA certificate path is only supported for HTTPS endpoints");
-            }
-            _ => clients::tower::Configuration::builder()
-                .with_timeout(Some(cfg.io_timeout()))
-                .with_concurrency_limit(Some(concurrency_limit))
-                .build_url(url)
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to create openapi configuration, Error: '{:?}'",
-                        error
-                    )
-                })?,
-        };
+        let tls = TlsMode::new(
+            cfg.ca_certificate_path(),
+            cfg.client_certificate_path(),
+            cfg.client_key_path(),
+        )
+        .map_err(|error| anyhow!("Failed to create TLS configuration: {error}"))?;
+        let client_security = ClientSecurity::try_new(cfg.jwt(), tls)
+            .map_err(|error| anyhow!("Failed to read JWT file: {error}"))?;
+
+        let builder = clients::tower::Configuration::builder()
+            .with_timeout(Some(cfg.io_timeout()))
+            .with_concurrency_limit(Some(concurrency_limit))
+            .with_client_security(Some(client_security));
+
+        let tower = builder.build_url(url).map_err(|error| {
+            anyhow::anyhow!("Failed to create openapi configuration, Error: '{error:?}'")
+        })?;
 
         REST_CLIENT.get_or_init(|| Self {
             rest_client: clients::tower::ApiClient::new(tower.clone()),
         });
 
         info!(
-            "API client is initialized with endpoint {}, I/O timeout = {:?}",
-            endpoint,
+            "API client is initialized with endpoint {endpoint}, I/O timeout = {:?}",
             cfg.io_timeout(),
         );
         Ok(())

--- a/control-plane/csi-driver/src/bin/controller/config.rs
+++ b/control-plane/csi-driver/src/bin/controller/config.rs
@@ -1,11 +1,7 @@
 use anyhow::Context;
 use clap::ArgMatches;
 use once_cell::sync::OnceCell;
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 static CONFIG: OnceCell<CsiControllerConfig> = OnceCell::new();
 
@@ -23,6 +19,12 @@ pub(crate) struct CsiControllerConfig {
     force_unstage_volume: bool,
     /// Path to the CA certificate file.
     ca_certificate_path: Option<PathBuf>,
+    /// Path to the TLS client certificate file.
+    client_certificate_path: Option<PathBuf>,
+    /// Path to the TLS client private key file.
+    client_key_path: Option<PathBuf>,
+    /// Path to a file containing the JWT bearer token for REST authentication.
+    jwt: Option<PathBuf>,
 }
 
 impl CsiControllerConfig {
@@ -58,7 +60,10 @@ impl CsiControllerConfig {
             );
         };
 
-        let ca_certificate_path: Option<&PathBuf> = args.get_one::<PathBuf>("tls-client-ca-path");
+        let ca_certificate_path: Option<&PathBuf> = args.get_one::<PathBuf>("tls-ca-file");
+        let client_certificate_path: Option<&PathBuf> = args.get_one::<PathBuf>("tls-cert-file");
+        let client_key_path: Option<&PathBuf> = args.get_one::<PathBuf>("tls-key-file");
+        let jwt = args.get_one::<PathBuf>("jwt").cloned();
 
         CONFIG.get_or_init(|| Self {
             rest_endpoint: rest_endpoint.into(),
@@ -67,6 +72,9 @@ impl CsiControllerConfig {
             create_volume_limit,
             force_unstage_volume,
             ca_certificate_path: ca_certificate_path.cloned(),
+            client_certificate_path: client_certificate_path.cloned(),
+            client_key_path: client_key_path.cloned(),
+            jwt,
         });
         Ok(())
     }
@@ -103,7 +111,22 @@ impl CsiControllerConfig {
     }
 
     /// Path to the CA certificate file.
-    pub(crate) fn ca_certificate_path(&self) -> Option<&Path> {
-        self.ca_certificate_path.as_deref()
+    pub(crate) fn ca_certificate_path(&self) -> Option<&PathBuf> {
+        self.ca_certificate_path.as_ref()
+    }
+
+    /// Path to the TLS client certificate file.
+    pub(crate) fn client_certificate_path(&self) -> Option<&PathBuf> {
+        self.client_certificate_path.as_ref()
+    }
+
+    /// Path to the TLS client private key file.
+    pub(crate) fn client_key_path(&self) -> Option<&PathBuf> {
+        self.client_key_path.as_ref()
+    }
+
+    /// Path to the file containing the JWT bearer token for REST authentication.
+    pub(crate) fn jwt(&self) -> &Option<PathBuf> {
+        &self.jwt
     }
 }

--- a/control-plane/csi-driver/src/bin/controller/identity.rs
+++ b/control-plane/csi-driver/src/bin/controller/identity.rs
@@ -61,7 +61,7 @@ impl rpc::csi::identity_server::Identity for CsiIdentitySvc {
         let ready = match RestApiClient::get_client().list_nodes().await {
             Ok(_) => true,
             Err(ApiClientError::ServerCommunication { .. }) => {
-                error!("Failed to access REST API gateway, CSI Controller plugin is not ready",);
+                error!("Failed to access REST API gateway, CSI Controller plugin is not ready");
                 false
             }
             Err(_) => true,

--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -132,10 +132,30 @@ async fn main() -> anyhow::Result<()> {
                 .help("Enable force unstage volume feature")
         )
         .arg(
-            Arg::new("tls-client-ca-path")
-                .long("tls-client-ca-path")
+            Arg::new("tls-ca-file")
+                .long("tls-ca-file")
                 .help("path to the CA certificate file")
                 .value_parser(clap::value_parser!(std::path::PathBuf))
+        )
+        .arg(
+            Arg::new("tls-cert-file")
+                .long("tls-cert-file")
+                .help("path to the TLS client certificate file")
+                .requires("tls-key-file")
+                .value_parser(clap::value_parser!(std::path::PathBuf))
+        )
+        .arg(
+            Arg::new("tls-key-file")
+                .long("tls-key-file")
+                .help("path to the TLS client private key file")
+                .requires("tls-cert-file")
+                .value_parser(clap::value_parser!(std::path::PathBuf))
+        )
+        .arg(
+            Arg::new("jwt")
+                .long("jwt")
+                .value_parser(clap::value_parser!(std::path::PathBuf))
+                .help("path to a file containing the JWT bearer token for REST authentication")
         )
         .get_matches();
 

--- a/control-plane/csi-driver/src/bin/node/client.rs
+++ b/control-plane/csi-driver/src/bin/node/client.rs
@@ -1,21 +1,17 @@
 use stor_port::types::v0::openapi::{
-    apis::app_nodes_api::tower::client::AppNodesClient,
-    clients,
-    clients::tower::StatusCode,
-    models::{RegisterAppNode, RestJsonError},
-};
-
-use anyhow::anyhow;
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
-use stor_port::types::v0::openapi::{
     apis::{
-        app_nodes_api::tower::client::direct::AppNodes,
+        app_nodes_api::tower::client::{direct::AppNodes, AppNodesClient},
         volumes_api::tower::client::{direct::Volumes, VolumesClient},
     },
-    models::NexusState,
+    clients::{
+        self,
+        tower::{configuration::Configuration, StatusCode},
+    },
+    models::{NexusState, RegisterAppNode, RestJsonError},
 };
+
+use std::sync::Arc;
 use tonic::Status;
-use tracing::info;
 
 #[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq)]
@@ -104,71 +100,11 @@ pub(crate) struct AppNodesClientWrapper {
 }
 
 impl AppNodesClientWrapper {
-    /// Initialize AppNodes API client instance.
-    pub(crate) fn initialize(
-        endpoint: Option<&String>,
-        ca_certificate_path: Option<&PathBuf>,
-    ) -> anyhow::Result<Option<AppNodesClientWrapper>> {
-        const REST_TIMEOUT: Duration = Duration::from_secs(5);
-
-        let Some(endpoint) = endpoint else {
-            return Ok(None);
-        };
-
-        let url = clients::tower::Url::parse(endpoint)
-            .map_err(|error| anyhow!("Invalid API endpoint URL {endpoint}: {error:?}"))?;
-
-        let cert = match ca_certificate_path {
-            Some(path) => {
-                let cert = std::fs::read(path).map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to create openapi configuration at path {}, Error: '{:?}'",
-                        path.display(),
-                        error
-                    )
-                })?;
-                Some(cert)
-            }
-            None => None,
-        };
-
-        let tower = match (url.scheme(), cert) {
-            ("https", Some(cert)) => clients::tower::Configuration::builder()
-                .with_timeout(REST_TIMEOUT)
-                .with_concurrency_limit(Some(10))
-                .with_certificate(&cert)
-                .build_url(url)
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to create openapi configuration***, Error: '{:?}'",
-                        error
-                    )
-                })?,
-            ("https", None) => {
-                anyhow::bail!("HTTPS endpoint requires a CA certificate path");
-            }
-            (_, Some(_path)) => {
-                anyhow::bail!("CA certificate path is only supported for HTTPS endpoints");
-            }
-            _ => clients::tower::Configuration::builder()
-                .with_timeout(REST_TIMEOUT)
-                .with_concurrency_limit(Some(10))
-                .build_url(url)
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to create openapi configuration, Error???: '{:?}'",
-                        error
-                    )
-                })?,
-        };
-
-        info!(
-            "API client is initialized with endpoint {endpoint}, request timeout = {REST_TIMEOUT:?}"
-        );
-
-        Ok(Some(Self {
-            client: AppNodesClient::new(Arc::new(tower)),
-        }))
+    /// Create from a shared configuration.
+    pub(crate) fn new(configuration: Configuration) -> Self {
+        Self {
+            client: AppNodesClient::new(Arc::new(configuration)),
+        }
     }
 
     /// Register an app node.
@@ -176,7 +112,7 @@ impl AppNodesClientWrapper {
         &self,
         app_node_id: &str,
         endpoint: &str,
-        labels: &Option<HashMap<String, String>>,
+        labels: &Option<std::collections::HashMap<String, String>>,
     ) -> Result<(), ApiClientError> {
         self.client
             .register_app_node(
@@ -206,65 +142,11 @@ pub(crate) struct VolumesClientWrapper {
 }
 
 impl VolumesClientWrapper {
-    /// Initialize VolumesClientWrapper instance.
-    pub(crate) fn new(
-        endpoint: &str,
-        ca_certificate_path: Option<PathBuf>,
-    ) -> anyhow::Result<Self> {
-        /// TODO: what's the NodeStage timeout?
-        const REST_TIMEOUT: Duration = Duration::from_secs(10);
-
-        let url = clients::tower::Url::parse(endpoint)
-            .map_err(|error| anyhow!("Invalid API endpoint URL {endpoint}: {error:?}"))?;
-        let cert = match ca_certificate_path {
-            Some(path) => {
-                let cert = std::fs::read(path.clone()).map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to create openapi configuration at path {}, Error: '{:?}'",
-                        path.display(),
-                        error
-                    )
-                })?;
-                Some(cert)
-            }
-            None => None,
-        };
-
-        let config = match (url.scheme(), cert) {
-            ("https", Some(cert)) => clients::tower::Configuration::builder()
-                .with_timeout(REST_TIMEOUT)
-                .with_certificate(&cert)
-                .build_url(url)
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to create openapi configuration***, Error: '{:?}'",
-                        error
-                    )
-                })?,
-            ("https", None) => {
-                anyhow::bail!("HTTPS endpoint requires a CA certificate path");
-            }
-            (_, Some(_path)) => {
-                anyhow::bail!("CA certificate path is only supported for HTTPS endpoints");
-            }
-            _ => clients::tower::Configuration::builder()
-                .with_timeout(REST_TIMEOUT)
-                .build_url(url)
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to create openapi configuration, Error???: '{:?}'",
-                        error
-                    )
-                })?,
-        };
-
-        info!(
-            "VolumesClient API is initialized with endpoint {endpoint}, request timeout = {REST_TIMEOUT:?}"
-        );
-
-        Ok(Self {
-            client: VolumesClient::new(Arc::new(config)),
-        })
+    /// Create from a shared configuration.
+    pub(crate) fn new(configuration: Configuration) -> Self {
+        Self {
+            client: VolumesClient::new(Arc::new(configuration)),
+        }
     }
 
     /// Get the target URI for the given volume.

--- a/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
@@ -262,7 +262,7 @@ impl Attach for NvmfAttach {
                         // If the timeout was higher than nexus's timeout then IOs could
                         // error out earlier than they should. Therefore we should make sure
                         // that timeouts in the nexus are set to a very high value.
-                        tracing::debug!("Setting IO timeout on \"{path_str}\" to {io_timeout}s",);
+                        tracing::debug!("Setting IO timeout on \"{path_str}\" to {io_timeout}s");
                         sysfs::write_value(&path, "io_timeout", 1000 * io_timeout).map_err(
                             |error| {
                                 tracing::error!(%error, path=%path_str, "Failed to set io_timeout to {io_timeout}s");

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -200,11 +200,34 @@ pub(super) async fn main() -> anyhow::Result<()> {
                 .help("Kubelet path on the host system")
         )
         .arg(
-            Arg::new("tls-client-ca-path")
-                .long("tls-client-ca-path")
+            Arg::new("tls-ca-file")
+                .long("tls-ca-file")
                 .value_parser(clap::value_parser!(PathBuf))
                 .requires("enable-rest")
                 .help("path to the CA certificate file")
+        )
+        .arg(
+            Arg::new("tls-cert-file")
+                .long("tls-cert-file")
+                .value_parser(clap::value_parser!(PathBuf))
+                .requires("enable-rest")
+                .requires("tls-key-file")
+                .help("path to the TLS client certificate file")
+        )
+        .arg(
+            Arg::new("tls-key-file")
+                .long("tls-key-file")
+                .value_parser(clap::value_parser!(PathBuf))
+                .requires("enable-rest")
+                .requires("tls-cert-file")
+                .help("path to the TLS client private key file")
+        )
+        .arg(
+            Arg::new("jwt")
+                .long("jwt")
+                .requires("enable-rest")
+                .value_parser(clap::value_parser!(PathBuf))
+                .help("path to a file containing the JWT bearer token for REST authentication")
         )
         .subcommand(
             clap::Command::new("fs-freeze")
@@ -359,11 +382,43 @@ pub(super) async fn main() -> anyhow::Result<()> {
         }
     }
 
+    // Build REST API configuration once, shared by all clients.
+    let rest_config = match matches.get_one::<String>("rest-endpoint") {
+        Some(endpoint) => {
+            use stor_port::types::v0::openapi::clients::tower::{
+                configuration::{ClientSecurity, TlsMode},
+                Url,
+            };
+
+            let url = Url::parse(endpoint)
+                .map_err(|e| anyhow::anyhow!("Invalid REST endpoint URL {endpoint}: {e}"))?;
+            let tls = TlsMode::new(
+                matches.get_one::<PathBuf>("tls-ca-file"),
+                matches.get_one::<PathBuf>("tls-cert-file"),
+                matches.get_one::<PathBuf>("tls-key-file"),
+            )
+            .map_err(|e| anyhow::anyhow!("Failed to create TLS configuration: {e}"))?;
+            let security =
+                ClientSecurity::try_new(&matches.get_one::<PathBuf>("jwt").cloned(), tls)
+                    .map_err(|e| anyhow::anyhow!("Failed to read JWT file: {e}"))?;
+
+            let config = stor_port::types::v0::openapi::clients::tower::Configuration::builder()
+                .with_timeout(std::time::Duration::from_secs(10))
+                .with_concurrency_limit(Some(10))
+                .with_client_security(Some(security))
+                .build_url(url)
+                .map_err(|e| anyhow::anyhow!("Failed to create openapi configuration: {e:?}"))?;
+
+            info!("REST API client configured for endpoint {endpoint}");
+            Some(config)
+        }
+        None => None,
+    };
+
     // Initialize the rest api client.
-    let client = AppNodesClientWrapper::initialize(
-        matches.get_one::<String>("rest-endpoint"),
-        matches.get_one::<PathBuf>("tls-client-ca-path"),
-    )?;
+    let client = rest_config
+        .as_ref()
+        .map(|cfg| AppNodesClientWrapper::new(cfg.clone()));
 
     let registration_enabled = matches.get_flag("enable-registration");
 
@@ -376,7 +431,7 @@ pub(super) async fn main() -> anyhow::Result<()> {
     // enabled.
     *crate::config::config().nvme_as_mut() = TryFrom::try_from(&matches)?;
     let (csi, grpc, registration) = tokio::join!(
-        CsiServer::run(csi_socket, &matches)?,
+        CsiServer::run(csi_socket, &matches, &rest_config)?,
         NodePluginGrpcServer::run(grpc_sock_addr, kubelet_path.to_owned()),
         run_registration_loop(
             node_name.clone(),
@@ -395,6 +450,7 @@ impl CsiServer {
     fn run(
         csi_socket: &str,
         cli_args: &clap::ArgMatches,
+        rest_config: &Option<stor_port::types::v0::openapi::clients::tower::Configuration>,
     ) -> anyhow::Result<impl Future<Output = anyhow::Result<()>>> {
         let node_name = cli_args.get_one::<String>("node-name").expect("required");
         let node_selector = csi_driver::csi_node_selector_parse(
@@ -420,10 +476,9 @@ impl CsiServer {
             UnixListenerStream::new(uds)
         };
 
-        let vol_client = match cli_args.get_one::<String>("rest-endpoint") {
-            Some(ep) if cli_args.get_flag("enable-rest") => {
-                let cert = cli_args.get_one::<PathBuf>("tls-client-ca-path");
-                Some(VolumesClientWrapper::new(ep, cert.cloned())?)
+        let vol_client = match rest_config {
+            Some(cfg) if cli_args.get_flag("enable-rest") => {
+                Some(VolumesClientWrapper::new(cfg.clone()))
             }
             _ => {
                 tracing::warn!("The rest client is not enabled - functionality may be limited");

--- a/control-plane/plugin/Cargo.toml
+++ b/control-plane/plugin/Cargo.toml
@@ -39,6 +39,7 @@ chrono = { workspace = true }
 snafu = { workspace = true }
 inquire = { workspace = true, default-features = false, features = ["crossterm"] }
 itertools = { workspace = true }
+kube-proxy = { path = "../../k8s/proxy" }
 
 [dev-dependencies]
 shutdown_hooks = { workspace = true }

--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
-use openapi::tower::client::Url;
+use openapi::tower::client::{configuration::ClientSecurity, Url};
 
 use plugin::{operations::Operations, rest_wrapper::RestClient, ExecuteOperation};
 use snafu::ResultExt;
-use std::env;
+use std::path::PathBuf;
 
 #[derive(clap::Parser, Debug)]
-#[clap(name = utils::package_description!(), version = utils::version_info_str!())]
+#[clap(name = utils::package_description!(), version = utils::version_info_string!())]
 #[group(skip)]
 struct CliArgs {
     /// The rest endpoint to connect to.
@@ -17,6 +17,22 @@ struct CliArgs {
     #[clap(subcommand)]
     operation: Operations,
 
+    /// Path to the TLS CA certificate bundle used to validate REST server certificates.
+    #[clap(global = true, long)]
+    tls_ca_file: Option<PathBuf>,
+
+    /// Path to the client TLS certificate chain file (PEM) for mTLS.
+    #[clap(global = true, long, requires = "tls_key_file")]
+    tls_cert_file: Option<PathBuf>,
+
+    /// Path to the client TLS private key file (PEM) for mTLS.
+    #[clap(global = true, long, requires = "tls_cert_file")]
+    tls_key_file: Option<PathBuf>,
+
+    /// Path to a file containing the JWT bearer token for REST authentication.
+    #[clap(global = true, long)]
+    jwt: Option<PathBuf>,
+
     #[clap(flatten)]
     args: plugin::CliArgs,
 }
@@ -26,7 +42,7 @@ async fn main() {
     let cli_args = CliArgs::args();
     let _trace_flush = cli_args.args.init_tracing();
     if let Err(error) = cli_args.execute().await {
-        eprintln!("{error}");
+        eprintln!("{error:?}");
         std::process::exit(-1);
     }
 }
@@ -47,12 +63,27 @@ impl CliArgs {
     async fn execute(&self) -> Result<(), Error> {
         // todo: client connection is lazy, we should do sanity connection test here.
         //  Example, we can use use rest liveness probe.
+        let tls = kube_proxy::TlsMode::new(
+            self.tls_ca_file.as_ref(),
+            self.tls_cert_file.as_ref(),
+            self.tls_key_file.as_ref(),
+        )
+        .map_err(anyhow::Error::from)
+        .context(RestClientSnafu)?;
+        let client_security = ClientSecurity::try_new(&self.jwt, tls)
+            .map_err(anyhow::Error::from)
+            .context(RestClientSnafu)?;
+
+        // todo: client connection is lazy, we should do sanity connection test here.
+        //  Example, we can use use rest liveness probe.
         RestClient::init(
             self.rest.clone(),
             self.args.jaeger.is_some(),
             *self.args.timeout,
+            client_security,
         )
         .context(RestClientSnafu)?;
+
         self.operation
             .execute(&self.args)
             .await

--- a/control-plane/plugin/src/resources/tests.rs
+++ b/control-plane/plugin/src/resources/tests.rs
@@ -53,6 +53,7 @@ async fn setup() {
         cluster.rest_url().clone(),
         false,
         Duration::from_millis(200),
+        Default::default(),
     )
     .unwrap();
 

--- a/control-plane/plugin/src/rest_wrapper.rs
+++ b/control-plane/plugin/src/rest_wrapper.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use once_cell::sync::OnceCell;
-use openapi::tower::client::{ApiClient, Configuration, Uri, Url};
+use openapi::tower::client::{configuration::ClientSecurity, ApiClient, Configuration, Uri, Url};
 
 static REST_SERVER: OnceCell<RestClient> = OnceCell::new();
 
@@ -12,8 +12,13 @@ pub struct RestClient {
 
 impl RestClient {
     /// Initialize the URL of the REST server.
-    pub fn init(url: Url, tracing: bool, timeout: std::time::Duration) -> Result<()> {
-        REST_SERVER.get_or_try_init(|| Self::new(url, tracing, timeout))?;
+    pub fn init(
+        url: Url,
+        tracing: bool,
+        timeout: std::time::Duration,
+        tls: ClientSecurity,
+    ) -> Result<()> {
+        REST_SERVER.get_or_try_init(|| Self::new(url, tracing, timeout, tls))?;
         Ok(())
     }
 
@@ -24,19 +29,23 @@ impl RestClient {
     }
 
     /// Create new Rest Client.
-    pub fn new(url: Url, tracing: bool, timeout: std::time::Duration) -> Result<RestClient> {
-        // TODO: Support HTTPS Certificates
+    pub fn new(
+        url: Url,
+        tracing: bool,
+        timeout: std::time::Duration,
+        security: ClientSecurity,
+    ) -> Result<RestClient> {
         let uri = url.as_str().parse()?;
-        let cfg = Configuration::builder()
+
+        let builder = Configuration::builder()
             .with_timeout(timeout)
             .with_tracing(tracing)
-            .build_url(url)
-            .map_err(|error| {
-                anyhow::anyhow!(
-                    "Failed to create openapi configuration, Error: '{:?}'",
-                    error
-                )
-            })?;
+            .with_tls(security.tls)
+            .with_bearer_token(security.jwt);
+
+        let cfg = builder.build_url(url).map_err(|error| {
+            anyhow::anyhow!("Failed to create openapi configuration, Error: '{error:?}'")
+        })?;
         Ok(Self {
             uri,
             client: ApiClient::new(cfg),

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -41,6 +41,7 @@ utils = { path = "../../utils/utils-lib" }
 humantime = { workspace = true }
 grpc = { path = "../grpc" }
 num_cpus = { workspace = true }
+rcgen = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/control-plane/rest/certs/build.sh
+++ b/control-plane/rest/certs/build.sh
@@ -2,6 +2,9 @@
 
 set -xe
 
+SCRIPT_DIR="$(dirname "$0")"
+cd "$SCRIPT_DIR"
+
 rm -rf rsa/
 mkdir -p rsa/
 

--- a/control-plane/rest/service/src/authentication.rs
+++ b/control-plane/rest/service/src/authentication.rs
@@ -29,7 +29,7 @@ pub enum AuthError {
 
 /// Initialize JWK with the contents of the file at 'jwk_path'.
 /// If jwk_path is 'None', authentication is disabled.
-pub fn init(jwk_path: Option<String>) -> JsonWebKey {
+pub fn init(jwk_path: Option<std::path::PathBuf>) -> JsonWebKey {
     match jwk_path {
         Some(path) => {
             let jwk_file = File::open(path).expect("Failed to open JWK file");

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -20,9 +20,14 @@ use actix_web::{
 use clap::Parser;
 use grpc::{client::CoreClient, operations::jsongrpc::client::JsonGrpcClient};
 use http::Uri;
-use rustls::{pki_types::PrivateKeyDer, ServerConfig};
-use rustls_pemfile::{certs, rsa_private_keys};
-use std::{fs::File, io::BufReader, time::Duration};
+use rcgen::generate_simple_self_signed;
+use rustls::{
+    pki_types::{CertificateDer, PrivateKeyDer},
+    server::{danger::ClientCertVerifier, WebPkiClientVerifier},
+    RootCertStore, ServerConfig,
+};
+use rustls_pemfile::{certs, private_key};
+use std::{fs::File, io::BufReader, path::PathBuf, sync::Arc, time::Duration};
 use stor_port::transport_api::{RequestMinTimeout, TimeoutOptions};
 use utils::{
     tracing_telemetry::{FmtLayer, FmtStyle, KeyValue},
@@ -51,16 +56,25 @@ pub(crate) struct CliArgs {
     #[clap(long, short = 'J')]
     json_grpc: Option<Uri>,
 
-    /// Path to the certificate file.
-    #[clap(long, short, required_unless_present = "dummy_certificates")]
-    cert_file: Option<String>,
-    /// Path to the key file.
-    #[clap(long, short, required_unless_present = "dummy_certificates")]
-    key_file: Option<String>,
+    /// Path to the TLS server certificate chain file.
+    #[clap(long = "tls-cert-file", required_unless_present_any = ["dummy_certificates", "auto_tls"])]
+    cert_file: Option<PathBuf>,
+    /// Path to the TLS server private key file.
+    #[clap(long = "tls-key-file", required_unless_present_any = ["dummy_certificates", "auto_tls"])]
+    key_file: Option<PathBuf>,
 
     /// Use dummy HTTPS certificates (for testing).
-    #[clap(long, short, required_unless_present = "cert_file")]
+    #[clap(long, short, required_unless_present_any = ["cert_file", "auto_tls"], conflicts_with_all = ["cert_file", "key_file"])]
     dummy_certificates: bool,
+
+    /// Auto-generate an ephemeral self-signed server certificate for HTTPS.
+    #[clap(long, conflicts_with_all = ["dummy_certificates", "cert_file", "key_file"])]
+    auto_tls: bool,
+
+    /// Path to the certificate authority (CA) bundle used to authenticate TLS clients.
+    /// When specified, TLS client authentication is required.
+    #[clap(long = "tls-ca-file", alias = "client-ca-file")]
+    client_ca_file: Option<PathBuf>,
 
     /// Trace rest requests to the Jaeger endpoint agent.
     #[clap(long, short)]
@@ -68,7 +82,7 @@ pub(crate) struct CliArgs {
 
     /// Path to JSON Web KEY file used for authenticating REST requests.
     #[clap(long, required_unless_present = "no_auth")]
-    jwk: Option<String>,
+    jwk: Option<PathBuf>,
 
     /// Don't authenticate REST requests.
     #[clap(long, required_unless_present = "jwk")]
@@ -151,7 +165,11 @@ where
 }
 
 fn get_certificates() -> anyhow::Result<ServerConfig> {
-    if CliArgs::args().dummy_certificates {
+    let client_ca_file = CliArgs::args().client_ca_file;
+
+    if CliArgs::args().auto_tls {
+        get_auto_certificates(client_ca_file)
+    } else if CliArgs::args().dummy_certificates {
         get_dummy_certificates()
     } else {
         // guaranteed to be `Some` by the require_unless attribute
@@ -159,43 +177,116 @@ fn get_certificates() -> anyhow::Result<ServerConfig> {
         let key_file = CliArgs::args().key_file.expect("key_file is required");
         let cert_file = &mut BufReader::new(File::open(cert_file)?);
         let key_file = &mut BufReader::new(File::open(key_file)?);
-        load_certificates(cert_file, key_file)
+        let mut client_ca = match client_ca_file {
+            Some(path) => Some(BufReader::new(File::open(path)?)),
+            None => None,
+        };
+
+        load_certificates(
+            cert_file,
+            key_file,
+            client_ca
+                .as_mut()
+                .map(|file| file as &mut dyn std::io::BufRead),
+        )
     }
 }
 
 fn get_dummy_certificates() -> anyhow::Result<ServerConfig> {
     let cert_file = &mut BufReader::new(&std::include_bytes!("../../certs/rsa/user.chain")[..]);
     let key_file = &mut BufReader::new(&std::include_bytes!("../../certs/rsa/user.rsa")[..]);
+    let mut client_ca = BufReader::new(&std::include_bytes!("../../certs/rsa/ca.cert")[..]);
 
-    load_certificates(cert_file, key_file)
+    load_certificates(
+        cert_file,
+        key_file,
+        Some(&mut client_ca as &mut dyn std::io::BufRead),
+    )
 }
 
-fn load_certificates<R: std::io::Read>(
-    cert_file: &mut BufReader<R>,
-    key_file: &mut BufReader<R>,
+fn get_auto_certificates(client_ca_file: Option<PathBuf>) -> anyhow::Result<ServerConfig> {
+    let cert_material = generate_simple_self_signed(vec!["localhost".to_string()])
+        .map_err(|error| anyhow::anyhow!("Failed to generate self-signed certificate: {error}"))?;
+
+    let cert_pem = cert_material.cert.pem();
+    let key_pem = cert_material.key_pair.serialize_pem();
+
+    let cert_file = &mut BufReader::new(cert_pem.as_bytes());
+    let key_file = &mut BufReader::new(key_pem.as_bytes());
+    let mut client_ca = match client_ca_file {
+        Some(path) => Some(BufReader::new(File::open(path)?)),
+        None => None,
+    };
+
+    load_certificates(
+        cert_file,
+        key_file,
+        client_ca
+            .as_mut()
+            .map(|file| file as &mut dyn std::io::BufRead),
+    )
+}
+
+fn load_certificates(
+    cert_file: &mut dyn std::io::BufRead,
+    key_file: &mut dyn std::io::BufRead,
+    client_ca_file: Option<&mut dyn std::io::BufRead>,
 ) -> anyhow::Result<ServerConfig> {
     let config = ServerConfig::builder();
-    let cert_chain = certs(cert_file)
+    let cert_chain: Vec<CertificateDer<'static>> = certs(cert_file)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|_| {
-            anyhow::anyhow!("Failed to retrieve certificates from the certificate file",)
+            anyhow::anyhow!("Failed to retrieve certificates from the certificate file")
         })?;
-    let mut keys = rsa_private_keys(key_file)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|_| {
-            anyhow::anyhow!("Failed to retrieve the rsa private keys from the key file",)
+    let key: PrivateKeyDer<'static> = private_key(key_file)
+        .map_err(|_| anyhow::anyhow!("Failed to retrieve private key from the key file"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No private key found in the key file (expected a PEM key like PKCS#8, PKCS#1, or SEC1)"
+            )
         })?;
 
-    if keys.is_empty() {
-        anyhow::bail!("No keys found in the keys file");
-    }
     let config = config
-        .with_no_client_auth()
-        .with_single_cert(cert_chain, PrivateKeyDer::Pkcs1(keys.remove(0)))?;
+        .with_client_cert_verifier(client_cert_verifier(client_ca_file)?)
+        .with_single_cert(cert_chain, key)?;
+
     Ok(config)
 }
 
-fn get_jwk_path() -> Option<String> {
+fn client_cert_verifier(
+    client_ca_file: Option<&mut dyn std::io::BufRead>,
+) -> anyhow::Result<Arc<dyn ClientCertVerifier>> {
+    let Some(ca_file) = client_ca_file else {
+        return Ok(WebPkiClientVerifier::no_client_auth());
+    };
+    let client_certs = certs(ca_file)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| anyhow::anyhow!("Failed to retrieve certificates from client CA file"))?;
+
+    if client_certs.is_empty() {
+        anyhow::bail!("No certificates found in the client CA file");
+    }
+
+    let mut roots = RootCertStore::empty();
+    let (valid, invalid) = roots.add_parsable_certificates(client_certs);
+    if valid == 0 {
+        anyhow::bail!("No valid certificates found in the client CA file");
+    }
+    if invalid > 0 {
+        tracing::warn!(
+            ignored = invalid,
+            "Some certificates from the client CA file were ignored"
+        );
+    }
+
+    WebPkiClientVerifier::builder(Arc::new(roots))
+        .build()
+        .map_err(|error| {
+            anyhow::anyhow!("Failed to configure client certificate verifier: {error}")
+        })
+}
+
+fn get_jwk_path() -> Option<PathBuf> {
     match CliArgs::args().jwk {
         Some(path) => Some(path),
         None => match CliArgs::args().no_auth {

--- a/control-plane/rest/src/lib.rs
+++ b/control-plane/rest/src/lib.rs
@@ -15,7 +15,10 @@
 /// expose different versions of the client
 pub mod versions;
 
-use stor_port::types::v0::openapi::client;
+use stor_port::types::v0::openapi::{
+    client,
+    client::configuration::{ClientSecurity, TlsMode},
+};
 
 /// Tower Rest Client
 #[derive(Clone)]
@@ -55,16 +58,14 @@ impl RestClient {
         bearer_token: Option<String>,
         trace: bool,
     ) -> anyhow::Result<Self> {
-        let cert_file = &std::include_bytes!("../certs/rsa/ca.cert")[..];
+        let client_security = ClientSecurity::new(bearer_token, TlsMode::Auto);
 
         let openapi_client_config =
-            client::Configuration::new(url, timeout, bearer_token, Some(cert_file), trace, None)
-                .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{:?}'", e))?;
-        let openapi_client = client::direct::ApiClient::new(openapi_client_config);
+            client::Configuration::new(url, timeout, Some(client_security), trace, None)
+                .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{e:?}'"))?;
+        let openapi_client_v0 = client::direct::ApiClient::new(openapi_client_config);
 
-        Ok(Self {
-            openapi_client_v0: openapi_client,
-        })
+        Ok(Self { openapi_client_v0 })
     }
     /// creates a new client
     fn new_http(
@@ -73,12 +74,11 @@ impl RestClient {
         bearer_token: Option<String>,
         trace: bool,
     ) -> anyhow::Result<Self> {
+        let client_security = bearer_token.map(|jwt| ClientSecurity::new(Some(jwt), TlsMode::Auto));
         let openapi_client_config =
-            client::Configuration::new(url, timeout, bearer_token, None, trace, None)
-                .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{:?}'", e))?;
-        let openapi_client = client::direct::ApiClient::new(openapi_client_config);
-        Ok(Self {
-            openapi_client_v0: openapi_client,
-        })
+            client::Configuration::new(url, timeout, client_security, trace, None)
+                .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{e:?}'"))?;
+        let openapi_client_v0 = client::direct::ApiClient::new(openapi_client_config);
+        Ok(Self { openapi_client_v0 })
     }
 }

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -64,8 +64,10 @@ fn bearer_token() -> String {
 async fn client() {
     // Run the client test both with and without authentication.
     for auth in &[false, true] {
-        let cluster = test_setup(auth).await;
-        client_test(&cluster, auth).await;
+        {
+            let cluster = test_setup(auth).await;
+            client_test(&cluster, auth).await;
+        }
         // Seems that with otlp we can't simply reinstall a new tracer if running on the same
         // thread. todo: handle this within Cluster build.
         // https://github.com/open-telemetry/opentelemetry-rust/issues/868

--- a/deployer/src/infra/rest.rs
+++ b/deployer/src/infra/rest.rs
@@ -17,7 +17,7 @@ impl ComponentAction for Rest {
                     .status()?;
             }
             let binary = Binary::from_dbg("rest")
-                .with_arg("--dummy-certificates")
+                .with_arg("--auto-tls")
                 .with_args(vec!["--https", "rest:8080"])
                 .with_args(vec!["--http", "rest:8081"])
                 .with_arg("--workers=1");

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -782,7 +782,7 @@ impl ListOptions {
         }
         components.sort_by_key(|a| a.0.clone());
         for (name, ip, command) in components {
-            println!("[{name}] [{ip}] {command}",);
+            println!("[{name}] [{ip}] {command}");
         }
         Ok(())
     }

--- a/k8s/forward/Cargo.toml
+++ b/k8s/forward/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 kube = { workspace = true, features = ["ws"] }
 k8s-openapi = { workspace = true }
+openapi = { workspace = true, default-features = false, features = ["tower-trace"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["net"] }
 futures = { workspace = true }

--- a/k8s/forward/examples/http-forward.rs
+++ b/k8s/forward/examples/http-forward.rs
@@ -10,7 +10,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let selector = kube_forward::TargetSelector::svc_label("app", "api-rest");
-    let target = kube_forward::Target::new(selector, "http", "mayastor");
+    let target = kube_forward::Target::new(selector, "https", "mayastor");
     let uri = kube_forward::HttpForward::new(target, None, kube::Client::try_default().await?)
         .uri()
         .await?;

--- a/k8s/forward/examples/port-forward.rs
+++ b/k8s/forward/examples/port-forward.rs
@@ -3,7 +3,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::fmt().init();
 
     let selector = kube_forward::TargetSelector::svc_label("app", "api-rest");
-    let target = kube_forward::Target::new(selector, "http", "mayastor");
+    let target = kube_forward::Target::new(selector, "https", "mayastor");
     let pf = kube_forward::PortForward::new(target, 30011, kube::Client::try_default().await?);
 
     let (_, handle) = pf.port_forward().await?;

--- a/k8s/forward/src/lib.rs
+++ b/k8s/forward/src/lib.rs
@@ -13,6 +13,7 @@ mod port_forward;
 
 /// Layer 7 proxies.
 pub use http_forward::{HttpForward, HttpProxy};
+use openapi::tower::client::configuration::TlsMode;
 /// Layer 4 proxies.
 pub use port_forward::PortForward;
 
@@ -23,6 +24,128 @@ use anyhow::Context;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::ResourceExt;
 use vx::Pod;
+
+/// Default pod annotation prefix for TLS/JWT material.
+pub const DEFAULT_REST_TLS_PREFIX: &str = "openebs.io/rest";
+
+/// The purpose of a Kubernetes Secret, which determines the expected key names.
+#[derive(Debug, Clone)]
+pub(crate) enum SecretPurpose {
+    Tls(crate::TlsModeAnno),
+    Jwt(crate::AuthModeAnno),
+}
+
+/// TLS mode as specified by pod annotation.
+#[derive(Default, Clone, Copy, Debug)]
+pub(crate) enum TlsModeAnno {
+    #[default]
+    None,
+    Auto,
+    ClientVerify,
+    ServerVerify,
+    Mtls,
+}
+impl From<&str> for TlsModeAnno {
+    fn from(s: &str) -> Self {
+        match s {
+            "none" => Self::None,
+            "auto" => Self::Auto,
+            "client-verify" => Self::ClientVerify,
+            "server-verify" => Self::ServerVerify,
+            "mtls" => Self::Mtls,
+            _ => Self::None,
+        }
+    }
+}
+
+/// Authentication mode as specified by pod annotation.
+#[derive(Default, Clone, Copy, Debug)]
+pub(crate) enum AuthModeAnno {
+    #[default]
+    None,
+    Jwt,
+}
+impl From<&str> for AuthModeAnno {
+    fn from(s: &str) -> Self {
+        match s {
+            "none" => Self::None,
+            "jwt" => Self::Jwt,
+            _ => Self::None,
+        }
+    }
+}
+
+/// A reference to a Kubernetes Secret with fixed key names.
+#[derive(Clone, Debug)]
+pub(crate) struct SecretRef {
+    /// Name of the Kubernetes Secret.
+    pub(crate) name: String,
+    /// Purpose of the Kubernetes Secret (ie tls or auth).
+    pub(crate) kind: SecretPurpose,
+}
+impl SecretRef {
+    /// Create a new `SecretRef` with the given secret name.
+    pub(crate) fn new_tls(name: impl Into<String>, mode: crate::TlsModeAnno) -> Self {
+        Self {
+            name: name.into(),
+            kind: SecretPurpose::Tls(mode),
+        }
+    }
+    /// Create a new `SecretRef` with the given secret name.
+    pub(crate) fn new_jwt(name: impl Into<String>, mode: crate::AuthModeAnno) -> Self {
+        Self {
+            name: name.into(),
+            kind: SecretPurpose::Jwt(mode),
+        }
+    }
+    fn ca_key(&self) -> &str {
+        "ca.crt"
+    }
+    fn cert_key(&self) -> &str {
+        "tls.crt"
+    }
+    fn key_key(&self) -> &str {
+        "tls.key"
+    }
+    fn jwt_key(&self) -> &str {
+        "jwt"
+    }
+}
+
+/// Data fetched from a Kubernetes Secret.
+#[derive(Clone, Default, Debug)]
+pub(crate) struct SecretData {
+    /// CA certificate PEM bytes, if found.
+    pub(crate) ca_certificate: Option<Vec<u8>>,
+    /// Client certificate PEM bytes, if found.
+    pub(crate) client_certificate: Option<Vec<u8>>,
+    /// Client private key PEM bytes, if found.
+    pub(crate) client_key: Option<Vec<u8>>,
+    /// JWT bearer token string, if found.
+    pub(crate) jwt: Option<String>,
+}
+
+impl From<SecretData> for TlsMode {
+    fn from(data: SecretData) -> Self {
+        match (
+            data.ca_certificate,
+            data.client_certificate,
+            data.client_key,
+        ) {
+            (Some(ca_certificate), None, None) => TlsMode::ServerVerify { ca_certificate },
+            (None, Some(client_certificate), Some(client_key)) => TlsMode::ClientVerify {
+                client_certificate,
+                client_key,
+            },
+            (Some(ca_certificate), Some(client_certificate), Some(client_key)) => TlsMode::Mtls {
+                ca_certificate,
+                client_certificate,
+                client_key,
+            },
+            _ => TlsMode::Auto,
+        }
+    }
+}
 
 /// The error exposed.
 pub use crate::error::Error;

--- a/k8s/forward/src/port_forward.rs
+++ b/k8s/forward/src/port_forward.rs
@@ -1,17 +1,18 @@
 use anyhow::Context;
 use futures::{StreamExt, TryStreamExt};
+use openapi::tower::client::configuration::{ClientSecurity, TlsMode};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 
 use crate::{
     pod_selection::{AnyReady, PodSelection},
-    vx::{Pod, Service},
+    vx::{Pod, Secret, Service},
     Error,
 };
 use kube::{
     api::{Api, ListParams},
-    Client,
+    Client, ResourceExt,
 };
 
 /// Used to "proxy" connections to a pod by use of port forwarding.
@@ -22,15 +23,17 @@ use kube::{
 /// let client = kube::Client::try_default().await?;
 /// let pf = kube_forward::PortForward::new(target, 35003, client).await?;
 ///
-/// let (_port, handle) = pf.port_forward().await?;
+/// let (_port, _client_security, handle) = pf.port_forward(true).await?;
 /// handle.await?;
 /// ```
 #[derive(Clone)]
 pub struct PortForward {
     target: crate::Target,
     local_port: Option<u16>,
+    security_prefix: String,
     pod_api: Api<Pod>,
     svc_api: Api<Service>,
+    secret_api: Api<Secret>,
 }
 
 impl PortForward {
@@ -39,13 +42,30 @@ impl PortForward {
     /// * `target` - the target we'll forward to
     /// * `local_port` - specific local port to use, if Some
     pub fn new(target: crate::Target, local_port: impl Into<Option<u16>>, client: Client) -> Self {
+        Self::new_with_secrets(target, local_port, client, None)
+    }
+
+    /// Return a new `Self` with optional REST TLS/JWT secret names.
+    /// Defaults are `rest-tls` and `rest-jwt` when names are not provided.
+    pub fn new_with_secrets(
+        target: crate::Target,
+        local_port: impl Into<Option<u16>>,
+        client: Client,
+        security_prefix: impl Into<Option<String>>,
+    ) -> Self {
         let namespace = target.namespace.name_any();
+        let security_prefix = security_prefix
+            .into()
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(|| crate::DEFAULT_REST_TLS_PREFIX.to_string());
 
         Self {
             target,
             local_port: local_port.into(),
+            security_prefix,
             pod_api: Api::namespaced(client.clone(), &namespace),
-            svc_api: Api::namespaced(client, &namespace),
+            svc_api: Api::namespaced(client.clone(), &namespace),
+            secret_api: Api::namespaced(client, &namespace),
         }
     }
 
@@ -53,6 +73,33 @@ impl PortForward {
     /// Port 0 is special as it tells the kernel to give us the next free port.
     fn local_port(&self) -> u16 {
         self.local_port.unwrap_or(0)
+    }
+
+    /// Runs the port forwarding proxy until a SIGINT signal is received.
+    pub async fn discover_client_security(
+        &self,
+        client_security: &ClientSecurity,
+    ) -> Result<ClientSecurity, Error> {
+        if client_security.discover() {
+            let (_, client_security) = self
+                .finder()
+                .find(&self.target, Some(client_security))
+                .await?;
+            Ok(client_security)
+        } else {
+            Ok(client_security.clone())
+        }
+    }
+
+    /// Runs the port forwarding proxy until a SIGINT signal is received.
+    pub async fn secure_port_forward(
+        self,
+        client_security: &ClientSecurity,
+    ) -> Result<(u16, ClientSecurity, tokio::task::JoinHandle<()>), Error> {
+        let client_security = self.discover_client_security(client_security).await?;
+
+        let (port, task) = self.port_forward().await?;
+        Ok((port, client_security, task))
     }
 
     /// Runs the port forwarding proxy until a SIGINT signal is received.
@@ -100,11 +147,10 @@ impl PortForward {
         ))
     }
     async fn forward_connection(self, mut client_conn: tokio::net::TcpStream) -> Result<(), Error> {
-        let target = self.finder().find(&self.target).await?;
+        let (target, _) = self.finder().find(&self.target, None).await?;
         let (pod_name, pod_port) = target.into_parts();
 
         let mut forwarder = self.pod_api.portforward(&pod_name, &[pod_port]).await?;
-
         let mut upstream_conn = forwarder
             .take_stream(pod_port)
             .context("port not found in forwarder")?;
@@ -130,6 +176,8 @@ impl PortForward {
         TargetPodFinder {
             pod_api: &self.pod_api,
             svc_api: &self.svc_api,
+            secret_api: &self.secret_api,
+            anno_prefix: &self.security_prefix,
         }
     }
 }
@@ -140,25 +188,41 @@ impl PortForward {
 struct TargetPodFinder<'a> {
     pod_api: &'a Api<Pod>,
     svc_api: &'a Api<Service>,
+    secret_api: &'a Api<Secret>,
+    anno_prefix: &'a str,
 }
 impl<'a> TargetPodFinder<'a> {
-    /// Finds the name and port of the target pod specified by the selector.
-    /// # Arguments
-    /// * `target` - the target to be found
-    pub(crate) async fn find(&self, target: &crate::Target) -> Result<crate::TargetPod, Error> {
+    /// Finds the name and port of the target pod specified by the selector,
+    /// and optionally fetches `ClientSecurity` from the resolved pod/service metadata.
+    pub(crate) async fn find(
+        &self,
+        target: &crate::Target,
+        client_security: Option<&ClientSecurity>,
+    ) -> Result<(crate::TargetPod, ClientSecurity), Error> {
         let pod_api = self.pod_api;
         let svc_api = self.svc_api;
         let ready_pod = AnyReady {};
 
+        let security = ClientSecurity::default();
+        let security = client_security.unwrap_or(&security);
+        let fetch_sec = async |pod: &Pod| -> Result<ClientSecurity, Error> {
+            if client_security.is_none() || !security.discover() {
+                return Ok(security.clone());
+            }
+            self.fetch_client_security_from_pod(pod, security).await
+        };
+
         match &target.selector {
             crate::TargetSelector::PodName(name) => {
                 let pod = pod_api.get(name).await?;
-                target.find(&pod, None)
+                let pod_target = target.find(&pod, None)?;
+                Ok((pod_target, fetch_sec(&pod).await?))
             }
             crate::TargetSelector::PodLabel(selector) => {
                 let pods = pod_api.list(&Self::pod_params(selector)).await?;
                 let pod = ready_pod.select(&pods.items, selector)?;
-                target.find(pod, None)
+                let pod_target = target.find(pod, None)?;
+                Ok((pod_target, fetch_sec(pod).await?))
             }
             crate::TargetSelector::ServiceLabel(selector) => {
                 let pods = pod_api.list(&Self::pod_params(selector)).await?;
@@ -167,7 +231,7 @@ impl<'a> TargetPodFinder<'a> {
                 let services = svc_api.list(&Self::svc_params(selector)).await?;
                 let service = match services.items.into_iter().next() {
                     Some(service) => Ok(service),
-                    None => Err(anyhow::anyhow!("Service '{}' not found", selector)),
+                    None => Err(anyhow::anyhow!("Service '{selector}' not found")),
                 }?;
 
                 let svc = service.spec.context("Spec is not defined")?;
@@ -180,9 +244,173 @@ impl<'a> TargetPodFinder<'a> {
                     })
                     .context("No port found in pod")?;
 
-                target.find(pod, port.target_port.map(|p| p.into()))
+                let pod_target = target.find(pod, port.target_port.map(|p| p.into()))?;
+                Ok((pod_target, fetch_sec(pod).await?))
             }
         }
+    }
+
+    /// Fetches `ClientSecurity` from secrets mounted in the resolved pod.
+    async fn fetch_client_security_from_pod(
+        &self,
+        pod: &Pod,
+        security: &ClientSecurity,
+    ) -> Result<ClientSecurity, Error> {
+        let mut security = security.clone();
+        let secret_refs = self.secret_refs_from_pod(pod, &mut security);
+        self.fetch_secret_data_from_refs(secret_refs, security)
+            .await
+    }
+
+    async fn fetch_secret_data_from_refs(
+        &self,
+        secret_refs: Vec<crate::SecretRef>,
+        security: ClientSecurity,
+    ) -> Result<ClientSecurity, Error> {
+        let mut security = security.clone();
+
+        for secret_ref in secret_refs {
+            match secret_ref.kind {
+                crate::SecretPurpose::Tls(ref mode) => {
+                    if matches!(mode, crate::TlsModeAnno::None) {
+                        security.tls = TlsMode::None;
+                        continue;
+                    }
+                    // If the secret is for TLS and the client security doesn't require discovery, skip fetching it.
+                    if !security.tls.is_auto() {
+                        continue;
+                    }
+                    let data = self.read_tls_secret(&secret_ref, mode).await?;
+                    security.tls = TlsMode::from(data);
+                }
+                crate::SecretPurpose::Jwt(ref mode) => {
+                    if matches!(mode, crate::AuthModeAnno::None) {
+                        security.jwt = None;
+                        continue;
+                    }
+                    // If the secret is for JWT and the client security doesn't require discovery, skip fetching it.
+                    if security.jwt.is_some() {
+                        continue;
+                    }
+                    let data = self.read_jwt_secret(&secret_ref, mode).await?;
+                    security.jwt = data.jwt;
+                }
+            }
+        }
+        security.discover = false;
+
+        Ok(security)
+    }
+
+    fn tls_key(&self) -> String {
+        format!("{}-tls", self.anno_prefix)
+    }
+
+    fn auth_key(&self) -> String {
+        format!("{}-auth", self.anno_prefix)
+    }
+
+    fn secret_refs_from_pod(
+        &self,
+        pod: &Pod,
+        security: &mut ClientSecurity,
+    ) -> Vec<crate::SecretRef> {
+        let Some(spec) = pod.spec.as_ref() else {
+            return vec![];
+        };
+        let Some(volumes) = spec.volumes.as_ref() else {
+            return vec![];
+        };
+
+        let pod_anno = pod.annotations();
+        let binding = String::new();
+
+        let tls_mode = pod_anno.get(&self.tls_key()).unwrap_or(&binding);
+        let (tls_mode, tls_name) = tls_mode.split_once(':').unwrap_or((tls_mode.as_str(), ""));
+        let tls_mode = crate::TlsModeAnno::from(tls_mode);
+
+        let jwt_mode = pod_anno.get(&self.auth_key()).unwrap_or(&binding);
+        let (jwt_mode, jwt_name) = jwt_mode.split_once(':').unwrap_or((jwt_mode.as_str(), ""));
+        let jwt_mode = crate::AuthModeAnno::from(jwt_mode);
+
+        if matches!(tls_mode, crate::TlsModeAnno::None) {
+            security.tls = TlsMode::None;
+        }
+        if matches!(jwt_mode, crate::AuthModeAnno::None) {
+            security.jwt = None;
+        }
+
+        let mut secret_refs = Vec::new();
+        for volume in volumes {
+            let Some(secret) = volume.secret.as_ref() else {
+                continue;
+            };
+            let Some(secret_name) = secret.secret_name.as_ref() else {
+                continue;
+            };
+
+            if !matches!(tls_mode, crate::TlsModeAnno::None) && volume.name == tls_name {
+                secret_refs.push(crate::SecretRef::new_tls(secret_name.clone(), tls_mode));
+            }
+            if !matches!(jwt_mode, crate::AuthModeAnno::None) && volume.name == jwt_name {
+                secret_refs.push(crate::SecretRef::new_jwt(secret_name.clone(), jwt_mode));
+            }
+        }
+
+        secret_refs
+    }
+
+    async fn read_tls_secret(
+        &self,
+        secret_ref: &crate::SecretRef,
+        mode: &crate::TlsModeAnno,
+    ) -> Result<crate::SecretData, Error> {
+        if matches!(mode, crate::TlsModeAnno::None | crate::TlsModeAnno::Auto) {
+            return Ok(crate::SecretData::default());
+        }
+
+        let secret = self.secret_api.get(&secret_ref.name).await?;
+        let mut data = secret.data.unwrap_or_default();
+        let get = |key: &str,
+                   data: &mut std::collections::BTreeMap<String, k8s_openapi::ByteString>|
+         -> Option<Vec<u8>> { data.remove(key).map(|b| b.0) };
+        Ok(match mode {
+            crate::TlsModeAnno::None | crate::TlsModeAnno::Auto => crate::SecretData::default(),
+            crate::TlsModeAnno::ClientVerify => crate::SecretData {
+                client_certificate: get(secret_ref.cert_key(), &mut data),
+                client_key: get(secret_ref.key_key(), &mut data),
+                ..Default::default()
+            },
+            crate::TlsModeAnno::ServerVerify => crate::SecretData {
+                ca_certificate: get(secret_ref.ca_key(), &mut data),
+                ..Default::default()
+            },
+            crate::TlsModeAnno::Mtls => crate::SecretData {
+                ca_certificate: get(secret_ref.ca_key(), &mut data),
+                client_certificate: get(secret_ref.cert_key(), &mut data),
+                client_key: get(secret_ref.key_key(), &mut data),
+                ..Default::default()
+            },
+        })
+    }
+    async fn read_jwt_secret(
+        &self,
+        secret_ref: &crate::SecretRef,
+        mode: &crate::AuthModeAnno,
+    ) -> Result<crate::SecretData, Error> {
+        match mode {
+            crate::AuthModeAnno::None => return Ok(crate::SecretData::default()),
+            crate::AuthModeAnno::Jwt => {}
+        }
+        let secret = self.secret_api.get(&secret_ref.name).await?;
+        let mut data = secret.data.unwrap_or_default();
+        let jwt = data
+            .remove(secret_ref.jwt_key())
+            .and_then(|b| String::from_utf8(b.0).ok());
+        Ok(crate::SecretData {
+            jwt,
+            ..Default::default()
+        })
     }
     fn pod_params(selector: &str) -> ListParams {
         ListParams::default()

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -19,7 +19,13 @@ use diskpool::crd::{
 };
 use error::Error;
 use mayastorpool::client::{check_crd, delete, list};
-use openapi::clients::{self, tower::Url};
+use openapi::clients::{
+    self,
+    tower::{
+        configuration::{ClientSecurity, TlsMode},
+        Url,
+    },
+};
 use tracing::{error, info, trace, warn};
 use utils::tracing_telemetry::{FmtLayer, FmtStyle};
 
@@ -34,7 +40,14 @@ use kube::{
     },
     Client, CustomResourceExt, Resource, ResourceExt,
 };
-use std::{collections::HashMap, fs::File, io::Write, path::Path, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 use strum_macros::{Display, EnumString};
 
 const PAGINATION_LIMIT: u32 = 100;
@@ -195,49 +208,23 @@ async fn pool_controller(args: ArgMatches) -> anyhow::Result<()> {
         .expect("timeout value is invalid")
         .into();
 
-    let ca_certificate_path: Option<&str> = args
-        .get_one::<String>("tls-client-ca-path")
-        .map(|x| x.as_str());
-    // take in cert path and make pem file
-    let cert = match ca_certificate_path {
-        Some(path) => {
-            let cert = std::fs::read(path).map_err(|error| {
-                anyhow::anyhow!("Failed to read certificate file, Error: '{:?}'", error)
-            })?;
-            Some(cert)
-        }
-        None => None,
-    };
-    let cfg = match (url.scheme(), cert) {
-        ("https", Some(cert)) => clients::tower::Configuration::new(
-            url,
-            timeout,
-            None,
-            Some(cert.as_slice()),
-            true,
-            None,
-        )
+    let tls = TlsMode::new(
+        args.get_one::<PathBuf>("tls-ca-file"),
+        args.get_one::<PathBuf>("tls-cert-file"),
+        args.get_one::<PathBuf>("tls-key-file"),
+    )
+    .map_err(|error| anyhow::anyhow!("Failed to create TLS configuration, Error: {error:?}"))?;
+    let jwt_file = args.get_one::<PathBuf>("jwt").cloned();
+    let client_security = ClientSecurity::try_new(&jwt_file, tls)
+        .map_err(|error| anyhow::anyhow!("Failed to read JWT file, Error: {error:?}"))?;
+
+    let cfg = clients::tower::Configuration::builder()
+        .with_timeout(timeout)
+        .with_client_security(Some(client_security))
+        .build_url(url)
         .map_err(|error| {
-            anyhow::anyhow!(
-                "Failed to create openapi configuration, Error: '{:?}'",
-                error
-            )
-        })?,
-        ("https", None) => {
-            anyhow::bail!("HTTPS endpoint requires a CA certificate path");
-        }
-        (_, Some(_path)) => {
-            anyhow::bail!("CA certificate path is only supported for HTTPS endpoints");
-        }
-        _ => clients::tower::Configuration::new(url, timeout, None, None, true, None).map_err(
-            |error| {
-                anyhow::anyhow!(
-                    "Failed to create openapi configuration, Error: '{:?}'",
-                    error
-                )
-            },
-        )?,
-    };
+            anyhow::anyhow!("Failed to create openapi configuration, Error: {error:?}")
+        })?;
     let interval = args
         .get_one::<String>("interval")
         .unwrap()
@@ -376,9 +363,30 @@ async fn main() -> anyhow::Result<()> {
                 .help("Enable ansi color for logs"),
         )
         .arg(
-            Arg::new("tls-client-ca-path")
-                .long("tls-client-ca-path")
+            Arg::new("tls-ca-file")
+                .long("tls-ca-file")
+                .value_parser(clap::value_parser!(PathBuf))
                 .help("path to the CA certificate file"),
+        )
+        .arg(
+            Arg::new("tls-cert-file")
+                .long("tls-cert-file")
+                .requires("tls-key-file")
+                .value_parser(clap::value_parser!(PathBuf))
+                .help("path to the TLS client certificate file"),
+        )
+        .arg(
+            Arg::new("tls-key-file")
+                .long("tls-key-file")
+                .requires("tls-cert-file")
+                .value_parser(clap::value_parser!(PathBuf))
+                .help("path to the TLS client private key file"),
+        )
+        .arg(
+            Arg::new("jwt")
+                .long("jwt")
+                .value_parser(clap::value_parser!(PathBuf))
+                .help("path to a file containing the JWT bearer token for REST authentication"),
         )
         .get_matches();
 

--- a/k8s/proxy/src/lib.rs
+++ b/k8s/proxy/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 //! A utility library to facilitate connections to a kubernetes cluster via
 //! the k8s-proxy library.
 
@@ -11,7 +11,7 @@ mod proxy;
 pub use error::Error;
 use kube::config::KubeConfigOptions;
 /// OpenApi client helpers.
-pub use proxy::{ConfigBuilder, ForwardingProxy, LokiClient, Scheme};
+pub use proxy::{ConfigBuilder, ForwardingProxy, LokiClient, Scheme, TlsMode};
 
 /// Get the `kube::Config` from the given kubeconfig file, or the default.
 pub async fn config_from_kubeconfig(

--- a/k8s/proxy/src/proxy.rs
+++ b/k8s/proxy/src/proxy.rs
@@ -3,10 +3,12 @@ use anyhow::anyhow;
 use openapi::{
     apis::Url,
     clients::tower::{Configuration, Uri},
-    tower::client::hyper,
+    tower::client::{configuration::ClientSecurity, hyper},
 };
 use std::{convert::TryFrom, path::PathBuf};
 use tower::{util::BoxService, ServiceExt};
+
+pub use openapi::tower::client::configuration::TlsMode;
 
 /// A builder type for the openapi `Configuration`.
 /// The configuration is tailored for a kubernetes proxy using the `kube_forward::HttpProxy`.
@@ -25,9 +27,11 @@ pub struct ConfigBuilder<T> {
     context: Option<String>,
     target: kube_forward::Target,
     timeout: Option<std::time::Duration>,
-    jwt: Option<String>,
     method: ForwardingProxy,
     scheme: Scheme,
+    /// Prefix for the kind of material for auto-discovery (ie: `rest`).
+    security_prefix: Option<String>,
+    client: Option<kube::Client>,
     builder_target: std::marker::PhantomData<T>,
 }
 
@@ -39,34 +43,45 @@ pub struct Etcd {}
 pub struct Loki {}
 
 /// The scheme component of the URI.
+#[derive(Clone, Debug)]
 pub enum Scheme {
     /// HTTP.
     HTTP,
-    /// HTTPS with/without Certificate.
-    /// todo: What should the certificate format be here?
-    HTTPS(Option<String>),
+    /// HTTPS with optional explicit client-side security material.
+    /// If `ClientSecurity::discover`, security material is discovered from pod secret volumes.
+    HTTPS(ClientSecurity),
 }
 impl Scheme {
-    fn parts(&self) -> (String, Option<&[u8]>) {
+    fn name(&self) -> &'static str {
         match self {
-            Self::HTTP => ("http".to_string(), None),
-            Self::HTTPS(certificate) => (
-                "https".to_string(),
-                certificate.as_ref().map(|i| i.as_bytes()),
-            ),
+            Self::HTTP => "http",
+            Self::HTTPS(_) => "https",
+        }
+    }
+
+    fn client_security(&self) -> Option<&ClientSecurity> {
+        match self {
+            Self::HTTP => None,
+            Self::HTTPS(client_security) => Some(client_security),
         }
     }
 }
-impl From<Scheme> for hyper::http::uri::Scheme {
-    fn from(value: Scheme) -> Self {
+impl From<&Scheme> for hyper::http::uri::Scheme {
+    fn from(value: &Scheme) -> Self {
         match value {
             Scheme::HTTP => hyper::http::uri::Scheme::HTTP,
             Scheme::HTTPS(_) => hyper::http::uri::Scheme::HTTPS,
         }
     }
 }
+impl From<Scheme> for hyper::http::uri::Scheme {
+    fn from(value: Scheme) -> Self {
+        Self::from(&value)
+    }
+}
 
 /// Type of forwarding proxy to use.
+#[derive(Clone, Copy)]
 pub enum ForwardingProxy {
     /// HTTP via the kube-api proxy.
     HTTP,
@@ -77,54 +92,57 @@ pub enum ForwardingProxy {
 impl Default for ConfigBuilder<ApiRest> {
     fn default() -> Self {
         Self {
-            kube_config: None,
-            context: None,
             target: kube_forward::Target::new(
                 kube_forward::TargetSelector::ServiceLabel(utils::API_REST_LABEL.to_string()),
-                utils::API_REST_HTTP_PORT,
+                utils::API_REST_HTTPS_PORT,
                 utils::DEFAULT_NAMESPACE,
             ),
             timeout: Some(std::time::Duration::from_secs(5)),
-            jwt: None,
             method: ForwardingProxy::HTTP,
-            scheme: Scheme::HTTP,
-            builder_target: Default::default(),
+            scheme: Scheme::HTTPS(ClientSecurity::default()),
+            kube_config: None,
+            context: None,
+            security_prefix: None,
+            client: None,
+            builder_target: std::marker::PhantomData,
         }
     }
 }
 impl Default for ConfigBuilder<Etcd> {
     fn default() -> Self {
         Self {
-            kube_config: None,
-            context: None,
             target: kube_forward::Target::new(
                 kube_forward::TargetSelector::PodLabel(utils::ETCD_LABEL.to_string()),
                 utils::ETCD_PORT,
                 utils::DEFAULT_NAMESPACE,
             ),
             timeout: Some(std::time::Duration::from_secs(5)),
-            jwt: None,
             method: ForwardingProxy::TCP,
             scheme: Scheme::HTTP,
-            builder_target: Default::default(),
+            kube_config: None,
+            context: None,
+            security_prefix: None,
+            client: None,
+            builder_target: std::marker::PhantomData,
         }
     }
 }
 impl Default for ConfigBuilder<Loki> {
     fn default() -> Self {
         Self {
-            kube_config: None,
-            context: None,
             target: kube_forward::Target::new(
                 kube_forward::TargetSelector::ServiceLabel(utils::LOKI_LABEL.to_string()),
                 utils::LOKI_PORT,
                 utils::DEFAULT_NAMESPACE,
             ),
             timeout: Some(std::time::Duration::from_secs(5)),
-            jwt: None,
             method: ForwardingProxy::HTTP,
             scheme: Scheme::HTTP,
-            builder_target: Default::default(),
+            kube_config: None,
+            context: None,
+            security_prefix: None,
+            client: None,
+            builder_target: std::marker::PhantomData,
         }
     }
 }
@@ -172,6 +190,11 @@ impl<T> ConfigBuilder<T> {
         self.target = modify(self.target);
         self
     }
+    /// Override the prefix used for TLS and JWT auto-discovery.
+    pub fn with_secret_prefix(mut self, security_prefix: impl Into<Option<String>>) -> Self {
+        self.security_prefix = security_prefix.into();
+        self
+    }
 }
 
 impl ConfigBuilder<ApiRest> {
@@ -190,57 +213,127 @@ impl ConfigBuilder<ApiRest> {
         self.scheme = scheme;
         self
     }
+    /// Move self with the following security information.
+    /// We now default to HTTPS with auto-discovered security, though this is reverted back to
+    /// HTTP if the discovered security is none.
+    pub fn with_security(mut self, security: ClientSecurity) -> Self {
+        self.scheme = Scheme::HTTPS(security);
+        self
+    }
+
+    async fn build_client(&mut self) -> Result<kube::Client, Error> {
+        if let Some(client) = self.client.clone() {
+            Ok(client)
+        } else {
+            let client =
+                super::client_from_kubeconfig(self.kube_config.clone(), self.context.clone())
+                    .await?;
+            self.client = Some(client.clone());
+            Ok(client)
+        }
+    }
+    async fn client(&self) -> Result<kube::Client, Error> {
+        if let Some(client) = self.client.clone() {
+            Ok(client)
+        } else {
+            let client =
+                super::client_from_kubeconfig(self.kube_config.clone(), self.context.clone())
+                    .await?;
+            Ok(client)
+        }
+    }
 
     /// Tries to build a `Configuration` from the current self.
-    pub async fn build(self) -> Result<Configuration, Error> {
-        match self.method {
+    pub async fn build(mut self) -> Result<Configuration, Error> {
+        let mut method = self.method;
+
+        if matches!(method, ForwardingProxy::HTTP) {
+            let client = self.build_client().await?;
+            let pf = self.port_forward(client);
+            if let Scheme::HTTPS(client_security) = &mut self.scheme {
+                *client_security = pf.discover_client_security(client_security).await?;
+
+                // kube-apiserver HTTP proxy can only be used when discovered auth is none, auto-tls and no jwt.
+                if !matches!(client_security.tls, TlsMode::Auto | TlsMode::None)
+                    || client_security.jwt.is_some()
+                {
+                    method = ForwardingProxy::TCP;
+                }
+                // If the api-rest is not configured for tls, then switch to HTTP.
+                if client_security.tls.is_none() {
+                    self.target = self.target.with_port(utils::API_REST_HTTP_PORT);
+                    self.scheme = Scheme::HTTP;
+                }
+            }
+        }
+
+        match method {
             ForwardingProxy::HTTP => self.build_http().await,
             ForwardingProxy::TCP => self.build_tcp().await,
         }
     }
+
     /// Tries to build an HTTP `Configuration` from the current self.
     async fn build_http(self) -> Result<Configuration, Error> {
-        let client = super::client_from_kubeconfig(self.kube_config, self.context).await?;
-        let uri =
-            kube_forward::HttpForward::new(self.target, Some(self.scheme.into()), client.clone())
-                .uri()
-                .await?;
+        let client = self.client().await?;
+        let uri = kube_forward::HttpForward::new(
+            self.target,
+            Some((&self.scheme).into()),
+            client.clone(),
+        )
+        .uri()
+        .await?;
 
         let proxy = kube_forward::HttpProxy::new(client);
 
+        let jwt = match self.scheme.client_security() {
+            Some(client_security) => client_security.jwt.clone(),
+            None => None,
+        };
+
         let config = Configuration::builder()
             .with_timeout(self.timeout)
-            .with_bearer_token(self.jwt)
+            .with_bearer_token(jwt)
             .with_tracing(true)
             .build_with_svc(uri, proxy)
-            .map_err(|e| anyhow!("Failed to Create OpenApi config: {:?}", e))?;
+            .map_err(|e| anyhow!("Failed to Create OpenApi config: {e:?}"))?;
         Ok(config)
     }
     /// Tries to build a TCP `Configuration` from the current self.
     async fn build_tcp(self) -> Result<Configuration, Error> {
-        let client = super::client_from_kubeconfig(self.kube_config, self.context).await?;
+        let client = self.client().await?;
 
-        let pf = kube_forward::PortForward::new(self.target, None, client);
-
-        let (port, _handle) = pf.port_forward().await?;
+        let pf = self.port_forward(client);
+        let (port, client_security, _handle) = pf
+            .secure_port_forward(
+                self.scheme
+                    .client_security()
+                    .unwrap_or(&ClientSecurity::default()),
+            )
+            .await?;
 
         let timeout = self
             .timeout
             .unwrap_or_else(|| std::time::Duration::from_secs(5));
-        let (scheme, certificate) = self.scheme.parts();
+
+        let scheme = self.scheme.name();
         let url = Url::parse(&format!("{scheme}://localhost:{port}"))?;
 
-        let config = Configuration::builder()
+        Configuration::builder()
             .with_timeout(timeout)
-            .with_bearer_token(self.jwt)
-            .with_tracing(true);
-        // todo: fix client to receive option...
-        match certificate {
-            Some(certificate) => config.with_certificate(certificate),
-            None => config,
-        }
-        .build_url(url)
-        .map_err(|e| anyhow!("Failed to Create OpenApi config: {:?}", e).into())
+            .with_bearer_token(client_security.jwt)
+            .with_tracing(true)
+            .with_tls(client_security.tls)
+            .build_url(url)
+            .map_err(|e| anyhow!("Failed to Create OpenApi config: {:?}", e).into())
+    }
+    fn port_forward(&self, client: kube::Client) -> kube_forward::PortForward {
+        kube_forward::PortForward::new_with_secrets(
+            self.target.clone(),
+            None,
+            client,
+            self.security_prefix.clone(),
+        )
     }
 }
 
@@ -249,11 +342,16 @@ impl ConfigBuilder<Etcd> {
     pub async fn build(self) -> Result<Uri, Error> {
         let client = super::client_from_kubeconfig(self.kube_config, self.context).await?;
 
-        let pf = kube_forward::PortForward::new(self.target, None, client);
+        let pf = kube_forward::PortForward::new_with_secrets(
+            self.target,
+            None,
+            client,
+            self.security_prefix,
+        );
 
         let (port, _handle) = pf.port_forward().await?;
 
-        let (scheme, _certificate) = self.scheme.parts();
+        let scheme = self.scheme.name();
         let uri = Uri::try_from(&format!("{scheme}://localhost:{port}"))?;
         Ok(uri)
     }
@@ -311,7 +409,12 @@ impl ConfigBuilder<Loki> {
     async fn build_tcp(self) -> Result<(Uri, LokiClient), Error> {
         let client = super::client_from_kubeconfig(self.kube_config, self.context).await?;
 
-        let pf = kube_forward::PortForward::new(self.target, None, client);
+        let pf = kube_forward::PortForward::new_with_secrets(
+            self.target,
+            None,
+            client,
+            self.security_prefix,
+        );
 
         let (port, _handle) = pf.port_forward().await?;
 
@@ -319,10 +422,10 @@ impl ConfigBuilder<Loki> {
             .timeout
             .unwrap_or_else(|| std::time::Duration::from_secs(5));
 
-        let (scheme, _certificate) = self.scheme.parts();
+        let scheme = self.scheme.name();
         let uri = Uri::try_from(&format!("{scheme}://localhost:{port}"))?;
 
-        let service = match self.scheme {
+        let service = match &self.scheme {
             Scheme::HTTP => {
                 let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
                 connector.set_connect_timeout(self.timeout);

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -41,7 +41,7 @@ let
       inherit tag;
       created = "now";
       name = "${repo-org}/${img_prefix}-${name}${image_suffix.${buildType}}";
-      copyToRoot = [ tini busybox package ];
+      copyToRoot = [ tini busybox package pkgs.cacert ];
       config = {
         Entrypoint = [ "tini" "--" package.binary ];
       } // config;

--- a/openapi/templates/default/tower-hyper/client/configuration.mustache
+++ b/openapi/templates/default/tower-hyper/client/configuration.mustache
@@ -5,7 +5,7 @@ pub type ReqBody = hyper_body::Body;
 pub use hyper::{body, Request, Response, Uri};
 
 use hyper_rustls::ConfigBuilderExt;
-use std::{sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tower::{util::BoxCloneService, Layer, Service, ServiceExt};
 
@@ -41,6 +41,9 @@ pub struct ApiKey {
 pub enum Error {
     NativeRootCerts(std::io::Error),
     Certificate,
+    ClientKey,
+    ClientIdentity,
+    ClientAuth(rustls::Error),
     TlsConnector,
     NoTracingFeature,
     UrlToUri(hyper::http::uri::InvalidUri),
@@ -48,17 +51,142 @@ pub enum Error {
     AddingVersionPath(hyper::http::uri::InvalidUri),
 }
 
+/// The TLS configuration for HTTPS connections.
+#[derive(Debug, Clone, Default)]
+pub enum TlsMode {
+    /// No TLS, plain HTTP. This is not recommended for production use.
+    None,
+    /// No verification of the server's TLS certificate, and no client TLS certificate.
+    #[default]
+    Auto,
+    /// Verification of the server's TLS certificate using the provided CA certificate, 
+    /// but no client TLS certificate.
+    ServerVerify {
+        ca_certificate: Vec<u8>,
+    },
+    /// No verification of the server's TLS certificate, 
+    /// but use the provided client TLS certificate for authentication.
+    ClientVerify {
+        client_certificate: Vec<u8>,
+        client_key: Vec<u8>,
+    },
+    /// Verification of the server's TLS certificate using the provided CA certificate,
+    /// and use the provided client TLS certificate for authentication.
+    /// Essentially, mTLS.
+    Mtls {
+        ca_certificate: Vec<u8>,
+        client_certificate: Vec<u8>,
+        client_key: Vec<u8>,
+    },
+}
+impl TlsMode {
+    /// Check if tls mode is auto.
+    pub fn is_auto(&self) -> bool {
+        matches!(self, Self::Auto)
+    }
+    /// Check if tls mode is None.
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+/// Authentication and TLS settings for OpenAPI client connections.
+#[derive(Debug, Clone, Default)]
+pub struct ClientSecurity {
+    /// Optional JWT bearer token for HTTP Authorization.
+    pub jwt: Option<String>,
+    /// TLS mode for HTTPS connections.
+    pub tls: TlsMode,
+    /// Discovery of properties. 
+    /// If true, the client will attempt to discover the required TLS and Auth configuration
+    pub discover: bool,
+}
+impl ClientSecurity {
+    /// Creates a new client security configuration.
+    pub fn try_new(jwt: &Option<PathBuf>, tls: TlsMode) -> Result<Self, std::io::Error> {
+        let jwt = jwt.as_ref().map(std::fs::read_to_string).transpose()?;
+        Ok(Self {
+            discover: tls.is_auto() || jwt.is_none(),
+            jwt: jwt.map(|jwt| jwt.trim().to_string()),
+            tls,
+        })
+    }
+    /// Creates a new client security configuration.
+    pub fn new(jwt: Option<String>, tls: TlsMode) -> Self {
+        Self {
+            discover: tls.is_auto() || jwt.is_none(),
+            jwt,
+            tls,
+        }
+    }
+    /// Check if the client security configuration requires discovery 
+    /// (i.e. if TLS is auto or JWT is not provided).
+    pub fn discover(&self) -> bool {
+        self.discover
+    }
+}
+
+impl TlsMode {
+    /// Creates a new TLS mode configuration from the given certificate and client key paths.
+    pub fn new(
+        certificate: Option<&PathBuf>,
+        client_cert: Option<&PathBuf>,
+        client_key: Option<&PathBuf>,
+    ) -> Result<Self, std::io::Error> {
+        let ca = certificate.map(std::fs::read).transpose()?;
+        let cl = client_cert
+            .zip(client_key)
+            .map(|(cert_path, key_path)| {
+                Ok::<_, std::io::Error>((std::fs::read(cert_path)?, std::fs::read(key_path)?))
+            })
+            .transpose()?;
+
+        Ok(match (ca, cl) {
+            (None, None) => TlsMode::Auto,
+            (Some(ca_certificate), None) => TlsMode::ServerVerify {
+                ca_certificate
+            },
+            (None, Some((client_certificate, client_key))) => Self::ClientVerify {
+                client_certificate,
+                client_key,
+            },
+            (Some(ca_certificate), Some((client_certificate, client_key))) => Self::Mtls {
+                ca_certificate,
+                client_certificate,
+                client_key,
+            }
+        })
+    }
+    fn certificate(&self) -> Option<&[u8]> {
+        match &self {
+            Self::ServerVerify { ca_certificate } | Self::Mtls { ca_certificate, .. } => Some(&ca_certificate[..]),
+            _ => None,
+        }
+    }
+    fn client_cert(&self) -> Option<&[u8]> {
+        match &self {
+            Self::ClientVerify { client_certificate, .. } | Self::Mtls { client_certificate, .. } => Some(&client_certificate[..]),
+            _ => None,
+        }
+    }
+    fn client_key(&self) -> Option<&[u8]> {
+        match &self {
+            Self::ClientVerify { client_key, .. } | Self::Mtls { client_key, .. } => Some(&client_key[..]),
+            _ => None,
+        }
+    }
+}
+
 /// `ConfigurationBuilder` that can be used to build a `Configuration`.
 #[derive(Clone)]
 pub struct ConfigurationBuilder {
     /// Timeout for each HTTP Request.
     timeout: Option<std::time::Duration>,
-    /// Bearer Access Token for bearer-configured routes.
-    bearer_token: Option<String>,
+    /// Optional client security configuration (JWT + TLS mode).
+    client_security: Option<ClientSecurity>,
     /// OpenTel and Tracing layer.
     #[cfg(feature = "tower-trace")]
     tracing_layer: bool,
-    certificate: Option<Vec<u8>>,
     concurrency_limit: Option<usize>,
 }
 
@@ -66,10 +194,9 @@ impl Default for ConfigurationBuilder {
     fn default() -> Self {
         Self {
             timeout: Some(std::time::Duration::from_secs(5)),
-            bearer_token: None,
+            client_security: None,
             #[cfg(feature = "tower-trace")]
             tracing_layer: true,
-            certificate: None,
             concurrency_limit: None,
         }
     }
@@ -85,9 +212,20 @@ impl ConfigurationBuilder {
         self.timeout = timeout.into();
         self
     }
+    /// Enable/Disable the given request client security configuration.
+    pub fn with_client_security(mut self, client_security: Option<ClientSecurity>) -> Self {
+        self.client_security = client_security;
+        self
+    }
+    /// Enable/Disable the given request auth configuration.
+    pub fn with_auth(self, auth: Option<ClientSecurity>) -> Self {
+        self.with_client_security(auth)
+    }
     /// Enable/Disable the given request bearer token.
     pub fn with_bearer_token(mut self, bearer_token: Option<String>) -> Self {
-        self.bearer_token = bearer_token;
+        let mut client_security = self.client_security.unwrap_or_default();
+        client_security.jwt = bearer_token;
+        self.client_security = Some(client_security);
         self
     }
     /// Add a request concurrency limit.
@@ -95,9 +233,11 @@ impl ConfigurationBuilder {
         self.concurrency_limit = limit;
         self
     }
-    /// Add a PEM-format certificate file.
-    pub fn with_certificate(mut self, certificate: &[u8]) -> Self {
-        self.certificate = Some(certificate.to_vec());
+    /// TLS.
+    pub fn with_tls(mut self, tls: TlsMode) -> Self {
+        let mut client_security = self.client_security.unwrap_or_default();
+        client_security.tls = tls;
+        self.client_security = Some(client_security);
         self
     }
     /// Enable/Disable the telemetry and tracing layer.
@@ -111,8 +251,7 @@ impl ConfigurationBuilder {
         Configuration::new(
             uri.to_string().parse().map_err(Error::UriToUrl)?,
             self.timeout.unwrap(),
-            self.bearer_token,
-            self.certificate.as_ref().map(|c| &c[..]),
+            self.client_security,
             self.tracing_layer,
             self.concurrency_limit,
         )
@@ -122,8 +261,7 @@ impl ConfigurationBuilder {
         Configuration::new(
             url,
             self.timeout.unwrap_or_else(|| Duration::from_secs(5)),
-            self.bearer_token,
-            self.certificate.as_ref().map(|c| &c[..]),
+            self.client_security,
             self.tracing_layer,
             self.concurrency_limit,
         )
@@ -147,7 +285,7 @@ impl ConfigurationBuilder {
             uri,
             client_service,
             self.timeout,
-            self.bearer_token,
+            self.client_security.and_then(|security| security.jwt),
             tracing_layer,
             self.concurrency_limit,
         )
@@ -278,27 +416,46 @@ impl Configuration {
     pub fn new(
         mut url: url::Url,
         timeout: Duration,
-        bearer_access_token: Option<String>,
-        certificate: Option<&[u8]>,
+        client_security: Option<ClientSecurity>,
         trace_requests: bool,
         concurrency_limit: Option<usize>,
     ) -> Result<Self, Error> {
+        let client_security = client_security.unwrap_or_default();
+        let bearer_access_token = client_security.jwt;
+        let tls = client_security.tls;
+        let insecure_skip_verify = url.scheme() == "https" && tls.certificate().is_none();
         #[cfg(all(not(feature = "tower-client-tls"), feature = "tower-client-rls"))]
         let client = {
-            match certificate {
+            match tls.certificate() {
                 None => {
                     let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
 
                     let tls = match url.scheme() == "https" {
                         true => {
                             http.enforce_http(false);
-                            let mut config = rustls::ClientConfig::builder()
+                            let builder = rustls::ClientConfig::builder()
                                 .with_native_roots()
-                                .map_err(Error::NativeRootCerts)?
-                                .with_no_client_auth();
-                            config
-                                .dangerous()
-                                .set_certificate_verifier(Arc::new(NoCertificateVerification {}));
+                                .map_err(Error::NativeRootCerts)?;
+                            let mut config = match (tls.client_cert(), tls.client_key()) {
+                                (Some(cert_bytes), Some(key_bytes)) => {
+                                    let cert_chain = rustls_pemfile::certs(&mut std::io::BufReader::new(cert_bytes))
+                                        .collect::<Result<Vec<_>, _>>()
+                                        .map_err(|_| Error::Certificate)?;
+                                    let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(key_bytes))
+                                        .map_err(|_| Error::ClientKey)?
+                                        .ok_or(Error::ClientKey)?;
+                                    builder
+                                        .with_client_auth_cert(cert_chain, key)
+                                        .map_err(Error::ClientAuth)?
+                                }
+                                (None, None) => builder.with_no_client_auth(),
+                                _ => return Err(Error::ClientIdentity),
+                            };
+                            if insecure_skip_verify {
+                                config
+                                    .dangerous()
+                                    .set_certificate_verifier(Arc::new(NoCertificateVerification {}));
+                            }
                             config
                         }
                         false => rustls::ClientConfig::builder()
@@ -319,9 +476,22 @@ impl Configuration {
                             .collect::<Result<Vec<_>, _>>()
                             .map_err(|_| Error::Certificate)?,
                     );
-                    let config = rustls::ClientConfig::builder()
-                        .with_root_certificates(root_store)
-                        .with_no_client_auth();
+                    let builder = rustls::ClientConfig::builder()
+                        .with_root_certificates(root_store);
+                    let config = match (tls.client_cert(), tls.client_key()) {
+                        (Some(cert_bytes), Some(key_bytes)) => {
+                            let cert_chain = rustls_pemfile::certs(&mut std::io::BufReader::new(cert_bytes))
+                                .collect::<Result<Vec<_>, _>>()
+                                .map_err(|_| Error::Certificate)?;
+                            let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(key_bytes))
+                                .map_err(|_| Error::ClientKey)?
+                                .ok_or(Error::ClientKey)?;
+                            builder.with_client_auth_cert(cert_chain, key)
+                                .map_err(Error::ClientAuth)?
+                        }
+                        (None, None) => builder.with_no_client_auth(),
+                        _ => return Err(Error::ClientIdentity),
+                    };
 
                     let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
                     http.enforce_http(false);
@@ -335,17 +505,28 @@ impl Configuration {
         };
         #[cfg(feature = "tower-client-tls")]
         let client = {
-            match certificate {
+            match tls.certificate() {
                 None => {
                     let mut http = hyper_tls::HttpsConnector::new();
                     if url.scheme() == "https" {
                         http.https_only(true);
                     }
 
-                    let tls = hyper_tls::native_tls::TlsConnector::builder()
-                        .danger_accept_invalid_certs(true)
-                        .build()
-                        .map_err(|_| Error::TlsConnector)?;
+                    let mut tls_builder = hyper_tls::native_tls::TlsConnector::builder();
+                    tls_builder
+                        .danger_accept_invalid_certs(insecure_skip_verify)
+                        .danger_accept_invalid_hostnames(insecure_skip_verify);
+                    match (tls.client_cert(), tls.client_key()) {
+                        (Some(cert_bytes), Some(key_bytes)) => {
+                            let identity =
+                                hyper_tls::native_tls::Identity::from_pkcs8(cert_bytes, key_bytes)
+                                    .map_err(|_| Error::ClientIdentity)?;
+                            tls_builder.identity(identity);
+                        }
+                        (None, None) => {}
+                        _ => return Err(Error::ClientIdentity),
+                    }
+                    let tls = tls_builder.build().map_err(|_| Error::TlsConnector)?;
                     let tls = tokio_native_tls::TlsConnector::from(tls);
 
                     let connector = hyper_tls::HttpsConnector::from((http, tls));
@@ -356,12 +537,22 @@ impl Configuration {
                     let certificate = hyper_tls::native_tls::Certificate::from_pem(bytes)
                         .map_err(|_| Error::Certificate)?;
 
-                    let tls = hyper_tls::native_tls::TlsConnector::builder()
+                    let mut tls_builder = hyper_tls::native_tls::TlsConnector::builder();
+                    tls_builder
                         .add_root_certificate(certificate)
-                        .danger_accept_invalid_hostnames(true)
-                        .disable_built_in_roots(true)
-                        .build()
-                        .map_err(|_| Error::TlsConnector)?;
+                        .danger_accept_invalid_hostnames(insecure_skip_verify)
+                        .disable_built_in_roots(true);
+                    match (tls.client_cert(), tls.client_key()) {
+                        (Some(cert_bytes), Some(key_bytes)) => {
+                            let identity =
+                                hyper_tls::native_tls::Identity::from_pkcs8(cert_bytes, key_bytes)
+                                    .map_err(|_| Error::ClientIdentity)?;
+                            tls_builder.identity(identity);
+                        }
+                        (None, None) => {}
+                        _ => return Err(Error::ClientIdentity),
+                    }
+                    let tls = tls_builder.build().map_err(|_| Error::TlsConnector)?;
                     let tls = tokio_native_tls::TlsConnector::from(tls);
 
                     let mut http = hyper_tls::HttpsConnector::new();

--- a/openapi/templates/default/tower-hyper/examples/example.rs
+++ b/openapi/templates/default/tower-hyper/examples/example.rs
@@ -38,7 +38,6 @@ async fn main() {
         "http://localhost:8081/".parse().unwrap(),
         Duration::from_secs(5),
         None,
-        None,
         true,
         Some(1),
     )

--- a/utils/deployer-cluster/src/rest_client.rs
+++ b/utils/deployer-cluster/src/rest_client.rs
@@ -1,4 +1,10 @@
-use openapi::tower::{client, client::Url};
+use openapi::tower::{
+    client,
+    client::{
+        configuration::{ClientSecurity, TlsMode},
+        Url,
+    },
+};
 
 /// Tower Rest Client
 #[derive(Clone)]
@@ -43,11 +49,16 @@ impl RestClient {
         trace: bool,
     ) -> anyhow::Result<Self> {
         let cert_file = &std::include_bytes!("../../../control-plane/rest/certs/rsa/ca.cert")[..];
+        let client_security = ClientSecurity::new(
+            bearer_token,
+            TlsMode::ServerVerify {
+                ca_certificate: cert_file.to_vec(),
+            },
+        );
 
         let openapi_client_config = client::Configuration::builder()
             .with_timeout(timeout)
-            .with_bearer_token(bearer_token)
-            .with_certificate(cert_file)
+            .with_client_security(Some(client_security))
             .with_tracing(trace)
             .build_url(url.clone())
             .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{:?}'", e))?;
@@ -65,9 +76,10 @@ impl RestClient {
         bearer_token: Option<String>,
         trace: bool,
     ) -> anyhow::Result<Self> {
+        let client_security = bearer_token.map(|jwt| ClientSecurity::new(Some(jwt), TlsMode::Auto));
         let openapi_client_config = client::Configuration::builder()
             .with_timeout(timeout)
-            .with_bearer_token(bearer_token)
+            .with_client_security(client_security)
             .with_tracing(trace)
             .build_url(url.clone())
             .map_err(|e| anyhow::anyhow!("Failed to create rest client config: '{:?}'", e))?;

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -65,6 +65,8 @@ pub const DSP_OPERATOR: &str = "operator-diskpool";
 pub const API_REST_LABEL: &str = "app=api-rest";
 /// The service port for the api-rest label for the etcd pods.
 pub const API_REST_HTTP_PORT: &str = "http";
+/// The service port for the api-rest label for the etcd pods.
+pub const API_REST_HTTPS_PORT: &str = "https";
 
 /// The service label for the upgrade operator service.
 pub const UPGRADE_OPERATOR_LABEL: &str = "app=operator-upgrade";


### PR DESCRIPTION
- Change JWT parameters from raw string tokens to file paths throughout:
  * CSI node and controller drivers
  * Pool operator
  * REST plugin
  * Test/deployer utilities
  * This defers token reading to the openapi client layer

- Simplify TLS path API:
  * TlsMode::new now accepts Option<&PathBuf> instead of &Option<PathBuf> to avoid unnecessary temporary clones
  * CsiControllerConfig getters return Option<&PathBuf> for consistency

- Reduce duplication in CSI node client:
  * Share single Configuration across AppNodes and Volumes clients
  * Remove duplicated TLS/security setup logic
  * Both wrappers now take Configuration by value (cheap clone internally)

- Add kube-forward secret discovery infrastructure:
  * Pod tls and auth discovery via annotations and volumes
  * Fixed SecretRef keys: ca.crt, tls.crt, tls.key, jwt

- Add auto-tls generation for HTTPS TLS without verification

This will allow our plugin to discover the cert and auth information from a running cluster.
Also we switch from the kube-apiserver proxy to port forwarding since otherwise we can't use HTTPS with verification.
This is because the kube-apiserver proxy terminates the request and issues a new request to the target pod, meaning our certificates or header bearer tokens cannot be send across.
So, the kube-apiserver proxy will only for in case of AutoTLS with no auth. If no TLS is configured, then we revert back to HTTP fully.

A flag has been added to the rest-client to force http usage. Eventually we can disable http binding from the rest service by default.

Also worth noting that this is only tackling the rest interface, and not the internal service gRPC nor the data-plane gRPC.