### PR TITLE
feat(core): handle CSI publish promotion on offline-rebuild volumes

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/offline_rebuild.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/offline_rebuild.rs
@@ -9,7 +9,7 @@ use crate::controller::{
 
 use stor_port::types::v0::{
     store::volume::VolumeSpec,
-    transport::{PublishVolume, UnpublishVolume, VolumeState, VolumeStatus},
+    transport::{PublishVolume, UnpublishVolume, VolumeState, VolumeStatus, VolumeTargetMode},
 };
 
 /// Offline Volume Rebuild.
@@ -67,10 +67,12 @@ async fn offline_rebuild_reconcile(
     }
 
     // Early bails that don't need the volume state: a real (shared) publish is
-    // not our concern, and a never-published volume has no data to rebuild.
+    // not our concern, an unshared target we don't own is also not our concern
+    // (e.g. user produced one via direct REST publish), and a never-published
+    // volume has no data to rebuild.
     let has_offline_rebuild_target = match volume.as_ref().target() {
         Some(target) => {
-            if target.protocol().is_some() {
+            if target.protocol().is_some() || !volume.as_ref().is_offline_rebuild_target() {
                 return PollResult::Ok(PollerState::Idle);
             }
             true
@@ -148,7 +150,10 @@ async fn initiate_offline_rebuild(
         Default::default(),
     );
 
-    match volume.publish(registry, &request).await {
+    match volume
+        .publish_with_mode(registry, &request, VolumeTargetMode::OfflineRebuild)
+        .await
+    {
         Ok(_) => {
             tracing::info!(
                 volume.uuid = %volume.uuid(),

--- a/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
@@ -1,11 +1,11 @@
 #![cfg(test)]
 
-use super::helpers::wait_till_volume_status;
+use super::helpers::{wait_node_online, wait_till_volume_status};
 use deployer_cluster::ClusterBuilder;
 use std::{collections::HashMap, time::Duration};
 use stor_port::types::v0::{
     openapi::models::{self, VolumePolicy, VolumeStatus},
-    transport::VolumeId,
+    transport::{NodeId, VolumeId},
 };
 use uuid::Uuid;
 
@@ -13,13 +13,25 @@ const RECONCILE_PERIOD_MS: u64 = 250;
 const GRACE_PERIOD_SECS: u64 = 2;
 const REBUILD_TIMEOUT_SECS: u64 = 30;
 
-/// Happy path: create a 2-replica volume, publish to establish health_info,
-/// unpublish, stop one io-engine node → volume becomes Degraded.
-/// With offline rebuild enabled, the reconciler creates a temp nexus,
-/// HotSpare rebuilds the replica, then the reconciler tears down the nexus.
-/// Final state: volume Online with no target (unpublished).
+/// End-to-end coverage for the offline-rebuild reconciler. Drives three
+/// scenarios sequentially on a single shared cluster (each scenario takes a
+/// node down and brings it back up before handing off), which avoids the
+/// per-test cluster spin-up cost while still exercising each path on a clean
+/// pool layout:
+///
+/// 1. **Happy path**: degraded unpublished volume gets a temp nexus, the
+///    rebuild runs, the temp nexus is torn down, the volume returns to
+///    Online with no target. A second volume that was never published must
+///    not be touched.
+/// 2. **Promote-on-publish**: while the temp nexus exists, a CSI publish
+///    promotes the existing unshared nexus instead of creating a new one.
+///    The rebuild keeps going on the now-shared nexus and the volume reaches
+///    Online still published.
+/// 3. **GC safety**: during an active offline rebuild, the GarbageCollector
+///    must not strip ownership from the surviving healthy replicas of the
+///    volume being rebuilt.
 #[tokio::test]
-async fn offline_rebuild_happy_path() {
+async fn offline_rebuild_e2e() {
     let reconcile = Duration::from_millis(RECONCILE_PERIOD_MS);
     let cluster = ClusterBuilder::builder()
         .with_rest(true)
@@ -39,6 +51,13 @@ async fn offline_rebuild_happy_path() {
         .await
         .unwrap();
 
+    happy_path(&cluster).await;
+    promote_on_publish(&cluster).await;
+    gc_safety(&cluster).await;
+}
+
+/// Happy path scenario, see [`offline_rebuild_e2e`] doc.
+async fn happy_path(cluster: &deployer_cluster::Cluster) {
     let api_client = cluster.rest_v00();
     let volume_api = api_client.volumes_api();
 
@@ -78,7 +97,6 @@ async fn offline_rebuild_happy_path() {
 
     assert_eq!(volume.state.status, VolumeStatus::Online);
 
-    // Unpublish — volume returns to no-target state.
     volume_api
         .del_volume_target(&uid, None, None)
         .await
@@ -90,23 +108,16 @@ async fn offline_rebuild_happy_path() {
         "Volume should have no target after unpublish"
     );
 
-    // Stop a node hosting a replica — makes volume Degraded.
-    let replicas = api_client.replicas_api().get_replicas().await.unwrap();
-    let victim_replica = replicas
-        .iter()
-        .find(|r| r.node != cluster.node(0).to_string())
-        .expect("Should have a replica on a non-target node");
-    let victim_node = victim_replica.node.clone();
-
+    // Stop a node hosting a replica, this makes the volume Degraded.
+    let victim_node = pick_victim_node(&api_client, &cluster.node(0).to_string(), uid).await;
     cluster
         .composer()
         .stop(&victim_node)
         .await
         .expect("Should stop io-engine node");
 
-    // Wait for Degraded status.
     wait_till_volume_status(
-        &cluster,
+        cluster,
         &uid,
         VolumeStatus::Degraded,
         Duration::from_secs(10),
@@ -114,27 +125,293 @@ async fn offline_rebuild_happy_path() {
     .await
     .expect("Volume should become Degraded");
 
-    // Now wait for grace period + rebuild time. The reconciler should:
-    // 1. Wait for grace period (GRACE_PERIOD_SECS)
-    // 2. Create temporary unshared nexus
-    // 3. HotSpare rebuilds replica onto remaining healthy node's pool
-    // 4. Volume goes Online
-    // 5. Reconciler tears down temporary nexus
-    //
-    // We wait for the volume to return to Online with no target.
+    // Wait for grace period + rebuild. Final state: Online, no target.
     let timeout = Duration::from_secs(GRACE_PERIOD_SECS + REBUILD_TIMEOUT_SECS);
-    wait_till_volume_online_no_target(&cluster, &uid, timeout)
+    wait_till_volume_online_no_target(cluster, &uid, timeout)
         .await
         .expect("Volume should be Online with no target after offline rebuild");
 
-    // The never-published volume must still have no target — the reconciler
-    // skips it for lack of health_info_id.
+    // The never-published volume must still have no target.
     let never_pub = volume_api.get_volume(&never_pub_uid).await.unwrap();
     assert!(
         never_pub.state.target.is_none(),
         "Never-published volume must not be touched by the offline rebuild reconciler; got {:?}",
         never_pub.state.target
     );
+
+    // Cleanup so later scenarios start from a known volume set, and bring the
+    // stopped node back so subsequent scenarios have the full 3-node pool.
+    volume_api.del_volume(&uid).await.unwrap();
+    volume_api.del_volume(&never_pub_uid).await.unwrap();
+    restart_node(cluster, &victim_node).await;
+}
+
+/// Promote-on-publish scenario, see [`offline_rebuild_e2e`] doc.
+async fn promote_on_publish(cluster: &deployer_cluster::Cluster) {
+    let api_client = cluster.rest_v00();
+    let volume_api = api_client.volumes_api();
+
+    let volid = VolumeId::new();
+    let body = models::CreateVolumeBody::new(VolumePolicy::new(true), 2, 10485760u64, false, false);
+    let volume = volume_api.put_volume(&volid, body).await.unwrap();
+    let uid = volume.spec.uuid;
+
+    // Publish + unpublish to establish health_info.
+    volume_api
+        .put_volume_target(
+            &uid,
+            models::PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                cluster.node(0).to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+                None,
+            ),
+        )
+        .await
+        .unwrap();
+    volume_api
+        .del_volume_target(&uid, None, None)
+        .await
+        .unwrap();
+
+    // Stop a replica node so the volume becomes Degraded.
+    let victim_node = pick_victim_node(&api_client, &cluster.node(0).to_string(), uid).await;
+    cluster.composer().stop(&victim_node).await.unwrap();
+
+    // Wait for the offline-rebuild reconciler to create the unshared nexus.
+    let unshared_target = wait_for_unshared_target(cluster, &uid, Duration::from_secs(15))
+        .await
+        .expect("Offline rebuild should create unshared target");
+    let rebuild_node = unshared_target.node.clone();
+
+    // CSI publish arrives mid-rebuild, should promote (share the existing nexus).
+    let volume = volume_api
+        .put_volume_target(
+            &uid,
+            models::PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                rebuild_node.clone(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+                None,
+            ),
+        )
+        .await
+        .expect("Publish should promote the offline-rebuild nexus");
+
+    let target = volume.state.target.expect("target present after promote");
+    assert_eq!(
+        target.node, rebuild_node,
+        "Promoted nexus should stay on same node"
+    );
+    assert!(
+        !target.device_uri.is_empty(),
+        "Promoted nexus should be shared (device_uri set)"
+    );
+
+    // Rebuild continues on the promoted (now shared) nexus, volume eventually Online.
+    let volume = wait_for_volume_state(
+        cluster,
+        &uid,
+        VolumeStatus::Online,
+        Duration::from_secs(REBUILD_TIMEOUT_SECS),
+    )
+    .await
+    .expect("Volume should reach Online after promoted rebuild");
+
+    assert!(
+        volume.state.target.is_some(),
+        "Volume stays published after promotion"
+    );
+
+    volume_api
+        .del_volume_target(&uid, None, None)
+        .await
+        .unwrap();
+    volume_api.del_volume(&uid).await.unwrap();
+    restart_node(cluster, &victim_node).await;
+}
+
+/// GC safety scenario, see [`offline_rebuild_e2e`] doc.
+async fn gc_safety(cluster: &deployer_cluster::Cluster) {
+    let api_client = cluster.rest_v00();
+    let volume_api = api_client.volumes_api();
+
+    let volid = VolumeId::new();
+    let body = models::CreateVolumeBody::new(VolumePolicy::new(true), 2, 10485760u64, false, false);
+    let volume = volume_api.put_volume(&volid, body).await.unwrap();
+    let uid = volume.spec.uuid;
+
+    volume_api
+        .put_volume_target(
+            &uid,
+            models::PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                cluster.node(0).to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+                None,
+            ),
+        )
+        .await
+        .unwrap();
+    volume_api
+        .del_volume_target(&uid, None, None)
+        .await
+        .unwrap();
+
+    // Snapshot the surviving replicas before triggering rebuild. Ownership
+    // lives on the spec; runtime state has the node placement. We need both:
+    // state to find a victim node, spec to identify the volume's own replicas
+    // and verify ownership after the fact.
+    let pre_state = api_client.replicas_api().get_replicas().await.unwrap();
+    let pre_specs = api_client.specs_api().get_specs().await.unwrap();
+    let owned_replica_uuids: Vec<uuid::Uuid> = pre_specs
+        .replicas
+        .iter()
+        .filter(|r| r.owners.volume == Some(uid))
+        .map(|r| r.uuid)
+        .collect();
+    let victim_node = pre_state
+        .iter()
+        .find(|r| owned_replica_uuids.contains(&r.uuid) && r.node != cluster.node(0).to_string())
+        .expect("Should find a replica of the test volume on a non-target node")
+        .node
+        .clone();
+    let live_replica_uuids: Vec<_> = owned_replica_uuids
+        .iter()
+        .filter(|u| {
+            !pre_state
+                .iter()
+                .any(|r| r.uuid == **u && r.node == victim_node)
+        })
+        .copied()
+        .collect();
+    assert!(!live_replica_uuids.is_empty());
+
+    cluster.composer().stop(&victim_node).await.unwrap();
+
+    // Wait until offline rebuild creates the unshared nexus.
+    wait_for_unshared_target(cluster, &uid, Duration::from_secs(15))
+        .await
+        .expect("Offline rebuild should start");
+
+    // Sleep briefly to let GC poll at least once with the rebuild active.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // The surviving replicas should still exist *and* still be owned by the
+    // test volume. Without the ownership check, a disown-without-destroy would
+    // slip past.
+    let post_specs = api_client.specs_api().get_specs().await.unwrap();
+    for live_uuid in &live_replica_uuids {
+        let live = post_specs
+            .replicas
+            .iter()
+            .find(|r| r.uuid == *live_uuid)
+            .unwrap_or_else(|| {
+                panic!("Live replica {live_uuid} was destroyed during offline rebuild")
+            });
+        assert_eq!(
+            live.owners.volume,
+            Some(uid),
+            "Live replica {live_uuid} was disowned (owners.volume cleared) during offline rebuild"
+        );
+    }
+
+    volume_api.del_volume(&uid).await.unwrap();
+    restart_node(cluster, &victim_node).await;
+}
+
+/// Pick a node that hosts a replica of the given volume, excluding the publish
+/// target node. Filtering by the test volume's ownership matters because
+/// leftover replicas from a prior scenario can otherwise be picked, and
+/// stopping a node that doesn't host *this* volume's data leaves the volume
+/// Online, the reconciler never sees a degraded state, and the test stalls.
+async fn pick_victim_node(
+    api_client: &stor_port::types::v0::openapi::tower::client::direct::ApiClient,
+    target_node: &str,
+    volume_uid: uuid::Uuid,
+) -> String {
+    let specs = api_client.specs_api().get_specs().await.unwrap();
+    let owned_replica_uuids: Vec<uuid::Uuid> = specs
+        .replicas
+        .iter()
+        .filter(|r| r.owners.volume == Some(volume_uid))
+        .map(|r| r.uuid)
+        .collect();
+    let replicas = api_client.replicas_api().get_replicas().await.unwrap();
+    replicas
+        .iter()
+        .find(|r| owned_replica_uuids.contains(&r.uuid) && r.node != target_node)
+        .expect("Should have a replica of this volume on a non-target node")
+        .node
+        .clone()
+}
+
+/// Restart a node previously stopped by `composer().stop()` so the next
+/// scenario starts from a healthy 3-node cluster. Waits for the node to
+/// re-register as Online before returning, so the caller can assume a clean
+/// cluster state.
+async fn restart_node(cluster: &deployer_cluster::Cluster, node: &str) {
+    cluster
+        .composer()
+        .start(node)
+        .await
+        .expect("Should restart io-engine node");
+    let node_client = cluster.grpc_client().node();
+    wait_node_online(&node_client, NodeId::from(node))
+        .await
+        .expect("Restarted node should come back Online");
+}
+
+/// Wait for the volume to have a target with no share protocol (offline-rebuild marker).
+async fn wait_for_unshared_target(
+    cluster: &deployer_cluster::Cluster,
+    volume: &Uuid,
+    timeout: Duration,
+) -> Result<models::Nexus, String> {
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(vol) = cluster.rest_v00().volumes_api().get_volume(volume).await {
+            if let Some(target) = vol.state.target {
+                if target.protocol == models::Protocol::None {
+                    return Ok(target);
+                }
+            }
+        }
+        if std::time::Instant::now() > (start + timeout) {
+            return Err("Timeout waiting for unshared target".to_string());
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Wait for the volume to reach a specific status, returning the full Volume.
+async fn wait_for_volume_state(
+    cluster: &deployer_cluster::Cluster,
+    volume: &Uuid,
+    status: VolumeStatus,
+    timeout: Duration,
+) -> Result<models::Volume, String> {
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(vol) = cluster.rest_v00().volumes_api().get_volume(volume).await {
+            if vol.state.status == status {
+                return Ok(vol);
+            }
+        }
+        if std::time::Instant::now() > (start + timeout) {
+            return Err(format!("Timeout waiting for volume status {status:?}"));
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
 }
 
 /// Wait for volume to reach Online status with no target (nexus torn down).

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -42,7 +42,7 @@ use stor_port::{
             DestroyVolume, NodeTopology, Protocol, PublishVolume, Replica, ReplicaId,
             ReplicaOwners, RepublishVolume, ResizeVolume, SetVolumeProperty, SetVolumeReplica,
             ShareNexus, ShareVolume, ShutdownNexus, UnpublishVolume, UnshareNexus, UnshareVolume,
-            Volume, VolumeShareProtocol,
+            Volume, VolumeShareProtocol, VolumeTargetMode,
         },
     },
     HostAccessControl,
@@ -325,109 +325,12 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         registry: &Registry,
         request: &Self::Publish,
     ) -> Result<Self::PublishOutput, SvcError> {
-        let state = registry.volume_state(&request.uuid).await?;
-
-        if let Some(mut target_cfg) = self.as_ref().target_cfg().cloned() {
-            let host_acl =
-                registry.host_acl_nodename(HostAccessControl::Nexuses, &request.frontend_nodes);
-            target_cfg.frontend_mut().add_acls(host_acl);
-
-            let target = target_cfg.target();
-            let mut nexus = registry.specs().nexus(target.nexus()).await?;
-            let nexus_state = registry.nexus(target.nexus()).await?;
-
-            let operation =
-                VolumeOperation::Publish(PublishOperation::new(target_cfg.clone(), request));
-            let spec_clone = self.start_update(registry, &state, operation).await?;
-
-            let result = nexus
-                .share(
-                    registry,
-                    &ShareNexus::new(
-                        &nexus_state,
-                        VolumeShareProtocol::Nvmf,
-                        target_cfg.frontend().node_nqns(),
-                    ),
-                )
-                .await;
-
-            self.complete_update(registry, result, spec_clone).await?;
-
-            let volume = registry.volume(&request.uuid).await?;
-            registry
-                .notify_if_degraded(&volume, PollTriggerEvent::VolumeDegraded)
-                .await;
-            return Ok(volume);
-        }
-
-        let nexus_node = self
-            .next_target_node(registry, request, &state, false)
-            .await?;
-
-        let last_target = self.as_ref().health_info_id().cloned();
-        let frontend_nodes = &request.frontend_nodes;
-        let target_cfg = self
-            .next_target_config(
-                registry,
-                nexus_node.candidate(),
-                &request.share,
-                frontend_nodes,
-            )
-            .await;
-
-        let operation =
-            VolumeOperation::Publish(PublishOperation::new(target_cfg.clone(), request));
-        let spec_clone = self.start_update(registry, &state, operation).await?;
-
-        // Create a Nexus on the requested or auto-selected node.
-        let result = self.create_nexus(registry, &target_cfg).await;
-
-        let (mut nexus, nexus_state) = self
-            .validate_update_step(registry, result, &spec_clone)
-            .await?;
-
-        // Share the Nexus if it was requested.
-        let mut result = Ok(());
-        if let Some(share) = request.share {
-            let allowed_hosts = target_cfg.frontend().node_nqns();
-            result = match nexus
-                .share(
-                    registry,
-                    &ShareNexus::new(&nexus_state, share, allowed_hosts),
-                )
-                .await
-            {
-                Ok(_) => Ok(()),
-                Err(error) => {
-                    // Since we failed to share, we'll revert back to the previous state.
-                    // If we fail to do this inline, the reconcilers will pick up the slack.
-                    nexus
-                        .destroy(registry, &DestroyNexus::from(nexus_state).with_disown_all())
-                        .await
-                        .ok();
-                    Err(error)
-                }
-            }
-        }
-
-        self.complete_update(registry, result, spec_clone).await?;
-
-        // If there was a previous nexus we should delete the persisted NexusInfo structure.
-        if let Some(nexus_id) = last_target {
-            ResourceSpecsLocked::delete_nexus_info(
-                &NexusInfoKey::new(&Some(self.uuid().clone()), &nexus_id),
-                registry,
-            )
-            .await;
-        }
-
-        self.prune_health(registry);
-
-        let volume = registry.volume(&request.uuid).await?;
-        registry
-            .notify_if_degraded(&volume, PollTriggerEvent::VolumeDegraded)
-            .await;
-        Ok(volume)
+        // Public publish path: all callers that reach the trait method (CSI
+        // publish, REST publish) are front-end app publishes by definition.
+        // Internal callers that need a different mode use `publish_with_mode`
+        // directly on the impl.
+        self.publish_with_mode(registry, request, VolumeTargetMode::ServeFrontendApp)
+            .await
     }
 
     async fn unpublish(
@@ -707,6 +610,169 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         };
 
         self.complete_update(registry, result, spec_clone).await?;
+        self.prune_health(registry);
+
+        let volume = registry.volume(&request.uuid).await?;
+        registry
+            .notify_if_degraded(&volume, PollTriggerEvent::VolumeDegraded)
+            .await;
+        Ok(volume)
+    }
+}
+
+impl OperationGuardArc<VolumeSpec> {
+    /// Publish a volume, recording the supplied `target_mode` on the resulting
+    /// `target_config`. This is the internal entry point used by callers that
+    /// need to set up a target for a non-app purpose (the offline-rebuild
+    /// reconciler, future maintenance flows). The public `ResourcePublishing`
+    /// trait method delegates here with [`VolumeTargetMode::ServeFrontendApp`].
+    pub(crate) async fn publish_with_mode(
+        &mut self,
+        registry: &Registry,
+        request: &PublishVolume,
+        target_mode: VolumeTargetMode,
+    ) -> Result<Volume, SvcError> {
+        // Reject double-offline-rebuild: a publish requesting `OfflineRebuild` on a
+        // volume whose current target is already `OfflineRebuild` would overwrite
+        // the in-flight rebuild's `target_config`. The reconciler self-prevents
+        // this in its own poll loop (it goes to teardown rather than initiate when
+        // a target already exists), and the only other caller today is the test
+        // suite. Defensive guard so any internal caller added later inherits the
+        // same protection without each having to re-implement it.
+        if matches!(target_mode, VolumeTargetMode::OfflineRebuild)
+            && self.as_ref().is_offline_rebuild_target()
+        {
+            let target = self.as_ref().target_cfg().expect("checked above").target();
+            return Err(SvcError::VolumeAlreadyPublished {
+                vol_id: request.uuid.to_string(),
+                node: target.node().to_string(),
+                protocol: "offline-rebuild".to_string(),
+            });
+        }
+
+        let state = registry.volume_state(&request.uuid).await?;
+
+        if let Some(mut target_cfg) = self.as_ref().target_cfg().cloned() {
+            // Promotion happens when CSI publish arrives mid-offline-rebuild —
+            // share the existing nexus and record the new protocol so future
+            // reconciler polls treat the volume as a real publish. Only do this
+            // if the current target_config is one the reconciler set up; an
+            // unshared target produced by a direct REST publish
+            // (`protocol: None`, mode `ServeFrontendApp`) is left alone.
+            let promoting_offline_rebuild = target_cfg.target().protocol().is_none()
+                && request.share.is_some()
+                && self.as_ref().is_offline_rebuild_target();
+
+            if promoting_offline_rebuild {
+                if let Some(share) = request.share {
+                    target_cfg.target_mut().set_protocol(Some(share));
+                }
+            }
+            // Whatever mode the caller asked for now applies to the target. For
+            // an offline-rebuild promotion the CSI publish path passes
+            // `ServeFrontendApp`, transitioning the target out of the
+            // reconciler's ownership.
+            target_cfg.target_mut().set_target_mode(target_mode);
+
+            let host_acl =
+                registry.host_acl_nodename(HostAccessControl::Nexuses, &request.frontend_nodes);
+            target_cfg.frontend_mut().add_acls(host_acl);
+
+            let target = target_cfg.target();
+            let mut nexus = registry.specs().nexus(target.nexus()).await?;
+            let nexus_state = registry.nexus(target.nexus()).await?;
+
+            let share_protocol = target
+                .protocol()
+                .copied()
+                .unwrap_or(VolumeShareProtocol::Nvmf);
+
+            let operation =
+                VolumeOperation::Publish(PublishOperation::new(target_cfg.clone(), request));
+            let spec_clone = self.start_update(registry, &state, operation).await?;
+
+            let result = nexus
+                .share(
+                    registry,
+                    &ShareNexus::new(
+                        &nexus_state,
+                        share_protocol,
+                        target_cfg.frontend().node_nqns(),
+                    ),
+                )
+                .await;
+
+            self.complete_update(registry, result, spec_clone).await?;
+
+            let volume = registry.volume(&request.uuid).await?;
+            registry
+                .notify_if_degraded(&volume, PollTriggerEvent::VolumeDegraded)
+                .await;
+            return Ok(volume);
+        }
+
+        let nexus_node = self
+            .next_target_node(registry, request, &state, false)
+            .await?;
+
+        let last_target = self.as_ref().health_info_id().cloned();
+        let frontend_nodes = &request.frontend_nodes;
+        let target_cfg = self
+            .next_target_config(
+                registry,
+                nexus_node.candidate(),
+                &request.share,
+                frontend_nodes,
+            )
+            .await
+            .with_target_mode(target_mode);
+
+        let operation =
+            VolumeOperation::Publish(PublishOperation::new(target_cfg.clone(), request));
+        let spec_clone = self.start_update(registry, &state, operation).await?;
+
+        // Create a Nexus on the requested or auto-selected node.
+        let result = self.create_nexus(registry, &target_cfg).await;
+
+        let (mut nexus, nexus_state) = self
+            .validate_update_step(registry, result, &spec_clone)
+            .await?;
+
+        // Share the Nexus if it was requested.
+        let mut result = Ok(());
+        if let Some(share) = request.share {
+            let allowed_hosts = target_cfg.frontend().node_nqns();
+            result = match nexus
+                .share(
+                    registry,
+                    &ShareNexus::new(&nexus_state, share, allowed_hosts),
+                )
+                .await
+            {
+                Ok(_) => Ok(()),
+                Err(error) => {
+                    // Since we failed to share, we'll revert back to the previous state.
+                    // If we fail to do this inline, the reconcilers will pick up the slack.
+                    nexus
+                        .destroy(registry, &DestroyNexus::from(nexus_state).with_disown_all())
+                        .await
+                        .ok();
+                    Err(error)
+                }
+            }
+        }
+
+        self.complete_update(registry, result, spec_clone).await?;
+
+        // If there was a previous nexus we should delete the persisted NexusInfo structure.
+        if let Some(nexus_id) = last_target {
+            ResourceSpecsLocked::delete_nexus_info(
+                &NexusInfoKey::new(&Some(self.uuid().clone()), &nexus_id),
+                registry,
+            )
+            .await;
+        }
+
         self.prune_health(registry);
 
         let volume = registry.volume(&request.uuid).await?;

--- a/control-plane/agents/src/bin/core/volume/specs.rs
+++ b/control-plane/agents/src/bin/core/volume/specs.rs
@@ -360,7 +360,18 @@ fn validate_publish(
         let target = target_cfg.target();
         let frontend = target_cfg.frontend();
 
-        if volume.publish_context.as_ref() != Some(args.publish_context()) {
+        // Promotion of an offline-rebuild target on an incoming publish: the existing
+        // `target_config` was set up by the reconciler with a default/empty publish_context and
+        // an empty frontend (the reconciler doesn't know anything about CSI publish_context or
+        // app-side frontend nodes), so the incoming publish is what should win for both. Skip
+        // the divergence and frontend-update checks in that case. The
+        // `is_offline_rebuild_target()` gate keeps a user-created unshared target out of this
+        // path.
+        let promoting_offline_rebuild = volume.is_offline_rebuild_target();
+
+        if !promoting_offline_rebuild
+            && volume.publish_context.as_ref() != Some(args.publish_context())
+        {
             return Err(SvcError::VolumePublishCtxDiffer {
                 vol_id: volume.uuid_str(),
                 current: volume.publish_context.clone().unwrap_or_default(),
@@ -374,7 +385,7 @@ fn validate_publish(
             });
         }
 
-        if !frontend.needs_update(args.new_frontend().nodes_info()) {
+        if !promoting_offline_rebuild && !frontend.needs_update(args.new_frontend().nodes_info()) {
             return Err(SvcError::VolumeAlreadyPublished {
                 vol_id: volume.uuid_str(),
                 node: target.node().to_string(),
@@ -383,8 +394,10 @@ fn validate_publish(
         }
 
         // Volume already published to different frontend node, and specified mode is SNW,
-        // then we must error out since this is not allowed
-        if args.access_mode() == VolumeAccessMode::SingleNodeWriter {
+        // then we must error out since this is not allowed.
+        // Exception: offline-rebuild target_cfg has an empty frontend by design, so the
+        // empty→single transition during promotion is legitimate.
+        if !promoting_offline_rebuild && args.access_mode() == VolumeAccessMode::SingleNodeWriter {
             return Err(SvcError::VolumePublishSingle {
                 vol_id: volume.uuid_str(),
                 nodes: target_cfg.frontend().node_names(),

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -13,6 +13,7 @@ use crate::{
             self, AffinityGroup, CreateVolume, HostNqn, NexusId, NexusNvmfConfig, NodeId,
             PublishVolume, ReplicaId, SnapshotId, Topology, VolumeAccessMode, VolumeId,
             VolumeLabels, VolumePolicy, VolumeProperty, VolumeShareProtocol, VolumeStatus,
+            VolumeTargetMode,
         },
     },
     IntoOption,
@@ -161,15 +162,30 @@ pub struct VolumeTarget {
     nexus: NexusId,
     /// The protocol to use on the target.
     protocol: Option<VolumeShareProtocol>,
+    /// Purpose this target is serving. Defaults to `ServeFrontendApp` so existing
+    /// persisted state round-trips unchanged. Used by the offline-rebuild
+    /// reconciler to identify its own nexus, by the promote-on-publish path to
+    /// decide whether to flip the protocol on an incoming CSI publish, and as
+    /// the extension point for future `MaintenanceMode` flows.
+    #[serde(default, skip_serializing_if = "VolumeTargetMode::is_default")]
+    target_mode: VolumeTargetMode,
 }
 impl VolumeTarget {
     /// Create a new `Self` based on the given parameters.
+    /// The target mode defaults to [`VolumeTargetMode::ServeFrontendApp`]; use
+    /// [`Self::with_target_mode`] to override for internal callers.
     pub fn new(node: NodeId, nexus: NexusId, protocol: Option<VolumeShareProtocol>) -> Self {
         Self {
             node,
             nexus,
             protocol,
+            target_mode: VolumeTargetMode::default(),
         }
+    }
+    /// Builder: set the target mode on the resulting target.
+    pub fn with_target_mode(mut self, target_mode: VolumeTargetMode) -> Self {
+        self.target_mode = target_mode;
+        self
     }
     /// Get a reference to the node identification.
     pub fn node(&self) -> &NodeId {
@@ -182,6 +198,20 @@ impl VolumeTarget {
     /// Get a reference to the volume protocol.
     pub fn protocol(&self) -> Option<&VolumeShareProtocol> {
         self.protocol.as_ref()
+    }
+    /// Set the volume protocol. Used when promoting an offline-rebuild nexus
+    /// (originally unshared) into a real publish on CSI request.
+    pub fn set_protocol(&mut self, protocol: Option<VolumeShareProtocol>) {
+        self.protocol = protocol;
+    }
+    /// Get the purpose this target is serving.
+    pub fn target_mode(&self) -> VolumeTargetMode {
+        self.target_mode
+    }
+    /// Set the purpose this target is serving. Used on promote-on-publish, where
+    /// an offline-rebuild target is being taken over by a CSI publish.
+    pub fn set_target_mode(&mut self, target_mode: VolumeTargetMode) {
+        self.target_mode = target_mode;
     }
 }
 impl From<&InitiatorAC> for models::NodeAccessInfo {
@@ -437,6 +467,10 @@ impl TargetConfig {
     pub fn target(&self) -> &VolumeTarget {
         &self.target
     }
+    /// Get a mutable reference to the target.
+    pub fn target_mut(&mut self) -> &mut VolumeTarget {
+        &mut self.target
+    }
     /// Get the active target.
     pub fn active_target(&self) -> Option<&VolumeTarget> {
         match self.active {
@@ -459,6 +493,11 @@ impl TargetConfig {
     /// Get the target's nvmf configuration.
     pub fn config(&self) -> &NexusNvmfConfig {
         &self.config
+    }
+    /// Builder: set the target mode on the inner [`VolumeTarget`].
+    pub fn with_target_mode(mut self, target_mode: VolumeTargetMode) -> Self {
+        self.target = self.target.with_target_mode(target_mode);
+        self
     }
 }
 
@@ -564,6 +603,22 @@ impl VolumeSpec {
         }
         // todo: is there any case where we might want to keep it around?
         self.publish_context = None;
+        // No need to reset the target mode here: it lives on the target
+        // itself, so it goes away when the target is replaced on the next
+        // publish.
+    }
+    /// Purpose the current `target_config` is serving, if any. Proxies through
+    /// the target so the volume only carries the mode while a target exists.
+    pub fn target_mode(&self) -> VolumeTargetMode {
+        self.target_config
+            .as_ref()
+            .map(|cfg| cfg.target().target_mode())
+            .unwrap_or_default()
+    }
+    /// Convenience: whether the current `target_config` was set up by the
+    /// offline-rebuild reconciler.
+    pub fn is_offline_rebuild_target(&self) -> bool {
+        matches!(self.target_mode(), VolumeTargetMode::OfflineRebuild)
     }
     /// Get the health info key which is used to retrieve the volume's replica health information.
     pub fn health_info_id(&self) -> Option<&NexusId> {
@@ -636,6 +691,8 @@ impl SpecTransaction<VolumeOperation> for VolumeSpec {
                 }
                 VolumeOperation::Publish(args) => {
                     self.last_nexus_id = None;
+                    // The target mode is carried on the embedded `VolumeTarget`
+                    // inside `args.config`, so storing the config is sufficient.
                     self.target_config = Some(args.config);
                     self.publish_context = Some(args.publish_context);
                 }
@@ -780,6 +837,9 @@ pub struct OldPublishOperation {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct PublishOperation {
     /// The new target configuration, considering a successful completion.
+    /// The target mode is carried on the embedded `VolumeTarget` inside
+    /// this `TargetConfig`, so callers configure it there before constructing
+    /// the operation.
     config: TargetConfig,
     publish_context: HashMap<String, String>,
     access_mode: VolumeAccessMode,
@@ -814,6 +874,10 @@ impl PublishOperation {
     /// Get the volume access mode.
     pub fn access_mode(&self) -> VolumeAccessMode {
         self.access_mode
+    }
+    /// Get the target mode being established by this publish.
+    pub fn target_mode(&self) -> VolumeTargetMode {
+        self.config.target().target_mode()
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -703,6 +703,69 @@ impl PublishVolume {
     }
 }
 
+/// Describes the purpose a volume target is currently serving.
+/// Persisted on the volume metadata so internal callers (reconcilers, future
+/// maintenance flows) can identify a target they themselves established
+/// without leaking that distinction through the public publish API.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VolumeTargetMode {
+    /// The target is serving a front-end application publish (the default
+    /// path: CSI publish or REST publish that fronts a user workload).
+    ServeFrontendApp,
+    /// The target was set up by the offline-rebuild reconciler to drive a
+    /// rebuild on an unpublished volume. The reconciler owns its lifecycle.
+    OfflineRebuild,
+    /// The target was set up for an operator-initiated maintenance flow
+    /// (fsck, grow, migrate) and must not be promoted to serve app traffic
+    /// until the maintenance flow releases it. Reserved for future use.
+    MaintenanceMode,
+}
+
+impl Default for VolumeTargetMode {
+    fn default() -> Self {
+        Self::ServeFrontendApp
+    }
+}
+
+impl VolumeTargetMode {
+    /// Skip-serializing-if helper so the common case stays out of the persisted
+    /// volume metadata.
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::ServeFrontendApp)
+    }
+}
+
+/// Internal wrapper around `PublishVolume` that carries the `VolumeTargetMode`
+/// alongside the request. Used by core-agent call paths that need to record
+/// the purpose of a publish (e.g. the offline-rebuild reconciler) without
+/// exposing it on the public `PublishVolume` API.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PublishVolumeWithMode {
+    /// The underlying publish request.
+    pub request: PublishVolume,
+    /// The purpose of the publish.
+    pub target_mode: VolumeTargetMode,
+}
+
+impl PublishVolumeWithMode {
+    /// Wrap a `PublishVolume` request with the given target mode.
+    pub fn new(request: PublishVolume, target_mode: VolumeTargetMode) -> Self {
+        Self {
+            request,
+            target_mode,
+        }
+    }
+}
+
+impl From<PublishVolume> for PublishVolumeWithMode {
+    fn from(request: PublishVolume) -> Self {
+        Self {
+            request,
+            target_mode: VolumeTargetMode::default(),
+        }
+    }
+}
+
 /// Republishes the target on a new node (pre-selected or determined by the control-plane).
 /// If online, the previous target nexus is first shutdown which may gives us enough time for the
 /// switchover as it'd be prevent from failing any IO outright.


### PR DESCRIPTION
Iteration 3 of offline volume rebuild ([openebs/openebs#4208](https://github.com/openebs/openebs/issues/4208)), builds on iteration 2 ([#1108](https://github.com/openebs/mayastor-control-plane/pull/1108)) which handles the basic create/rebuild/teardown lifecycle.

When a CSI publish arrives while an offline rebuild is in progress, the publish flow now promotes the existing unshared nexus, shares it via the existing `share_nexus`, flips the protocol on the spec instead of trying to create a new nexus. The rebuild keeps going on the now-shared nexus, the reconciler stops treating it as its own, and the volume becomes a normal published volume.

To support this safely, the volume metadata records the *purpose* of the current target via a `VolumeTargetMode` enum (`ServeFrontendApp`, `OfflineRebuild`, with `MaintenanceMode` reserved for follow-up work). The reconciler's identify-our-nexus check and the publish flow's promotion path both gate on `OfflineRebuild`, so a user-created unshared nexus produced via direct REST publish (which stays at the default `ServeFrontendApp`) never gets touched. The mode is kept off the public `PublishVolume` API, internal callers like the reconciler go through `OperationGuardArc::<VolumeSpec>::publish_with_mode` instead, which records the mode on the resulting `target_config`.

BDD tests cover the promote-on-publish path and GC safety during rebuild; the existing iteration 2 happy path still passes.