### PR TITLE
fix(csi/node): check nvme_rdma kernel module for RDMA capability

### DIFF
--- a/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
+++ b/control-plane/csi-driver/src/bin/node/dev/nvmf.rs
@@ -500,10 +500,12 @@ pub(crate) fn check_nvme_tcp_module() -> Result<(), std::io::Error> {
     Ok(())
 }
 
-/// Check for the presence of nvme tcp kernel module.
-/// TODO: Handle the case where this(and for that matter nvme_tcp too)
-/// could be builtin module.
-#[allow(unused)]
+/// Check for the presence of the `nvme_rdma` kernel module by looking at
+/// `/sys/module/nvme_rdma`. Used by the CSI node startup to decide whether
+/// this node is RDMA-capable even when `ibv_devinfo` reports HCAs.
+///
+/// TODO: Handle the case where this (and for that matter nvme_tcp too) could
+/// be a builtin module.
 pub(crate) fn check_nvme_rdma_module() -> Result<(), std::io::Error> {
     let path = "/sys/module/nvme_rdma";
     std::fs::metadata(path)?;

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -35,7 +35,7 @@ use std::{
 use tokio::net::UnixListener;
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::Server;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 const GRPC_PORT: u16 = 50051;
 
@@ -349,10 +349,26 @@ pub(super) async fn main() -> anyhow::Result<()> {
             // In an unlikely case string from utf8 fails, err towards incapability.
             let outstr = String::from_utf8(okstdout.stdout).unwrap_or("0 HCA".to_string());
             if !outstr.starts_with("0 HCA") {
-                info!("host node rdma capable. conn_fallback({conn_fallback:?}), {outstr:?}");
-                // todo: check for the presence of nvme_rdma too. But don't bail out as we do for
-                // nvme_tcp.
-                true
+                // RDMA hardware is present, but the transport still requires the `nvme_rdma`
+                // kernel module to be loaded on this node. If it is missing, treat the node as
+                // RDMA-incapable so `transport_from_url` can fall back to TCP (when the operator
+                // enabled fallback) rather than fail the connect with a hard error.
+                match crate::dev::nvmf::check_nvme_rdma_module() {
+                    Ok(()) => {
+                        info!(
+                            "host node rdma capable. conn_fallback({conn_fallback:?}), {outstr:?}"
+                        );
+                        true
+                    }
+                    Err(error) => {
+                        warn!(
+                            "host node has rdma hardware but nvme_rdma kernel module is not \
+                            loaded, treating as rdma incapable. \
+                            conn_fallback({conn_fallback:?}), {outstr:?}, error: {error}"
+                        );
+                        false
+                    }
+                }
             } else {
                 info!(
                     "host node is not rdma capable. conn_fallback({conn_fallback:?}), {outstr:?}"


### PR DESCRIPTION
The CSI node startup previously decided a host was RDMA-capable purely from `ibv_devinfo -l` output (presence of RDMA HCAs), and hardcoded `cap = true` when any HCA was reported. On a node with RDMA hardware (e.g. ConnectX-7) but no `nvme_rdma` kernel module loaded, this made `RDMA_CONNECT_CHECK.1 = true`, which in turn caused `transport_from_url` to skip the RDMA → TCP fallback branch even when `--nvme-connect-fallback` was set. The subsequent `nvme connect -t rdma` then fails because the transport module is missing, and the volume mount fails hard instead of falling back.

## Root cause

`main_.rs` line ~355:
```rust
if !outstr.starts_with("0 HCA") {
    info!("host node rdma capable...");
    // todo: check for the presence of nvme_rdma too. But don't bail out as we do for
    // nvme_tcp.
    true                    // ← hardcoded; ignores kernel module state
}
```

The TODO comment explicitly acknowledges the gap, and the `check_nvme_rdma_module()` function that would perform the check already exists in `dev::nvmf` but was carrying `#[allow(unused)]` because it was never wired up.

## Fix

- Wire `check_nvme_rdma_module()` into the capability decision in `main_.rs`.
- Drop the `#[allow(unused)]` from the function definition; add a short doc comment explaining who uses it.

## Behaviour

| HCAs present? | `nvme_rdma` loaded? | Before | After |
|---|---|---|---|
| Yes | Yes | `cap = true`, RDMA connects | Same |
| Yes | **No** | `cap = true`, `nvme connect -t rdma` fails hard | `cap = false`, falls back to TCP when `--nvme-connect-fallback` is on |
| No | any | `cap = false` (unchanged) | Same |

The strict-RDMA case (fallback flag off, module missing) still errors, matching current semantics.

## Reproduction

Environment:
- Kubernetes v1.36.1
- Ubuntu 22.04.5 LTS, kernel 5.15.0-181-generic
- Mayastor v2.11.1 (OpenEBS chart 4.5.1)
- MLNX_OFED 24.10-2.1.8 (nvme_rdma module incompatible with kernel 5.15, won't load)
- 8× ConnectX-7 NICs (ibv_devinfo reports 8 HCAs)

Steps:
1. Install Mayastor with RDMA enabled: `io_engine.target.nvmf.rdma.enabled=true`
2. Set TCP fallback: `csi.node.nvme.tcpFallback=true`
3. Ensure `nvme_rdma` module is NOT loaded (`/sys/module/nvme_rdma` does not exist)
4. Create a volume and attempt to mount in a pod

Expected: CSI node detects missing nvme_rdma, falls back to TCP, volume mounts

Actual: CSI node reports RDMA-capable (ibv_devinfo finds HCAs), attempts `nvme connect -t rdma`, fails with `IO error: Invalid argument (os error 22)`