### PR TITLE
fix(health): don't cache readiness failure before first successful probe

### DIFF
--- a/control-plane/rest/service/src/health/core_state.rs
+++ b/control-plane/rest/service/src/health/core_state.rs
@@ -13,7 +13,10 @@ pub struct CachedCoreState {
 /// This type remembers a liveness state, and when this data was refreshed.
 struct ServerState {
     is_live: bool,
-    last_updated: Instant,
+    /// Initially `None`, causing every readiness check to make the actual gRPC
+    /// call. Set to `Some` on the first successful probe, and updated on every
+    /// probe thereafter so that cache expiry works correctly for failures too.
+    last_updated: Option<Instant>,
 }
 
 impl ServerState {
@@ -22,19 +25,19 @@ impl ServerState {
     async fn update_or_assume_unavailable(&mut self) {
         let new_value = core_grpc().node().probe(None).await.unwrap_or(false);
         self.is_live = new_value;
-        self.last_updated = Instant::now();
+        if new_value || self.last_updated.is_some() {
+            self.last_updated = Some(Instant::now());
+        }
     }
 }
 
 impl CachedCoreState {
     /// Create a new cache for serving readiness health checks based on agent-core health.
-    pub async fn new(cache_duration: Duration) -> Self {
-        let agent_core_is_live = core_grpc().node().probe(None).await.unwrap_or(false);
-
+    pub fn new(cache_duration: Duration) -> Self {
         CachedCoreState {
             state: Mutex::new(ServerState {
-                is_live: agent_core_is_live,
-                last_updated: Instant::now(),
+                is_live: false,
+                last_updated: None,
             }),
             cache_duration,
         }
@@ -45,7 +48,11 @@ impl CachedCoreState {
     pub async fn get_or_assume_unavailable(&self) -> bool {
         let mut state = self.state.lock().await;
 
-        if state.last_updated.elapsed() >= self.cache_duration {
+        let cache_expired = state
+            .last_updated
+            .is_none_or(|t| t.elapsed() >= self.cache_duration);
+
+        if cache_expired {
             state.update_or_assume_unavailable().await;
         }
 

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -330,8 +330,7 @@ async fn main() -> anyhow::Result<()> {
         .ok()
         .expect("Expect to be initialised only once");
 
-    let cached_core_state =
-        Data::new(CachedCoreState::new(cli_args.core_liveness_check_frequency).await);
+    let cached_core_state = Data::new(CachedCoreState::new(cli_args.core_liveness_check_frequency));
 
     let app = move || {
         actix_web::App::new()


### PR DESCRIPTION
CachedCoreState previously probed core-grpc in its constructor and
cached the result. If the gRPC service wasn't up yet, a false value
was cached with a fresh timestamp, and no retry happened until the
cache expired. This caused the readiness probe to report not-ready
for the entire cache_duration even if core-grpc came up moments later.

Make last_updated an Option that starts as None. While None, every
readiness check makes the actual gRPC call instead of serving a cached
false. On the first successful probe last_updated becomes Some, and
is refreshed on every probe thereafter so that cache expiry continues
to work correctly when core-grpc later goes down. Also make
CachedCoreState::new() synchronous since the eager probe is no longer
needed.