### PR TITLE
refactor: use version_info_string macro

### DIFF
--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -20,14 +20,14 @@ pub(crate) mod watch;
 use clap::Parser;
 use controller::registry::NumRebuilds;
 use std::{net::SocketAddr, num::ParseIntError};
-use utils::{version_info_str, DEFAULT_GRPC_SERVER_ADDR, ETCD_MAX_PAGE_LIMIT};
+use utils::{version_info_string, DEFAULT_GRPC_SERVER_ADDR, ETCD_MAX_PAGE_LIMIT};
 
 use stor_port::HostAccessControl;
 use utils::tracing_telemetry::{trace::TracerProvider, FmtLayer, FmtStyle, KeyValue};
 
 /// The Cli arguments for this binary.
 #[derive(Debug, Parser)]
-#[structopt(name = utils::package_description!(), version = version_info_str!())]
+#[structopt(name = utils::package_description!(), version = version_info_string!())]
 pub(crate) struct CliArgs {
     /// The period at which the registry updates its cache of all
     /// resources from all nodes.

--- a/control-plane/agents/src/bin/ha/cluster/main.rs
+++ b/control-plane/agents/src/bin/ha/cluster/main.rs
@@ -7,7 +7,7 @@ use tracing::info;
 use utils::{
     package_description,
     tracing_telemetry::{FmtLayer, FmtStyle, KeyValue},
-    version_info_str, DEFAULT_CLUSTER_AGENT_SERVER_ADDR, DEFAULT_GRPC_CLIENT_ADDR,
+    version_info_string, DEFAULT_CLUSTER_AGENT_SERVER_ADDR, DEFAULT_GRPC_CLIENT_ADDR,
 };
 
 mod etcd;
@@ -17,7 +17,7 @@ mod switchover;
 mod volume;
 
 #[derive(Debug, Parser)]
-#[structopt(name = package_description!(), version = version_info_str!())]
+#[structopt(name = package_description!(), version = version_info_string!())]
 struct Cli {
     /// IP address and port for the cluster-agent to listen on.
     #[clap(long, short, default_value = DEFAULT_CLUSTER_AGENT_SERVER_ADDR)]

--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -17,7 +17,7 @@ use tokio::net::UnixStream;
 use tonic::transport::{Channel, Endpoint};
 use tower::service_fn;
 use utils::{
-    package_description, tracing_telemetry::KeyValue, version_info_str,
+    package_description, tracing_telemetry::KeyValue, version_info_string,
     DEFAULT_CLUSTER_AGENT_CLIENT_ADDR, DEFAULT_NODE_AGENT_SERVER_IP,
     DEFAULT_NODE_AGENT_SERVER_PORT, NVME_PATH_AGGREGATION_PERIOD, NVME_PATH_CHECK_PERIOD,
     NVME_PATH_CONNECTION_PERIOD, NVME_PATH_RETRANSMISSION_PERIOD, NVME_SUBSYS_REFRESH_PERIOD,
@@ -34,7 +34,7 @@ use utils::tracing_telemetry::{FmtLayer, FmtStyle};
 
 /// TODO
 #[derive(Debug, Parser)]
-#[structopt(name = package_description!(), version = version_info_str!())]
+#[structopt(name = package_description!(), version = version_info_string!())]
 struct Cli {
     /// HA Cluster Agent URL or address to connect to the services.
     #[clap(long, short, default_value = DEFAULT_CLUSTER_AGENT_CLIENT_ADDR)]

--- a/control-plane/agents/src/bin/jsongrpc/main.rs
+++ b/control-plane/agents/src/bin/jsongrpc/main.rs
@@ -11,7 +11,7 @@ use tracing::{error, info};
 use utils::{DEFAULT_GRPC_CLIENT_ADDR, DEFAULT_JSON_GRPC_SERVER_ADDR};
 
 #[derive(Debug, Parser)]
-#[structopt(name = utils::package_description!(), version = utils::version_info_str!())]
+#[structopt(name = utils::package_description!(), version = utils::version_info_string!())]
 struct CliArgs {
     /// The json grpc server URL or address to connect to the its services.
     #[clap(long, short = 'J', default_value = DEFAULT_JSON_GRPC_SERVER_ADDR)]

--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -42,7 +42,7 @@ async fn ping_rest_api() {
 #[tokio::main(worker_threads = 2)]
 async fn main() -> anyhow::Result<()> {
     let args = clap::Command::new(utils::package_description!())
-        .version(utils::version_info_str!())
+        .version(utils::version_info_string!())
         .arg(
             Arg::new("endpoint")
                 .long("rest-endpoint")

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -43,7 +43,7 @@ pub(super) async fn main() -> anyhow::Result<()> {
     // Parse command line arguments.
     let matches = clap::Command::new(utils::package_description!())
         .about("k8s sidecar for IoEngine implementing CSI among others")
-        .version(utils::version_info_str!())
+        .version(utils::version_info_string!())
         .subcommand_negates_reqs(true)
         .arg(
             Arg::new("rest-endpoint")

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -35,7 +35,7 @@ use utils::{
 };
 
 #[derive(Debug, Parser)]
-#[structopt(name = utils::package_description!(), version = utils::version_info_str!())]
+#[structopt(name = utils::package_description!(), version = utils::version_info_string!())]
 pub(crate) struct CliArgs {
     /// The bind address for the REST interface (with HTTPS).
     #[clap(long, default_value = "[::]:8080")]

--- a/deployer/bin/src/deployer.rs
+++ b/deployer/bin/src/deployer.rs
@@ -27,7 +27,7 @@ fn init_tracing() {
 }
 
 #[derive(Debug, Parser)]
-#[clap(name = utils::package_description!(), version = utils::version_info_str!())]
+#[clap(name = utils::package_description!(), version = utils::version_info_string!())]
 struct CliArgs {
     #[clap(subcommand)]
     action: Action,

--- a/k8s/operators/src/pool/main.rs
+++ b/k8s/operators/src/pool/main.rs
@@ -281,7 +281,7 @@ fn write_diskpool_crd(output_dir: &str) -> anyhow::Result<()> {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     let matches = clap::Command::new(utils::package_description!())
-        .version(utils::version_info_str!())
+        .version(utils::version_info_string!())
         .arg(
             Arg::new("generate-crd")
                 .long("generate-crd")

--- a/utils/bundle-sim/src/bin/bundle-sim.rs
+++ b/utils/bundle-sim/src/bin/bundle-sim.rs
@@ -28,7 +28,7 @@ fn init_tracing() {
 }
 
 #[derive(Debug, Parser)]
-#[clap(name = utils::package_description!(), version = utils::version_info_str!())]
+#[clap(name = utils::package_description!(), version = utils::version_info_string!())]
 struct CliArgs {
     #[clap(subcommand)]
     action: Action,

--- a/utils/pstor-usage/src/main.rs
+++ b/utils/pstor-usage/src/main.rs
@@ -23,7 +23,7 @@ use openapi::apis::Url;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = utils::package_description!(), version = utils::version_info_str!())]
+#[clap(name = utils::package_description!(), version = utils::version_info_string!())]
 struct CliArgs {
     /// The rest endpoint if reusing a cluster.
     #[clap(short, long)]

--- a/utils/utils-lib/src/version.rs
+++ b/utils/utils-lib/src/version.rs
@@ -23,15 +23,6 @@ pub mod macros {
         };
     }
 
-    /// Gets package's version info as a static str.
-    /// Each call to this macro leaks a string.
-    #[macro_export]
-    macro_rules! version_info_str {
-        () => {
-            Box::leak(Box::new(String::from($crate::version_info!()))) as &'static str
-        };
-    }
-
     /// Formats package related information.
     /// This includes the package name and version, and commit info.
     #[macro_export]


### PR DESCRIPTION
Since clap now supports an owned string, use it so we can remove the leaked version.