### PR TITLE
docs: update terraform adoc

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,8 +11,8 @@ queue_rules:
     batch_size: 3
     merge_conditions:
       - check-success = bors-ci
-      - check-success = submodule-branch
       - check-success = commitlint
+      - check-success = submodule-branch
       - -label ~= do-not-merge
     queue_conditions:
       - check-success = commitlint

--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -10,14 +10,16 @@ on:
 jobs:
   commitlint:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     steps:
       - uses: actions/checkout@v7
+        if: ${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'mergify/merge-queue/') }}
         with:
           fetch-depth: 0
       - name: Install CommitLint and Dependencies
+        if: ${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'mergify/merge-queue/') }}
         run: npm install @commitlint/config-conventional @commitlint/cli
       - name: Lint Commits
+        if: ${{ github.event_name != 'merge_group' && !startsWith(github.head_ref, 'mergify/merge-queue/') }}
         run: |
           # Only run for PR's and simply succeed the bors staging branch
           if [ ! ${{ github.ref }} = "refs/heads/staging" ]; then

--- a/terraform/cluster/README.adoc
+++ b/terraform/cluster/README.adoc
@@ -62,8 +62,8 @@ master node.
 
 . Follow OS-specific steps to install libvirt
 . Download one of the following ubuntu images in qcow2 format:
-.. `wget https://cloud-images.ubuntu.com/releases/bionic/release/ubuntu-18.04-server-cloudimg-amd64.img`
-.. `wget https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img`
+.. `wget https://cloud-images.ubuntu.com/releases/bionic/release/ubuntu-20.04-server-cloudimg-amd64.img`
+.. `wget https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-22.04-server-cloudimg-amd64.img`
 . Set `qcow2_image` TF variable to a location of the downloaded image
 
 TF commands don't need to be run with sudo, though internally TF uses
@@ -265,5 +265,3 @@ EOF
 
 docker-compose up
 ----
-
-

--- a/tests/bdd/features/volume/create/test_feature.py
+++ b/tests/bdd/features/volume/create/test_feature.py
@@ -34,7 +34,7 @@ NODE_NAME = "io-engine-1"
 
 @pytest.fixture(scope="module")
 def init():
-    Deployer.start(1)
+    Deployer.start(io_engines=1, cache_period="1s", reconcile_period="100ms")
     yield
     Deployer.stop()
 


### PR DESCRIPTION
We now use 20/22 ubuntu versions.

This change is to test the mergify bot