### PR TITLE
Restrict HTTP to alive/ready probes

### DIFF
--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -13,9 +13,9 @@ use actix_service::ServiceFactory;
 use actix_web::{
     body::MessageBody,
     dev::{ServiceRequest, ServiceResponse},
-    middleware,
+    middleware::{self, from_fn, Condition, Next},
     web::Data,
-    HttpServer,
+    HttpResponse, HttpServer,
 };
 use clap::Parser;
 use grpc::{client::CoreClient, operations::jsongrpc::client::JsonGrpcClient};
@@ -43,6 +43,10 @@ pub(crate) struct CliArgs {
     /// The bind address for the REST interface (with HTTP).
     #[clap(long)]
     http: Option<String>,
+
+    /// The bind address for the HTTP liveness and readiness probes interface (with HTTP).
+    #[clap(long, conflicts_with = "http")]
+    http_probes: Option<String>,
 
     /// The CORE gRPC Server URL or address to connect to the services.
     #[clap(long, short = 'z', default_value = DEFAULT_GRPC_CLIENT_ADDR)]
@@ -296,6 +300,23 @@ fn get_jwk_path() -> Option<PathBuf> {
     }
 }
 
+/// Only the liveness (`/live`) and readiness (`/ready`) probes are served over an
+/// insecure (plain HTTP) connection.
+/// Every other route is rejected with `421 Misdirected Request`, since the full API
+/// is only served on the separate HTTPS port.
+async fn probes_only_on_insecure(
+    req: ServiceRequest,
+    next: Next<impl MessageBody + 'static>,
+) -> Result<ServiceResponse, actix_web::Error> {
+    let is_probe = matches!(req.path(), "/live" | "/ready");
+    if req.app_config().secure() || is_probe {
+        Ok(next.call(req).await?.map_into_boxed_body())
+    } else {
+        let response = HttpResponse::MisdirectedRequest().finish();
+        Ok(req.into_response(response))
+    }
+}
+
 fn workers(args: &CliArgs) -> usize {
     let max_workers = match args.max_workers {
         0 => num_cpus::get_physical(),
@@ -332,11 +353,18 @@ async fn main() -> anyhow::Result<()> {
 
     let cached_core_state = Data::new(CachedCoreState::new(cli_args.core_liveness_check_frequency));
 
+    let restrict_http_to_probes = cli_args.http_probes.is_some();
+
     let app = move || {
         actix_web::App::new()
             .app_data(cached_core_state.clone())
             .service(liveness)
             .service(readiness)
+            // Restrict everything except the liveness/readiness probes to secure (HTTPS) connections
+            .wrap(Condition::new(
+                restrict_http_to_probes,
+                from_fn(probes_only_on_insecure),
+            ))
             .wrap(tracing_actix_web::TracingLogger::default())
             .wrap(middleware::Logger::default())
             .app_data(authentication::init(get_jwk_path()))
@@ -355,6 +383,8 @@ async fn main() -> anyhow::Result<()> {
         HttpServer::new(app).bind_rustls_0_23(CliArgs::args().https, get_certificates()?)?;
     let result = if let Some(http) = CliArgs::args().http {
         server.bind(http).map_err(anyhow::Error::from)?
+    } else if let Some(http_probes) = CliArgs::args().http_probes {
+        server.bind(http_probes).map_err(anyhow::Error::from)?
     } else {
         server
     }

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -34,6 +34,11 @@ fn jwk_file() -> String {
 
 // Setup the infrastructure ready for the tests.
 async fn test_setup(auth: &bool) -> Cluster {
+    test_setup_(auth, false).await
+}
+
+// Setup the infrastructure ready for the tests.
+async fn test_setup_(auth: &bool, http_restrict: bool) -> Cluster {
     let rest_jwk = match auth {
         true => Some(jwk_file()),
         false => None,
@@ -41,6 +46,7 @@ async fn test_setup(auth: &bool) -> Cluster {
 
     ClusterBuilder::builder()
         .with_rest_auth(true, rest_jwk)
+        .with_http_restrict(http_restrict)
         .with_options(|o| o.with_jaeger(true))
         .with_agents(vec!["core", "jsongrpc"])
         .with_io_engines(2)
@@ -65,7 +71,7 @@ async fn client() {
     // Run the client test both with and without authentication.
     for auth in &[false, true] {
         {
-            let cluster = test_setup(auth).await;
+            let cluster = test_setup_(auth, true).await;
             client_test(&cluster, auth).await;
         }
         // Seems that with otlp we can't simply reinstall a new tracer if running on the same
@@ -476,6 +482,51 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
             .unwrap(),
         node
     );
+
+    let http_client = RestClient::new(
+        "http://localhost:8081",
+        true,
+        match auth {
+            true => Some(bearer_token()),
+            false => None,
+        },
+    )
+    .unwrap()
+    .v00();
+
+    // HTTP is restricted to the liveness/ready probes
+    let nodes = http_client.nodes_api().get_nodes(None).await.unwrap_err();
+    assert!(nodes.status() == Some(apis::StatusCode::MISDIRECTED_REQUEST));
+
+    // The liveness probe is served over plain HTTP.
+    let live_status = http_probe_status("localhost:8081", "/live").await;
+    assert!(
+        live_status.starts_with("HTTP/1.1 200"),
+        "unexpected liveness probe status line: {}",
+        live_status
+    );
+}
+
+/// Issue a raw HTTP/1.1 GET request and return the response status line.
+async fn http_probe_status(addr: &str, path: &str) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("Failed to connect to the HTTP probes port");
+    let request = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("Failed to send the HTTP probe request");
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .expect("Failed to read the HTTP probe response");
+    let response = String::from_utf8_lossy(&response);
+    response.lines().next().unwrap_or_default().to_string()
 }
 
 async fn wait_until_node_not_online(client: &ApiClient, node: &NodeId, timeout: Duration) {

--- a/deployer/src/infra/rest.rs
+++ b/deployer/src/infra/rest.rs
@@ -16,10 +16,15 @@ impl ComponentAction for Rest {
                     .args(["build", "-p", "rest", "--bin", "rest"])
                     .status()?;
             }
+            let http = if options.http_restrict {
+                "--http-probes"
+            } else {
+                "--http"
+            };
             let binary = Binary::from_dbg("rest")
                 .with_arg("--auto-tls")
                 .with_args(vec!["--https", "rest:8080"])
-                .with_args(vec!["--http", "rest:8081"])
+                .with_args(vec![http, "rest:8081"])
                 .with_arg("--workers=1");
             let binary = if let Some(jwk) = &options.rest_jwk {
                 binary.with_arg("--jwk").with_arg(jwk)

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -129,6 +129,10 @@ pub struct StartOptions {
     #[clap(long, conflicts_with = "no_rest")]
     pub rest_jwk: Option<String>,
 
+    /// Restrict HTTP to the liveness/ready probes.
+    #[clap(long, env = "HTTP_PROBES")]
+    pub http_restrict: bool,
+
     /// Set the rest-to-core health probe frequency on the rest.
     #[arg(long)]
     pub rest_core_health_freq: Option<String>,
@@ -485,6 +489,11 @@ impl StartOptions {
     pub fn with_rest(mut self, enabled: bool, jwk: Option<String>) -> Self {
         self.no_rest = !enabled;
         self.rest_jwk = jwk;
+        self
+    }
+    #[must_use]
+    pub fn with_http_restrict(mut self, enabled: bool) -> Self {
+        self.http_restrict = enabled;
         self
     }
     #[must_use]

--- a/tests/bdd/common/docker.py
+++ b/tests/bdd/common/docker.py
@@ -1,5 +1,6 @@
 import os
 import re
+import subprocess
 from datetime import datetime
 
 import docker
@@ -99,16 +100,16 @@ class Docker(object):
             print(f"No match for test file and name in current_test: {current_test}")
             return
 
-        print(f"Dumping container logs for test: {current_test}")
+        # print(f"Dumping container logs for test: {current_test}")
 
         if failed_logs_var in os.environ and os.environ[failed_logs_var]:
             logs = os.environ.get(failed_logs_var)
-            print(f"Dumping container logs to: {logs}")
+            # print(f"Dumping container logs to: {logs}")
         elif ci in os.environ and os.environ[ci] in ["1", "True", "true"]:
             logs = os.path.join(
                 os.environ.get("ROOT_DIR"), "ci-report", "docker-logs.txt"
             )
-            print(f"Dumping container logs to: {logs}")
+            # print(f"Dumping container logs to: {logs}")
 
         if logs is None:
             print("No log file specified for docker logs. Skipping log dump.")
@@ -130,6 +131,8 @@ class Docker(object):
         docker_client = docker.from_env()
 
         for container in docker_client.containers.list():
+            if container.labels.get("io.composer.test.name") != "cluster":
+                continue
             file = os.path.join(
                 dump_path, f"{test_file}/{test_name}/{action}/{container.name}.txt"
             )
@@ -137,6 +140,27 @@ class Docker(object):
             with open(file, "w") as log_file:
                 container_logs = container.logs().decode("utf-8")
                 log_file.write(container_logs)
+
+        file = os.path.join(
+            dump_path, f"{test_file}/{test_name}/{action}/etcd-data.txt"
+        )
+        Docker.dump_etcd(file)
+
+    @staticmethod
+    def dump_etcd(file: str):
+        os.makedirs(os.path.dirname(file), exist_ok=True)
+        try:
+            with open(file, "w") as log_file:
+                subprocess.run(
+                    'etcdctl get --prefix ""',
+                    check=True,
+                    shell=True,
+                    stdout=log_file,
+                    stderr=subprocess.PIPE,
+                )
+        except subprocess.CalledProcessError as e:
+            current_test = os.environ.get("PYTEST_CURRENT_TEST")
+            print(f"Failed to collect etcd logs for {current_test}: {e.stderr}")
 
     @staticmethod
     def dump_logs_single(dump_path: str, current_test: str):

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -1086,6 +1086,12 @@ impl ClusterBuilder {
         self.opts = self.opts.with_rest(enabled, jwk);
         self
     }
+    /// Specify whether HTTP requests are restricted to the liveness/ready probes.
+    #[must_use]
+    pub fn with_http_restrict(mut self, enabled: bool) -> Self {
+        self.opts = self.opts.with_http_restrict(enabled);
+        self
+    }
     /// Specify whether the components should be cargo built or not.
     #[must_use]
     pub fn with_build(mut self, enabled: bool) -> Self {


### PR DESCRIPTION
    test: ensure http restricted mode is respected
    
    Adds a new http restrict mode to the deployer cluster.
    When enabled, ensure any requests other than live/ready are rejected
    with status code 421.
    
---

    feat(tls): enable http only for the alive/ready probes
    
    This is configurable via new cli arg to make it backwards compatible.
    When enabled, then we reject requests for anything other than the
    /live and /ready paths if not using HTTPS.
