### PR TITLE
fix: add read_only field to v1 Nexus/PublishNexus struct literals

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -532,6 +532,8 @@ impl AgentToIoEngine for transport::ShareNexus {
             key: self.key.clone().unwrap_or_default(),
             share: self.protocol as i32,
             allowed_hosts: self.allowed_hosts.clone().into_vec(),
+            // publish always requests RWO until the consumer PR lands.
+            read_only: None,
         }
     }
 }

--- a/utils/bundle-sim/src/bin/io-engine.rs
+++ b/utils/bundle-sim/src/bin/io-engine.rs
@@ -219,6 +219,7 @@ impl IoEngine {
                         }
                     }),
                     bdev_size: state.bdev_size,
+                    read_only: None,
                 };
                 if let Some(node) = io_engine.sims.get_mut(state.node.as_str()) {
                     node.nexuses.push(nexus);


### PR DESCRIPTION
Bumps utils/dependencies to include openebs/mayastor-dependencies#162 which added an `optional bool read_only` field to both the v1 `Nexus` proto message and `PublishNexusRequest`. Two sites in the control-plane construct these as struct literals without `..Default::default()`, so bumping the submodule alone breaks the build with `E0063: missing field read_only`.

Add the field explicitly as `None` at both sites:

  - `utils/bundle-sim/src/bin/io-engine.rs:190`: the `Nexus { ... }` literal in the bundle-sim io-engine simulator. bundle-sim replays a snapshot of nexus state and doesn't model publish transitions, so `None` matches the "not currently tracked" shape.
  - `control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs:530`: the `PublishNexusRequest { ... }` literal in the `ShareNexus -> PublishNexusRequest` translation. ROX is not modelled on the CP side yet, so publish always requests RWO here until the consumer PR lands and threads a per-volume `read_only` decision through this call.

Companion to the io-engine fix: openebs/mayastor#2033.

Refs: openebs/mayastor#2033
Refs: openebs/mayastor-dependencies#162