### PR TITLE
swagger default body changes for PublishVolumeBody and CreateVolumeBody

### DIFF
--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3187,6 +3187,7 @@ components:
           ctrl_loss_timeout: "1980"
         republish: false
         reuse_existing: true
+        frontend_node: "csi-node-1"
       description: Publish Volume Body
       type: object
       properties:


### PR DESCRIPTION
This PR:

adds example value to `frontend_node` arg of `PublishVolumeBody`

Sets pool `cluster_size` in `CreateVolumeBody` to 4MiB. Thats the default in `CreatePoolBody` also.