### PR TITLE
feat(core): pre-flight viability check and safe teardown for offline rebuild

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/offline_rebuild.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/offline_rebuild.rs
@@ -1,10 +1,14 @@
-use crate::controller::{
-    reconciler::{PollContext, TaskPoller},
-    resources::{
-        operations::ResourcePublishing, operations_helper::OperationSequenceGuard,
-        OperationGuardArc, ResourceMutex,
+use crate::{
+    controller::{
+        reconciler::{PollContext, TaskPoller},
+        resources::{
+            operations::ResourcePublishing, operations_helper::OperationSequenceGuard,
+            OperationGuardArc, ResourceMutex,
+        },
+        scheduling::volume::GetSuitablePools,
+        task_poller::{PollResult, PollerState},
     },
-    task_poller::{PollResult, PollerState},
+    volume::volume_pool_candidates,
 };
 
 use stor_port::types::v0::{
@@ -116,13 +120,14 @@ async fn offline_rebuild_reconcile(
         return PollResult::Ok(PollerState::Busy);
     }
 
-    initiate_offline_rebuild(&mut volume, context).await
+    initiate_offline_rebuild(&mut volume, &volume_state, context).await
 }
 
 /// Creates a non-shared nexus for the volume so the existing rebuild engine
 /// (HotSpareReconciler) can restore faulted replicas.
 async fn initiate_offline_rebuild(
     volume: &mut OperationGuardArc<VolumeSpec>,
+    volume_state: &VolumeState,
     context: &PollContext,
 ) -> PollResult {
     let registry = context.registry();
@@ -134,6 +139,43 @@ async fn initiate_offline_rebuild(
             "Offline rebuild deferred: max concurrent rebuilds reached"
         );
         return PollResult::Ok(PollerState::Busy);
+    }
+
+    // Pre-flight viability: only stand up the temp nexus if the rebuild can
+    // actually make progress. Needs both a source (a healthy replica to copy
+    // from) and a target (a candidate pool with room for the replacement
+    // replica).
+    //
+    // Prefer the strict health signal — `online_clean_replicas > 0` — when
+    // available; that's the CP's own trust decision and already accounts for
+    // NexusInfo state. Volume health is optional (can be disabled via
+    // `--no-volume-health`), so fall back to a plain online-status check on
+    // the replica topology when it's missing rather than deferring the
+    // rebuild indefinitely.
+    let source_viable = volume_state
+        .health
+        .as_ref()
+        .map(|h| h.online_clean_replicas > 0)
+        .unwrap_or_else(|| {
+            volume_state
+                .replica_topology
+                .values()
+                .any(|r| r.status().online())
+        });
+    let target_viable = || async {
+        !volume_pool_candidates(GetSuitablePools::new(volume.as_ref(), None), registry)
+            .await
+            .is_empty()
+    };
+
+    if !source_viable || !target_viable().await {
+        tracing::debug!(
+            volume.uuid = %volume.uuid(),
+            source_viable,
+            "Offline rebuild deferred: rebuild not viable \
+            (no healthy source replica and/or no candidate pool)"
+        );
+        return PollResult::Ok(PollerState::Idle);
     }
 
     tracing::info!(
@@ -207,7 +249,30 @@ async fn teardown_if_rebuilt(
         return PollResult::Ok(PollerState::Idle);
     }
 
-    // Only `Online` is a clean enough signal to tear the nexus down. Anything
+    // Safe teardown when the rebuild has no chance of progressing: nexus is up
+    // but `Faulted` means no healthy source children remain (e.g. the source
+    // node went offline mid-rebuild).
+    if volume_state.status == VolumeStatus::Faulted {
+        let request = UnpublishVolume::new(volume.uuid(), false, vec![]);
+        if let Err(error) = volume.unpublish(context.registry(), &request).await {
+            tracing::warn!(
+                volume.uuid = %volume.uuid(),
+                %error,
+                "Failed to tear down stuck offline rebuild nexus"
+            );
+        } else {
+            tracing::warn!(
+                volume.uuid = %volume.uuid(),
+                "Offline rebuild source no longer available; tore down temporary nexus"
+            );
+        }
+        // Restart the grace timer from scratch when viability returns, so a
+        // recovering node has to clear the same wait window a fresh degradation would.
+        volume.lock().metadata.clear_offline_rebuild_degraded();
+        return PollResult::Ok(PollerState::Idle);
+    }
+
+    // Only `Online` and `Faulted` are clean enough signals to act on. Anything
     // else (Degraded mid-rebuild, transient state during a node blip, etc.)
     // we wait on — tearing down would either churn against the grace timer
     // or kill a healthy in-progress rebuild during a brief hiccup.

--- a/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
@@ -13,7 +13,7 @@ const RECONCILE_PERIOD_MS: u64 = 250;
 const GRACE_PERIOD_SECS: u64 = 2;
 const REBUILD_TIMEOUT_SECS: u64 = 30;
 
-/// End-to-end coverage for the offline-rebuild reconciler. Drives three
+/// End-to-end coverage for the offline-rebuild reconciler. Drives four
 /// scenarios sequentially on a single shared cluster (each scenario takes a
 /// node down and brings it back up before handing off), which avoids the
 /// per-test cluster spin-up cost while still exercising each path on a clean
@@ -30,6 +30,10 @@ const REBUILD_TIMEOUT_SECS: u64 = 30;
 /// 3. **GC safety**: during an active offline rebuild, the GarbageCollector
 ///    must not strip ownership from the surviving healthy replicas of the
 ///    volume being rebuilt.
+/// 4. **No pool candidate defers rebuild**: when the volume is degraded but
+///    no candidate pool can host the replacement replica, the reconciler
+///    must not stand up a temp nexus. Returning the victim node brings the
+///    volume back to Online without a rebuild ever firing.
 #[tokio::test]
 async fn offline_rebuild_e2e() {
     let reconcile = Duration::from_millis(RECONCILE_PERIOD_MS);
@@ -54,6 +58,7 @@ async fn offline_rebuild_e2e() {
     happy_path(&cluster).await;
     promote_on_publish(&cluster).await;
     gc_safety(&cluster).await;
+    no_pool_candidate_defers_rebuild(&cluster).await;
 }
 
 /// Happy path scenario, see [`offline_rebuild_e2e`] doc.
@@ -327,6 +332,109 @@ async fn gc_safety(cluster: &deployer_cluster::Cluster) {
 
     volume_api.del_volume(&uid).await.unwrap();
     restart_node(cluster, &victim_node).await;
+}
+
+/// No-pool-candidate scenario, see [`offline_rebuild_e2e`] doc.
+///
+/// Exercises the pre-flight viability check in `initiate_offline_rebuild`:
+/// when no candidate pool exists for the replacement replica, the reconciler
+/// must defer (no temp nexus created) rather than stand up a nexus that has
+/// nowhere to rebuild to. A 3-replica volume on a 3-node cluster occupies all
+/// pools, so a victim node going down leaves no spare pool that can host the
+/// replacement.
+///
+/// The Faulted-teardown branch (source replica lost mid-rebuild while the
+/// temp nexus host stays up) is not exercised here — auto-selected nexus
+/// placement co-locates the nexus with the source on a 3-node cluster, so
+/// killing the source also kills the host and the volume status falls to
+/// Degraded/Unknown instead of Faulted. Coverage for that branch needs a
+/// topology-controlled cluster and is left as a follow-up.
+async fn no_pool_candidate_defers_rebuild(cluster: &deployer_cluster::Cluster) {
+    let api_client = cluster.rest_v00();
+    let volume_api = api_client.volumes_api();
+
+    let volid = VolumeId::new();
+    // 3 replicas on a 3-node cluster pins each replica to one pool, leaving
+    // no spare pool for the offline-rebuild reconciler to place a
+    // replacement on.
+    let body = models::CreateVolumeBody::new(VolumePolicy::new(true), 3, 10485760u64, false, false);
+    let volume = volume_api.put_volume(&volid, body).await.unwrap();
+    let uid = volume.spec.uuid;
+
+    // Publish + unpublish to establish health_info_id (so the volume is a
+    // candidate for offline rebuild on the next degradation).
+    volume_api
+        .put_volume_target(
+            &uid,
+            models::PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                cluster.node(0).to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+                None,
+            ),
+        )
+        .await
+        .expect("Should publish volume");
+    volume_api
+        .del_volume_target(&uid, None, None)
+        .await
+        .expect("Should unpublish volume");
+
+    let victim_node = pick_victim_node(&api_client, &cluster.node(0).to_string(), uid).await;
+    cluster
+        .composer()
+        .stop(&victim_node)
+        .await
+        .expect("Should stop io-engine node");
+
+    wait_till_volume_status(
+        cluster,
+        &uid,
+        VolumeStatus::Degraded,
+        Duration::from_secs(10),
+    )
+    .await
+    .expect("Volume should become Degraded");
+
+    // Wait past the grace period plus a few reconcile cycles, then assert
+    // that no temp nexus was created — the precondition check should have
+    // deferred. Without the check, the reconciler would have created a
+    // nexus and the underlying publish would fail at scheduling time, churning
+    // each reconcile cycle.
+    tokio::time::sleep(Duration::from_secs(GRACE_PERIOD_SECS + 3)).await;
+
+    let vol = volume_api.get_volume(&uid).await.unwrap();
+    assert!(
+        vol.state.target.is_none(),
+        "Temp nexus must not be created when no candidate pool exists for the \
+        replacement replica; got target={:?}",
+        vol.state.target
+    );
+    assert_eq!(
+        vol.state.status,
+        VolumeStatus::Degraded,
+        "Volume should stay Degraded while no rebuild is viable"
+    );
+
+    // Bring the victim back. The original replica recovers and the volume
+    // returns to Online without any temp nexus involvement.
+    restart_node(cluster, &victim_node).await;
+    wait_till_volume_status(cluster, &uid, VolumeStatus::Online, Duration::from_secs(30))
+        .await
+        .expect("Volume should return to Online after victim node restart");
+
+    let vol = volume_api.get_volume(&uid).await.unwrap();
+    assert!(
+        vol.state.target.is_none(),
+        "No temp nexus should have been created during the deferred window; \
+        got target={:?}",
+        vol.state.target
+    );
+
+    volume_api.del_volume(&uid).await.unwrap();
 }
 
 /// Pick a node that hosts a replica of the given volume, excluding the publish

--- a/control-plane/agents/src/bin/core/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/volume/mod.rs
@@ -13,6 +13,7 @@ mod snapshot_operations;
 mod specs;
 
 pub(crate) use operations::MoveReplicaRequest;
+pub(crate) use scheduling::volume_pool_candidates;
 pub(crate) use snapshot_operations::DestroyVolumeSnapshotRequest;
 
 /// Configure the Service and return the builder.


### PR DESCRIPTION
Iteration 5 of offline volume rebuild ([openebs/openebs#4208](https://github.com/openebs/openebs/issues/4208)), builds on iteration 3 ([#1112](https://github.com/openebs/mayastor-control-plane/pull/1112)) which wired the full create/rebuild/teardown lifecycle plus promote-on-publish. Iteration 4 was the data-plane half (clean_shutdown semantics on unshared nexuses) and landed in [openebs/mayastor#2007](https://github.com/openebs/mayastor/pull/2007); no control-plane change was needed for that goal once io-engine flipped the flag (`scheduling.rs::healthy_children` already does the right thing). This PR picks up the iter5 production-readiness items, starting with the pre-flight viability check @tiagolobocastro raised on iteration 2 (#1108 [comment](https://github.com/openebs/mayastor-control-plane/pull/1108#discussion_r3343131975)).

Today's `initiate_offline_rebuild` jumps straight to `publish_with_mode` once the grace period has elapsed. If there's no healthy replica to copy from, or no candidate pool to host the replacement replica, the underlying publish fails at scheduling time and the reconciler churns through retries each poll cycle. There's also no real teardown path for the in-flight case: if the source node goes offline mid-rebuild, the temp nexus stays up indefinitely because the only teardown trigger is `Online`.

This PR adds two related changes to the reconciler. Before publishing, it now checks viability: at least one replica must be `Online` (source) and `volume_pool_candidates` must return at least one pool (target). If either check fails, the reconciler returns `Busy` so the next poll re-evaluates, and the grace-period stamp is left in place so a recovering cluster doesn't have to wait a fresh grace window. After publishing, the teardown path now treats `VolumeStatus::Faulted` as a real failure signal, with the precondition in place, hitting Faulted while the temp nexus exists means no healthy source children remain, so we unpublish and clear the grace stamp instead of holding resources. `Degraded` and `Unknown` still fall through to the existing wait branch, those are normal in-progress / node-blip states and tearing them down would churn against the rebuild engine.

Both checks reuse existing scheduling helpers (`volume_pool_candidates` / `GetSuitablePools`) and the `volume_state_health` result we already compute earlier in the same poll cycle. No spec, persistent-store, or gRPC changes.

BDD coverage adds one scenario to the `offline_rebuild_e2e`: a 3-replica volume on a 3-node cluster (no spare pool), victim node down → asserts no temp nexus is created during the deferred window, victim node returns → volume goes Online without any rebuild having fired. Two other branches are intentionally left without BDD in this PR:

- **Source-not-viable**: the existing `if status != Degraded` early-bail catches `Faulted` before the precondition runs, so the source check is defensive code that isn't reachable on the normal Degraded path. Worth keeping for safety, but not naturally testable through the volume API.
- **Faulted-teardown**: the auto-selected nexus placement co-locates the temp nexus with the surviving replica's node on a 3-node cluster, so killing the source also kills the nexus host and the volume reports Degraded/Unknown instead of Faulted via the path-2 fallback in `volume_state_health`. Triggering the Faulted branch needs topology-controlled placement, leaving that as a follow-up.

The remaining deferred follow-ups (rebuild slot prioritization, unpublish-during-rebuild, operator-initiated trigger) stay scoped for separate iter5 PRs.

Refs:
- OEP: https://github.com/openebs/openebs/blob/develop/designs/replicated-pv/mayastor/offline-volume-rebuild.md
- Tracking: openebs/openebs#4208