### PR TITLE
feat(app-node): plumb transport capabilities through registration

### DIFF
--- a/control-plane/agents/src/bin/core/app_node/specs.rs
+++ b/control-plane/agents/src/bin/core/app_node/specs.rs
@@ -78,9 +78,11 @@ impl ResourceSpecsLocked {
                 Some(app_node_rsc) => {
                     let mut app_node_spec = app_node_rsc.lock();
                     let changed = app_node_spec.endpoint != req.grpc_endpoint()
-                        || app_node_spec.labels != req.labels();
+                        || app_node_spec.labels != req.labels()
+                        || app_node_spec.transport_caps != req.transport_caps;
 
                     app_node_spec.endpoint = req.grpc_endpoint();
+                    app_node_spec.transport_caps = req.transport_caps.clone();
                     (changed, app_node_spec.clone())
                 }
                 None => {
@@ -88,6 +90,7 @@ impl ResourceSpecsLocked {
                         req.app_node_id().clone(),
                         req.grpc_endpoint(),
                         req.labels.clone(),
+                        req.transport_caps.clone(),
                     );
                     specs.app_nodes.insert(app_node.clone());
                     (true, app_node)

--- a/control-plane/agents/src/bin/core/tests/app_node/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/app_node/mod.rs
@@ -1,6 +1,9 @@
 use deployer_cluster::ClusterBuilder;
 use grpc::operations::{app_node::traits::AppNodeOperations, Pagination};
-use stor_port::types::v0::transport::{DeregisterAppNode, Filter, RegisterAppNode};
+use stor_port::types::v0::{
+    store::app_node::TransportCaps,
+    transport::{DeregisterAppNode, Filter, RegisterAppNode},
+};
 
 /// Test for registration, listing, retrieval, and deregistration of app nodes in a cluster.
 ///
@@ -27,25 +30,34 @@ async fn app_node_registration() {
 
     let node_client = cluster.grpc_client().app_node();
 
-    // Register 2 app nodes.
+    // Register 2 app nodes. csi-node-1 mimics an older csi-node that has no
+    // transport_caps field on the wire; csi-node-2 populates it. Both should
+    // persist and round-trip cleanly.
     node_client
         .register_app_node(
             &RegisterAppNode {
                 id: "csi-node-1".into(),
                 endpoint: "10.0.0.1:50052".parse().unwrap(),
                 labels: None,
+                transport_caps: None,
             },
             None,
         )
         .await
         .expect("Failed to register app node");
 
+    let node_2_caps = TransportCaps {
+        rdma_hca_present: true,
+        nvme_rdma_module_loaded: true,
+        ana_capable: true,
+    };
     node_client
         .register_app_node(
             &RegisterAppNode {
                 id: "csi-node-2".into(),
                 endpoint: "10.0.0.1:50052".parse().unwrap(),
                 labels: None,
+                transport_caps: Some(node_2_caps.clone()),
             },
             None,
         )
@@ -81,6 +93,14 @@ async fn app_node_registration() {
         .await
         .expect("Failed to get app node by id");
     assert_eq!(app_node.id, "csi-node-1".into());
+    assert!(app_node.spec.transport_caps.is_none());
+
+    // csi-node-2 should carry back the caps it registered with.
+    let app_node_2 = node_client
+        .get(Filter::AppNode("csi-node-2".into()), None)
+        .await
+        .expect("Failed to get csi-node-2");
+    assert_eq!(app_node_2.spec.transport_caps.as_ref(), Some(&node_2_caps));
 
     // Now restart core, to check if the app nodes are loaded from the database.
     cluster.restart_core().await;
@@ -95,6 +115,13 @@ async fn app_node_registration() {
         .await
         .expect("Failed to list app nodes after core restart with no pagination");
     assert_eq!(app_nodes.entries.len(), 2);
+
+    // Caps survive an etcd round-trip.
+    let app_node_2 = node_client
+        .get(Filter::AppNode("csi-node-2".into()), None)
+        .await
+        .expect("Failed to get csi-node-2 after restart");
+    assert_eq!(app_node_2.spec.transport_caps.as_ref(), Some(&node_2_caps));
 
     // Deregister one app node.
     node_client

--- a/control-plane/csi-driver/src/bin/node/client.rs
+++ b/control-plane/csi-driver/src/bin/node/client.rs
@@ -7,7 +7,7 @@ use stor_port::types::v0::openapi::{
         self,
         tower::{configuration::Configuration, StatusCode},
     },
-    models::{NexusState, RegisterAppNode, RestJsonError},
+    models::{NexusState, RegisterAppNode, RestJsonError, TransportCaps},
 };
 
 use std::sync::Arc;
@@ -113,11 +113,12 @@ impl AppNodesClientWrapper {
         app_node_id: &str,
         endpoint: &str,
         labels: &Option<std::collections::HashMap<String, String>>,
+        transport_caps: Option<TransportCaps>,
     ) -> Result<(), ApiClientError> {
         self.client
             .register_app_node(
                 app_node_id,
-                RegisterAppNode::new_all(endpoint, labels.clone()),
+                RegisterAppNode::new_all(endpoint, labels.clone(), transport_caps),
             )
             .await?;
 

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -344,44 +344,58 @@ pub(super) async fn main() -> anyhow::Result<()> {
         .output()
         .await;
 
-    let cap = match ibv_output {
+    let hca_present = match &ibv_output {
         Ok(okstdout) if okstdout.status.success() => {
             // In an unlikely case string from utf8 fails, err towards incapability.
-            let outstr = String::from_utf8(okstdout.stdout).unwrap_or("0 HCA".to_string());
-            if !outstr.starts_with("0 HCA") {
-                // RDMA hardware is present, but the transport still requires the `nvme_rdma`
-                // kernel module to be loaded on this node. If it is missing, treat the node as
-                // RDMA-incapable so `transport_from_url` can fall back to TCP (when the operator
-                // enabled fallback) rather than fail the connect with a hard error.
-                match crate::dev::nvmf::check_nvme_rdma_module() {
-                    Ok(()) => {
-                        info!(
-                            "host node rdma capable. conn_fallback({conn_fallback:?}), {outstr:?}"
-                        );
-                        true
-                    }
-                    Err(error) => {
-                        warn!(
-                            "host node has rdma hardware but nvme_rdma kernel module is not \
-                            loaded, treating as rdma incapable. \
-                            conn_fallback({conn_fallback:?}), {outstr:?}, error: {error}"
-                        );
-                        false
-                    }
-                }
-            } else {
-                info!(
-                    "host node is not rdma capable. conn_fallback({conn_fallback:?}), {outstr:?}"
-                );
-                false
-            }
+            let outstr =
+                String::from_utf8(okstdout.stdout.clone()).unwrap_or_else(|_| "0 HCA".into());
+            !outstr.starts_with("0 HCA")
         }
         Ok(_) | Err(_) => {
             error!("Error executing ibv_devinfo, or invalid command output. conn_fallback({conn_fallback:?}), {ibv_output:?}");
             false
         }
     };
+
+    // The `nvme_rdma` kernel module has to be loaded for the initiator to
+    // negotiate an RDMA transport at connect time; report both signals
+    // independently to the control-plane so it can differentiate hardware
+    // vs. software readiness when scheduling.
+    let nvme_rdma_module_loaded = match crate::dev::nvmf::check_nvme_rdma_module() {
+        Ok(()) => true,
+        Err(error) => {
+            if hca_present {
+                warn!(
+                    "host node has rdma hardware but nvme_rdma kernel module is not \
+                    loaded, treating as rdma incapable. \
+                    conn_fallback({conn_fallback:?}), error: {error}"
+                );
+            }
+            false
+        }
+    };
+
+    // Existing initiator-side RDMA gate: only attempt RDMA connect when both
+    // hardware and kernel module are ready.
+    let cap = hca_present && nvme_rdma_module_loaded;
+    if cap {
+        info!("host node rdma capable. conn_fallback({conn_fallback:?})");
+    } else if !hca_present {
+        info!("host node is not rdma capable (no HCA). conn_fallback({conn_fallback:?})");
+    }
     let _ = RDMA_CONNECT_CHECK.set((conn_fallback, cap));
+
+    // Transport capabilities forwarded to the control-plane at registration so
+    // volume placement / mount decisions can take them into account. Reports
+    // hardware and kernel-module readiness independently so the CP can
+    // differentiate them.
+    let transport_caps = Some(
+        stor_port::types::v0::openapi::models::TransportCaps::new_all(
+            hca_present,
+            nvme_rdma_module_loaded,
+            nvme_enabled,
+        ),
+    );
 
     // Parse the CSI socket file name from the command line arguments.
     let csi_socket = matches
@@ -453,6 +467,7 @@ pub(super) async fn main() -> anyhow::Result<()> {
             node_name.clone(),
             grpc_sock_addr.to_string(),
             Some(csi_labels),
+            transport_caps,
             &client,
             registration_enabled
         )

--- a/control-plane/csi-driver/src/bin/node/registration.rs
+++ b/control-plane/csi-driver/src/bin/node/registration.rs
@@ -1,5 +1,6 @@
 use crate::{client::AppNodesClientWrapper, shutdown_event::Shutdown};
 use std::{collections::HashMap, time::Duration};
+use stor_port::types::v0::openapi::models::TransportCaps;
 use tracing::error;
 
 /// Default registration interval.
@@ -11,6 +12,7 @@ pub(crate) async fn run_registration_loop(
     id: String,
     endpoint: String,
     labels: Option<HashMap<String, String>>,
+    transport_caps: Option<TransportCaps>,
     client: &Option<AppNodesClientWrapper>,
     registration_enabled: bool,
 ) -> anyhow::Result<()> {
@@ -26,7 +28,10 @@ pub(crate) async fn run_registration_loop(
 
     let mut logged_error = false;
     loop {
-        let interval_duration = match client.register_app_node(&id, &endpoint, &labels).await {
+        let interval_duration = match client
+            .register_app_node(&id, &endpoint, &labels, transport_caps.clone())
+            .await
+        {
             Ok(_) => {
                 if logged_error {
                     tracing::info!("Successfully re-registered the app node");

--- a/control-plane/grpc/proto/v1/misc/common.proto
+++ b/control-plane/grpc/proto/v1/misc/common.proto
@@ -240,3 +240,15 @@ message MapWrapper {
 message EncryptionSecret {
   string name = 1;
 }
+
+// Transport-layer capabilities reported by the csi-node at registration time.
+message TransportCaps {
+  // RDMA HCA hardware is present on this node (reported by `ibv_devinfo`).
+  bool rdma_hca_present = 1;
+  // The `nvme_rdma` kernel module is loaded on this node. Both this and
+  // `rdma_hca_present` are required for NVMe-oF RDMA to actually be usable.
+  bool nvme_rdma_module_loaded = 2;
+  // NVMe ANA multipath is enabled on this node
+  // (/sys/module/nvme_core/parameters/multipath = Y).
+  bool ana_capable = 3;
+}

--- a/control-plane/grpc/proto/v1/node/app_node.proto
+++ b/control-plane/grpc/proto/v1/node/app_node.proto
@@ -24,6 +24,9 @@ message AppNodeSpec {
   string grpc_endpoint = 2;
   // App node labels.
   optional common.StringMapValue labels = 3;
+  // Transport capabilities reported by the csi-node at registration.
+  // Optional for back-compat with older csi-nodes.
+  optional common.TransportCaps transport_caps = 4;
 }
 
 // App Node state.

--- a/control-plane/grpc/proto/v1/registration/app_node_registration.proto
+++ b/control-plane/grpc/proto/v1/registration/app_node_registration.proto
@@ -14,6 +14,9 @@ message RegisterRequest {
   string grpc_endpoint = 2;
   // App node labels.
   optional common.StringMapValue labels = 3;
+  // Transport capabilities reported by the csi-node.
+  // Optional for back-compat with older csi-nodes.
+  optional common.TransportCaps transport_caps = 4;
 }
 
 // Deregister a app node from the control-plane.

--- a/control-plane/grpc/src/operations/app_node/traits.rs
+++ b/control-plane/grpc/src/operations/app_node/traits.rs
@@ -13,7 +13,7 @@ use std::net::{AddrParseError, SocketAddr};
 use stor_port::{
     transport_api::{v0::AppNodes, ReplyError, ResourceKind},
     types::v0::{
-        store::app_node::{AppNodeLabels, AppNodeSpec},
+        store::app_node::{AppNodeLabels, AppNodeSpec, TransportCaps},
         transport::{
             AppNode, AppNodeId, AppNodeState, AppNodeStatus, DeregisterAppNode, Filter,
             RegisterAppNode,
@@ -54,6 +54,8 @@ pub trait AppNodeRegisterInfo: Send + Sync {
     fn grpc_endpoint(&self) -> SocketAddr;
     /// Labels to be set on the app node.
     fn labels(&self) -> Option<AppNodeLabels>;
+    /// Transport capabilities reported by the csi-node.
+    fn transport_caps(&self) -> Option<TransportCaps>;
 }
 
 /// Trait to be implemented for Deregister operation.
@@ -73,6 +75,10 @@ impl AppNodeRegisterInfo for RegisterAppNode {
 
     fn labels(&self) -> Option<AppNodeLabels> {
         self.labels.clone()
+    }
+
+    fn transport_caps(&self) -> Option<TransportCaps> {
+        self.transport_caps.clone()
     }
 }
 
@@ -94,6 +100,10 @@ impl AppNodeRegisterInfo for ValidatedRegisterAppNodeRequest {
 
     fn labels(&self) -> Option<AppNodeLabels> {
         self.inner.labels.clone().map(|l| l.value)
+    }
+
+    fn transport_caps(&self) -> Option<TransportCaps> {
+        self.inner.transport_caps.map(Into::into)
     }
 }
 
@@ -151,6 +161,7 @@ impl From<&dyn AppNodeRegisterInfo> for RegisterRequest {
             labels: value
                 .labels()
                 .map(|labels| StringMapValue { value: labels }),
+            transport_caps: value.transport_caps().map(Into::into),
         }
     }
 }
@@ -161,6 +172,7 @@ impl From<&dyn AppNodeRegisterInfo> for RegisterAppNode {
             id: value.app_node_id(),
             endpoint: value.grpc_endpoint(),
             labels: value.labels(),
+            transport_caps: value.transport_caps(),
         }
     }
 }
@@ -182,6 +194,7 @@ impl TryFrom<crate::app_node::AppNodeSpec> for AppNodeSpec {
                     )
                 })?,
             labels: value.labels.map(|l| l.value),
+            transport_caps: value.transport_caps.map(Into::into),
         })
     }
 }
@@ -194,6 +207,27 @@ impl From<AppNodeSpec> for crate::app_node::AppNodeSpec {
                 .labels
                 .map(|labels| crate::common::StringMapValue { value: labels }),
             grpc_endpoint: value.endpoint.to_string(),
+            transport_caps: value.transport_caps.map(Into::into),
+        }
+    }
+}
+
+impl From<crate::common::TransportCaps> for TransportCaps {
+    fn from(value: crate::common::TransportCaps) -> Self {
+        Self {
+            rdma_hca_present: value.rdma_hca_present,
+            nvme_rdma_module_loaded: value.nvme_rdma_module_loaded,
+            ana_capable: value.ana_capable,
+        }
+    }
+}
+
+impl From<TransportCaps> for crate::common::TransportCaps {
+    fn from(value: TransportCaps) -> Self {
+        Self {
+            rdma_hca_present: value.rdma_hca_present,
+            nvme_rdma_module_loaded: value.nvme_rdma_module_loaded,
+            ana_capable: value.ana_capable,
         }
     }
 }
@@ -332,5 +366,22 @@ impl TryFrom<Filter> for GetAppNodeRequest {
                 "invalid filter for get app node request",
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_caps_round_trip_proto() {
+        let store = TransportCaps {
+            rdma_hca_present: true,
+            nvme_rdma_module_loaded: false,
+            ana_capable: false,
+        };
+        let proto: crate::common::TransportCaps = store.clone().into();
+        let back: TransportCaps = proto.into();
+        assert_eq!(store, back);
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -5116,6 +5116,10 @@ components:
         labels:
           org.io/csi-node.nvme-ana: true,
           org.io/zone: us-east-1a
+        transportCaps:
+          rdmaHcaPresent: true
+          nvmeRdmaModuleLoaded: true
+          anaCapable: true
       type: object
       properties:
         endpoint:
@@ -5129,6 +5133,8 @@ components:
           type: object
           additionalProperties:
             type: string
+        transportCaps:
+          $ref: '#/components/schemas/TransportCaps'
       required:
         - id
         - endpoint
@@ -5164,9 +5170,36 @@ components:
           type: object
           additionalProperties:
             type: string
+        transportCaps:
+          $ref: '#/components/schemas/TransportCaps'
       required:
         - id
         - endpoint
+    TransportCaps:
+      description: |-
+        Transport-layer capabilities reported by the csi-node at registration time.
+      type: object
+      example:
+        rdmaHcaPresent: true
+        nvmeRdmaModuleLoaded: true
+        anaCapable: true
+      properties:
+        rdmaHcaPresent:
+          description: |-
+            RDMA HCA hardware is present on this node (reported by ibv_devinfo).
+          type: boolean
+        nvmeRdmaModuleLoaded:
+          description: |-
+            The nvme_rdma kernel module is loaded on this node. Both this and rdmaHcaPresent are required for NVMe-oF RDMA to actually be usable.
+          type: boolean
+        anaCapable:
+          description: |-
+            NVMe ANA multipath is enabled on this node.
+          type: boolean
+      required:
+        - rdmaHcaPresent
+        - nvmeRdmaModuleLoaded
+        - anaCapable
     AppNodeState:
       description: |-
         Deemed state of the app node.

--- a/control-plane/rest/service/src/v0/app_node.rs
+++ b/control-plane/rest/service/src/v0/app_node.rs
@@ -75,6 +75,7 @@ impl apis::actix_server::AppNodes for RestApi {
                         },
                     )?,
                     labels: register_app_node.labels,
+                    transport_caps: register_app_node.transport_caps.map(Into::into),
                 },
                 None,
             )

--- a/control-plane/stor-port/src/types/v0/store/app_node.rs
+++ b/control-plane/stor-port/src/types/v0/store/app_node.rs
@@ -39,6 +39,21 @@ impl StorableObject for AppNodeSpec {
 /// App node labels.
 pub type AppNodeLabels = std::collections::HashMap<String, String>;
 
+/// Transport-layer capabilities reported by the csi-node at registration time.
+/// Room to grow: further transport-related flags slot in here without needing
+/// another `AppNodeSpec` field per capability.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+pub struct TransportCaps {
+    /// RDMA HCA hardware is present on this node (reported by `ibv_devinfo`).
+    pub rdma_hca_present: bool,
+    /// The `nvme_rdma` kernel module is loaded on this node. Both this and
+    /// `rdma_hca_present` are required for NVMe-oF RDMA to actually be usable.
+    pub nvme_rdma_module_loaded: bool,
+    /// NVMe ANA multipath is enabled on this node
+    /// (`/sys/module/nvme_core/parameters/multipath = Y`).
+    pub ana_capable: bool,
+}
+
 /// App node spec.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AppNodeSpec {
@@ -48,6 +63,9 @@ pub struct AppNodeSpec {
     pub endpoint: std::net::SocketAddr,
     /// App Node labels.
     pub labels: Option<AppNodeLabels>,
+    /// Transport capabilities reported at registration.
+    #[serde(default)]
+    pub transport_caps: Option<TransportCaps>,
 }
 
 impl AppNodeSpec {
@@ -55,17 +73,87 @@ impl AppNodeSpec {
         id: AppNodeId,
         endpoint: std::net::SocketAddr,
         labels: Option<AppNodeLabels>,
+        transport_caps: Option<TransportCaps>,
     ) -> Self {
         Self {
             id,
             endpoint,
             labels,
+            transport_caps,
         }
     }
 }
 
 impl From<AppNodeSpec> for models::AppNodeSpec {
     fn from(src: AppNodeSpec) -> Self {
-        Self::new_all(src.id, src.endpoint.to_string(), src.labels)
+        Self::new_all(
+            src.id,
+            src.endpoint.to_string(),
+            src.labels,
+            src.transport_caps.map(Into::into),
+        )
+    }
+}
+
+impl From<TransportCaps> for models::TransportCaps {
+    fn from(src: TransportCaps) -> Self {
+        Self::new_all(
+            src.rdma_hca_present,
+            src.nvme_rdma_module_loaded,
+            src.ana_capable,
+        )
+    }
+}
+
+impl From<models::TransportCaps> for TransportCaps {
+    fn from(src: models::TransportCaps) -> Self {
+        Self {
+            rdma_hca_present: src.rdma_hca_present,
+            nvme_rdma_module_loaded: src.nvme_rdma_module_loaded,
+            ana_capable: src.ana_capable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_caps_round_trip_openapi() {
+        let store = TransportCaps {
+            rdma_hca_present: true,
+            nvme_rdma_module_loaded: false,
+            ana_capable: false,
+        };
+        let api: models::TransportCaps = store.clone().into();
+        let back: TransportCaps = api.into();
+        assert_eq!(store, back);
+    }
+
+    #[test]
+    fn app_node_spec_serde_back_compat_no_caps() {
+        // Simulates an etcd entry written by a pre-TransportCaps build:
+        // `transport_caps` is absent from the payload and must default to None.
+        let json = r#"{"id":"csi-node-1","endpoint":"10.0.0.1:50052","labels":null}"#;
+        let spec: AppNodeSpec = serde_json::from_str(json).unwrap();
+        assert!(spec.transport_caps.is_none());
+    }
+
+    #[test]
+    fn app_node_spec_serde_with_caps() {
+        let spec = AppNodeSpec::new(
+            "csi-node-2".into(),
+            "10.0.0.2:50052".parse().unwrap(),
+            None,
+            Some(TransportCaps {
+                rdma_hca_present: true,
+                nvme_rdma_module_loaded: true,
+                ana_capable: true,
+            }),
+        );
+        let json = serde_json::to_string(&spec).unwrap();
+        let back: AppNodeSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(spec, back);
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/app_node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/app_node.rs
@@ -1,7 +1,7 @@
 use crate::{
     rpc_impl_string_id, rpc_impl_string_id_inner,
     types::v0::{
-        store::app_node::{AppNodeLabels, AppNodeSpec, AppNodeSpecKey},
+        store::app_node::{AppNodeLabels, AppNodeSpec, AppNodeSpecKey, TransportCaps},
         transport::Filter,
     },
 };
@@ -19,6 +19,8 @@ pub struct RegisterAppNode {
     pub endpoint: std::net::SocketAddr,
     /// App Node labels.
     pub labels: Option<AppNodeLabels>,
+    /// Transport capabilities reported by the csi-node at registration.
+    pub transport_caps: Option<TransportCaps>,
 }
 
 impl RegisterAppNode {
@@ -26,11 +28,13 @@ impl RegisterAppNode {
         id: AppNodeId,
         endpoint: std::net::SocketAddr,
         labels: Option<AppNodeLabels>,
+        transport_caps: Option<TransportCaps>,
     ) -> Self {
         Self {
             id,
             endpoint,
             labels,
+            transport_caps,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an optional `TransportCaps { rdma_capable, ana_capable }` payload the csi-node reports at registration time, so the control-plane has each node's NVMe-oF RDMA and ANA multipath availability recorded on the `AppNodeSpec`.

## What's added

- **proto**: new `v1.common.TransportCaps` + optional field on `AppNodeSpec` / `RegisterRequest`
- **openapi**: matching `TransportCaps` schema + optional property
- **store / transport**: `TransportCaps` struct; `Option<TransportCaps>` on `AppNodeSpec` and `RegisterAppNode` with `#[serde(default)]` so existing etcd entries deserialize cleanly
- **gRPC conversion layer**: `AppNodeRegisterInfo::transport_caps()` trait method + `From` impls between proto ↔ store, openapi ↔ store, and through the `AppNodeSpec` conversions
- **core registry**: persists caps on register, and treats a change in caps as a spec change on re-registration
- **REST handler**: passes caps through from the openapi body to the transport type
- **csi-node**: reuses the RDMA/ANA detection already done at startup and passes it into the registration loop

## Backward compatibility

Optional end-to-end:
- an older csi-node that never populates the field just sends `None` and registers as before
- a control-plane reading an older csi-node's payload sees `None` and behaves as today
- existing etcd entries without the field deserialize cleanly (`#[serde(default)]` on the store type)

## Testing

- [x] Unit: `TransportCaps` round-trips proto ↔ store and openapi ↔ store
- [x] Unit: `AppNodeSpec` serde back-compat: a payload without `transport_caps` deserializes with the field set to `None`
- [x] Int: extended the existing `app_node_registration` test to register one node without caps and one with caps, and asserts the caps round-trip through gRPC/etcd, including across a `restart_core`