### PR TITLE
test: fix racy health check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,9 @@ jobs:
         run: nix-shell --run "black --diff --check tests/bdd/"
       - name: Lint nix code
         run: nix-shell --run "nixpkgs-fmt --check ."
+      - name: Ensure Cargo.lock is up to date
+        run: |
+          if git diff --name-only | grep -q 'Cargo.lock'; then
+            echo "Cargo.lock is not up to date!"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,8 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "strum",
+ "strum_macros",
  "tokio",
  "tonic",
  "tonic-build",

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -1702,37 +1702,31 @@ async fn health() {
     .await
     .unwrap();
 
-    // "Trust all when unshared" branch of `NexusInfo::clean_state()`: with no
-    // share, no front-end I/O can be in flight, so all healthy replicas are
-    // safe as rebuild sources even if `clean_shutdown` is false.
-    // Bring the two stopped nodes back so we have a live target to publish on,
-    // then republish the same volume without a share protocol.
-    cluster.composer().start(&cluster.node(0)).await.unwrap();
-    cluster.composer().start(&cluster.node(1)).await.unwrap();
-    cluster
-        .wait_node_status(cluster.node(0), transport::NodeStatus::Online)
-        .await
-        .unwrap();
-    cluster
-        .wait_node_status(cluster.node(1), transport::NodeStatus::Online)
-        .await
-        .unwrap();
-    cluster.wait_pool_online(cluster.pool(0, 0)).await.unwrap();
-    cluster.wait_pool_online(cluster.pool(1, 0)).await.unwrap();
-
     let volume = volume_client
         .unpublish(
-            &UnpublishVolume::new(&volume.spec().uuid, false, vec![]),
+            &UnpublishVolume::new(&volume.spec().uuid, true, vec![]),
             None,
         )
         .await
         .unwrap();
 
+    // "Trust all when unshared" branch of `NexusInfo::clean_state()`: with no
+    // share, no front-end I/O can be in flight, so all healthy replicas are
+    // safe as rebuild sources even if `clean_shutdown` is false.
+    // Bring the two stopped nodes back so we have a live target to publish on,
+    // then republish the same volume without a share protocol.
+    cluster.composer().start(&cluster.node(1)).await.unwrap();
+    cluster
+        .wait_node_status(cluster.node(1), transport::NodeStatus::Online)
+        .await
+        .unwrap();
+    cluster.wait_pool_online(cluster.pool(1, 0)).await.unwrap();
+
     let volume = volume_client
         .publish(
             &PublishVolume::new(
                 volume.spec().uuid.clone(),
-                Some(cluster.node(0)),
+                Some(cluster.node(1)),
                 None,
                 HashMap::new(),
                 vec![],
@@ -1742,8 +1736,7 @@ async fn health() {
         )
         .await
         .unwrap();
-
-    cluster.composer().kill(&cluster.node(2)).await.unwrap();
+    cluster.composer().kill(&cluster.node(1)).await.unwrap();
 
     wait_for_health(
         &volume.state(),


### PR DESCRIPTION
    test: fix racy health check

    Fix racyness by avoiding rebuilds and faulting during rebuilds.
    We do this by ensuring only the healthy replicas are online when the nexus
    is created.

    We can then safely kill the nexus node and verify all replicas are clean.

---

    ci: ensure Cargo.lock is up-to-date in PR

    When we modify the deps Cargo.lock may need updating and we should ensure
    the CI catches any missing changes.
