### PR TITLE
feat(event-consumer): create JetStream stream on startup if absent

### DIFF
--- a/utils/event-consumer/src/consumer.rs
+++ b/utils/event-consumer/src/consumer.rs
@@ -1,6 +1,9 @@
 use crate::ConsumerConfig;
 use async_nats::jetstream::consumer::{pull, Consumer};
-use events_api::common::retry::{backoff_with_options, BackoffOptions};
+use events_api::common::{
+    constants::{MAX_MSGS_PER_SUBJECT, STREAM_SIZE, SUBJECTS},
+    retry::{backoff_with_options, BackoffOptions},
+};
 use futures::StreamExt;
 use std::time::Duration;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -106,7 +109,7 @@ impl NatsConsumer {
         let stream_name = &self.config.jetstream_stream_name;
         let consumer_name = &self.config.jetstream_consumer_name;
         let subject = &self.config.subject_filter;
-        let request_timeout = self.config.request_timeout;
+        let setup_timeout = self.config.jetstream_setup_timeout;
         let backoff = consumer_backoff_options();
         let mut tries = 0u32;
 
@@ -126,7 +129,17 @@ impl NatsConsumer {
                 continue;
             }
 
-            match tokio::time::timeout(request_timeout, js.get_stream(stream_name)).await {
+            let stream_config = async_nats::jetstream::stream::Config {
+                name: stream_name.to_string(),
+                subjects: vec![SUBJECTS.into()],
+                max_messages_per_subject: MAX_MSGS_PER_SUBJECT,
+                max_bytes: STREAM_SIZE,
+                storage: async_nats::jetstream::stream::StorageType::Memory,
+                num_replicas: self.config.jetstream_stream_replicas,
+                ..Default::default()
+            };
+            match tokio::time::timeout(setup_timeout, js.get_or_create_stream(stream_config)).await
+            {
                 Ok(Ok(stream)) => {
                     match stream
                         .get_or_create_consumer(
@@ -140,17 +153,20 @@ impl NatsConsumer {
                         )
                         .await
                     {
-                        Ok(consumer) => return Ok(consumer),
+                        Ok(consumer) => {
+                            info!(stream = %stream_name, consumer = %consumer_name, "JetStream consumer ready");
+                            return Ok(consumer);
+                        }
                         Err(e) => {
-                            error!(tries, max = backoff.max_retries, error = %e, "JetStream consumer creation failed");
+                            warn!(tries, max = backoff.max_retries, error = %e, "JetStream consumer creation failed");
                         }
                     }
                 }
                 Ok(Err(e)) => {
-                    error!(tries, max = backoff.max_retries, error = %e, "JetStream API error");
+                    warn!(tries, max = backoff.max_retries, error = %e, "JetStream API error");
                 }
                 Err(_) => {
-                    error!(
+                    warn!(
                         tries,
                         max = backoff.max_retries,
                         "JetStream metadata discovery timed out"
@@ -216,7 +232,7 @@ impl NatsConsumer {
                             error!(max = backoff.max_retries, error = %e, "{err}");
                             return Err(err);
                         }
-                        error!(tries, error = %e, "Core NATS subscribe failed; retrying");
+                        warn!(tries, error = %e, "Core NATS subscribe failed; retrying");
                         backoff_with_options(&mut tries, &backoff).await;
                     }
                 }
@@ -248,7 +264,7 @@ async fn run_jetstream_loop(
                     error!(max = backoff.max_retries, error = %e, "{err}");
                     return Err(err);
                 }
-                error!(recovery_tries, error = %e, "Failed to get JetStream message iterator; retrying");
+                warn!(recovery_tries, error = %e, "Failed to get JetStream message iterator; retrying");
                 backoff_with_options(&mut recovery_tries, &backoff).await;
                 continue;
             }
@@ -263,7 +279,7 @@ async fn run_jetstream_loop(
                     }
                 }
                 Err(e) => {
-                    error!(error = %e, "Error reading JetStream message; re-binding consumer");
+                    warn!(error = %e, "Error reading JetStream message; re-binding consumer");
                     break;
                 }
             }

--- a/utils/event-consumer/src/lib.rs
+++ b/utils/event-consumer/src/lib.rs
@@ -1,6 +1,7 @@
 mod consumer;
 
 pub use consumer::{ConsumerError, NatsConsumer, UnifiedMessage};
+use events_api::common::constants::{STREAM_NAME, SUBJECTS};
 
 /// Configuration for the NATS event consumer.
 #[derive(Debug, Clone)]
@@ -13,8 +14,10 @@ pub struct ConsumerConfig {
     pub subject_filter: String,
     /// Timeout for the initial TCP connection to NATS.
     pub connection_timeout: std::time::Duration,
-    /// Timeout for NATS request/response operations and JetStream metadata discovery.
+    /// Timeout for NATS request/response operations (steady-state message fetching).
     pub request_timeout: std::time::Duration,
+    /// Timeout for each JetStream setup probe (stream/consumer discovery during startup).
+    pub jetstream_setup_timeout: std::time::Duration,
     /// Durable name for the JetStream pull consumer.
     pub jetstream_consumer_name: String,
     /// JetStream stream name to subscribe from.
@@ -22,6 +25,9 @@ pub struct ConsumerConfig {
     /// Maximum number of delivery attempts per message before JetStream gives up.
     /// Set to -1 for unlimited redeliveries.
     pub jetstream_max_deliver: i64,
+    /// Number of stream replicas. Must match the NATS cluster size.
+    /// Used when creating the stream if it does not already exist.
+    pub jetstream_stream_replicas: usize,
 }
 
 impl Default for ConsumerConfig {
@@ -29,12 +35,14 @@ impl Default for ConsumerConfig {
         Self {
             nats_url: "nats://mayastor-nats:4222".parse().expect("valid NATS URL"),
             jetstream_enabled: false,
-            subject_filter: "events.>".into(),
+            subject_filter: SUBJECTS.into(),
             connection_timeout: std::time::Duration::from_secs(5),
             request_timeout: std::time::Duration::from_secs(10),
+            jetstream_setup_timeout: std::time::Duration::from_secs(3),
             jetstream_consumer_name: "event-consumer".into(),
-            jetstream_stream_name: "events-stream".into(),
+            jetstream_stream_name: STREAM_NAME.into(),
             jetstream_max_deliver: 3,
+            jetstream_stream_replicas: 1,
         }
     }
 }


### PR DESCRIPTION
- Switch from get_stream() to get_or_create_stream() in create_pull_consumer
so whichever pod starts first (events-aggregator or obs-callhome-stats)
creates the events-stream. Eliminates all 404 "stream not found" WARNs
during startup caused by racing against callhome-stats initialisation.

- Adds jetstream_stream_replicas to ConsumerConfig (default 1) and wires
--events-replicas CLI arg in events-aggregator, using the same
events_replicas Helm helper as other eventing components to ensure the
replica count always matches the NATS cluster size.

- Downgrade transient JetStream setup errors from error to warn since
  stream-not-found during startup is an expected transient condition
- Use a shorter jetstream_setup_timeout (3s) for stream discovery probes
  instead of the 10s request_timeout, eliminating long stalls per retry