### PR TITLE
Auto reload tls secrets

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,23 +1,34 @@
 name: Bors CI
 on:
   workflow_call:
+    inputs:
+      trigger:
+        required: false
+        type: string
+        default: "merge_group"
   push:
     branches:
       - staging
       - trying
   merge_group:
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
 
 jobs:
   lint-ci:
+    if: github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')
     uses: ./.github/workflows/lint.yml
   int-ci:
+    if: github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')
     uses: ./.github/workflows/unit-int.yml
   bdd-ci:
+    if: github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')
     uses: ./.github/workflows/bdd.yml
   image-ci:
+    if: github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')
     uses: ./.github/workflows/image-pr.yml
   bors-ci:
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || inputs.trigger == 'try' || startsWith(github.head_ref, 'mergify/merge-queue/')) }}
     needs:
       - lint-ci
       - int-ci

--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -5,10 +5,12 @@ on:
   push:
     branches:
       - staging
+  merge_group:
 
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/pr-submodule-branch.yml
+++ b/.github/workflows/pr-submodule-branch.yml
@@ -7,6 +7,7 @@ on:
       - develop
       - 'release/**'
       - staging
+  merge_group:
 
 jobs:
   submodule-branch:

--- a/.github/workflows/pr-try-ci.yml
+++ b/.github/workflows/pr-try-ci.yml
@@ -7,6 +7,8 @@ jobs:
   ci-try:
     if: contains(github.event.pull_request.labels.*.name, 'ci/test')
     uses: ./.github/workflows/pr-ci.yml
+    with:
+      trigger: "try"
 
   remove-label:
     if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'ci/test') }}

--- a/.github/workflows/staging-dco.yml
+++ b/.github/workflows/staging-dco.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - staging
+  merge_group:
 
 jobs:
   DCO:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3820,6 +3820,7 @@ dependencies = [
  "grpc",
  "http 1.1.0",
  "humantime",
+ "inotify",
  "jsonwebtoken",
  "num_cpus",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,6 +2351,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inquire"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3106,6 +3126,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
+ "inotify",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ futures = { version = "0.3.31", default-features = false }
 futures-util = { version = "0.3.31" }
 pin-project = "1.1.7"
 tokio-udev = { version = "0.10.0" }
+inotify = { version = "0.11.0", default-features = false }
 
 # tracing and telemetry
 tracing = "0.1.40"

--- a/control-plane/plugin/src/rest_wrapper.rs
+++ b/control-plane/plugin/src/rest_wrapper.rs
@@ -40,8 +40,7 @@ impl RestClient {
         let builder = Configuration::builder()
             .with_timeout(timeout)
             .with_tracing(tracing)
-            .with_tls(security.tls)
-            .with_bearer_token(security.jwt);
+            .with_client_security(Some(security));
 
         let cfg = builder.build_url(url).map_err(|error| {
             anyhow::anyhow!("Failed to create openapi configuration, Error: '{error:?}'")

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -43,6 +43,10 @@ grpc = { path = "../grpc" }
 num_cpus = { workspace = true }
 rcgen = { workspace = true }
 
+# certificate file watching for TLS auto-reload; Linux/inotify only
+[target.'cfg(target_os = "linux")'.dependencies]
+inotify = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 deployer-cluster = { workspace = true }

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -1,5 +1,6 @@
 mod authentication;
 mod health;
+mod tls;
 mod v0;
 
 use crate::{
@@ -27,7 +28,7 @@ use rustls::{
     RootCertStore, ServerConfig,
 };
 use rustls_pemfile::{certs, private_key};
-use std::{fs::File, io::BufReader, path::PathBuf, sync::Arc, time::Duration};
+use std::{io::BufReader, path::PathBuf, sync::Arc, time::Duration};
 use stor_port::transport_api::{RequestMinTimeout, TimeoutOptions};
 use utils::{
     tracing_telemetry::{FmtLayer, FmtStyle, KeyValue},
@@ -72,7 +73,7 @@ pub(crate) struct CliArgs {
     dummy_certificates: bool,
 
     /// Auto-generate an ephemeral self-signed server certificate for HTTPS.
-    #[clap(long, conflicts_with_all = ["dummy_certificates", "cert_file", "key_file"])]
+    #[clap(long, conflicts_with_all = ["dummy_certificates", "cert_file", "key_file", "client_ca_file"])]
     auto_tls: bool,
 
     /// Path to the certificate authority (CA) bundle used to authenticate TLS clients.
@@ -126,17 +127,53 @@ impl CliArgs {
     fn args() -> Self {
         CliArgs::parse()
     }
-}
+    /// default timeout options for every bus request
+    fn timeout_opts(&self) -> TimeoutOptions {
+        let timeout_opts =
+            TimeoutOptions::new_no_retries().with_req_timeout(self.request_timeout.into());
 
-/// default timeout options for every bus request
-fn timeout_opts() -> TimeoutOptions {
-    let timeout_opts =
-        TimeoutOptions::new_no_retries().with_req_timeout(CliArgs::args().request_timeout.into());
+        if self.no_min_timeouts {
+            timeout_opts.with_min_req_timeout(None)
+        } else {
+            timeout_opts.with_min_req_timeout(RequestMinTimeout::default())
+        }
+    }
+    fn certificates(&self) -> anyhow::Result<ServerConfig> {
+        let client_ca_file = self.client_ca_file.clone();
 
-    if CliArgs::args().no_min_timeouts {
-        timeout_opts.with_min_req_timeout(None)
-    } else {
-        timeout_opts.with_min_req_timeout(RequestMinTimeout::default())
+        if self.auto_tls {
+            auto_certificates()
+        } else if self.dummy_certificates {
+            dummy_certificates()
+        } else {
+            // guaranteed to be `Some` by the require_unless attribute
+            let cert_file = self.cert_file.clone().expect("cert_file is required");
+            let key_file = self.key_file.clone().expect("key_file is required");
+            reloadable_certificates(cert_file, key_file, client_ca_file)
+        }
+    }
+    fn jwk_path(&self) -> Option<PathBuf> {
+        match self.jwk.clone() {
+            Some(path) => Some(path),
+            None => match self.no_auth {
+                true => None,
+                false => panic!("Cannot authenticate without a JWK file"),
+            },
+        }
+    }
+
+    fn workers(&self) -> usize {
+        let max_workers = match self.max_workers {
+            0 => num_cpus::get_physical(),
+            max => max,
+        };
+
+        let workers = match self.workers {
+            0 => num_cpus::get_physical(),
+            workers => workers,
+        };
+
+        workers.clamp(1, max_workers)
     }
 }
 
@@ -168,35 +205,29 @@ where
     }
 }
 
-fn get_certificates() -> anyhow::Result<ServerConfig> {
-    let client_ca_file = CliArgs::args().client_ca_file;
+/// Server config whose certificate is served through a resolver that a background watcher swaps
+/// when the certificate files change on disk, so renewals apply without a restart.
+///
+/// When mTLS is enabled, the client CA verifier is likewise reloaded so a rotated or fully
+///  recreated client CA bundle is honoured.
+fn reloadable_certificates(
+    cert_file: PathBuf,
+    key_file: PathBuf,
+    client_ca_file: Option<PathBuf>,
+) -> anyhow::Result<ServerConfig> {
+    let builder = ServerConfig::builder();
+    let provider = builder.crypto_provider().clone();
 
-    if CliArgs::args().auto_tls {
-        get_auto_certificates(client_ca_file)
-    } else if CliArgs::args().dummy_certificates {
-        get_dummy_certificates()
-    } else {
-        // guaranteed to be `Some` by the require_unless attribute
-        let cert_file = CliArgs::args().cert_file.expect("cert_file is required");
-        let key_file = CliArgs::args().key_file.expect("key_file is required");
-        let cert_file = &mut BufReader::new(File::open(cert_file)?);
-        let key_file = &mut BufReader::new(File::open(key_file)?);
-        let mut client_ca = match client_ca_file {
-            Some(path) => Some(BufReader::new(File::open(path)?)),
-            None => None,
-        };
+    let (resolver, verifier) = tls::reloadable_tls(cert_file, key_file, client_ca_file, provider)?;
 
-        load_certificates(
-            cert_file,
-            key_file,
-            client_ca
-                .as_mut()
-                .map(|file| file as &mut dyn std::io::BufRead),
-        )
-    }
+    let config = builder
+        .with_client_cert_verifier(verifier)
+        .with_cert_resolver(resolver);
+
+    Ok(config)
 }
 
-fn get_dummy_certificates() -> anyhow::Result<ServerConfig> {
+fn dummy_certificates() -> anyhow::Result<ServerConfig> {
     let cert_file = &mut BufReader::new(&std::include_bytes!("../../certs/rsa/user.chain")[..]);
     let key_file = &mut BufReader::new(&std::include_bytes!("../../certs/rsa/user.rsa")[..]);
     let mut client_ca = BufReader::new(&std::include_bytes!("../../certs/rsa/ca.cert")[..]);
@@ -208,7 +239,7 @@ fn get_dummy_certificates() -> anyhow::Result<ServerConfig> {
     )
 }
 
-fn get_auto_certificates(client_ca_file: Option<PathBuf>) -> anyhow::Result<ServerConfig> {
+fn auto_certificates() -> anyhow::Result<ServerConfig> {
     let cert_material = generate_simple_self_signed(vec!["localhost".to_string()])
         .map_err(|error| anyhow::anyhow!("Failed to generate self-signed certificate: {error}"))?;
 
@@ -217,18 +248,8 @@ fn get_auto_certificates(client_ca_file: Option<PathBuf>) -> anyhow::Result<Serv
 
     let cert_file = &mut BufReader::new(cert_pem.as_bytes());
     let key_file = &mut BufReader::new(key_pem.as_bytes());
-    let mut client_ca = match client_ca_file {
-        Some(path) => Some(BufReader::new(File::open(path)?)),
-        None => None,
-    };
 
-    load_certificates(
-        cert_file,
-        key_file,
-        client_ca
-            .as_mut()
-            .map(|file| file as &mut dyn std::io::BufRead),
-    )
+    load_certificates(cert_file, key_file, None)
 }
 
 fn load_certificates(
@@ -290,16 +311,6 @@ fn client_cert_verifier(
         })
 }
 
-fn get_jwk_path() -> Option<PathBuf> {
-    match CliArgs::args().jwk {
-        Some(path) => Some(path),
-        None => match CliArgs::args().no_auth {
-            true => None,
-            false => panic!("Cannot authenticate without a JWK file"),
-        },
-    }
-}
-
 /// Only the liveness (`/live`) and readiness (`/ready`) probes are served over an
 /// insecure (plain HTTP) connection.
 /// Every other route is rejected with `421 Misdirected Request`, since the full API
@@ -315,20 +326,6 @@ async fn probes_only_on_insecure(
         let response = HttpResponse::MisdirectedRequest().finish();
         Ok(req.into_response(response))
     }
-}
-
-fn workers(args: &CliArgs) -> usize {
-    let max_workers = match args.max_workers {
-        0 => num_cpus::get_physical(),
-        max => max,
-    };
-
-    let workers = match args.workers {
-        0 => num_cpus::get_physical(),
-        workers => workers,
-    };
-
-    workers.clamp(1, max_workers)
 }
 
 #[actix_web::main]
@@ -347,14 +344,13 @@ async fn main() -> anyhow::Result<()> {
 
     // Initialize the core client to be used in rest
     CORE_CLIENT
-        .set(CoreClient::new(cli_args.core_grpc, timeout_opts()).await)
+        .set(CoreClient::new(cli_args.core_grpc.clone(), cli_args.timeout_opts()).await)
         .ok()
         .expect("Expect to be initialised only once");
 
     let cached_core_state = Data::new(CachedCoreState::new(cli_args.core_liveness_check_frequency));
-
     let restrict_http_to_probes = cli_args.http_probes.is_some();
-
+    let jwk_path = cli_args.jwk_path();
     let app = move || {
         actix_web::App::new()
             .app_data(cached_core_state.clone())
@@ -367,28 +363,28 @@ async fn main() -> anyhow::Result<()> {
             ))
             .wrap(tracing_actix_web::TracingLogger::default())
             .wrap(middleware::Logger::default())
-            .app_data(authentication::init(get_jwk_path()))
+            .app_data(authentication::init(jwk_path.clone()))
             .configure_api(&v0::configure_api)
     };
 
     // Initialize the json grpc client to be used in rest
-    if let Some(json_grpc) = CliArgs::args().json_grpc {
+    if let Some(json_grpc) = cli_args.json_grpc.clone() {
         JSON_GRPC_CLIENT
-            .set(JsonGrpcClient::new(json_grpc, timeout_opts()).await)
+            .set(JsonGrpcClient::new(json_grpc, cli_args.timeout_opts()).await)
             .ok()
             .expect("Expect to be initialised only once");
     }
 
     let server =
-        HttpServer::new(app).bind_rustls_0_23(CliArgs::args().https, get_certificates()?)?;
-    let result = if let Some(http) = CliArgs::args().http {
+        HttpServer::new(app).bind_rustls_0_23(&cli_args.https, cli_args.certificates()?)?;
+    let result = if let Some(http) = &cli_args.http {
         server.bind(http).map_err(anyhow::Error::from)?
     } else if let Some(http_probes) = CliArgs::args().http_probes {
         server.bind(http_probes).map_err(anyhow::Error::from)?
     } else {
         server
     }
-    .workers(workers(&CliArgs::args()))
+    .workers(cli_args.workers())
     .run()
     .await;
 

--- a/control-plane/rest/service/src/tls.rs
+++ b/control-plane/rest/service/src/tls.rs
@@ -1,0 +1,439 @@
+//! Hot-reloading of the REST server's TLS material.
+//!
+//! The server certificate/key are served through a [`ResolvesServerCert`], and (when mTLS is
+//! enabled) client certificates are validated through a swappable [`ClientCertVerifier`]. A
+//! single background watcher swaps both whenever the underlying files change on disk (e.g.
+//! cert-manager rotations or a full secret recreation that also replaces the client CA bundle).
+//! Renewals therefore take effect without a restart: existing TLS sessions are unaffected and the
+//! new material is used on subsequent handshakes.
+
+use rustls::{
+    client::danger::HandshakeSignatureValid,
+    crypto::CryptoProvider,
+    pki_types::{CertificateDer, UnixTime},
+    server::{
+        danger::{ClientCertVerified, ClientCertVerifier},
+        ClientHello, ResolvesServerCert, WebPkiClientVerifier,
+    },
+    sign::CertifiedKey,
+    DigitallySignedStruct, DistinguishedName, Error as RustlsError, RootCertStore, SignatureScheme,
+};
+use rustls_pemfile::{certs, private_key};
+use std::{
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+    sync::{Arc, PoisonError, RwLock},
+};
+
+/// A [`ResolvesServerCert`] whose certificate can be swapped at runtime.
+#[derive(Debug)]
+pub(crate) struct ReloadableCertResolver {
+    current: RwLock<Arc<CertifiedKey>>,
+}
+
+impl ReloadableCertResolver {
+    fn new(certified_key: Arc<CertifiedKey>) -> Self {
+        Self {
+            current: RwLock::new(certified_key),
+        }
+    }
+    fn store(&self, certified_key: Arc<CertifiedKey>) {
+        *self.current.write().unwrap_or_else(PoisonError::into_inner) = certified_key;
+    }
+}
+
+impl ResolvesServerCert for ReloadableCertResolver {
+    fn resolve(&self, _client_hello: ClientHello) -> Option<Arc<CertifiedKey>> {
+        Some(
+            self.current
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone(),
+        )
+    }
+}
+
+/// A [`ClientCertVerifier`] whose backing verifier (the trusted client CA roots) can be swapped
+/// at runtime, so a rotated or fully recreated client CA bundle is honoured without a restart.
+///
+/// All decisions are delegated to the inner verifier. `root_hint_subjects` returns an empty slice
+/// because the trait requires it to borrow from `&self`, which is incompatible with swapping the
+/// inner verifier behind a lock; the hint is optional and only advertises accepted CA names to the
+/// client, so clients configured with an explicit certificate are unaffected.
+#[derive(Debug)]
+pub(crate) struct ReloadableClientCertVerifier {
+    current: RwLock<Arc<dyn ClientCertVerifier>>,
+}
+
+impl ReloadableClientCertVerifier {
+    fn new(verifier: Arc<dyn ClientCertVerifier>) -> Self {
+        Self {
+            current: RwLock::new(verifier),
+        }
+    }
+    fn store(&self, verifier: Arc<dyn ClientCertVerifier>) {
+        *self.current.write().unwrap_or_else(PoisonError::into_inner) = verifier;
+    }
+    fn get(&self) -> Arc<dyn ClientCertVerifier> {
+        self.current
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+}
+
+impl ClientCertVerifier for ReloadableClientCertVerifier {
+    fn offer_client_auth(&self) -> bool {
+        self.get().offer_client_auth()
+    }
+    fn client_auth_mandatory(&self) -> bool {
+        self.get().client_auth_mandatory()
+    }
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
+        &[]
+    }
+    fn verify_client_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        now: UnixTime,
+    ) -> Result<ClientCertVerified, RustlsError> {
+        self.get()
+            .verify_client_cert(end_entity, intermediates, now)
+    }
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        self.get().verify_tls12_signature(message, cert, dss)
+    }
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        self.get().verify_tls13_signature(message, cert, dss)
+    }
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.get().supported_verify_schemes()
+    }
+}
+
+/// Create the reloadable server certificate resolver and (optionally) client certificate verifier.
+///
+/// The initial material is loaded from the given files and a single background watcher is spawned
+/// that swaps the server certificate and/or the client CA verifier whenever their files change.
+/// When `client_ca_path` is `None`, client authentication is disabled and the returned verifier
+/// accepts anonymous clients.
+pub(crate) fn reloadable_tls(
+    cert_path: PathBuf,
+    key_path: PathBuf,
+    client_ca_path: Option<PathBuf>,
+    provider: Arc<CryptoProvider>,
+) -> anyhow::Result<(Arc<ReloadableCertResolver>, Arc<dyn ClientCertVerifier>)> {
+    let certified_key = load_certified_key(&cert_path, &key_path, &provider)?;
+    let resolver = Arc::new(ReloadableCertResolver::new(certified_key));
+
+    let (verifier, reloadable_verifier): (Arc<dyn ClientCertVerifier>, _) = match &client_ca_path {
+        Some(ca_path) => {
+            let inner = build_client_verifier(ca_path, &provider)?;
+            let reloadable = Arc::new(ReloadableClientCertVerifier::new(inner));
+            (reloadable.clone(), Some(reloadable))
+        }
+        None => (WebPkiClientVerifier::no_client_auth(), None),
+    };
+
+    spawn_cert_watcher(WatchContext {
+        cert_path,
+        key_path,
+        client_ca_path,
+        provider,
+        resolver: resolver.clone(),
+        verifier: reloadable_verifier,
+        targets: vec![],
+    });
+
+    Ok((resolver, verifier))
+}
+
+/// Build a [`CertifiedKey`] from certificate and key files, using `provider`'s key loader so the
+/// signing key matches the process-wide crypto provider.
+fn load_certified_key(
+    cert_path: &Path,
+    key_path: &Path,
+    provider: &CryptoProvider,
+) -> anyhow::Result<Arc<CertifiedKey>> {
+    let cert_file = &mut BufReader::new(File::open(cert_path)?);
+    let key_file = &mut BufReader::new(File::open(key_path)?);
+    let cert_chain: Vec<CertificateDer<'static>> = certs(cert_file)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| {
+            anyhow::anyhow!("Failed to retrieve certificates from the certificate file")
+        })?;
+    let key = private_key(key_file)
+        .map_err(|_| anyhow::anyhow!("Failed to retrieve private key from the key file"))?
+        .ok_or_else(|| anyhow::anyhow!("No private key found in the key file"))?;
+    let signing_key = provider
+        .key_provider
+        .load_private_key(key)
+        .map_err(|error| anyhow::anyhow!("Failed to load TLS private key: {error}"))?;
+    Ok(Arc::new(CertifiedKey::new(cert_chain, signing_key)))
+}
+
+/// Build a client certificate verifier from a client CA bundle file, trusting its certificates as
+/// roots for client authentication.
+fn build_client_verifier(
+    ca_path: &Path,
+    provider: &Arc<CryptoProvider>,
+) -> anyhow::Result<Arc<dyn ClientCertVerifier>> {
+    let ca_file = &mut BufReader::new(File::open(ca_path)?);
+    let client_certs = certs(ca_file)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| anyhow::anyhow!("Failed to retrieve certificates from client CA file"))?;
+    if client_certs.is_empty() {
+        anyhow::bail!("No certificates found in the client CA file");
+    }
+
+    let mut roots = RootCertStore::empty();
+    let (valid, invalid) = roots.add_parsable_certificates(client_certs);
+    if valid == 0 {
+        anyhow::bail!("No valid certificates found in the client CA file");
+    }
+    if invalid > 0 {
+        tracing::warn!(
+            ignored = invalid,
+            "Some certificates from the client CA file were ignored"
+        );
+    }
+
+    WebPkiClientVerifier::builder_with_provider(Arc::new(roots), provider.clone())
+        .build()
+        .map_err(|error| {
+            anyhow::anyhow!("Failed to configure client certificate verifier: {error}")
+        })
+}
+
+/// Inputs shared with the background watcher.
+struct WatchContext {
+    cert_path: PathBuf,
+    key_path: PathBuf,
+    client_ca_path: Option<PathBuf>,
+    provider: Arc<CryptoProvider>,
+    resolver: Arc<ReloadableCertResolver>,
+    verifier: Option<Arc<ReloadableClientCertVerifier>>,
+    targets: Vec<PathBuf>,
+}
+
+/// Spawn the certificate watch loop on a background OS thread.
+///
+/// A plain OS thread is used because the watch blocks in `inotify` reads and the reload path is
+/// fully synchronous/blocking.
+#[cfg(target_os = "linux")]
+fn spawn_cert_watcher(ctx: WatchContext) {
+    std::thread::Builder::new()
+        .name("tls-cert-watch".into())
+        .spawn(move || ctx.watch())
+        .ok();
+}
+
+#[cfg(not(target_os = "linux"))]
+fn spawn_cert_watcher(_ctx: WatchContext) {
+    tracing::warn!(
+        "TLS certificate watch is only supported on Linux; automatic reload is disabled"
+    );
+}
+
+/// Last-modified time of a file, used to skip redundant reloads.
+#[cfg(target_os = "linux")]
+fn modified(path: &Path) -> Option<std::time::SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+/// Reload the server certificate into the resolver, but only when the files actually changed, so
+/// duplicate or spurious watch events are no-ops.
+///
+/// Returns `Ok(true)` when the certificate was reloaded, `Ok(false)` when the files were unchanged
+/// since the last reload, and `Err` when the modification times cannot be read or the certificate
+/// material fails to load (a rotation can briefly leave the files inconsistent; the next event
+/// retries).
+#[cfg(target_os = "linux")]
+fn maybe_reload_cert(
+    ctx: &WatchContext,
+    last: &mut Option<(std::time::SystemTime, std::time::SystemTime)>,
+) -> anyhow::Result<bool> {
+    let current = modified(&ctx.cert_path)
+        .zip(modified(&ctx.key_path))
+        .ok_or_else(|| {
+            anyhow::anyhow!("Failed to read modification times for TLS certificate/key files")
+        })?;
+    if *last == Some(current) {
+        return Ok(false);
+    }
+    let certified_key = load_certified_key(&ctx.cert_path, &ctx.key_path, &ctx.provider)?;
+    ctx.resolver.store(certified_key);
+    *last = Some(current);
+    Ok(true)
+}
+
+/// Reload the client CA verifier, but only when the client CA file actually changed.
+///
+/// Returns `Ok(true)` when the verifier was reloaded, `Ok(false)` when the file was unchanged (or
+/// client authentication is disabled), and `Err` when the modification time cannot be read or the
+/// CA bundle fails to load.
+#[cfg(target_os = "linux")]
+fn maybe_reload_verifier(
+    ctx: &WatchContext,
+    last: &mut Option<std::time::SystemTime>,
+) -> anyhow::Result<bool> {
+    let (Some(ca_path), Some(verifier)) = (&ctx.client_ca_path, &ctx.verifier) else {
+        return Ok(false);
+    };
+    let current = modified(ca_path)
+        .ok_or_else(|| anyhow::anyhow!("Failed to read modification time for client CA file"))?;
+    if *last == Some(current) {
+        return Ok(false);
+    }
+    let inner = build_client_verifier(ca_path, &ctx.provider)?;
+    verifier.store(inner);
+    *last = Some(current);
+    Ok(true)
+}
+
+impl WatchContext {
+    /// Filesystem paths to watch for certificate changes.
+    ///
+    /// If all certs share a parent, watch that directory. This catches atomic
+    /// symlink-swap rotations where individual file symlinks may not emit events.
+    #[cfg(target_os = "linux")]
+    fn paths(&self) -> Vec<PathBuf> {
+        let mut paths = vec![self.cert_path.clone(), self.key_path.clone()];
+        if let Some(ca_path) = &self.client_ca_path {
+            paths.push(ca_path.clone());
+        }
+        if paths.is_empty() || std::env::var("KUBERNETES_SERVICE_HOST").is_err() {
+            return paths;
+        }
+        let mut parents = paths.iter().map(|path| path.parent().map(PathBuf::from));
+        if let Some(Some(first)) = parents.next() {
+            if parents.all(|parent| parent.as_ref() == Some(&first)) {
+                return vec![first];
+            }
+        }
+        paths
+    }
+
+    // Reload both the server certificate and the client CA verifier, returning `Ok(true)` if
+    // either was actually swapped, `Ok(false)` if nothing had changed, and `Err` on failure.
+    fn reload_all_(
+        &self,
+        last_cert: &mut Option<(std::time::SystemTime, std::time::SystemTime)>,
+        last_ca: &mut Option<std::time::SystemTime>,
+    ) -> anyhow::Result<bool> {
+        let cert_changed = maybe_reload_cert(self, last_cert)?;
+        let verifier_changed = maybe_reload_verifier(self, last_ca)?;
+        Ok(cert_changed || verifier_changed)
+    }
+    fn reload_all(
+        &self,
+        last_cert: &mut Option<(std::time::SystemTime, std::time::SystemTime)>,
+        last_ca: &mut Option<std::time::SystemTime>,
+    ) {
+        let targets = &self.targets;
+        match self.reload_all_(last_cert, last_ca) {
+            Ok(true) => {
+                tracing::info!(?targets, "Reloaded TLS certificates");
+            }
+            Ok(false) => {}
+            Err(error) => {
+                tracing::warn!(?targets, %error, "Failed to reload TLS certificates");
+            }
+        }
+    }
+
+    /// Watch the certificate files and reload after changes.
+    ///
+    /// The parent directories are watched (rather than the files) so atomic symlink-swap rotations,
+    /// as used by Kubernetes secret mounts, are observed even when the individual file symlinks do
+    /// not emit events. Fingerprint guards collapse the batch of events a single rotation produces
+    /// into one reload each. When inotify cannot be armed, this falls back to a polling reload on a
+    /// timer.
+    #[cfg(target_os = "linux")]
+    fn watch(mut self) {
+        use inotify::{Inotify, WatchMask};
+        use std::time::Duration;
+
+        /// The polling interval used whenever the inotify watch is unavailable.
+        const POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+        self.targets = self.paths();
+
+        let mut last_cert = modified(&self.cert_path).zip(modified(&self.key_path));
+        let mut last_ca = self.client_ca_path.as_deref().and_then(modified);
+
+        let mut inotify = loop {
+            match Inotify::init() {
+                Ok(inotify) => break inotify,
+                Err(error) => {
+                    tracing::warn!(%error, "Failed to initialise inotify for TLS watch; polling for changes");
+                    std::thread::sleep(POLL_INTERVAL);
+                    if let Err(error) = self.reload_all_(&mut last_cert, &mut last_ca) {
+                        tracing::warn!(%error, "Failed to reload TLS certificates during polling fallback");
+                    }
+                }
+            }
+        };
+
+        let mask = WatchMask::MODIFY | WatchMask::MOVED_TO;
+        let mut buffer = [0u8; 4096];
+        'outer: loop {
+            for target in &self.targets {
+                if let Err(error) = inotify.watches().add(target, mask) {
+                    tracing::warn!(%error, path = %target.display(), "Failed to watch TLS path; will retry");
+                    std::thread::sleep(POLL_INTERVAL);
+                    if let Err(error) = self.reload_all_(&mut last_cert, &mut last_ca) {
+                        tracing::warn!(%error, "Failed to reload TLS certificates during polling fallback");
+                    }
+                    continue 'outer;
+                }
+            }
+
+            // Catch up on any change that happened before the watches were (re-)armed, since
+            // such changes emit no events; the fingerprint guards make this a no-op otherwise.
+            self.reload_all(&mut last_cert, &mut last_ca);
+
+            loop {
+                // Blocks until an event is available, then returns the whole batch of
+                // currently-queued events in one read.
+                let events = match inotify.read_events_blocking(&mut buffer) {
+                    Ok(events) => events,
+                    Err(error) => {
+                        tracing::warn!(%error, "TLS watch read error; re-arming");
+                        break;
+                    }
+                };
+
+                tracing::debug!(targets = ?self.targets, "TLS watch events received");
+
+                // The watch descriptor is only dropped when the watched inode itself is
+                // removed (delivered as `IGNORED`); in-directory rotations keep the inode
+                // and the watch keeps reporting `MOVED_TO`/`MODIFY`.
+                let ignored = events
+                    .into_iter()
+                    .any(|event| event.mask.contains(inotify::EventMask::IGNORED));
+
+                self.reload_all(&mut last_cert, &mut last_ca);
+
+                if ignored {
+                    break;
+                }
+            }
+
+            // Brief settle time before re-arming.
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}

--- a/k8s/forward/src/lib.rs
+++ b/k8s/forward/src/lib.rs
@@ -132,15 +132,23 @@ impl From<SecretData> for TlsMode {
             data.client_certificate,
             data.client_key,
         ) {
-            (Some(ca_certificate), None, None) => TlsMode::ServerVerify { ca_certificate },
+            (Some(ca_certificate), None, None) => TlsMode::ServerVerify {
+                ca_certificate,
+                ca_certificate_path: None,
+            },
             (None, Some(client_certificate), Some(client_key)) => TlsMode::ClientVerify {
                 client_certificate,
                 client_key,
+                client_certificate_path: None,
+                client_key_path: None,
             },
             (Some(ca_certificate), Some(client_certificate), Some(client_key)) => TlsMode::Mtls {
                 ca_certificate,
                 client_certificate,
                 client_key,
+                ca_certificate_path: None,
+                client_certificate_path: None,
+                client_key_path: None,
             },
             _ => TlsMode::Auto,
         }

--- a/k8s/proxy/src/proxy.rs
+++ b/k8s/proxy/src/proxy.rs
@@ -321,9 +321,8 @@ impl ConfigBuilder<ApiRest> {
 
         Configuration::builder()
             .with_timeout(timeout)
-            .with_bearer_token(client_security.jwt)
             .with_tracing(true)
-            .with_tls(client_security.tls)
+            .with_client_security(Some(client_security))
             .build_url(url)
             .map_err(|e| anyhow!("Failed to Create OpenApi config: {:?}", e).into())
     }

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -64,3 +64,7 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry-http = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
+
+# certificate file watching for TLS auto-reload (tower client); Linux/inotify only
+[target.'cfg(target_os = "linux")'.dependencies]
+inotify = { workspace = true }

--- a/openapi/templates/default/tower-hyper/client/configuration.mustache
+++ b/openapi/templates/default/tower-hyper/client/configuration.mustache
@@ -4,8 +4,16 @@ pub type ReqBody = hyper_body::Body;
 
 pub use hyper::{body, Request, Response, Uri};
 
+#[cfg(all(not(feature = "tower-client-tls"), feature = "tower-client-rls"))]
 use hyper_rustls::ConfigBuilderExt;
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
 use tokio::sync::Mutex;
 use tower::{util::BoxCloneService, Layer, Service, ServiceExt};
 
@@ -50,9 +58,29 @@ pub enum Error {
     UriToUrl(url::ParseError),
     AddingVersionPath(hyper::http::uri::InvalidUri),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NativeRootCerts(error) => write!(f, "failed to load native root certificates: {error}"),
+            Self::Certificate => write!(f, "failed to parse TLS certificate"),
+            Self::ClientKey => write!(f, "failed to parse TLS client key"),
+            Self::ClientIdentity => write!(f, "failed to configure TLS client identity"),
+            Self::ClientAuth(error) => write!(f, "failed to configure TLS client authentication: {error}"),
+            Self::TlsConnector => write!(f, "failed to create TLS connector"),
+            Self::NoTracingFeature => write!(f, "tower tracing feature is not enabled"),
+            Self::UrlToUri(error) => write!(f, "failed to convert URL to URI: {error}"),
+            Self::UriToUrl(error) => write!(f, "failed to convert URI to URL: {error}"),
+            Self::AddingVersionPath(error) => write!(f, "failed to add API version path: {error}"),
+        }
+    }
+}
+impl std::error::Error for Error {}
 
-/// The TLS configuration for HTTPS connections.
-#[derive(Debug, Clone, Default)]
+/// TLS configuration for HTTPS connections.
+///
+/// Certificate bytes are loaded up front. File-based modes also keep source paths,
+/// allowing reload to re-read renewed certificates without rebuilding the configuration.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum TlsMode {
     /// No TLS, plain HTTP. This is not recommended for production use.
     None,
@@ -63,12 +91,15 @@ pub enum TlsMode {
     /// but no client TLS certificate.
     ServerVerify {
         ca_certificate: Vec<u8>,
+        ca_certificate_path: Option<PathBuf>,
     },
     /// No verification of the server's TLS certificate, 
     /// but use the provided client TLS certificate for authentication.
     ClientVerify {
         client_certificate: Vec<u8>,
         client_key: Vec<u8>,
+        client_certificate_path: Option<PathBuf>,
+        client_key_path: Option<PathBuf>,
     },
     /// Verification of the server's TLS certificate using the provided CA certificate,
     /// and use the provided client TLS certificate for authentication.
@@ -77,8 +108,30 @@ pub enum TlsMode {
         ca_certificate: Vec<u8>,
         client_certificate: Vec<u8>,
         client_key: Vec<u8>,
+        ca_certificate_path: Option<PathBuf>,
+        client_certificate_path: Option<PathBuf>,
+        client_key_path: Option<PathBuf>,
     },
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TlsFingerprint {
+    None,
+    Auto,
+    ServerVerify {
+        ca_certificate: std::time::SystemTime,
+    },
+    ClientVerify {
+        client_certificate: std::time::SystemTime,
+        client_key: std::time::SystemTime,
+    },
+    Mtls {
+        ca_certificate: std::time::SystemTime,
+        client_certificate: std::time::SystemTime,
+        client_key: std::time::SystemTime,
+    },
+}
+
 impl TlsMode {
     /// Check if tls mode is auto.
     pub fn is_auto(&self) -> bool {
@@ -97,6 +150,8 @@ pub struct ClientSecurity {
     pub jwt: Option<String>,
     /// TLS mode for HTTPS connections.
     pub tls: TlsMode,
+    /// Watches file-based TLS certs and rebuilds the connector on renewal.
+    pub tls_reload: bool,
     /// Discovery of properties. 
     /// If true, the client will attempt to discover the required TLS and Auth configuration
     pub discover: bool,
@@ -106,31 +161,47 @@ impl Default for ClientSecurity {
         Self {
             jwt: None,
             tls: TlsMode::default(),
+            tls_reload: false,
             discover: true,
         }
     }
 }
 impl ClientSecurity {
     /// Creates a new client security configuration.
-    pub fn try_new(jwt: &Option<PathBuf>, tls: TlsMode) -> Result<Self, std::io::Error> {
+    pub fn try_new(
+        jwt: &Option<PathBuf>,
+        tls: impl Into<TlsMode>,
+    ) -> Result<Self, std::io::Error> {
+        let tls = tls.into();
         let jwt = jwt.as_ref().map(std::fs::read_to_string).transpose()?;
         Ok(Self {
             discover: tls.is_auto() || jwt.is_none(),
             jwt: jwt.map(|jwt| jwt.trim().to_string()),
+            tls_reload: tls.is_reloadable(),
             tls,
         })
     }
     /// Creates a new client security configuration.
-    pub fn new(jwt: Option<String>, tls: TlsMode) -> Self {
+    pub fn new(jwt: Option<String>, tls: impl Into<TlsMode>) -> Self {
+        let tls = tls.into();
         Self {
             discover: tls.is_auto() || jwt.is_none(),
             jwt,
+            tls_reload: tls.is_reloadable(),
             tls,
         }
     }
     /// Update self with the discover field.
     pub fn with_discover(self, discover: bool) -> Self {
         Self { discover, ..self }
+    }
+    /// Enable automatic reload for file-based TLS certificates.
+    ///
+    /// Automatically enabled when the TLS mode carries certificate paths. This watches
+    /// certificate paths retained by [`TlsMode::new`]. Byte-only TLS modes and non-Linux
+    /// platforms keep the existing static connector.
+    pub fn with_tls_reload(self, tls_reload: bool) -> Self {
+        Self { tls_reload, ..self }
     }
     /// Check if the client security configuration requires discovery 
     /// (i.e. if TLS is auto or JWT is not provided).
@@ -140,54 +211,593 @@ impl ClientSecurity {
 }
 
 impl TlsMode {
-    /// Creates a new TLS mode configuration from the given certificate and client key paths.
+    /// Creates TLS mode from optional certificate file paths.
+    ///
+    /// The files are read immediately, and their paths are retained for runtime reload.
     pub fn new(
         certificate: Option<&PathBuf>,
         client_cert: Option<&PathBuf>,
         client_key: Option<&PathBuf>,
     ) -> Result<Self, std::io::Error> {
-        let ca = certificate.map(std::fs::read).transpose()?;
-        let cl = client_cert
-            .zip(client_key)
-            .map(|(cert_path, key_path)| {
-                Ok::<_, std::io::Error>((std::fs::read(cert_path)?, std::fs::read(key_path)?))
-            })
-            .transpose()?;
-
-        Ok(match (ca, cl) {
-            (None, None) => TlsMode::Auto,
-            (Some(ca_certificate), None) => TlsMode::ServerVerify {
-                ca_certificate
+        Ok(match (certificate, client_cert.zip(client_key)) {
+            (None, None) => Self::Auto,
+            (Some(ca_certificate), None) => Self::ServerVerify {
+                ca_certificate: std::fs::read(ca_certificate)?,
+                ca_certificate_path: Some(ca_certificate.clone()),
             },
             (None, Some((client_certificate, client_key))) => Self::ClientVerify {
-                client_certificate,
-                client_key,
+                client_certificate: std::fs::read(client_certificate)?,
+                client_key: std::fs::read(client_key)?,
+                client_certificate_path: Some(client_certificate.clone()),
+                client_key_path: Some(client_key.clone()),
             },
             (Some(ca_certificate), Some((client_certificate, client_key))) => Self::Mtls {
-                ca_certificate,
-                client_certificate,
-                client_key,
-            }
+                ca_certificate: std::fs::read(ca_certificate)?,
+                client_certificate: std::fs::read(client_certificate)?,
+                client_key: std::fs::read(client_key)?,
+                ca_certificate_path: Some(ca_certificate.clone()),
+                client_certificate_path: Some(client_certificate.clone()),
+                client_key_path: Some(client_key.clone()),
+            },
         })
     }
     fn certificate(&self) -> Option<&[u8]> {
         match &self {
-            Self::ServerVerify { ca_certificate } | Self::Mtls { ca_certificate, .. } => Some(&ca_certificate[..]),
+            Self::ServerVerify { ca_certificate, .. } | Self::Mtls { ca_certificate, .. } => {
+                Some(&ca_certificate[..])
+            }
             _ => None,
         }
     }
     fn client_cert(&self) -> Option<&[u8]> {
         match &self {
-            Self::ClientVerify { client_certificate, .. } | Self::Mtls { client_certificate, .. } => Some(&client_certificate[..]),
+            Self::ClientVerify {
+                client_certificate, ..
+            }
+            | Self::Mtls {
+                client_certificate, ..
+            } => Some(&client_certificate[..]),
             _ => None,
         }
     }
     fn client_key(&self) -> Option<&[u8]> {
         match &self {
-            Self::ClientVerify { client_key, .. } | Self::Mtls { client_key, .. } => Some(&client_key[..]),
+            Self::ClientVerify { client_key, .. } | Self::Mtls { client_key, .. } => {
+                Some(&client_key[..])
+            }
             _ => None,
         }
     }
+    /// True when all certificate paths needed for reload are present.
+    fn is_reloadable(&self) -> bool {
+        match self {
+            Self::None | Self::Auto => false,
+            Self::ServerVerify { ca_certificate_path, .. } => ca_certificate_path.is_some(),
+            Self::ClientVerify {
+                client_certificate_path,
+                client_key_path,
+                ..
+            } => client_certificate_path.is_some() && client_key_path.is_some(),
+            Self::Mtls {
+                ca_certificate_path,
+                client_certificate_path,
+                client_key_path,
+                ..
+            } => ca_certificate_path.is_some()
+                && client_certificate_path.is_some()
+                && client_key_path.is_some(),
+        }
+    }
+
+    /// Certificate paths to watch for reload.
+    fn paths(&self) -> Vec<PathBuf> {
+        match self {
+            Self::None | Self::Auto => Vec::new(),
+            Self::ServerVerify { ca_certificate_path, .. } => {
+                vec![ca_certificate_path.clone()]
+            }
+            Self::ClientVerify {
+                client_certificate_path,
+                client_key_path,
+                ..
+            } => vec![client_certificate_path.clone(), client_key_path.clone()],
+            Self::Mtls {
+                ca_certificate_path,
+                client_certificate_path,
+                client_key_path,
+                ..
+            } => vec![
+                ca_certificate_path.clone(),
+                client_certificate_path.clone(),
+                client_key_path.clone(),
+            ],
+        }
+        .into_iter()
+        .flatten()
+        .collect()
+    }
+
+    /// Re-read certificate files from their stored paths.
+    fn reload_from_paths(&self) -> Result<Self, std::io::Error> {
+        Ok(match self {
+            Self::None => Self::None,
+            Self::Auto => Self::Auto,
+            Self::ServerVerify {
+                ca_certificate_path: Some(ca_certificate),
+                ..
+            } => Self::ServerVerify {
+                ca_certificate: std::fs::read(ca_certificate)?,
+                ca_certificate_path: Some(ca_certificate.clone()),
+            },
+            Self::ClientVerify {
+                client_certificate_path: Some(client_certificate),
+                client_key_path: Some(client_key),
+                ..
+            } => Self::ClientVerify {
+                client_certificate: std::fs::read(client_certificate)?,
+                client_key: std::fs::read(client_key)?,
+                client_certificate_path: Some(client_certificate.clone()),
+                client_key_path: Some(client_key.clone()),
+            },
+            Self::Mtls {
+                ca_certificate_path: Some(ca_certificate),
+                client_certificate_path: Some(client_certificate),
+                client_key_path: Some(client_key),
+                ..
+            } => Self::Mtls {
+                ca_certificate: std::fs::read(ca_certificate)?,
+                client_certificate: std::fs::read(client_certificate)?,
+                client_key: std::fs::read(client_key)?,
+                ca_certificate_path: Some(ca_certificate.clone()),
+                client_certificate_path: Some(client_certificate.clone()),
+                client_key_path: Some(client_key.clone()),
+            },
+            mode => mode.clone(),
+        })
+    }
+
+    /// Last-modified fingerprint used to skip duplicate reload events.
+    fn fingerprint(&self) -> Result<TlsFingerprint, std::io::Error> {
+        fn modified(path: &PathBuf) -> Result<std::time::SystemTime, std::io::Error> {
+            std::fs::metadata(path)?.modified()
+        }
+        Ok(match self {
+            Self::None => TlsFingerprint::None,
+            Self::Auto => TlsFingerprint::Auto,
+            Self::ServerVerify {
+                ca_certificate_path: Some(ca_certificate),
+                ..
+            } => TlsFingerprint::ServerVerify {
+                ca_certificate: modified(ca_certificate)?,
+            },
+            Self::ClientVerify {
+                client_certificate_path: Some(client_certificate),
+                client_key_path: Some(client_key),
+                ..
+            } => TlsFingerprint::ClientVerify {
+                client_certificate: modified(client_certificate)?,
+                client_key: modified(client_key)?,
+            },
+            Self::Mtls {
+                ca_certificate_path: Some(ca_certificate),
+                client_certificate_path: Some(client_certificate),
+                client_key_path: Some(client_key),
+                ..
+            } => TlsFingerprint::Mtls {
+                ca_certificate: modified(ca_certificate)?,
+                client_certificate: modified(client_certificate)?,
+                client_key: modified(client_key)?,
+            },
+            _ => TlsFingerprint::None,
+        })
+    }
+    /// Filesystem paths to watch for certificate changes.
+    ///
+    /// If all certs share a parent, watch that directory. This catches atomic
+    /// symlink-swap rotations where individual file symlinks may not emit events.
+    fn watch_targets(&self) -> Vec<PathBuf> {
+        let paths = self.paths();
+        if paths.is_empty() || std::env::var("KUBERNETES_SERVICE_HOST").is_err() {
+            return paths;
+        }
+        let mut parents = paths.iter().map(|path| path.parent().map(PathBuf::from));
+        if let Some(Some(first)) = parents.next() {
+            if parents.all(|parent| parent.as_ref() == Some(&first)) {
+                return vec![first];
+            }
+        }
+        paths
+    }
+}
+
+type HttpClientService = BoxCloneService<Request<ReqBody>, Response<ReqBody>, BoxedError>;
+
+/// Tower service that swaps its inner TLS client after certificate reloads.
+///
+/// Requests clone the current inner client; reload work stays in the background watcher.
+#[derive(Clone)]
+struct TlsReloadService {
+    state: Arc<std::sync::Mutex<TlsReloadState>>,
+}
+
+struct TlsReloadState {
+    url: url::Url,
+    tls: TlsMode,
+    fingerprint: TlsFingerprint,
+    client: HttpClientService,
+}
+
+impl TlsReloadService {
+    /// Build the initial client and start the background certificate watcher.
+    fn new(mut url: url::Url, tls: TlsMode) -> Result<(Self, url::Url), Error> {
+        let fingerprint = tls.fingerprint().map_err(Error::NativeRootCerts)?;
+        let client = build_http_client(&mut url, &tls)?;
+
+        let watch_paths = tls.watch_targets();
+        let state = Arc::new(std::sync::Mutex::new(TlsReloadState {
+            url: url.clone(),
+            tls,
+            fingerprint,
+            client,
+        }));
+
+        Self::spawn_watcher(watch_paths, state.clone());
+
+        Ok((Self { state }, url))
+    }
+
+    /// The current inner client.
+    fn client(&self) -> HttpClientService {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .client
+            .clone()
+    }
+
+    fn reload_(state: &Arc<std::sync::Mutex<TlsReloadState>>) -> Result<bool, Error> {
+        let mut state = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let fingerprint = state.tls.fingerprint().map_err(Error::NativeRootCerts)?;
+        if fingerprint == state.fingerprint {
+            return Ok(false);
+        }
+        let tls = state.tls.reload_from_paths().map_err(Error::NativeRootCerts)?;
+        let mut url = state.url.clone();
+        let client = build_http_client(&mut url, &tls)?;
+        state.client = client;
+        state.url = url;
+        state.tls = tls;
+        state.fingerprint = fingerprint;
+        Ok(true)
+    }
+    /// Re-read the certificate files and rebuild the TLS client, but only when the
+    /// fingerprint changed, so duplicate or spurious watch events are no-ops.
+    ///
+    /// Returns `true` when the client was rebuilt.
+    fn reload(state: &Arc<std::sync::Mutex<TlsReloadState>>, paths: &[PathBuf]) {
+        // Catch up on any change that happened before the watches were (re-)armed, since
+        // such changes emit no events; the fingerprint guard makes this a no-op otherwise.
+        match Self::reload_(state) {
+            Ok(true) => {
+                #[cfg(feature = "tower-trace")]
+                tracing::info!(?paths, "Reloaded TLS certificates");
+            }
+            Ok(false) => {}
+            Err(_error) => {
+                #[cfg(feature = "tower-trace")]
+                tracing::warn!(?paths, error = %_error, "Failed to reload TLS certificates");
+            }
+        }
+    }
+
+    /// Spawn the certificate watch loop on a background OS thread.
+    ///
+    /// A plain OS thread is used rather than a Tokio task because the watch blocks in
+    /// `inotify` reads and the reload path is fully synchronous/blocking.
+    #[cfg(target_os = "linux")]
+    fn spawn_watcher(watch_paths: Vec<PathBuf>, state: Arc<std::sync::Mutex<TlsReloadState>>) {
+        if watch_paths.is_empty() {
+            return;
+        }
+        std::thread::Builder::new()
+            .name("tls-cert-watch".into())
+            .spawn(move || Self::watch(watch_paths, state))
+            .ok();
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn spawn_watcher(watch_paths: Vec<PathBuf>, _state: Arc<std::sync::Mutex<TlsReloadState>>) {
+        #[cfg(feature = "tower-trace")]
+        tracing::warn!(
+            "TLS certificate watch is only supported on Linux; automatic reload is disabled"
+        );
+        let _ = watch_paths;
+    }
+
+    /// Watch certificate paths and reload after changes.
+    ///
+    /// Watch targets come from [`TlsMode::watch_targets`]: either the shared parent
+    /// directory of the certificate files, or the individual files as a fallback. A
+    /// single inotify instance reacts to `MODIFY` (in-place writes) and `MOVED_TO` (an
+    /// entry moved into the watched directory, i.e. an atomic-rename rotation).
+    ///
+    /// A renewal usually touches several files at once; each blocking read drains the
+    /// whole batch of queued events, which collapses into a single reload, and the
+    /// fingerprint guard in [`TlsReloadService::reload`] ensures the client is rebuilt
+    /// only once per actual change. Watches are re-armed only if the watched inode is
+    /// removed (`IGNORED`); the common Kubernetes symlink swap keeps the directory inode.
+    ///
+    /// inotify can fail at runtime: `init` when `fs.inotify.max_user_instances` is
+    /// exhausted, and `add` when a path is briefly missing mid-rotation or
+    /// `fs.inotify.max_user_watches` is exhausted. Whenever a watch cannot be (re)armed,
+    /// this falls back to a fingerprint-guarded reload on a timer until it recovers.
+    #[cfg(target_os = "linux")]
+    fn watch(watch_paths: Vec<PathBuf>, state: Arc<std::sync::Mutex<TlsReloadState>>) {
+        use inotify::{EventMask, Inotify, WatchMask};
+
+        /// The polling interval used whenever the inotify watch is unavailable.
+        const POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+        /// A fingerprint-guarded reload, used when polling for changes.
+        fn poll_reload(state: &Arc<std::sync::Mutex<TlsReloadState>>) {
+            match TlsReloadService::reload_(state) {
+                Ok(true) => {
+                    #[cfg(feature = "tower-trace")]
+                    tracing::info!("Reloaded TLS certificates after change (polled)");
+                }
+                Ok(false) => {}
+                Err(_error) => {
+                    #[cfg(feature = "tower-trace")]
+                    tracing::warn!(error = %_error, "Failed to reload TLS certificates");
+                }
+            }
+        }
+
+        tracing::debug!(?watch_paths, "TLS watch requested");
+
+        // Keep one inotify instance for the watcher's lifetime: the kernel only drops the
+        // watch descriptors when their inodes are deleted, the instance stays usable.
+        let mut inotify = loop {
+            match Inotify::init() {
+                Ok(inotify) => break inotify,
+                Err(_error) => {
+                    #[cfg(feature = "tower-trace")]
+                    tracing::warn!(
+                        error = %_error,
+                        "Failed to initialise inotify for TLS watch; polling for changes"
+                    );
+                    std::thread::sleep(POLL_INTERVAL);
+                    poll_reload(&state);
+                }
+            }
+        };
+
+        let mask = WatchMask::MODIFY | WatchMask::MOVED_TO;
+        let mut buffer = [0u8; 4096];
+        'outer: loop {
+            for path in &watch_paths {
+                if let Err(_error) = inotify.watches().add(path, mask) {
+                    #[cfg(feature = "tower-trace")]
+                    tracing::warn!(
+                        error = %_error,
+                        path = %path.display(),
+                        "Failed to watch TLS path; will retry"
+                    );
+                    // Fall back to polling until the full set can be re-armed
+                    std::thread::sleep(POLL_INTERVAL);
+                    poll_reload(&state);
+                    continue 'outer;
+                }
+            }
+
+            // Catch up on any change that happened before the watches were (re-)armed, since
+            // such changes emit no events; the fingerprint guard makes this a no-op otherwise.
+            Self::reload(&state, &watch_paths);
+
+            loop {
+                // Blocks until an event is available, then returns the whole batch of
+                // currently-queued events in one read.
+                let events = match inotify.read_events_blocking(&mut buffer) {
+                    Ok(events) => events,
+                    Err(_error) => {
+                        #[cfg(feature = "tower-trace")]
+                        tracing::warn!(error = %_error, "TLS watch read error; re-arming");
+                        break;
+                    }
+                };
+
+                #[cfg(feature = "tower-trace")]
+                tracing::debug!(?watch_paths, "TLS watch events received");
+
+                // The watch descriptor is only dropped when the watched inode itself is
+                // removed (delivered as `IGNORED`); in-directory rotations keep the inode
+                // and the watch keeps reporting `MOVED_TO`/`MODIFY`.
+                let ignored = events
+                    .into_iter()
+                    .any(|event| event.mask.contains(EventMask::IGNORED));
+
+                Self::reload(&state, &watch_paths);
+
+                if ignored {
+                    break;
+                }
+            }
+            // Brief settle time before re-arming.
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+impl Service<Request<ReqBody>> for TlsReloadService {
+    type Response = Response<ReqBody>;
+    type Error = BoxedError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let mut client = self.client();
+        Box::pin(async move {
+            client
+                .ready()
+                .await?
+                .call(request)
+                .await
+        })
+    }
+}
+
+fn build_http_client(url: &mut url::Url, tls: &TlsMode) -> Result<HttpClientService, Error> {
+    let insecure_skip_verify = url.scheme() == "https" && tls.certificate().is_none();
+    #[cfg(all(not(feature = "tower-client-tls"), feature = "tower-client-rls"))]
+    let client = {
+        match tls.certificate() {
+            None => {
+                let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
+
+                let tls = match url.scheme() == "https" {
+                    true => {
+                        http.enforce_http(false);
+                        let builder = rustls::ClientConfig::builder()
+                            .with_native_roots()
+                            .map_err(Error::NativeRootCerts)?;
+                        let mut config = match (tls.client_cert(), tls.client_key()) {
+                            (Some(cert_bytes), Some(key_bytes)) => {
+                                let cert_chain = rustls_pemfile::certs(&mut std::io::BufReader::new(cert_bytes))
+                                    .collect::<Result<Vec<_>, _>>()
+                                    .map_err(|_| Error::Certificate)?;
+                                let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(key_bytes))
+                                    .map_err(|_| Error::ClientKey)?
+                                    .ok_or(Error::ClientKey)?;
+                                builder
+                                    .with_client_auth_cert(cert_chain, key)
+                                    .map_err(Error::ClientAuth)?
+                            }
+                            (None, None) => builder.with_no_client_auth(),
+                            _ => return Err(Error::ClientIdentity),
+                        };
+                        if insecure_skip_verify {
+                            config
+                                .dangerous()
+                                .set_certificate_verifier(Arc::new(NoCertificateVerification {}));
+                        }
+                        config
+                    }
+                    false => rustls::ClientConfig::builder()
+                        .with_root_certificates(rustls::RootCertStore::empty())
+                        .with_no_client_auth(),
+                };
+
+                let connector =
+                    hyper_rustls::HttpsConnector::from((http, std::sync::Arc::new(tls)));
+                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                    .build(connector)
+            }
+            Some(bytes) => {
+                let mut cert_file = std::io::BufReader::new(bytes);
+                let mut root_store = rustls::RootCertStore::empty();
+                root_store.add_parsable_certificates(
+                    rustls_pemfile::certs(&mut cert_file)
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(|_| Error::Certificate)?,
+                );
+                let builder = rustls::ClientConfig::builder()
+                    .with_root_certificates(root_store);
+                let config = match (tls.client_cert(), tls.client_key()) {
+                    (Some(cert_bytes), Some(key_bytes)) => {
+                        let cert_chain = rustls_pemfile::certs(&mut std::io::BufReader::new(cert_bytes))
+                            .collect::<Result<Vec<_>, _>>()
+                            .map_err(|_| Error::Certificate)?;
+                        let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(key_bytes))
+                            .map_err(|_| Error::ClientKey)?
+                            .ok_or(Error::ClientKey)?;
+                        builder
+                            .with_client_auth_cert(cert_chain, key)
+                            .map_err(Error::ClientAuth)?
+                    }
+                    (None, None) => builder.with_no_client_auth(),
+                    _ => return Err(Error::ClientIdentity),
+                };
+
+                let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
+                http.enforce_http(false);
+                let connector =
+                    hyper_rustls::HttpsConnector::from((http, std::sync::Arc::new(config)));
+                url.set_scheme("https").ok();
+                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                    .build(connector)
+            }
+        }
+    };
+    #[cfg(feature = "tower-client-tls")]
+    let client = {
+        match tls.certificate() {
+            None => {
+                let mut http = hyper_tls::HttpsConnector::new();
+                if url.scheme() == "https" {
+                    http.https_only(true);
+                }
+
+                let mut tls_builder = hyper_tls::native_tls::TlsConnector::builder();
+                tls_builder
+                    .danger_accept_invalid_certs(insecure_skip_verify)
+                    .danger_accept_invalid_hostnames(insecure_skip_verify);
+                match (tls.client_cert(), tls.client_key()) {
+                    (Some(cert_bytes), Some(key_bytes)) => {
+                        let identity =
+                            hyper_tls::native_tls::Identity::from_pkcs8(cert_bytes, key_bytes)
+                                .map_err(|_| Error::ClientIdentity)?;
+                        tls_builder.identity(identity);
+                    }
+                    (None, None) => {}
+                    _ => return Err(Error::ClientIdentity),
+                }
+                let tls = tls_builder.build().map_err(|_| Error::TlsConnector)?;
+                let tls = tokio_native_tls::TlsConnector::from(tls);
+
+                let connector = hyper_tls::HttpsConnector::from((http, tls));
+                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                    .build(connector)
+            }
+            Some(bytes) => {
+                let certificate = hyper_tls::native_tls::Certificate::from_pem(bytes)
+                    .map_err(|_| Error::Certificate)?;
+
+                let mut tls_builder = hyper_tls::native_tls::TlsConnector::builder();
+                tls_builder
+                    .add_root_certificate(certificate)
+                    .danger_accept_invalid_hostnames(insecure_skip_verify)
+                    .disable_built_in_roots(true);
+                match (tls.client_cert(), tls.client_key()) {
+                    (Some(cert_bytes), Some(key_bytes)) => {
+                        let identity =
+                            hyper_tls::native_tls::Identity::from_pkcs8(cert_bytes, key_bytes)
+                                .map_err(|_| Error::ClientIdentity)?;
+                        tls_builder.identity(identity);
+                    }
+                    (None, None) => {}
+                    _ => return Err(Error::ClientIdentity),
+                }
+                let tls = tls_builder.build().map_err(|_| Error::TlsConnector)?;
+                let tls = tokio_native_tls::TlsConnector::from(tls);
+
+                let mut http = hyper_tls::HttpsConnector::new();
+                http.https_only(true);
+                let connector = hyper_tls::HttpsConnector::from((http, tls));
+                url.set_scheme("https").ok();
+                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                    .build(connector)
+            }
+        }
+    };
+
+    Ok(BoxCloneService::new(
+        client
+            .map_response(|r| r.map(ReqBody::wrap_body))
+            .map_err(Into::<BoxedError>::into),
+    ))
 }
 
 /// `ConfigurationBuilder` that can be used to build a `Configuration`.
@@ -247,9 +857,10 @@ impl ConfigurationBuilder {
         self
     }
     /// TLS.
-    pub fn with_tls(mut self, tls: TlsMode) -> Self {
+    pub fn with_tls(mut self, tls: TlsMode, reload: bool) -> Self {
         let mut client_security = self.client_security.unwrap_or_default();
         client_security.tls = tls;
+        client_security.tls_reload = reload;
         self.client_security = Some(client_security);
         self
     }
@@ -434,154 +1045,22 @@ impl Configuration {
         concurrency_limit: Option<usize>,
     ) -> Result<Self, Error> {
         let client_security = client_security.unwrap_or_default();
+        let tls_reload = client_security.tls_reload;
         let bearer_access_token = client_security.jwt;
         let tls = client_security.tls;
-        let insecure_skip_verify = url.scheme() == "https" && tls.certificate().is_none();
-        #[cfg(all(not(feature = "tower-client-tls"), feature = "tower-client-rls"))]
-        let client = {
-            match tls.certificate() {
-                None => {
-                    let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
-
-                    let tls = match url.scheme() == "https" {
-                        true => {
-                            http.enforce_http(false);
-                            let builder = rustls::ClientConfig::builder()
-                                .with_native_roots()
-                                .map_err(Error::NativeRootCerts)?;
-                            let mut config = match (tls.client_cert(), tls.client_key()) {
-                                (Some(cert_bytes), Some(key_bytes)) => {
-                                    let cert_chain = rustls_pemfile::certs(&mut std::io::BufReader::new(cert_bytes))
-                                        .collect::<Result<Vec<_>, _>>()
-                                        .map_err(|_| Error::Certificate)?;
-                                    let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(key_bytes))
-                                        .map_err(|_| Error::ClientKey)?
-                                        .ok_or(Error::ClientKey)?;
-                                    builder
-                                        .with_client_auth_cert(cert_chain, key)
-                                        .map_err(Error::ClientAuth)?
-                                }
-                                (None, None) => builder.with_no_client_auth(),
-                                _ => return Err(Error::ClientIdentity),
-                            };
-                            if insecure_skip_verify {
-                                config
-                                    .dangerous()
-                                    .set_certificate_verifier(Arc::new(NoCertificateVerification {}));
-                            }
-                            config
-                        }
-                        false => rustls::ClientConfig::builder()
-                            .with_root_certificates(rustls::RootCertStore::empty())
-                            .with_no_client_auth(),
-                    };
-
-                    let connector =
-                        hyper_rustls::HttpsConnector::from((http, std::sync::Arc::new(tls)));
-                    hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                        .build(connector)
-                }
-                Some(bytes) => {
-                    let mut cert_file = std::io::BufReader::new(bytes);
-                    let mut root_store = rustls::RootCertStore::empty();
-                    root_store.add_parsable_certificates(
-                        rustls_pemfile::certs(&mut cert_file)
-                            .collect::<Result<Vec<_>, _>>()
-                            .map_err(|_| Error::Certificate)?,
-                    );
-                    let builder = rustls::ClientConfig::builder()
-                        .with_root_certificates(root_store);
-                    let config = match (tls.client_cert(), tls.client_key()) {
-                        (Some(cert_bytes), Some(key_bytes)) => {
-                            let cert_chain = rustls_pemfile::certs(&mut std::io::BufReader::new(cert_bytes))
-                                .collect::<Result<Vec<_>, _>>()
-                                .map_err(|_| Error::Certificate)?;
-                            let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(key_bytes))
-                                .map_err(|_| Error::ClientKey)?
-                                .ok_or(Error::ClientKey)?;
-                            builder.with_client_auth_cert(cert_chain, key)
-                                .map_err(Error::ClientAuth)?
-                        }
-                        (None, None) => builder.with_no_client_auth(),
-                        _ => return Err(Error::ClientIdentity),
-                    };
-
-                    let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
-                    http.enforce_http(false);
-                    let connector =
-                        hyper_rustls::HttpsConnector::from((http, std::sync::Arc::new(config)));
-                    url.set_scheme("https").ok();
-                    hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                        .build(connector)
-                }
+        let client = match (tls_reload, tls.is_reloadable()) {
+            (true, true) => {
+                let (client, reloaded_url) = TlsReloadService::new(url.clone(), tls)?;
+                url = reloaded_url;
+                BoxCloneService::new(client)
             }
-        };
-        #[cfg(feature = "tower-client-tls")]
-        let client = {
-            match tls.certificate() {
-                None => {
-                    let mut http = hyper_tls::HttpsConnector::new();
-                    if url.scheme() == "https" {
-                        http.https_only(true);
-                    }
-
-                    let mut tls_builder = hyper_tls::native_tls::TlsConnector::builder();
-                    tls_builder
-                        .danger_accept_invalid_certs(insecure_skip_verify)
-                        .danger_accept_invalid_hostnames(insecure_skip_verify);
-                    match (tls.client_cert(), tls.client_key()) {
-                        (Some(cert_bytes), Some(key_bytes)) => {
-                            let identity =
-                                hyper_tls::native_tls::Identity::from_pkcs8(cert_bytes, key_bytes)
-                                    .map_err(|_| Error::ClientIdentity)?;
-                            tls_builder.identity(identity);
-                        }
-                        (None, None) => {}
-                        _ => return Err(Error::ClientIdentity),
-                    }
-                    let tls = tls_builder.build().map_err(|_| Error::TlsConnector)?;
-                    let tls = tokio_native_tls::TlsConnector::from(tls);
-
-                    let connector = hyper_tls::HttpsConnector::from((http, tls));
-                    hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                        .build(connector)
-                }
-                Some(bytes) => {
-                    let certificate = hyper_tls::native_tls::Certificate::from_pem(bytes)
-                        .map_err(|_| Error::Certificate)?;
-
-                    let mut tls_builder = hyper_tls::native_tls::TlsConnector::builder();
-                    tls_builder
-                        .add_root_certificate(certificate)
-                        .danger_accept_invalid_hostnames(insecure_skip_verify)
-                        .disable_built_in_roots(true);
-                    match (tls.client_cert(), tls.client_key()) {
-                        (Some(cert_bytes), Some(key_bytes)) => {
-                            let identity =
-                                hyper_tls::native_tls::Identity::from_pkcs8(cert_bytes, key_bytes)
-                                    .map_err(|_| Error::ClientIdentity)?;
-                            tls_builder.identity(identity);
-                        }
-                        (None, None) => {}
-                        _ => return Err(Error::ClientIdentity),
-                    }
-                    let tls = tls_builder.build().map_err(|_| Error::TlsConnector)?;
-                    let tls = tokio_native_tls::TlsConnector::from(tls);
-
-                    let mut http = hyper_tls::HttpsConnector::new();
-                    http.https_only(true);
-                    let connector = hyper_tls::HttpsConnector::from((http, tls));
-                    url.set_scheme("https").ok();
-                    hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                        .build(connector)
-                }
-            }
+            _ => build_http_client(&mut url, &tls)?,
         };
 
         let uri = url.to_string().parse().map_err(Error::UrlToUri)?;
         Self::new_with_client(
             uri,
-            client.map_response(|r| r.map(ReqBody::wrap_body)),
+            client,
             Some(timeout),
             bearer_access_token,
             trace_requests,

--- a/utils/deployer-cluster/src/rest_client.rs
+++ b/utils/deployer-cluster/src/rest_client.rs
@@ -53,6 +53,7 @@ impl RestClient {
             bearer_token,
             TlsMode::ServerVerify {
                 ca_certificate: cert_file.to_vec(),
+                ca_certificate_path: None,
             },
         );
 


### PR DESCRIPTION
    feat(rest/server): hot-reload TLS certificates without restart
    
    Serve the REST server certificate through a swappable ResolvesServerCert
    and (for mTLS) a swappable ClientCertVerifier.
    
    A background inotify watcher reloads both when the files change on disk
    (e.g. cert-manager rotation or secret recreation), falling back to polling
    when inotify is unavailable.
    
    A catch-up reload after (re-)arming the watches closes the race where
    a rotation lands before the watch is armed.
    
    Also add the same catch-up reload to the openapi tower-hyper client
    template's TLS reload watcher.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(rest/client): add auto-reload by watching for cert changes
    
    Adds opt-in automatic reloading of file-based TLS certificates for the
    tower-hyper OpenAPI client. TlsMode now retains the source certificate
    paths alongside the loaded bytes, so renewed certificates (e.g.
    cert-manager rotations) can be re-read at runtime without rebuilding the
    Configuration.
    
    A background TlsReloadService watches the certificate paths via inotify
    (Linux) and swaps the inner HTTP client once a change is observed.
    A last-modified fingerprint guards against duplicate/spurious events so the
    connector is rebuilt at most once per actual change, and a polling
    fallback covers the cases where inotify cannot be armed.
    When all certs share a parent directory that directory is watched, which
    catches atomic symlink-swap rotations.
    
    Reload is enabled automatically whenever the TLS mode carries certificate
    paths (ClientSecurity::try_new/new), and can be toggled explicitly via
    ClientSecurity::with_tls_reload.
    Byte-only modes and non-Linux platforms keep the existing static connector.