### PR TITLE
test(pool): don't starve other io-engines

### DIFF
--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -325,8 +325,10 @@ impl Service {
     /// Deregister a node through the deregister information.
     #[tracing::instrument(level = "debug", skip(self), fields(node.id = %node.id))]
     pub(super) async fn deregister(&self, node: &Deregister) {
+        tracing::error!(node.id=%node.id, "Node is deregistering itself");
+
         if let Err(error) = self.specs().deregister_node(&self.registry, node).await {
-            tracing::error!(node=%node.id, %error, "Failed to deregister node with pstor");
+            tracing::error!(node.id=%node.id, %error, "Failed to deregister node with pstor");
         }
 
         let nodes = self.registry.nodes().read().await.get(&node.id).cloned();

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -441,9 +441,19 @@ impl NodeWrapper {
         })
     }
 
+    /// Set the node as down if it's not already offline.
+    pub(super) fn set_down(&mut self) -> NodeStatus {
+        let status = self.status();
+        if status == NodeStatus::Offline {
+            return status;
+        }
+        self.set_status_(status, NodeStatus::Unknown)
+    }
     /// Set the node status and return the previous status.
     pub(super) fn set_status(&mut self, next: NodeStatus) -> NodeStatus {
-        let previous = self.status();
+        self.set_status_(self.status(), next)
+    }
+    fn set_status_(&mut self, previous: NodeStatus, next: NodeStatus) -> NodeStatus {
         if previous != next {
             if next == NodeStatus::Online {
                 tracing::info!(
@@ -665,6 +675,7 @@ impl NodeWrapper {
         tracing::info!(
             node.id = %self.id(),
             node.endpoint = self.endpoint_str(),
+            node.status = %self.status(),
             api.versions = ?self.node_state.api_versions,
             startup,
             "Preloading node"
@@ -678,13 +689,14 @@ impl NodeWrapper {
                 Ok(())
             }
             Err(error) => {
-                self.set_status(NodeStatus::Unknown);
                 tracing::error!(
                     node.id = %self.id(),
                     node.endpoint = %self.endpoint_str(),
-                    %error,
+                    node.status = %self.status(),
+                    ?error,
                     "Failed to preload node"
                 );
+                self.set_down();
                 Err(error)
             }
         }
@@ -720,12 +732,13 @@ impl NodeWrapper {
                     Ok(())
                 }
                 Err(error) => {
-                    self.set_status(NodeStatus::Unknown);
                     tracing::error!(
                         node.id = %self.id(),
+                        node.status = %self.status(),
                         ?error,
                         "Failed to reload node"
                     );
+                    self.set_down();
                     Err(error)
                 }
             }
@@ -1225,7 +1238,7 @@ impl InternalOps for Arc<tokio::sync::RwLock<NodeWrapper>> {
                 node.update(setting_online, results)
             }
             Err((_guard, error)) => {
-                self.write().await.set_status(NodeStatus::Unknown);
+                self.write().await.set_down();
                 Err(error)
             }
         }

--- a/control-plane/agents/src/bin/core/tests/pool/purge.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/purge.rs
@@ -91,7 +91,7 @@ async fn pool_purge() {
     normal_delete_still_works(&pool_client, &delete_pool).await;
 
     // --- Phase 2: io-engine offline ---
-    cluster.composer().stop("io-engine-1").await.unwrap();
+    cluster.composer().stop(&cluster.node(0)).await.unwrap();
     cluster
         .wait_node_status_tmo(cluster.node(0), NodeStatus::Offline, NODE_OFFLINE_TIMEOUT)
         .await

--- a/tests/bdd/features/pool/delete/test_feature.py
+++ b/tests/bdd/features/pool/delete/test_feature.py
@@ -146,7 +146,12 @@ VOLUME_SIZE = 10485761
 
 @pytest.fixture(scope="module")
 def background():
-    Deployer.start(2, node_deadline="250ms", io_engine_env="MAYASTOR_HB_INTERVAL_SEC=0")
+    Deployer.start(
+        2,
+        io_engine_coreisol=True,
+        node_deadline="250ms",
+        io_engine_env="MAYASTOR_HB_INTERVAL_SEC=1",
+    )
     yield
     Deployer.stop()
 
@@ -221,10 +226,7 @@ def a_pool_on_an_unreachable_online_node(pool):
     wait_node_offline(pool.spec.node)
     Docker.restart_container(pool.spec.node)
     wait_node_online(pool.spec.node)
-    try:
-        ApiClient.pools_api().del_pool(pool.id)
-    except NotFoundException:
-        pass
+    wait_pool_deleted(pool.id)
 
 
 @pytest.fixture
@@ -234,10 +236,7 @@ def a_pool_on_an_unreachable_offline_node(pool):
     yield pool
     Docker.restart_container(pool.spec.node)
     wait_node_online(pool.spec.node)
-    try:
-        ApiClient.pools_api().del_pool(pool.id)
-    except NotFoundException:
-        pass
+    wait_pool_deleted(pool.id)
 
 
 @retry(wait_fixed=200, stop_max_attempt_number=30)
@@ -249,3 +248,11 @@ def wait_node_online(node_id):
 def wait_node_offline(node_id):
     node_status = ApiClient.nodes_api().get_node(node_id).state.status
     assert node_status == NodeStatus("Offline") or node_status == NodeStatus("Unknown")
+
+
+@retry(wait_fixed=50, stop_max_attempt_number=30)
+def wait_pool_deleted(pool_id):
+    try:
+        ApiClient.pools_api().del_pool(pool_id)
+    except NotFoundException:
+        pass

--- a/tests/bdd/features/pool/label/test_label_unlabel_pool.py
+++ b/tests/bdd/features/pool/label/test_label_unlabel_pool.py
@@ -42,7 +42,7 @@ REPLICA_ERROR = "replica_error"
 
 @pytest.fixture(scope="module")
 def init():
-    Deployer.start(NUM_IO_ENGINES, io_engine_env="MAYASTOR_HB_INTERVAL_SEC=0")
+    Deployer.start(NUM_IO_ENGINES, io_engine_env="MAYASTOR_HB_INTERVAL_SEC=1")
     ApiClient.pools_api().put_node_pool(
         NODE_1_NAME,
         POOL_1_UUID,

--- a/tests/bdd/features/pool/reconcile/test_feature.py
+++ b/tests/bdd/features/pool/reconcile/test_feature.py
@@ -10,6 +10,7 @@ from openapi.exceptions import ApiException, NotFoundException
 from openapi.models.create_pool_body import CreatePoolBody
 from openapi.models.node_status import NodeStatus
 from openapi.models.pool_status import PoolStatus
+from openapi.models.spec_status import SpecStatus
 from pytest_bdd import (
     given,
     scenario,
@@ -78,7 +79,7 @@ def the_pool_should_eventually_be_imported(pool):
 
 @pytest.fixture(scope="module")
 def background():
-    Deployer.start(2, node_deadline="250ms", io_engine_env="MAYASTOR_HB_INTERVAL_SEC=0")
+    Deployer.start(2, node_deadline="250ms", io_engine_env="MAYASTOR_HB_INTERVAL_SEC=1")
     yield
     Deployer.stop()
 
@@ -143,7 +144,7 @@ def wait_node_offline(node_id):
 def wait_pool_deleted(pool):
     try:
         pool = ApiClient.pools_api().get_pool(pool.id)
-        assert pool.state == PoolStatus("Deleted")
+        assert pool.spec.status == SpecStatus("Deleted")
     except NotFoundException:
         pass
 


### PR DESCRIPTION
On CI this test failed because import pool was taking 7s seconds 
and the import was still not complete!!
It looks like the issue is that the heartbeat, when set to 0, tries to
do it in a busy loop and on CI this seems to lead into one of the
io-engines not allowing the other to run! I'm not sure what kind of
scheduler is setup there, but perhaps it's not yielding or something.

So we now ensure the heartbeat period is every second.
todo: change io-engine to allow sub-second heartbeats for testing.