### PR TITLE
ci: enable mergeq and mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,31 @@
+queue_rules:
+  - name: default
+    update_method: rebase
+    branch_protection_injection_mode: merge
+    update_bot_account: openebs-ci
+    commit_message_format:
+      title: inherit
+      body: pr-body
+      trailers:
+        - co-authored-by
+    batch_size: 3
+    merge_conditions:
+      - check-success = bors-ci
+      - check-success = submodule-branch
+      - check-success = commitlint
+      - -label ~= do-not-merge
+    queue_conditions:
+      - check-success = commitlint
+      - check-success = submodule-branch
+      - -label ~= do-not-merge
+      - -draft
+      - check-success = DCO
+    batch_max_wait_time: 15s
+merge_queue:
+  max_parallel_checks: 2
+  status_comments: outcomes
+merge_protections_settings:
+  reporting_method: check-runs
 pull_request_rules:
   - name: auto-label and approve backport PRs
     conditions:

--- a/.github/workflows/develop-to-release.yml
+++ b/.github/workflows/develop-to-release.yml
@@ -53,9 +53,9 @@ jobs:
           gh pr review ${{ steps.cpr.outputs.pull-request-number }} --approve
         env:
           GH_TOKEN: ${{ secrets.ORG_CI_GITHUB_2 }}
-      - name: Bors Merge Pull Request
+      - name: Merge Pull Request
         if: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          gh pr comment ${{ steps.cpr.outputs.pull-request-number }} --body "bors merge"
+          gh pr comment ${{ steps.cpr.outputs.pull-request-number }} --body "@mergify queue"
         env:
           GH_TOKEN: ${{ secrets.ORG_CI_GITHUB }}

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - staging
       - trying
+  merge_group:
 
 jobs:
   lint-ci:
@@ -16,7 +17,7 @@ jobs:
   image-ci:
     uses: ./.github/workflows/image-pr.yml
   bors-ci:
-    if: ${{ success() }}
+    if: ${{ !cancelled() }}
     needs:
       - lint-ci
       - int-ci
@@ -25,4 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded
-        run: exit 0
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi
+          exit 0

--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -1,7 +1,7 @@
 name: Lint Commit Messages
 on:
   pull_request:
-    types: ['opened', 'edited', 'reopened', 'synchronize']
+    types: ['opened', 'reopened', 'synchronize']
   push:
     branches:
       - staging

--- a/.github/workflows/pr-submodule-branch.yml
+++ b/.github/workflows/pr-submodule-branch.yml
@@ -1,7 +1,7 @@
 name: Submodule Branch Check
 on:
   pull_request:
-    types: ['opened', 'edited', 'reopened', 'synchronize']
+    types: ['opened', 'reopened', 'synchronize']
   push:
     branches:
       - develop

--- a/.github/workflows/pr-try-ci.yml
+++ b/.github/workflows/pr-try-ci.yml
@@ -1,0 +1,38 @@
+name: CI Try
+on:
+  pull_request:
+    types: ['labeled']
+
+jobs:
+  ci-try:
+    if: contains(github.event.pull_request.labels.*.name, 'ci/test')
+    uses: ./.github/workflows/pr-ci.yml
+
+  remove-label:
+    if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'ci/test') }}
+    needs:
+      - ci-try
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove ci/test label
+        uses: actions/github-script@v9
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'ci/test',
+              });
+            } catch (error) {
+              const status = error.status || error.response?.status;
+              if (status === 403 || status === 404) {
+                const reason = status === 403 ? 'insufficient permissions' : 'label not found';
+                console.log(`Skipping ci/test label removal due to ${reason}: ${error.message}`);
+                return;
+              }
+              throw error;
+            }


### PR DESCRIPTION
Support GitHub MergeQ and mergify for merging.
We've seen a few issues on bors, so we've switched to mergeq/mergify on the extensions repo.

So we carry on that initiative and now do the same on this repo.

The native mergeq will be preferred on the develop branch, where it'll be enabled.
On the release branches it has to be manually enabled, so we keep mergify as the alternative that will work on any newer branches in addition to the develop branch.