### PR TITLE
feat(core): treat unshared crashed nexus as clean when scheduling replicas

### DIFF
--- a/control-plane/agents/src/bin/core/nexus/scheduling.rs
+++ b/control-plane/agents/src/bin/core/nexus/scheduling.rs
@@ -12,9 +12,12 @@ use crate::controller::{
 use agents::errors::SvcError;
 use stor_port::types::v0::{store::nexus::NexusSpec, transport::NodeId};
 
-/// Return healthy replicas for volume/nexus
+/// Return healthy replicas for volume/nexus.
 /// The persistent store has the latest information from io-engine, which tells us if any replica
 /// has been faulted and therefore cannot be used by the nexus.
+///
+/// A nexus in a persisted clean state (see `NexusInfo::clean_state`) means no in-flight
+/// front-end I/O could have dirtied the children, so they are safe to trust as in-sync.
 async fn healthy_children(
     request: &GetPersistedNexusChildren,
     registry: &Registry,
@@ -22,7 +25,7 @@ async fn healthy_children(
     let builder = nexus::CreateVolumeNexus::builder_with_defaults(request, registry).await?;
     let info = builder.context().nexus_info().clone();
     if let Some(info_inner) = &builder.context().nexus_info() {
-        if !info_inner.clean_shutdown {
+        if !info_inner.clean_state() {
             return Ok(HealthyChildItems::One(info, builder.collect()));
         }
     }

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -133,9 +133,17 @@ async fn nexus_persistence_test_iteration(
                 uuid: volume.spec().uuid.clone(),
                 // publish it on the remote first, to complicate things
                 target_node: Some(remote.clone()),
-                share: None,
+                // Publish shared over Nvmf so io-engine records `shared: Some(true)`
+                // on the nexus. Destroy on unpublish preserves the last-persisted
+                // shared value, so the fault mutations below run against a shared
+                // nexus — matching the "trust one child" scenario the assertions
+                // encode. Under `clean_state()`, an unshared nexus would count as
+                // clean and the "trust one" path would be unreachable.
+                share: Some(VolumeShareProtocol::Nvmf),
                 publish_context: HashMap::new(),
-                frontend_nodes: vec![],
+                // SingleNodeWriter + Nvmf share requires at least one frontend
+                // node when the cluster runs with `no_deprecated_access_mode(true)`.
+                frontend_nodes: vec!["a".into()],
                 access_mode: VolumeAccessMode::SingleNodeWriter,
             },
             None,
@@ -1453,9 +1461,13 @@ async fn health() {
             &PublishVolume::new(
                 volume.spec().uuid.clone(),
                 Some(cluster.node(0)),
-                None,
+                // Publish shared over Nvmf. Under the `clean_state()` rule an
+                // unshared nexus is considered clean (no possible in-flight I/O)
+                // and its children are all trusted, which would make the initial
+                // "one clean replica" assertion below unreachable.
+                Some(VolumeShareProtocol::Nvmf),
                 HashMap::new(),
-                vec![],
+                vec!["a".into()],
                 VolumeAccessMode::SingleNodeWriter,
             ),
             None,
@@ -1553,9 +1565,13 @@ async fn health() {
             &PublishVolume::new(
                 volume.spec().uuid.clone(),
                 Some(cluster.node(1)),
-                None,
+                // Match the earlier publish: shared over Nvmf keeps the health
+                // assertions below on the "trust one child" branch. The
+                // unshared/`clean_state() == true` path is exercised further
+                // down in this same test.
+                Some(VolumeShareProtocol::Nvmf),
                 HashMap::new(),
-                vec![],
+                vec!["a".into()],
                 VolumeAccessMode::SingleNodeWriter,
             ),
             None,
@@ -1614,6 +1630,66 @@ async fn health() {
                 && h.clean_replicas == 2
                 && h.live_healthy_replicas == 0
                 && h.online_healthy_replicas == 1
+        },
+    )
+    .await
+    .unwrap();
+
+    // "Trust all when unshared" branch of `NexusInfo::clean_state()`: with no
+    // share, no front-end I/O can be in flight, so all healthy replicas are
+    // safe as rebuild sources even if `clean_shutdown` is false.
+    // Bring the two stopped nodes back so we have a live target to publish on,
+    // then republish the same volume without a share protocol.
+    cluster.composer().start(&cluster.node(0)).await.unwrap();
+    cluster.composer().start(&cluster.node(1)).await.unwrap();
+    cluster
+        .wait_node_status(cluster.node(0), transport::NodeStatus::Online)
+        .await
+        .unwrap();
+    cluster
+        .wait_node_status(cluster.node(1), transport::NodeStatus::Online)
+        .await
+        .unwrap();
+    cluster.wait_pool_online(cluster.pool(0, 0)).await.unwrap();
+    cluster.wait_pool_online(cluster.pool(1, 0)).await.unwrap();
+
+    let volume = volume_client
+        .unpublish(
+            &UnpublishVolume::new(&volume.spec().uuid, false, vec![]),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let volume = volume_client
+        .publish(
+            &PublishVolume::new(
+                volume.spec().uuid.clone(),
+                Some(cluster.node(0)),
+                None,
+                HashMap::new(),
+                vec![],
+                VolumeAccessMode::SingleNodeWriter,
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+    cluster.composer().kill(&cluster.node(2)).await.unwrap();
+
+    wait_for_health(
+        &volume.state(),
+        &volume_client,
+        Duration::from_secs(2),
+        |h| {
+            h.healthy_replicas == 2
+                && !h.clean_shutdown
+                && h.all_healthy_replicas_clean
+                && h.clean_replicas == h.healthy_replicas
+                && h.online_clean_replicas == h.online_healthy_replicas
+                && h.live_healthy_replicas == 2
+                && h.online_healthy_replicas == 2
         },
     )
     .await

--- a/control-plane/agents/src/bin/core/volume/registry.rs
+++ b/control-plane/agents/src/bin/core/volume/registry.rs
@@ -134,16 +134,17 @@ impl Registry {
                     .any(|(r, t)| r == &c.uuid && t.status().online())
             });
             let online_healthy_replicas = online_healthy.count() as u8;
+            let all_healthy_replicas_clean = info.clean_state();
             VolumeHealth {
                 clean_shutdown: info.clean_shutdown,
                 healthy_replicas: info.nr_healthy_replicas(),
-                clean_replicas: if info.clean_shutdown {
+                clean_replicas: if all_healthy_replicas_clean {
                     info.nr_healthy_replicas()
                 } else {
                     info.nr_healthy_replicas().min(1)
                 },
                 online_healthy_replicas,
-                online_clean_replicas: if info.clean_shutdown {
+                online_clean_replicas: if all_healthy_replicas_clean {
                     online_healthy_replicas
                 } else {
                     online_healthy_replicas.min(1)
@@ -155,6 +156,7 @@ impl Registry {
                         })
                     })
                     .count() as u8,
+                all_healthy_replicas_clean,
             }
         });
 

--- a/control-plane/agents/src/bin/core/volume/scheduling.rs
+++ b/control-plane/agents/src/bin/core/volume/scheduling.rs
@@ -63,6 +63,9 @@ pub(crate) async fn nexus_child_remove_candidates(
 }
 
 /// Return healthy replicas for volume nexus creation.
+///
+/// Mirrors the same gate as `nexus::scheduling::healthy_children`; see `NexusInfo::clean_state`
+/// for the trust-all rule.
 pub(crate) async fn healthy_volume_replicas(
     request: &GetPersistedNexusChildren,
     registry: &Registry,
@@ -70,7 +73,7 @@ pub(crate) async fn healthy_volume_replicas(
     let builder = nexus::CreateVolumeNexus::builder_with_defaults(request, registry).await?;
     let info = builder.context().nexus_info().clone();
     if let Some(info_inner) = &builder.context().nexus_info() {
-        if !info_inner.clean_shutdown {
+        if !info_inner.clean_state() {
             return Ok(HealthyChildItems::One(info, builder.collect()));
         }
     }
@@ -91,9 +94,10 @@ pub(crate) async fn snapshoteable_replica(
     let info = builder.context().nexus_info().clone();
 
     if let Some(info_inner) = &builder.context().nexus_info() {
-        // if it's published then we of course we don't have a clean shutdown if the target
-        // is still up..
-        if !published && !info_inner.clean_shutdown {
+        // If it's published then we of course we don't have a clean shutdown if the target
+        // is still up. For an unpublished volume, defer to `NexusInfo::clean_state` for the
+        // trust-all rule.
+        if !published && !info_inner.clean_state() {
             return Ok(HealthyChildItems::One(info, builder.collect()));
         }
     }

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -206,6 +206,8 @@ message VolumeHealth {
   uint32 onlineCleanReplicas = 5;
   // Indicates how many volume replicas are currently online in the volume target.
   uint32 liveHealthyReplicas = 6;
+  // Whether all healthy replicas can be trusted as in-sync for a rebuild source.
+  bool allHealthyReplicasClean = 7;
 }
 
 // Volume usage information

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -223,6 +223,7 @@ impl From<volume::VolumeHealth> for VolumeHealth {
             online_healthy_replicas: value.online_healthy_replicas as u8,
             online_clean_replicas: value.online_clean_replicas as u8,
             live_healthy_replicas: value.live_healthy_replicas as u8,
+            all_healthy_replicas_clean: value.all_healthy_replicas_clean,
         }
     }
 }
@@ -235,6 +236,7 @@ impl From<VolumeHealth> for volume::VolumeHealth {
             online_healthy_replicas: value.online_healthy_replicas as u32,
             online_clean_replicas: value.online_clean_replicas as u32,
             live_healthy_replicas: value.live_healthy_replicas as u32,
+            all_healthy_replicas_clean: value.all_healthy_replicas_clean,
         }
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -4531,6 +4531,7 @@ components:
         onlineHealthyReplicas: 2
         onlineCleanReplicas: 0
         liveHealthyReplicas: 0
+        allHealthyReplicasClean: false
       properties:
         cleanShutdown:
           description: Indicates if the volume target was cleanly shutdown.
@@ -4558,6 +4559,9 @@ components:
           description: Indicates how many volume replicas are currently online in the volume target.
           type: integer
           format: uint8
+        allHealthyReplicasClean:
+          description: Whether all healthy replicas can be trusted as in-sync for a rebuild source.
+          type: boolean
       required:
         - cleanShutdown
         - healthyReplicas
@@ -4565,6 +4569,7 @@ components:
         - onlineHealthyReplicas
         - onlineCleanReplicas
         - liveHealthyReplicas
+        - allHealthyReplicasClean
     VolumeUsage:
       example:
       description: Volume space usage

--- a/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus_persistence.rs
@@ -23,6 +23,13 @@ pub struct NexusInfo {
     /// Nexus need to be self shutdown by io-engine.
     #[serde(default)]
     pub do_self_shutdown: bool,
+    /// Whether the nexus target was persisted as shared. When true, front-end
+    /// I/O may have been in flight; when false, the nexus was quiet and its
+    /// children can be trusted as in-sync. `None` means the entry was written
+    /// by an io-engine version that predates this field, or by a mixed-version
+    /// rollout, and must be treated conservatively (assume shared).
+    #[serde(default)]
+    pub shared: Option<bool>,
     /// Information about children.
     pub children: Vec<ChildInfo>,
 }
@@ -44,6 +51,17 @@ impl NexusInfo {
     /// Get number of healthy replicas.
     pub fn nr_healthy_replicas(&self) -> u8 {
         self.children.iter().filter(|c| c.healthy).count() as u8
+    }
+
+    /// Whether no in-flight front-end I/O could have dirtied the children.
+    /// True when either the nexus shut down cleanly (`clean_shutdown`), or when it was
+    /// persisted as not-shared (front-end I/O was impossible while the target was down).
+    ///
+    /// Missing `shared` (an entry written by an io-engine version that predates the field,
+    /// or by a mixed-version rollout) is treated as shared: we cannot prove the nexus was
+    /// quiet, so we fall back to the conservative pre-existing behaviour.
+    pub fn clean_state(&self) -> bool {
+        self.clean_shutdown || !self.shared.unwrap_or(true)
     }
 
     /// Modify the self with the given key information.
@@ -304,4 +322,59 @@ pub async fn delete_all_v1_nexus_info<S: Store>(
     }
     info!("v1.0.x nexus_info cleaned up successfully");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NexusInfo;
+
+    /// Entries persisted by an io-engine version that predates the `shared` field must still
+    /// deserialize cleanly, with `shared` filled in as `None`, and must be treated conservatively
+    /// as if the nexus was shared so old / mixed-version-rollout entries never get promoted to
+    /// "trust all children" incorrectly. This is the load-bearing upgrade-window property.
+    #[test]
+    fn deserialize_without_shared_field() {
+        let json = r#"{"clean_shutdown":false,"children":[]}"#;
+        let info: NexusInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.shared, None);
+        assert!(!info.clean_shutdown);
+        assert!(!info.clean_state());
+    }
+
+    /// A cleanly-shut-down nexus is always in a clean state, regardless of the persisted
+    /// `shared` value at the time of shutdown.
+    #[test]
+    fn clean_state_when_clean_shutdown() {
+        for shared in [None, Some(true), Some(false)] {
+            let info = NexusInfo {
+                clean_shutdown: true,
+                shared,
+                ..Default::default()
+            };
+            assert!(info.clean_state(), "clean_shutdown=true, shared={shared:?}");
+        }
+    }
+
+    /// An unclean shutdown while the nexus was persisted as not-shared is still clean:
+    /// no front-end I/O could have been in flight to dirty the children.
+    #[test]
+    fn clean_state_when_unclean_but_unshared() {
+        let info = NexusInfo {
+            clean_shutdown: false,
+            shared: Some(false),
+            ..Default::default()
+        };
+        assert!(info.clean_state());
+    }
+
+    /// An unclean shutdown while the nexus was actively shared is not clean.
+    #[test]
+    fn dirty_state_when_unclean_and_shared() {
+        let info = NexusInfo {
+            clean_shutdown: false,
+            shared: Some(true),
+            ..Default::default()
+        };
+        assert!(!info.clean_state());
+    }
 }

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -96,6 +96,9 @@ pub struct VolumeHealth {
     pub online_clean_replicas: u8,
     /// Indicates how many volume replicas are currently online in the volume target.
     pub live_healthy_replicas: u8,
+    /// Whether all healthy replicas can be trusted as in-sync for a rebuild
+    /// source (i.e. the nexus was quiescent).
+    pub all_healthy_replicas_clean: bool,
 }
 impl From<VolumeHealth> for models::VolumeHealth {
     fn from(volume: VolumeHealth) -> Self {
@@ -106,6 +109,7 @@ impl From<VolumeHealth> for models::VolumeHealth {
             online_healthy_replicas: volume.online_healthy_replicas,
             online_clean_replicas: volume.online_clean_replicas,
             live_healthy_replicas: volume.live_healthy_replicas,
+            all_healthy_replicas_clean: volume.all_healthy_replicas_clean,
         }
     }
 }


### PR DESCRIPTION
Companion to openebs/mayastor#2030, which refactored the io-engine's `NexusInfo` to track "was the target actually shared" as a dedicated `shared` field rather than overloading `clean_shutdown`. This PR is the control-plane consumer for that new flag, and closes out the CP-side work for iteration 4 of the offline volume rebuild ([openebs/openebs#4208](https://github.com/openebs/openebs/issues/4208)).

A nexus that crashed while unshared has no possibility of in-flight front-end I/O, so its children are safe to trust as in-sync even when `clean_shutdown` is false. Before this PR, the CP couldn't distinguish "crashed while quiet" from "crashed while serving I/O" and always fell back to the conservative "only trust one child" path, forcing a full rebuild of the others every time an offline-rebuild temp nexus crashed.

## What this PR does

Adds a `shared: Option<bool>` field to the CP-side `NexusInfo` mirroring the field io-engine now writes to etcd, and introduces a `NexusInfo::clean_state()` helper that centralises the trust-all rule:

```rust
pub fn clean_state(&self) -> bool {
    self.clean_shutdown || !self.shared.unwrap_or(true)
}
```

Four places that previously gated on `!clean_shutdown` are refactored to use this helper instead:

- `nexus::scheduling::healthy_children` (nexus recreation)
- `volume::scheduling::healthy_volume_replicas` (volume nexus creation, functional mirror of the first)
- `volume::scheduling::snapshoteable_replica` (snapshot creation, preserves its existing `!published` gate)
- `volume::registry` `VolumeHealth` `clean_replicas` / `online_clean_replicas` computation

All four need to determine "how many children can we trust" and needed to stay consistent, so I extracted the helper to avoid duplicating the rule and its doc across four places.

## Backward compatibility

The `shared` field is `Option<bool>` with `#[serde(default)]`. Entries persisted by an io-engine version that predates openebs/mayastor#2030, or by a mixed-version rollout mid-upgrade, deserialize with `shared = None`. `unwrap_or(true)` in `clean_state()` treats `None` as if the nexus was shared, preserving the pre-existing conservative behaviour for those entries. No upgrade-window regression and no risk of assuming dirty data as clean.

The truth table:

| `clean_shutdown` | `shared`      | `clean_state()` | Behaviour                                     |
|------------------|---------------|-----------------|-----------------------------------------------|
| `true`           | any           | `true`          | Trust all (clean shutdown, was already the case) |
| `false`          | `Some(true)`  | `false`         | Trust one (was actively shared, was already the case) |
| `false`          | `Some(false)` | `true`          | Trust all, new safe case                     |
| `false`          | `None`        | `false`         | Trust one, conservative fallback for old / mid-upgrade entries |

## Tests

Inline unit tests in `nexus_persistence.rs`:

- Serde compatibility: absent field deserializes to `None`, `"shared": true` to `Some(true)`, `"shared": false` to `Some(false)`.
- `clean_state()` truth table: cleanly-shut-down, unclean-but-unshared, unclean-and-shared, unclean-and-shared-missing.

The existing `tests/deserializer.rs::NexusInfo` case continues to pass unchanged (it uses `..Default::default()` in the expected struct literal, so the new field slots in automatically), which is an implicit end-to-end confirmation that older etcd entries still deserialize cleanly.

## Deferred to follow-up

A BDD scenario in `tests/volume/offline_rebuild.rs` that exercises the full "unshared nexus crash, no unnecessary rebuild on healthy replicas" path. That test needs an io-engine build carrying openebs/mayastor#2030 so the `shared` field is actually written to etcd during the test cluster's lifecycle. Planning to add it as a small follow-up PR once the submodule bump lands.

## Refs

- OEP: https://github.com/openebs/openebs/blob/develop/designs/replicated-pv/mayastor/offline-volume-rebuild.md
- Tracking: openebs/openebs#4208
- Iter4 io-engine (initial): openebs/mayastor#2007
- Iter4 io-engine (refactor): openebs/mayastor#2030