### PR TITLE
feat(core): add bestEffort snapshot restore policy

### DIFF
--- a/control-plane/agents/src/bin/core/tests/pool/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/pool/mod.rs
@@ -606,6 +606,7 @@ async fn volume_repl_placement_with_cluster_size() {
             Some(10),
             false,
             Some(33554432),
+            None,
         );
         let volume = VolumeId::new();
         volumes_api.put_volume(&volume, body).await.unwrap();

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot_clone.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot_clone.rs
@@ -9,7 +9,10 @@ use stor_port::{
     transport_api::ReplyErrorKind,
     types::v0::{
         store::pool::POOL_BS_CLUSTER_SIZE_DEFAULT,
-        transport::{CreatePool, CreateSnapshotVolume, CreateVolume, Filter, SnapshotId},
+        transport::{
+            CreatePool, CreateSnapshotVolume, CreateVolume, Filter, SnapshotId,
+            SnapshotRestorePolicy,
+        },
     },
 };
 
@@ -298,4 +301,108 @@ async fn snapshot_clone_pool_cluster_size_constraint() {
         .unwrap();
     vol_cli.destroy(&volume_1, None).await.unwrap();
     vol_cli.destroy(&volume_2, None).await.unwrap();
+}
+
+/// Restoring a snapshot when only a subset of source pools can host a clone.
+///
+/// Setup: 2 io-engines, 2-replica volume, snapshot. Then pause one of the
+/// io-engines so its pool is unreachable for new replica creation. With
+/// only one usable source pool left:
+///
+/// - `Strict` (default) restore must fail.
+/// - `BestEffort` restore must succeed with one clone replica. The remaining
+///   replica is left for the regular replica reconciler to fill in.
+#[tokio::test]
+async fn snapshot_restore_best_effort() {
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_io_engines(2)
+        .with_pools(1)
+        .with_cache_period("1s")
+        .with_reconcile_period(Duration::from_secs(1), Duration::from_secs(1))
+        .build()
+        .await
+        .unwrap();
+
+    let vol_cli = cluster.grpc_client().volume();
+
+    let source = vol_cli
+        .create(
+            &CreateVolume {
+                uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd8a0".try_into().unwrap(),
+                size: 20 * 1024 * 1024,
+                replicas: 2,
+                thin: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let snapshot = vol_cli
+        .create_snapshot(
+            &CreateVolumeSnapshot::new(source.uuid(), SnapshotId::new()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Make one of the two source pools unreachable.
+    cluster.composer().pause(&cluster.node(1)).await.unwrap();
+
+    // Strict: 2 replicas requested, only one source pool reachable, must fail.
+    // The upfront `setup` gate accepts both source pools (the scheduler does
+    // not drop the paused-node pool at candidate-listing time), so the failure
+    // surfaces from the per-replica create on the unreachable node and the
+    // post-create check against the requested replica count.
+    let strict_err = vol_cli
+        .create_snapshot_volume(
+            &CreateSnapshotVolume::new(
+                snapshot.spec().snap_id().clone(),
+                CreateVolume {
+                    uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd8a1".try_into().unwrap(),
+                    size: 20 * 1024 * 1024,
+                    replicas: 2,
+                    thin: true,
+                    snapshot_restore_policy: SnapshotRestorePolicy::Strict,
+                    ..Default::default()
+                },
+            ),
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(strict_err.kind, ReplyErrorKind::ReplicaCreateNumber);
+
+    // BestEffort: same request must succeed with one clone replica.
+    let restored = vol_cli
+        .create_snapshot_volume(
+            &CreateSnapshotVolume::new(
+                snapshot.spec().snap_id().clone(),
+                CreateVolume {
+                    uuid: "1e3cf927-80c2-47a8-adf0-95c486bdd8a2".try_into().unwrap(),
+                    size: 20 * 1024 * 1024,
+                    replicas: 2,
+                    thin: true,
+                    snapshot_restore_policy: SnapshotRestorePolicy::BestEffort,
+                    ..Default::default()
+                },
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // The volume spec still asks for 2 replicas, but only one was provisioned
+    // up-front. The replica reconciler is responsible for bringing the count
+    // back up once the paused node returns or another pool becomes a candidate.
+    assert_eq!(restored.spec().num_replicas, 2);
+    let actual_replicas = restored.state().replica_topology.len();
+    assert!(
+        actual_replicas >= 1,
+        "BestEffort restore should produce at least one replica, got {actual_replicas}",
+    );
+
+    cluster.composer().thaw(&cluster.node(1)).await.unwrap();
 }

--- a/control-plane/agents/src/bin/core/volume/clone_operations.rs
+++ b/control-plane/agents/src/bin/core/volume/clone_operations.rs
@@ -3,8 +3,8 @@ use crate::{
         registry::Registry,
         resources::{
             operations::{ResourceCloning, ResourceLifecycle, ResourceLifecycleExt},
-            operations_helper::{GuardedOperationsHelper, SpecOperationsHelper},
-            OperationGuardArc, TraceStrLog,
+            operations_helper::{GuardedOperationsHelper, OnCreateFail, SpecOperationsHelper},
+            OperationGuardArc, ResourceUid, TraceStrLog,
         },
         scheduling::{volume::CloneVolumeSnapshot, ResourceFilter},
     },
@@ -23,7 +23,7 @@ use stor_port::{
         },
         transport::{
             CreateSnapshotVolume, DestroyVolume, Replica, SnapshotCloneId, SnapshotCloneParameters,
-            SnapshotCloneSpecParams,
+            SnapshotCloneSpecParams, SnapshotRestorePolicy,
         },
     },
 };
@@ -120,16 +120,60 @@ impl CreateVolumeExeVal for SnapshotCloneOp<'_> {
 impl CreateVolumeExe for SnapshotCloneOp<'_> {
     type Candidates = Vec<SnapshotCloneSpecParams>;
 
+    async fn run<'a>(&'a self, mut context: Context<'a>) -> Result<Vec<Replica>, SvcError> {
+        // Override the default `run` so that BestEffort restores can succeed
+        // with fewer replicas than `num_replicas`. The remaining replicas are
+        // filled in afterwards by the regular replica reconciler.
+        let result = self.setup(&mut context).await;
+        let candidates = context
+            .volume
+            .validate_create_step_ext(context.registry, result, OnCreateFail::Delete)
+            .await?;
+        let replicas = self.create(&mut context, candidates).await;
+
+        let policy = self.0.params().snapshot_restore_policy;
+        let min_replicas = match policy {
+            SnapshotRestorePolicy::Strict => context.volume.as_ref().num_replicas as usize,
+            SnapshotRestorePolicy::BestEffort => 1,
+        };
+        if replicas.len() < min_replicas {
+            self.undo(&mut context, replicas).await;
+            Err(SvcError::ReplicaCreateNumber {
+                id: context.volume.uid_str(),
+            })
+        } else {
+            Ok(replicas)
+        }
+    }
+
     async fn setup<'a>(&'a self, context: &mut Context<'a>) -> Result<Self::Candidates, SvcError> {
         // todo: topology is not being used here at all
         let clonable_snapshots = self.cloneable_snapshot(context).await?;
         let volume = context.volume.as_ref();
-        if volume.num_replicas > clonable_snapshots.len() as u8 {
-            return Err(SvcError::InsufficientSnapshotsForClone {
-                snapshots: clonable_snapshots.len() as u8,
-                replicas: volume.num_replicas,
-                id: volume.uuid_str(),
-            });
+        let policy = self.0.params().snapshot_restore_policy;
+        match policy {
+            SnapshotRestorePolicy::Strict => {
+                if volume.num_replicas > clonable_snapshots.len() as u8 {
+                    return Err(SvcError::InsufficientSnapshotsForClone {
+                        snapshots: clonable_snapshots.len() as u8,
+                        replicas: volume.num_replicas,
+                        id: volume.uuid_str(),
+                    });
+                }
+            }
+            SnapshotRestorePolicy::BestEffort => {
+                // BestEffort: as long as at least one snapshot replica can be
+                // cloned, allow the restore to proceed. The missing replicas
+                // are filled in afterwards by the regular replica reconciler
+                // via a normal rebuild.
+                if clonable_snapshots.is_empty() {
+                    return Err(SvcError::InsufficientSnapshotsForClone {
+                        snapshots: 0,
+                        replicas: volume.num_replicas,
+                        id: volume.uuid_str(),
+                    });
+                }
+            }
         }
         Ok(clonable_snapshots)
     }
@@ -141,8 +185,6 @@ impl CreateVolumeExe for SnapshotCloneOp<'_> {
     ) -> Vec<Replica> {
         let mut replicas = Vec::new();
         let volume_replicas = context.volume.as_ref().num_replicas as usize;
-        // todo: need to add new replica and do full rebuild, if clonable snapshots
-        // count is less than volume replicas count.
         for clone_replica in clone_replicas {
             match OperationGuardArc::<ReplicaSpec>::create_ext(context.registry, &clone_replica)
                 .await
@@ -165,8 +207,9 @@ impl CreateVolumeExe for SnapshotCloneOp<'_> {
     }
 
     async fn undo<'a>(&'a self, _context: &mut Context<'a>, _replicas: Vec<Replica>) {
-        // nothing to undo since we only support 1-replica snapshot
-        // todo: we do support multi-replica snapshots, this should have been tweaked :(
+        // nothing to undo: replicas created so far are owned by the volume
+        // spec and will be cleaned up via the standard destroy path if the
+        // overall create fails.
     }
 }
 
@@ -190,7 +233,12 @@ impl SnapshotCloneOp<'_> {
         let pools = CloneVolumeSnapshot::builder_with_defaults(registry, new_volume, snapshots)
             .await
             .collect();
-        if pools.len() < new_volume.num_replicas as usize || pools.is_empty() {
+        let policy = self.0.params().snapshot_restore_policy;
+        let required_pools = match policy {
+            SnapshotRestorePolicy::Strict => new_volume.num_replicas as usize,
+            SnapshotRestorePolicy::BestEffort => 1,
+        };
+        if pools.is_empty() || pools.len() < required_pools {
             return Err(SvcError::NoSnapshotPools {
                 id: snapshot.spec().uuid().to_string(),
             });

--- a/control-plane/csi-driver/src/bin/controller/client.rs
+++ b/control-plane/csi-driver/src/bin/controller/client.rs
@@ -6,8 +6,8 @@ use stor_port::types::v0::openapi::{
     models,
     models::{
         rest_json_error::Kind, AffinityGroup, AppNode, CreateVolumeBody, Node, NodeTopology, Pool,
-        PoolTopology, PublishVolumeBody, ResizeVolumeBody, RestJsonError, Topology, Volume,
-        VolumeAccessMode, VolumePolicy, VolumeShareProtocol, Volumes,
+        PoolTopology, PublishVolumeBody, ResizeVolumeBody, RestJsonError, SnapshotRestorePolicy,
+        Topology, Volume, VolumeAccessMode, VolumePolicy, VolumeShareProtocol, Volumes,
     },
 };
 
@@ -281,6 +281,7 @@ impl RestApiClient {
             max_snapshots,
             encrypted,
             cluster_size,
+            snapshot_restore_policy: None,
         };
 
         let result = self
@@ -307,6 +308,7 @@ impl RestApiClient {
         affinity_group: Option<AffinityGroup>,
         max_snapshots: Option<u32>,
         encrypted: bool,
+        snapshot_restore_policy: Option<SnapshotRestorePolicy>,
     ) -> Result<Volume, ApiClientError> {
         let topology =
             Topology::new_all(volume_topology.node_topology, volume_topology.pool_topology);
@@ -322,6 +324,7 @@ impl RestApiClient {
             max_snapshots,
             encrypted,
             cluster_size: None,
+            snapshot_restore_policy,
         };
         let result = self
             .rest_client

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -456,6 +456,9 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                         // thin:false explicitly.
                         let thin_arg_passed = args.parameters.contains_key("thin");
                         let thin = !thin_arg_passed || thin;
+                        let snapshot_restore_policy = context
+                            .snapshot_restore_policy()
+                            .map(models::SnapshotRestorePolicy::from);
                         RestApiClient::get_client()
                             .create_snapshot_volume(
                                 &parsed_vol_uuid,
@@ -467,6 +470,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                                 affinity_group_name.map(AffinityGroup::new),
                                 max_snapshots,
                                 encrypted,
+                                snapshot_restore_policy,
                             )
                             .await?
                     }
@@ -1000,8 +1004,15 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
                     .create_volume_snapshot(&volume_uuid, &snap_uuid)
                     .await
                     .map_err(|error| match error {
+                        // The external-snapshotter side-car treats `ResourceExhausted` as retriable
+                        // and ends up in a tight retry loop when the failure is actually a permanent
+                        // capacity problem (no pool has enough space to host the snapshot). Report
+                        // it as `FailedPrecondition` instead so the side-car surfaces the failure to
+                        // the user rather than hammering the control-plane. The proper fix lives in
+                        // the side-car itself (kubernetes-csi/external-snapshotter#1334) and this
+                        // mapping can be reverted once that lands.
                         ApiClientError::ResourceExhausted(reason) => {
-                            Status::resource_exhausted(reason)
+                            Status::failed_precondition(reason)
                         }
                         ApiClientError::PreconditionFailed(reason) => {
                             Status::failed_precondition(reason)

--- a/control-plane/csi-driver/src/context.rs
+++ b/control-plane/csi-driver/src/context.rs
@@ -12,7 +12,10 @@ use std::{
     num::ParseIntError,
     str::{FromStr, ParseBoolError},
 };
-use stor_port::{platform, types::v0::openapi::models::VolumeShareProtocol};
+use stor_port::{
+    platform,
+    types::v0::{openapi::models::VolumeShareProtocol, transport::SnapshotRestorePolicy},
+};
 use strum_macros::{AsRefStr, Display, EnumString};
 use tracing::{debug, log::warn, trace};
 use utils::K8S_STS_PVC_NAMING_REGEX;
@@ -85,6 +88,8 @@ pub enum Parameters {
     PoolClusterSize,
     #[strum(serialize = "rwxBlock")]
     RwxBlock,
+    #[strum(serialize = "snapshotRestorePolicy")]
+    SnapshotRestorePolicy,
 }
 impl Parameters {
     fn parse_human_time(
@@ -288,6 +293,22 @@ impl Parameters {
         }
         Ok(None)
     }
+    /// Parse the value for `Self::SnapshotRestorePolicy`. Accepts the canonical
+    /// camelCase value names: `strict` or `bestEffort`.
+    pub fn snapshot_restore_policy(
+        value: Option<&String>,
+    ) -> Result<Option<SnapshotRestorePolicy>, tonic::Status> {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        match value.as_str() {
+            "strict" => Ok(Some(SnapshotRestorePolicy::Strict)),
+            "bestEffort" => Ok(Some(SnapshotRestorePolicy::BestEffort)),
+            other => Err(tonic::Status::invalid_argument(format!(
+                "Invalid `snapshotRestorePolicy` value {other:?}, expected `strict` or `bestEffort`",
+            ))),
+        }
+    }
 }
 
 /// Volume publish parameters.
@@ -452,6 +473,7 @@ pub struct CreateParams {
     node_affinity_topology_label: Option<HashMap<String, String>>,
     node_has_topology_key: Option<HashMap<String, String>>,
     node_spread_topology_key: Option<HashMap<String, String>>,
+    snapshot_restore_policy: Option<SnapshotRestorePolicy>,
 }
 impl CreateParams {
     /// Get the `Parameters::RwxBlock` value.
@@ -509,6 +531,10 @@ impl CreateParams {
     /// Get the `Parameters::NodeSpreadTopologyKey` value.
     pub fn node_spread_topology_key(&self) -> &Option<HashMap<String, String>> {
         &self.node_spread_topology_key
+    }
+    /// Get the `Parameters::SnapshotRestorePolicy` value.
+    pub fn snapshot_restore_policy(&self) -> Option<SnapshotRestorePolicy> {
+        self.snapshot_restore_policy
     }
 
     /// Get the sts_affinity_group name from annotations if exists else generate it.
@@ -730,6 +756,10 @@ impl TryFrom<&HashMap<String, String>> for CreateParams {
         validate_topology_params(&node_affinity_topology_label, &node_spread_topology_key)?;
         validate_topology_params(&node_has_topology_key, &node_spread_topology_key)?;
 
+        let snapshot_restore_policy = Parameters::snapshot_restore_policy(
+            args.get(Parameters::SnapshotRestorePolicy.as_ref()),
+        )?;
+
         Ok(Self {
             publish_params,
             rwx_block,
@@ -748,6 +778,7 @@ impl TryFrom<&HashMap<String, String>> for CreateParams {
             node_affinity_topology_label,
             node_has_topology_key,
             node_spread_topology_key,
+            snapshot_restore_policy,
         })
     }
 }

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -302,6 +302,21 @@ message CreateVolumeRequest {
   optional bool encrypted = 12;
   // Blobstore cluster size required for pools hosting this volume's replicas.
   optional uint32 cluster_size = 13;
+  // Policy controlling how a snapshot restore behaves when not every replica
+  // pool can host a clone of the source snapshot. Only meaningful for snapshot
+  // restore requests.
+  optional SnapshotRestorePolicy snapshot_restore_policy = 14;
+}
+
+// Policy controlling how a snapshot restore behaves when not every replica
+// pool can accept a clone of the source snapshot.
+enum SnapshotRestorePolicy {
+  // Require every requested replica to be cloned from the source snapshot.
+  STRICT = 0;
+  // Allow the restore to proceed with fewer clones than the requested replica
+  // count, as long as at least one clone succeeds. Missing replicas are filled
+  // in later by the regular replica reconciler.
+  BEST_EFFORT = 1;
 }
 
 enum AccessMode {

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -30,9 +30,9 @@ use stor_port::{
             DestroyVolume, ExplicitNodeTopology, Filter, LabelledTopology, Nexus, NexusId,
             NexusNvmfConfig, NodeId, NodeTopology, NvmeNqn, PoolTopology, PublishVolume, ReplicaId,
             ReplicaStatus, ReplicaTopology, ReplicaUsage, RepublishVolume, ResizeVolume,
-            SetVolumeProperty, SetVolumeReplica, ShareVolume, SnapshotId, Topology,
-            UnpublishVolume, UnshareVolume, Volume, VolumeAccessMode, VolumeHealth, VolumeId,
-            VolumeLabels, VolumePolicy, VolumeProperty, VolumeShareProtocol, VolumeState,
+            SetVolumeProperty, SetVolumeReplica, ShareVolume, SnapshotId, SnapshotRestorePolicy,
+            Topology, UnpublishVolume, UnshareVolume, Volume, VolumeAccessMode, VolumeHealth,
+            VolumeId, VolumeLabels, VolumePolicy, VolumeProperty, VolumeShareProtocol, VolumeState,
             VolumeUsage,
         },
     },
@@ -948,6 +948,9 @@ pub trait CreateVolumeInfo: Send + Sync + std::fmt::Debug {
     fn encrypted(&self) -> bool;
     /// Pool's blobstore cluster size required for replicas of this volume.
     fn cluster_size(&self) -> Option<u32>;
+    /// Policy controlling how a snapshot restore behaves when not every replica
+    /// pool can host a clone of the source snapshot.
+    fn snapshot_restore_policy(&self) -> SnapshotRestorePolicy;
 }
 
 impl CreateVolumeInfo for CreateVolume {
@@ -998,6 +1001,10 @@ impl CreateVolumeInfo for CreateVolume {
     fn cluster_size(&self) -> Option<u32> {
         self.cluster_size
     }
+
+    fn snapshot_restore_policy(&self) -> SnapshotRestorePolicy {
+        self.snapshot_restore_policy
+    }
 }
 
 /// Intermediate structure that validates the conversion to CreateVolumeRequest type.
@@ -1006,6 +1013,7 @@ pub struct ValidatedCreateVolumeRequest {
     inner: CreateVolumeRequest,
     uuid: VolumeId,
     topology: Option<Topology>,
+    snapshot_restore_policy: SnapshotRestorePolicy,
 }
 
 impl CreateVolumeInfo for ValidatedCreateVolumeRequest {
@@ -1062,11 +1070,30 @@ impl CreateVolumeInfo for ValidatedCreateVolumeRequest {
     fn cluster_size(&self) -> Option<u32> {
         self.inner.cluster_size
     }
+
+    fn snapshot_restore_policy(&self) -> SnapshotRestorePolicy {
+        self.snapshot_restore_policy
+    }
 }
 
 impl ValidateRequestTypes for CreateVolumeRequest {
     type Validated = ValidatedCreateVolumeRequest;
     fn validated(self) -> Result<Self::Validated, ReplyError> {
+        // Validate the snapshot restore policy here rather than at field-access time so an
+        // unknown enum value (e.g. a newer client talking to an older agent) fails fast with
+        // an explicit InvalidArgument instead of being silently treated as the default.
+        let snapshot_restore_policy = match self.snapshot_restore_policy {
+            Some(value) => volume::SnapshotRestorePolicy::try_from(value)
+                .map(SnapshotRestorePolicy::from)
+                .map_err(|_| {
+                    ReplyError::invalid_argument(
+                        ResourceKind::Volume,
+                        "create_volume_request.snapshot_restore_policy",
+                        format!("unknown SnapshotRestorePolicy value: {value}"),
+                    )
+                })?,
+            None => SnapshotRestorePolicy::default(),
+        };
         Ok(ValidatedCreateVolumeRequest {
             uuid: VolumeId::try_from(StringValue(self.uuid.clone()))?,
             topology: match self.topology.clone() {
@@ -1082,6 +1109,7 @@ impl ValidateRequestTypes for CreateVolumeRequest {
                 },
                 None => None,
             },
+            snapshot_restore_policy,
             inner: self,
         })
     }
@@ -1102,6 +1130,7 @@ impl From<&dyn CreateVolumeInfo> for CreateVolume {
             max_snapshots: data.max_snapshots(),
             encrypted: data.encrypted(),
             cluster_size: data.cluster_size(),
+            snapshot_restore_policy: data.snapshot_restore_policy(),
         }
     }
 }
@@ -1123,6 +1152,27 @@ impl From<&dyn CreateVolumeInfo> for CreateVolumeRequest {
             max_snapshots: data.max_snapshots(),
             encrypted: Some(data.encrypted()),
             cluster_size: data.cluster_size(),
+            snapshot_restore_policy: Some(volume::SnapshotRestorePolicy::from(
+                data.snapshot_restore_policy(),
+            ) as i32),
+        }
+    }
+}
+
+impl From<SnapshotRestorePolicy> for volume::SnapshotRestorePolicy {
+    fn from(value: SnapshotRestorePolicy) -> Self {
+        match value {
+            SnapshotRestorePolicy::Strict => Self::Strict,
+            SnapshotRestorePolicy::BestEffort => Self::BestEffort,
+        }
+    }
+}
+
+impl From<volume::SnapshotRestorePolicy> for SnapshotRestorePolicy {
+    fn from(value: volume::SnapshotRestorePolicy) -> Self {
+        match value {
+            volume::SnapshotRestorePolicy::Strict => Self::Strict,
+            volume::SnapshotRestorePolicy::BestEffort => Self::BestEffort,
         }
     }
 }

--- a/control-plane/plugin/src/resources/tests.rs
+++ b/control-plane/plugin/src/resources/tests.rs
@@ -44,6 +44,7 @@ async fn setup() {
                 max_snapshots: None,
                 encrypted: false,
                 cluster_size: None,
+                snapshot_restore_policy: None,
             },
         )
         .await
@@ -126,6 +127,7 @@ async fn get_volumes_paginated() {
                     max_snapshots: None,
                     encrypted: false,
                     cluster_size: None,
+                    snapshot_restore_policy: None,
                 },
             )
             .await

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3088,12 +3088,32 @@ components:
           format: int64
           minimum: 4194304
           multipleOf: 4194304
+        snapshot_restore_policy:
+          description: |-
+            Policy controlling how a snapshot restore behaves when not every replica
+            pool can host a clone of the source snapshot. Only meaningful when the
+            create request is part of a snapshot restore.
+          allOf:
+            - $ref: '#/components/schemas/SnapshotRestorePolicy'
       required:
         - policy
         - replicas
         - size
         - thin
         - encrypted
+    SnapshotRestorePolicy:
+      description: |-
+        Policy controlling how a snapshot restore behaves when not every replica
+        pool can accept a clone of the source snapshot.
+        - `strict`: every requested replica must be cloned from the source snapshot.
+        - `bestEffort`: allow the restore to proceed with fewer clones than the
+          requested replica count, as long as at least one clone succeeds. The
+          missing replicas are filled in later by the regular replica reconciler.
+      type: string
+      enum:
+        - strict
+        - bestEffort
+      default: strict
     SetVolumePropertyBody:
       example:
         max_snapshots: 10

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -16,9 +16,9 @@ pub use stor_port::{
             DestroyReplica, DestroyVolume, Filter, GetBlockDevices, HostNqn, HostNqnParseError,
             JsonGrpcRequest, LabelPool, Nexus, NexusId, NexusShareProtocol, Node, NodeId, Pool,
             PoolDeviceUri, PoolId, Protocol, RemoveNexusChild, Replica, ReplicaId,
-            ReplicaShareProtocol, ShareNexus, ShareReplica, SnapshotId, Specs, Topology,
-            UnshareNexus, UnshareReplica, VolumeId, VolumeLabels, VolumePolicy, VolumeProperty,
-            Watch, WatchCallback, WatchResourceId,
+            ReplicaShareProtocol, ShareNexus, ShareReplica, SnapshotId, SnapshotRestorePolicy,
+            Specs, Topology, UnshareNexus, UnshareReplica, VolumeId, VolumeLabels, VolumePolicy,
+            VolumeProperty, Watch, WatchCallback, WatchResourceId,
         },
     },
     IntoOption, IntoVec,
@@ -220,6 +220,10 @@ pub struct CreateVolumeBody {
     pub encryption: bool,
     /// Blobstore cluster size required for pools hosting this volume's replicas.
     pub cluster_size: Option<u32>,
+    /// Policy controlling how a snapshot restore behaves when not every replica
+    /// pool can host a clone of the source snapshot. Only meaningful when the
+    /// create request is part of a snapshot restore.
+    pub snapshot_restore_policy: SnapshotRestorePolicy,
 }
 impl From<models::CreateVolumeBody> for CreateVolumeBody {
     fn from(src: models::CreateVolumeBody) -> Self {
@@ -234,6 +238,10 @@ impl From<models::CreateVolumeBody> for CreateVolumeBody {
             max_snapshots: src.max_snapshots,
             encryption: src.encrypted,
             cluster_size: src.cluster_size.map(|c| c as u32),
+            snapshot_restore_policy: src
+                .snapshot_restore_policy
+                .map(SnapshotRestorePolicy::from)
+                .unwrap_or_default(),
         }
     }
 }
@@ -250,6 +258,7 @@ impl From<CreateVolume> for CreateVolumeBody {
             max_snapshots: create.max_snapshots,
             encryption: create.encrypted,
             cluster_size: create.cluster_size,
+            snapshot_restore_policy: create.snapshot_restore_policy,
         }
     }
 }
@@ -269,6 +278,7 @@ impl CreateVolumeBody {
             max_snapshots: self.max_snapshots,
             encrypted: self.encryption,
             cluster_size: self.cluster_size,
+            snapshot_restore_policy: self.snapshot_restore_policy,
         }
     }
     /// Convert into rpc request type.

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -487,6 +487,44 @@ impl GetVolumes {
     }
 }
 
+/// Policy for restoring a volume from a snapshot when one or more snapshot
+/// replica pools cannot accept a new clone (for example, the source pool is full).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotRestorePolicy {
+    /// Require every requested replica to be cloned from the source snapshot.
+    /// The restore fails if any clone cannot be created. This is the default.
+    Strict,
+    /// Allow the restore to proceed with fewer clones than the requested replica
+    /// count, as long as at least one clone can be created. The volume is created
+    /// in a degraded state and the missing replicas are filled in by the regular
+    /// replica reconciler via a full rebuild.
+    BestEffort,
+}
+
+impl Default for SnapshotRestorePolicy {
+    fn default() -> Self {
+        Self::Strict
+    }
+}
+
+impl From<models::SnapshotRestorePolicy> for SnapshotRestorePolicy {
+    fn from(value: models::SnapshotRestorePolicy) -> Self {
+        match value {
+            models::SnapshotRestorePolicy::Strict => Self::Strict,
+            models::SnapshotRestorePolicy::BestEffort => Self::BestEffort,
+        }
+    }
+}
+
+impl From<SnapshotRestorePolicy> for models::SnapshotRestorePolicy {
+    fn from(value: SnapshotRestorePolicy) -> Self {
+        match value {
+            SnapshotRestorePolicy::Strict => Self::Strict,
+            SnapshotRestorePolicy::BestEffort => Self::BestEffort,
+        }
+    }
+}
+
 /// Create volume request.
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -515,6 +553,10 @@ pub struct CreateVolume {
     pub encrypted: bool,
     /// Pool's blobstore cluster size required for replicas of this volume.
     pub cluster_size: Option<u32>,
+    /// Policy controlling how the volume is restored from a snapshot source.
+    /// Only meaningful when the create request is part of a snapshot restore.
+    #[serde(default)]
+    pub snapshot_restore_policy: SnapshotRestorePolicy,
 }
 
 /// Resize volume request.


### PR DESCRIPTION
## Summary

Adds a new StorageClass parameter `snapshotRestorePolicy` to control how a snapshot restore behaves when not every replica pool can host a clone of the source snapshot.

- `strict` (default): preserves current behavior. Every requested replica must be cloned from the snapshot.
- `bestEffort`: the restore proceeds as long as at least one clone succeeds. The volume comes up under-replicated and the regular replica reconciler fills in the missing replicas via a normal rebuild.

Also maps `ResourceExhausted` to `FailedPrecondition` on the snapshot create path so the external-snapshotter side-car stops retrying forever on permanent capacity failures. Reverts naturally once kubernetes-csi/external-snapshotter#1334 lands.

Refs openebs/mayastor#1987

## Test plan

- [x] New `snapshot_restore_best_effort` test under `agents::tests::volume::snapshot_clone`. Pauses one of two io-engines and asserts `Strict` returns `ReplicaCreateNumber` while `BestEffort` succeeds with one clone (and `num_replicas == 2` preserved on the spec).
- [x] Full `snapshot_clone` test set still passing (`cargo test --package agents --test core volume::snapshot_clone -- --test-threads=1`).
- [x] `cargo check --workspace` clean.
- [x] `cargo clippy --workspace --tests -- -D warnings` clean.