### PR TITLE
Flaky ci

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -22,6 +22,11 @@ jobs:
 
       - run: echo "CI_REPORT_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
 
+      - name: Configure Docker logging driver
+        run: |
+          echo '{"log-driver": "journald"}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - uses: cachix/install-nix-action@v31.10.6
         with:
           github_access_token: ''

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -22,6 +22,11 @@ jobs:
 
       - run: echo "CI_REPORT_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
 
+      - name: Configure Docker logging driver
+        run: |
+          echo '{"log-driver": "journald"}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - uses: cachix/install-nix-action@v31.10.6
         with:
           github_access_token: ''

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -1748,8 +1748,8 @@ async fn health() {
                 && h.all_healthy_replicas_clean
                 && h.clean_replicas == h.healthy_replicas
                 && h.online_clean_replicas == h.online_healthy_replicas
-                && h.live_healthy_replicas == 2
-                && h.online_healthy_replicas == 2
+                && h.live_healthy_replicas == 0
+                && h.online_healthy_replicas == 1
         },
     )
     .await

--- a/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use super::helpers::{wait_node_online, wait_till_volume_status};
+use super::helpers::wait_till_volume_status;
 use deployer_cluster::ClusterBuilder;
 use std::{collections::HashMap, time::Duration};
 use stor_port::types::v0::{
@@ -473,10 +473,10 @@ async fn restart_node(cluster: &deployer_cluster::Cluster, node: &str) {
         .start(node)
         .await
         .expect("Should restart io-engine node");
-    let node_client = cluster.grpc_client().node();
-    wait_node_online(&node_client, NodeId::from(node))
+    cluster
+        .wait_node_pool(&NodeId::from(node))
         .await
-        .expect("Restarted node should come back Online");
+        .expect("Node should come back Online after restart");
 }
 
 /// Wait for the volume to have a target with no share protocol (offline-rebuild marker).

--- a/control-plane/agents/src/bin/core/tests/volume/rwx.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/rwx.rs
@@ -164,6 +164,9 @@ async fn run_fio_vol(
     let fio_builder = |device: &str| {
         let filename = format!("--filename={device}");
         vec![
+            "taskset",
+            "-c",
+            cluster.fio_taskset().as_str(),
             "fio",
             "--direct=1",
             "--ioengine=libaio",

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -932,6 +932,9 @@ async fn run_fio_vol_verify(
     let fio_builder = |device: &str| {
         let filename = format!("--filename={device}");
         vec![
+            "taskset",
+            "-c",
+            cluster.fio_taskset().as_str(),
             "fio",
             "--direct=1",
             "--ioengine=libaio",

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -892,7 +892,7 @@ async fn republished_nexus_io_engine_txn_fail() {
     println!("STEP: disconnected container from network...");
 
     cluster
-        .wait_node_status(node_idx0.clone(), NodeStatus::Unknown)
+        .wait_node_status_ext(node_idx0.clone(), |s| !matches!(s, NodeStatus::Online))
         .await
         .unwrap();
     println!("STEP: node now unknown...");

--- a/control-plane/agents/src/bin/core/tests/volume/switchover.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/switchover.rs
@@ -974,6 +974,9 @@ async fn run_fio_vol_verify(
     let fio_builder = |device: &str| {
         let filename = format!("--filename={device}");
         vec![
+            "taskset",
+            "-c",
+            cluster.fio_taskset().as_str(),
             "fio",
             "--direct=1",
             "--ioengine=libaio",

--- a/control-plane/agents/src/bin/ha/node/detector.rs
+++ b/control-plane/agents/src/bin/ha/node/detector.rs
@@ -16,7 +16,9 @@ use tokio::{
 /// Possible states of every path record.
 #[derive(Debug, Clone, Eq, PartialEq)]
 enum PathState {
+    Added,
     Good,
+    AddedSuspected,
     Suspected,
     Failed,
     Removing,
@@ -55,7 +57,13 @@ impl PathRecords {
         self.paths
             .entry(path.clone())
             .or_insert_with(|| {
-                PathRecord::new(ctrlr.nqn().to_owned(), epoch, path, reporter.clone())
+                PathRecord::new(
+                    ctrlr.nqn().to_owned(),
+                    epoch,
+                    path,
+                    reporter.clone(),
+                    ctrlr.is_new(),
+                )
             })
             .with_epoch(epoch)
     }
@@ -91,13 +99,17 @@ struct PathRecord {
 }
 
 impl PathRecord {
-    fn new(nqn: String, epoch: u64, path: String, reporter: Rc<PathReporter>) -> Self {
+    fn new(nqn: String, epoch: u64, path: String, reporter: Rc<PathReporter>, new: bool) -> Self {
         tracing::trace!(%path, %nqn, "New PathRecord");
         Self {
             nqn,
             epoch,
             path,
-            state: PathState::Good,
+            state: if new {
+                PathState::Added
+            } else {
+                PathState::Good
+            },
             reporter,
         }
     }
@@ -118,10 +130,26 @@ impl PathRecord {
     /// Trigger state transition based on 'connecting' state of the underlying NVMe controller.
     fn report_connecting(&mut self) {
         match self.state {
+            PathState::Added => {
+                tracing::info!(
+                    target = self.nqn,
+                    path = self.path,
+                    "Target first seen as connecting (should settle in the next transition)"
+                );
+                self.state = PathState::AddedSuspected;
+            }
+            PathState::AddedSuspected => {
+                tracing::info!(
+                    target=self.nqn,
+                    path=self.path,
+                    "Target first seen as connecting, but it's still connecting so it's now suspected"
+                );
+                self.state = PathState::Suspected;
+            }
             PathState::Good => {
                 self.state = PathState::Suspected;
                 tracing::info!(
-                    state=%PathState::Suspected,
+                    state=%self.state,
                     target=self.nqn,
                     path=self.path,
                     "Target state transition"
@@ -131,7 +159,7 @@ impl PathRecord {
             PathState::Suspected => {
                 self.state = PathState::Failed;
                 tracing::error!(
-                    state=%PathState::Failed,
+                    state=%self.state,
                     target=self.nqn,
                     path=self.path,
                     "Target state transition",
@@ -145,14 +173,30 @@ impl PathRecord {
     }
 
     fn report_live(&mut self) {
-        if self.state != PathState::Good {
-            tracing::info!(
-                from=%self.state,
-                to=%PathState::Good,
-                target=self.nqn,
-                path=self.path,
-                "Target path has been fixed",
-            );
+        match &self.state {
+            PathState::Added | PathState::AddedSuspected => {
+                tracing::info!(
+                    from=%self.state,
+                    to=%PathState::Good,
+                    target=self.nqn,
+                    path=self.path,
+                    epoch=self.epoch,
+                    "Target path was newly added and is now live",
+                );
+            }
+            PathState::Good => {
+                return; // No state transition, path is already good.
+            }
+            _else => {
+                tracing::info!(
+                    from=%self.state,
+                    to=%PathState::Good,
+                    target=self.nqn,
+                    path=self.path,
+                    epoch=self.epoch,
+                    "Target path has been fixed",
+                );
+            }
         }
         self.state = PathState::Good;
     }
@@ -303,7 +347,7 @@ impl PathFailureDetector {
                 match subsystem.state.as_str() {
                     "connecting" => {
                         // Add a new record in case no record exists for target NQN.
-                        let rec = self
+                        let rec: &mut PathRecords = self
                             .suspected_paths
                             .entry(subsystem.nqn)
                             .or_insert_with(|| {
@@ -312,6 +356,7 @@ impl PathFailureDetector {
                                     self.epoch,
                                     ctrlr.path().to_string_lossy().to_string(),
                                     self.reporter.clone(),
+                                    ctrlr.is_new(),
                                 ))
                             });
                         rec.report_connecting(ctrlr, self.epoch, &self.reporter);

--- a/control-plane/agents/src/bin/ha/node/path_provider.rs
+++ b/control-plane/agents/src/bin/ha/node/path_provider.rs
@@ -25,35 +25,52 @@ const CACHE_EVENTS_BATCH_SIZE: usize = 128;
 pub struct NvmePath {
     path_buffer: PathBuf,
     nqn: String,
+    /// A new path may be added as connecting, though it should transition to live shortly.
+    /// We add this tracker to avoid adding confusing logs.
+    new: bool,
 }
 
 impl NvmePath {
     fn new(path_buffer: PathBuf, nqn: String) -> Self {
-        Self { path_buffer, nqn }
+        Self {
+            path_buffer,
+            nqn,
+            new: false,
+        }
     }
 
     /// Get the NVMe path reference.
-    #[inline]
     pub fn path(&self) -> &Path {
         self.path_buffer.as_path()
     }
 
     /// Get the NVMe nqn reference.
-    #[inline]
     pub fn nqn(&self) -> &String {
         &self.nqn
+    }
+
+    /// Get the NVMe nqn reference.
+    pub fn is_new(&self) -> bool {
+        self.new
+    }
+
+    /// Mark the NVMe path as new.
+    pub fn with_new(mut self) -> Self {
+        self.new = true;
+        self
     }
 }
 
 /// Check that NVMe path represents a target created by our product and
 /// obtain a Path object that represents a system path for this NVMe device.
-pub fn get_nvme_path_entry(path: &String) -> Option<NvmePath> {
+pub fn get_nvme_path_entry(path: &String) -> Option<(Subsystem, NvmePath)> {
     Path::new(path).canonicalize().ok().and_then(|pb| {
         Subsystem::new(pb.as_path()).ok().and_then(|s| {
             // Check NQN of the subsystem to make sure it belongs to the product.
             // todo: this won't work for nqn prefix upgrades
             if s.nqn.starts_with(&nvme_target_nqn_prefix()) {
-                Some(NvmePath::new(pb, s.nqn))
+                let path = NvmePath::new(pb, s.nqn.clone());
+                Some((s, path))
             } else {
                 // todo: right after being added a path may not yet be fully init
                 // in the sysfs, example: nqn: "(efault)", state: "connecting"
@@ -246,23 +263,53 @@ impl NvmePathNameCollection {
     }
 
     fn add_cache_entry(&mut self, path: String) {
-        if let Some(pb) = get_nvme_path_entry(&path) {
-            tracing::info!(path, nqn = pb.nqn, "Adding new NVMe path entry to cache");
+        if let Some((subsystem, pb)) = get_nvme_path_entry(&path) {
+            tracing::info!(
+                path,
+                nqn = pb.nqn,
+                ?subsystem,
+                "Adding newly discovered NVMe path entry to cache"
+            );
             self.entries.insert(path, pb);
         }
     }
 
+    /// Add a new cache entry, marking it as new.
+    fn add_new_cache_entry(&mut self, path: String) {
+        if let Some((subsystem, pb)) = get_nvme_path_entry(&path) {
+            tracing::info!(
+                path,
+                nqn = pb.nqn,
+                ?subsystem,
+                "Adding newly created NVMe path entry to cache"
+            );
+            self.entries.insert(path, pb.with_new());
+        }
+    }
+
     fn update_cache_entry(&mut self, path: String) {
-        if let Some(pb) = get_nvme_path_entry(&path) {
+        // todo: if we miss a udev event, we may not have the entry in the cache
+        //  do we need to verify any issues with add/remove events sync?
+        if let Some((subsystem, pb)) = get_nvme_path_entry(&path) {
             match self.entries.entry(path.clone()) {
                 Entry::Occupied(mut existing) => {
                     if existing.get() != &pb {
-                        tracing::warn!(path, nqn = pb.nqn, "Updating NVMe path entry in cache");
+                        tracing::warn!(
+                            path,
+                            nqn = pb.nqn,
+                            ?subsystem,
+                            "Updating NVMe path entry in cache"
+                        );
                         *existing.get_mut() = pb;
                     }
                 }
                 Entry::Vacant(entry) => {
-                    tracing::warn!(path, nqn = pb.nqn, "Adding new NVMe path entry to cache");
+                    tracing::warn!(
+                        path,
+                        nqn = pb.nqn,
+                        ?subsystem,
+                        "Adding newly discovered NVMe path entry to cache"
+                    );
                     entry.insert(pb);
                 }
             }
@@ -296,7 +343,7 @@ impl NvmePathNameCollection {
             if let Some(e) = self.udev_queue.pop() {
                 match e {
                     CacheOp::Add(p) => {
-                        self.add_cache_entry(p);
+                        self.add_new_cache_entry(p);
                     }
                     CacheOp::Change(p) => {
                         self.update_cache_entry(p);

--- a/control-plane/agents/src/bin/ha/node/server.rs
+++ b/control-plane/agents/src/bin/ha/node/server.rs
@@ -115,12 +115,7 @@ async fn disconnect_controller(
     let new_path_uri = parse_uri(new_path.as_str())?;
     let path = &ctrlr.path;
     match get_nvme_path_entry(path) {
-        Some(pbuf) => {
-            let subsystem = Subsystem::new(pbuf.path()).map_err(|_| SvcError::NotFound {
-                kind: ResourceKind::NvmeSubsystem,
-                id: path.to_owned(),
-            })?;
-
+        Some((subsystem, _)) => {
             // sanity check to make sure this information is still up to date!
             if subsystem.nqn != new_path_uri.nqn {
                 return Err(SvcError::UnexpectedSubsystemNqn {

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -37,4 +37,4 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tower = { workspace = true, features = ["timeout", "util"] }
 events-api = { workspace = true }
 anyhow = { workspace = true }
-nix = { workspace = true }
+nix = { workspace = true, features = ["signal", "process"] }

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -85,11 +85,19 @@ impl ComponentAction for CoreAgent {
             ContainerSpec::from_binary(name, binary).with_portmap("50051", "50051"),
         ))
     }
-    async fn start(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(
+        &self,
+        _options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         cfg.start("core").await?;
         Ok(())
     }
-    async fn wait_on(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        _options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         let ip = cfg.container_ip("core");
         let uri = tonic::transport::Uri::from_str(&format!("https://{ip}:50051")).unwrap();
         let timeout = grpc::context::TimeoutOptions::new()

--- a/deployer/src/infra/agents/ha/cluster.rs
+++ b/deployer/src/infra/agents/ha/cluster.rs
@@ -2,9 +2,7 @@ use std::convert::TryFrom;
 use tokio::time::{sleep, Duration};
 use tonic::transport::Endpoint;
 
-use crate::infra::{
-    async_trait, Builder, ComponentAction, ComposeTest, Error, HaClusterAgent, StartOptions,
-};
+use crate::infra::{async_trait, Builder, ComponentAction, Error, HaClusterAgent, StartOptions};
 use composer::{Binary, ContainerSpec};
 
 #[async_trait]
@@ -41,12 +39,20 @@ impl ComponentAction for HaClusterAgent {
         Ok(cfg.add_container_spec(spec))
     }
 
-    async fn start(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(
+        &self,
+        _options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         cfg.start("agent-ha-cluster").await?;
         Ok(())
     }
 
-    async fn wait_on(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        _options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         // Wait till cluster-agent's gRPC server is ready to server the request
         loop {
             match Endpoint::try_from(format!(

--- a/deployer/src/infra/agents/ha/node.rs
+++ b/deployer/src/infra/agents/ha/node.rs
@@ -1,5 +1,5 @@
 use crate::infra::{
-    async_trait, Builder, ComponentAction, ComposeTest, CsiNode, Error, HaNodeAgent, StartOptions,
+    async_trait, Builder, ComponentAction, CsiNode, Error, HaNodeAgent, StartOptions,
 };
 use composer::{Binary, ContainerSpec};
 use std::str::FromStr;
@@ -43,12 +43,20 @@ impl ComponentAction for HaNodeAgent {
         Ok(cfg.add_container_spec(spec))
     }
 
-    async fn start(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(
+        &self,
+        _options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         cfg.start("agent-ha-node").await?;
         Ok(())
     }
 
-    async fn wait_on(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        _options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         // Wait till node-agent's gRPC server is ready to server the request
         wait_on(&format!(
             "https://{}:11600",

--- a/deployer/src/infra/agents/jsongrpc.rs
+++ b/deployer/src/infra/agents/jsongrpc.rs
@@ -1,8 +1,6 @@
 use crate::{
     build_error,
-    infra::{
-        async_trait, Builder, ComponentAction, ComposeTest, Error, JsonGrpcAgent, StartOptions,
-    },
+    infra::{async_trait, Builder, ComponentAction, Error, JsonGrpcAgent, StartOptions},
 };
 use composer::Binary;
 use grpc::operations::jsongrpc::client::JsonGrpcClient;
@@ -31,11 +29,19 @@ impl ComponentAction for JsonGrpcAgent {
         }
         Ok(cfg.add_container_bin(name, binary))
     }
-    async fn start(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(
+        &self,
+        _options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         cfg.start("jsongrpc").await?;
         Ok(())
     }
-    async fn wait_on(&self, _options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        _options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         let ip = cfg.container_ip("jsongrpc");
         let uri = tonic::transport::Uri::from_str(&format!("https://{ip}:50052")).unwrap();
         let timeout = grpc::context::TimeoutOptions::new()

--- a/deployer/src/infra/csi-driver/controller.rs
+++ b/deployer/src/infra/csi-driver/controller.rs
@@ -1,6 +1,4 @@
-use crate::infra::{
-    async_trait, Builder, ComponentAction, ComposeTest, CsiController, Error, StartOptions,
-};
+use crate::infra::{async_trait, Builder, ComponentAction, CsiController, Error, StartOptions};
 use composer::{Binary, ContainerSpec};
 use std::convert::TryFrom;
 use tokio::{
@@ -50,14 +48,18 @@ impl ComponentAction for CsiController {
             )
         })
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if options.csi_controller {
             cfg.start("csi-controller").await?;
         }
         Ok(())
     }
 
-    async fn wait_on(&self, options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         if !options.csi_controller {
             return Ok(());
         }

--- a/deployer/src/infra/csi-driver/node.rs
+++ b/deployer/src/infra/csi-driver/node.rs
@@ -1,6 +1,4 @@
-use crate::infra::{
-    async_trait, Builder, ComponentAction, ComposeTest, CsiNode, Error, StartOptions,
-};
+use crate::infra::{async_trait, Builder, ComponentAction, CsiNode, Error, StartOptions};
 use composer::{Binary, ContainerSpec};
 use std::{convert::TryFrom, ops::Deref};
 use tokio::{
@@ -52,7 +50,7 @@ impl ComponentAction for CsiNode {
             cfg
         })
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if options.csi_node {
             let local_nodes = if options.local_nodes {
                 options.io_engines
@@ -75,7 +73,11 @@ impl ComponentAction for CsiNode {
         Ok(())
     }
 
-    async fn wait_on(&self, options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         if !options.csi_node {
             return Ok(());
         }

--- a/deployer/src/infra/dns.rs
+++ b/deployer/src/infra/dns.rs
@@ -1,4 +1,4 @@
-use crate::infra::{async_trait, Builder, ComponentAction, ComposeTest, Dns, Error, StartOptions};
+use crate::infra::{async_trait, Builder, ComponentAction, Dns, Error, StartOptions};
 use composer::ContainerSpec;
 
 #[async_trait]
@@ -14,13 +14,17 @@ impl ComponentAction for Dns {
             cfg
         })
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if options.dns {
             cfg.start("dns").await?;
         }
         Ok(())
     }
-    async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        _options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/deployer/src/infra/elastic.rs
+++ b/deployer/src/infra/elastic.rs
@@ -1,5 +1,5 @@
 use crate::infra::{
-    async_trait, Builder, ComponentAction, Components, ComposeTest, Elastic, Error, StartOptions,
+    async_trait, Builder, ComponentAction, Components, Elastic, Error, StartOptions,
 };
 use composer::ContainerSpec;
 
@@ -24,13 +24,17 @@ impl ComponentAction for Elastic {
         })
     }
 
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if options.elastic {
             cfg.start("elastic").await?;
         }
         Ok(())
     }
-    async fn wait_on(&self, options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         if options.elastic {
             Components::wait_url("http://localhost:9200").await?;
         }

--- a/deployer/src/infra/empty.rs
+++ b/deployer/src/infra/empty.rs
@@ -1,16 +1,22 @@
-use crate::infra::{
-    async_trait, Builder, ComponentAction, ComposeTest, Empty, Error, StartOptions,
-};
+use crate::infra::{async_trait, Builder, ComponentAction, Empty, Error, StartOptions};
 
 #[async_trait]
 impl ComponentAction for Empty {
     fn configure(&self, _options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
         Ok(cfg)
     }
-    async fn start(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(
+        &self,
+        _options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         Ok(())
     }
-    async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        _options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/deployer/src/infra/etcd.rs
+++ b/deployer/src/infra/etcd.rs
@@ -1,4 +1,4 @@
-use crate::infra::{async_trait, Builder, ComponentAction, ComposeTest, Error, Etcd, StartOptions};
+use crate::infra::{async_trait, Builder, ComponentAction, Error, Etcd, StartOptions};
 use composer::{Binary, ContainerSpec};
 use stor_port::pstor::etcd::Etcd as EtcdStore;
 
@@ -40,13 +40,17 @@ impl ComponentAction for Etcd {
             cfg
         })
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if !options.no_etcd {
             cfg.start("etcd").await?;
         }
         Ok(())
     }
-    async fn wait_on(&self, options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         if !options.no_etcd {
             let _store = EtcdStore::new("[::]:2379")
                 .await

--- a/deployer/src/infra/fio_spdk.rs
+++ b/deployer/src/infra/fio_spdk.rs
@@ -1,6 +1,4 @@
-use crate::infra::{
-    async_trait, Builder, ComponentAction, ComposeTest, Error, FioSpdk, StartOptions,
-};
+use crate::infra::{async_trait, Builder, ComponentAction, Error, FioSpdk, StartOptions};
 use composer::ContainerSpec;
 
 #[async_trait]
@@ -19,13 +17,17 @@ impl ComponentAction for FioSpdk {
             cfg
         })
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if options.fio_spdk {
             cfg.start("fio-spdk").await?;
         }
         Ok(())
     }
-    async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        _options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         // this is fine 🔥
         Ok(())
     }

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -1,6 +1,4 @@
-use crate::infra::{
-    async_trait, Builder, ComponentAction, ComposeTest, Error, IoEngine, StartOptions,
-};
+use crate::infra::{async_trait, Builder, ComponentAction, Error, IoEngine, StartOptions};
 use composer::{Binary, ContainerSpec};
 use rpc::io_engine::{IoEngineApiVersion, RpcHandle};
 use std::net::{IpAddr, SocketAddr};
@@ -113,13 +111,17 @@ impl ComponentAction for IoEngine {
         }
         Ok(cfg)
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         let io_engines = (0..options.io_engines)
             .map(|i| async move { cfg.start(&Self::name(i, options)).await });
         futures::future::try_join_all(io_engines).await?;
         Ok(())
     }
-    async fn wait_on(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         for i in 0..options.io_engines {
             let name = Self::name(i, options);
             let container_ip = cfg.container_ip_as_ref(&name);

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -65,6 +65,10 @@ impl ComponentAction for IoEngine {
                     .with_bind("/run/udev", "/run/udev");
             }
 
+            if !options.io_engine_isolate {
+                spec = spec.with_env("ENABLE_INTERRUPT_MODE", "true")
+            }
+
             let core_list = match options.io_engine_isolate {
                 true => {
                     let cores = 1.max(options.io_engine_cores);

--- a/deployer/src/infra/jaeger.rs
+++ b/deployer/src/infra/jaeger.rs
@@ -1,6 +1,4 @@
-use crate::infra::{
-    async_trait, Builder, ComponentAction, ComposeTest, Error, Jaeger, StartOptions,
-};
+use crate::infra::{async_trait, Builder, ComponentAction, Error, Jaeger, StartOptions};
 use composer::ContainerSpec;
 
 #[async_trait]
@@ -68,13 +66,17 @@ impl ComponentAction for Jaeger {
             cfg.add_container_spec(image)
         })
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if options.jaeger {
             cfg.start("jaeger").await?;
         }
         Ok(())
     }
-    async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        _options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/deployer/src/infra/kibana.rs
+++ b/deployer/src/infra/kibana.rs
@@ -1,5 +1,5 @@
 use crate::infra::{
-    async_trait, Builder, ComponentAction, Components, ComposeTest, Error, Kibana, StartOptions,
+    async_trait, Builder, ComponentAction, Components, Error, Kibana, StartOptions,
 };
 use composer::ContainerSpec;
 
@@ -20,13 +20,17 @@ impl ComponentAction for Kibana {
         })
     }
 
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if options.kibana {
             cfg.start("kibana").await?;
         }
         Ok(())
     }
-    async fn wait_on(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         if options.kibana && (options.jaeger || cfg.container_exists("jaeger").await) {
             loop {
                 let form = reqwest::multipart::Form::new().percent_encode_noop().part(

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -13,6 +13,8 @@ pub mod nats;
 mod rest;
 mod rwx_vm;
 
+use crate::ComposeTestNt;
+
 use super::StartOptions;
 use async_trait::async_trait;
 
@@ -159,7 +161,7 @@ impl Components {
     /// Start all components and wait up to the provided timeout.
     pub async fn start_wait(
         &self,
-        cfg: &ComposeTest,
+        cfg: &ComposeTestNt,
         timeout: std::time::Duration,
     ) -> Result<(), Error> {
         match tokio::time::timeout(timeout, self.start_wait_inner(cfg)).await {
@@ -171,7 +173,7 @@ impl Components {
         }
     }
     /// Start all components, in order, but don't wait for them.
-    pub async fn start(&self, cfg: &ComposeTest) -> Result<(), Error> {
+    pub async fn start(&self, cfg: &ComposeTestNt) -> Result<(), Error> {
         let mut last_done = None;
         for component in &self.0 {
             if let Some(last_done) = last_done {
@@ -195,7 +197,7 @@ impl Components {
     }
     /// Start all components, in order. Then wait for all components with a wait between each
     /// component to make sure they start orderly.
-    async fn start_wait_inner(&self, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start_wait_inner(&self, cfg: &ComposeTestNt) -> Result<(), Error> {
         let mut last_done = None;
 
         for component in &self.0 {
@@ -274,13 +276,13 @@ macro_rules! impl_component {
                     $(Self::$name(obj) => obj.configure(options, cfg),)+
                 }
             }
-            async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+            async fn start(&self, options: &StartOptions, cfg: &ComposeTestNt) -> Result<(), Error> {
                 let _trace = TraceFn::new(self, "start");
                 match self {
                     $(Self::$name(obj) => obj.start(options, cfg).await,)+
                 }
             }
-            async fn wait_on(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+            async fn wait_on(&self, options: &StartOptions, cfg: &ComposeTestNt) -> Result<(), Error> {
                 let _trace = TraceFn::new(self, "wait_on");
                 match self {
                     $(Self::$name(obj) => obj.wait_on(options, cfg).await,)+
@@ -315,8 +317,8 @@ macro_rules! impl_component {
 #[async_trait]
 pub trait ComponentAction {
     fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error>;
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error>;
-    async fn wait_on(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error>;
+    async fn start(&self, options: &StartOptions, cfg: &ComposeTestNt) -> Result<(), Error>;
+    async fn wait_on(&self, options: &StartOptions, cfg: &ComposeTestNt) -> Result<(), Error>;
 }
 /// List of Control Plane Components to deploy.
 #[derive(Debug, Clone)]
@@ -364,7 +366,7 @@ impl Components {
     }
     pub async fn wait_on(
         &self,
-        cfg: &ComposeTest,
+        cfg: &ComposeTestNt,
         timeout: std::time::Duration,
     ) -> Result<(), Error> {
         match tokio::time::timeout(timeout, self.wait_on_inner(cfg)).await {
@@ -378,7 +380,7 @@ impl Components {
     async fn wait_on_components(
         &self,
         components: &[&Component],
-        cfg: &ComposeTest,
+        cfg: &ComposeTestNt,
     ) -> Result<(), Error> {
         let mut futures = vec![];
         for component in components {
@@ -403,7 +405,7 @@ impl Components {
             Ok(())
         }
     }
-    async fn wait_on_inner(&self, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on_inner(&self, cfg: &ComposeTestNt) -> Result<(), Error> {
         self.wait_on_components(&self.0.iter().collect::<Vec<_>>(), cfg)
             .await
     }

--- a/deployer/src/infra/nats.rs
+++ b/deployer/src/infra/nats.rs
@@ -1,4 +1,4 @@
-use crate::infra::{async_trait, Builder, ComponentAction, ComposeTest, Error, Nats, StartOptions};
+use crate::infra::{async_trait, Builder, ComponentAction, Error, Nats, StartOptions};
 use composer::ContainerSpec;
 use events_api::mbus_nats::message_bus_init;
 use std::ffi::OsString;
@@ -29,7 +29,7 @@ impl ComponentAction for Nats {
             )
         })
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if options.eventing {
             cfg.start("nats").await?;
         }
@@ -38,7 +38,11 @@ impl ComponentAction for Nats {
         }
         Ok(())
     }
-    async fn wait_on(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         if options.eventing || cfg.container_exists("nats").await {
             let _ = message_bus_init("localhost:4222", Some(1)).await;
         }

--- a/deployer/src/infra/rest.rs
+++ b/deployer/src/infra/rest.rs
@@ -1,6 +1,4 @@
-use crate::infra::{
-    async_trait, Builder, ComponentAction, Components, ComposeTest, Error, Rest, StartOptions,
-};
+use crate::infra::{async_trait, Builder, ComponentAction, Components, Error, Rest, StartOptions};
 use composer::{Binary, ContainerSpec};
 use std::time::Duration;
 use utils::DEFAULT_JSON_GRPC_CLIENT_ADDR;
@@ -73,13 +71,17 @@ impl ComponentAction for Rest {
             )
         })
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if !options.no_rest {
             cfg.start("rest").await?;
         }
         Ok(())
     }
-    async fn wait_on(&self, options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         if options.no_rest {
             return Ok(());
         }

--- a/deployer/src/infra/rwx_vm.rs
+++ b/deployer/src/infra/rwx_vm.rs
@@ -11,6 +11,7 @@ macro_rules! ws_path {
     };
 }
 const RWX_VM: &str = ws_path!("/deployer/misc/rwx-vm");
+const RWX_VM_QC: &str = ws_path!("/deployer/misc/rwx-vm/nixos.qcow2");
 const RWX_VM_NIX: &str = ws_path!("/deployer/misc/rwx-vm/csi-node-2.nix");
 
 fn is_nixos() -> bool {
@@ -72,6 +73,7 @@ impl ComponentAction for RwxVm {
             .stderr(std::process::Stdio::null());
 
         if cfg.clean() {
+            // When clean is set, we don't need to make use of `RwxVm::stop()` to kill the VM
             unsafe {
                 cmd.pre_exec(|| {
                     // When parent dies, send SIGTERM to this process
@@ -91,5 +93,73 @@ impl ComponentAction for RwxVm {
     ) -> Result<(), Error> {
         // we let the csi-node-2 and agent-ha-node-2 do the waiting
         Ok(())
+    }
+}
+
+use nix::{
+    sys::signal::{self, Signal},
+    unistd::Pid,
+};
+use std::fs;
+
+impl RwxVm {
+    /// Stops the RWX VM by killing any QEMU processes that have the VM disk open.
+    pub fn stop() -> std::io::Result<()> {
+        let needle = format!("file={RWX_VM_QC}");
+
+        let mut pids = Vec::new();
+        for entry in fs::read_dir("/proc")? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+
+            let pid: i32 = match name.parse() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            let cmdline_path = format!("/proc/{pid}/cmdline");
+            let cmdline_bytes = match fs::read(&cmdline_path) {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+
+            // cmdline is NUL-separated args; replace with spaces for substring matching.
+            let cmdline = String::from_utf8_lossy(&cmdline_bytes);
+            if cmdline.contains("qemu-system") && cmdline.contains(&needle) {
+                pids.push(pid);
+            }
+        }
+
+        if pids.is_empty() {
+            tracing::info!("No QEMU processes found using {RWX_VM_QC}");
+            return Ok(());
+        }
+
+        tracing::info!(
+            "Found QEMU processes: {}",
+            pids.iter()
+                .map(i32::to_string)
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+
+        for pid in pids {
+            kill_pid(pid);
+        }
+
+        Ok(())
+    }
+}
+
+/// Similar to the cleanup script, kill with grace, then with force, and ignore errors.
+/// This is to avoid panics in the cleanup code when the process has already exited.
+/// kill "$pid" || kill -9 "$pid" || :
+fn kill_pid(pid: i32) {
+    let nix_pid = Pid::from_raw(pid);
+
+    if signal::kill(nix_pid, Signal::SIGTERM).is_err() {
+        // Ignore the error, matching the bash `|| :` fallback semantics.
+        let _ = signal::kill(nix_pid, Signal::SIGKILL);
     }
 }

--- a/deployer/src/infra/rwx_vm.rs
+++ b/deployer/src/infra/rwx_vm.rs
@@ -1,8 +1,6 @@
 use std::os::unix::process::CommandExt;
 
-use crate::infra::{
-    async_trait, Builder, ComponentAction, ComposeTest, Error, RwxVm, StartOptions,
-};
+use crate::infra::{async_trait, Builder, ComponentAction, Error, RwxVm, StartOptions};
 
 macro_rules! ws_path {
     ($p:literal) => {
@@ -61,7 +59,7 @@ impl ComponentAction for RwxVm {
 
         Ok(cfg)
     }
-    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+    async fn start(&self, options: &StartOptions, cfg: &crate::ComposeTestNt) -> Result<(), Error> {
         if !options.rwx_vm {
             return Ok(());
         }
@@ -86,7 +84,11 @@ impl ComponentAction for RwxVm {
 
         Ok(())
     }
-    async fn wait_on(&self, _options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+    async fn wait_on(
+        &self,
+        _options: &StartOptions,
+        _cfg: &crate::ComposeTestNt,
+    ) -> Result<(), Error> {
         // we let the csi-node-2 and agent-ha-node-2 do the waiting
         Ok(())
     }

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -691,9 +691,9 @@ impl StartOptions {
 }
 
 impl StartOptions {
-    pub async fn start(&self) -> Result<composer::ComposeTest, Error> {
+    pub async fn start(&self) -> Result<ComposeTestNt, Error> {
         let components = Components::new(self.clone());
-        let composer = Builder::new()
+        let compose_builder = Builder::new()
             .name(&self.cluster_label.name())
             .label_prefix(&self.cluster_label.prefix())
             .with_clean(false)
@@ -704,9 +704,9 @@ impl StartOptions {
             .with_rust_log_silence(self.rust_log_silence.clone())
             .load_existing_containers()
             .await
-            .configure(components.clone())?
-            .build()
-            .await?;
+            .configure(components.clone())?;
+
+        let composer = ComposeTestNt::new(compose_builder).await?;
 
         match self.wait_timeout {
             Some(timeout) => {
@@ -861,4 +861,145 @@ pub fn host_tmp() -> Result<String, std::io::Error> {
         std::fs::create_dir(&root_tmp)?;
     }
     Ok(root_tmp)
+}
+
+struct ComposeTestFlags {
+    logs_on_panic: bool,
+    clean: bool,
+    allow_clean_on_panic: bool,
+}
+impl ComposeTestFlags {
+    fn override_flags(flag: &mut bool, flag_name: &str) {
+        let key = format!("COMPOSE_{}", flag_name.to_ascii_uppercase());
+        if let Some(val) = std::env::var_os(&key) {
+            let clean = match val.to_str().unwrap_or_default() {
+                "true" => true,
+                "false" => false,
+                _ => return,
+            };
+            if clean != *flag {
+                tracing::warn!(
+                    "env::{} => Overriding the {} flag to {}",
+                    key,
+                    flag_name,
+                    clean
+                );
+                *flag = clean;
+            }
+        }
+    }
+    /// override clean flags with environment variable
+    /// useful for testing without having to change the code
+    fn override_debug_flags(&mut self) {
+        Self::override_flags(&mut self.clean, "clean");
+        Self::override_flags(&mut self.allow_clean_on_panic, "allow_clean_on_panic");
+        Self::override_flags(&mut self.logs_on_panic, "logs_on_panic");
+    }
+}
+/// A wrapper over the composer utility meant to ensure termination in the
+/// correct order.
+/// todo: add shutdown order!
+pub struct ComposeTestNt {
+    flags: ComposeTestFlags,
+    composer: composer::ComposeTest,
+    name: String,
+    shutdown_order: Vec<Vec<String>>,
+}
+impl ComposeTestNt {
+    /// Create a new instance of the ComposeTestNt wrapper.
+    pub async fn new(composer: Builder) -> Result<Self, Error> {
+        let mut flags = ComposeTestFlags {
+            logs_on_panic: composer.logs_on_panic(),
+            clean: composer.clean(),
+            allow_clean_on_panic: false,
+        };
+        flags.override_debug_flags();
+        let name = composer.get_name();
+        let mut composer = composer
+            .with_clean(false)
+            .with_clean_on_panic(false)
+            .with_logs(false)
+            .build()
+            .await?;
+        composer.clear_logs_on_panic();
+        Ok(Self {
+            flags,
+            composer,
+            name,
+            shutdown_order: vec![],
+        })
+    }
+    /// Output logs on drop if there was a panic.
+    pub fn logs_on_panic(&self) -> bool {
+        self.flags.logs_on_panic
+    }
+    /// Clear the `logs_on_panic` flag.
+    pub fn clear_logs_on_panic(&mut self) {
+        self.flags.logs_on_panic = false;
+    }
+    /// Cleans containers on drop.
+    pub fn clean(&self) -> bool {
+        self.flags.clean
+    }
+    /// Cleans containers on drop if there was a panic.
+    pub fn clean_on_panic(&self) -> bool {
+        self.flags.allow_clean_on_panic
+    }
+}
+impl std::ops::Deref for ComposeTestNt {
+    type Target = composer::ComposeTest;
+    fn deref(&self) -> &Self::Target {
+        &self.composer
+    }
+}
+impl Drop for ComposeTestNt {
+    fn drop(&mut self) {
+        use std::process::Command;
+
+        if std::thread::panicking() && self.logs_on_panic() {
+            self.print_all_logs();
+        }
+
+        if self.clean() && (!std::thread::panicking() || self.clean_on_panic()) {
+            let containers = self.composer.containers();
+            let container_names = containers.keys().map(|k| k.as_str());
+
+            // todo: shutdown order not in-place at the moment
+            if !self.shutdown_order.is_empty() {
+                let sh = self.shutdown_order.drain(..);
+                sh.into_iter().for_each(|c| {
+                    c.into_iter()
+                        .map(|c| {
+                            std::thread::spawn(move || {
+                                Command::new("docker")
+                                    .args(["kill", "-s", "term", c.as_str()])
+                                    .output()
+                                    .unwrap();
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                        .into_iter()
+                        .for_each(|h| {
+                            h.join().ok();
+                        });
+                });
+            } else {
+                // Kill with SIGTERM to allow for some cleanup
+                let cmd = vec!["kill", "-s", "term"]
+                    .into_iter()
+                    .chain(container_names.clone());
+                Command::new("docker").args(cmd).output().unwrap();
+            }
+
+            // Remove (killing with force if not already stopped)
+            let cmd = vec!["rm", "-vf"].into_iter().chain(container_names.clone());
+            Command::new("docker").args(cmd).output().unwrap();
+
+            // Finally remove the network, leaving no traces of our composer
+            Command::new("docker")
+                .args(["network", "rm", self.name.as_str()])
+                .output()
+                .unwrap();
+        }
+    }
 }

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -742,6 +742,7 @@ impl StopOptions {
         composer
             .remove_network_containers(&self.cluster_label.name())
             .await?;
+        RwxVm::stop()?;
         Ok(())
     }
 }

--- a/tests/bdd/common/fio.py
+++ b/tests/bdd/common/fio.py
@@ -4,6 +4,8 @@ import subprocess
 from typing import Optional
 from urllib.parse import ParseResult, parse_qs
 
+import pytest
+
 fio_bin = shutil.which("fio")
 
 
@@ -22,6 +24,7 @@ class Fio(object):
         norandommap=True,
         offset="0",
         extra_args="",
+        taskset=None,
     ):
         self.name = name
         self.rw = rw
@@ -36,6 +39,7 @@ class Fio(object):
         self.io_depth = io_depth
         self.offset = offset
         self.norandommap = norandommap
+        self.taskset = taskset
 
         if device is None == uri is None:
             raise "Device and Uri as exclusive!"
@@ -45,6 +49,8 @@ class Fio(object):
         if uri is not None:
             self.uri = uri
             self.userspace = True
+        if taskset is None:
+            self.taskset = f"{pytest.deployer_options.io_engines}"
 
     def build(self):
         if self.userspace:
@@ -66,14 +72,24 @@ class Fio(object):
         args = f"{args} --iodepth={self.io_depth} {self.extra_args}"
         return args
 
+    def taskset_args(self):
+        if self.taskset is not None:
+            return f"taskset -c {self.taskset} "
+        return ""
+
     def build_for_kernel(self):
         args = self.build_common_args()
         devs = [self.device] if isinstance(self.device, str) else self.device
         filename = ":".join(map(str, devs))
+        taskset = self.taskset_args()
+
+        taskset = ""
+        if self.taskset is not None:
+            taskset = f"taskset -c {self.taskset} "
 
         command = (
-            f"sudo {fio_bin} --ioengine=linuxaio --filename={filename} "
-            f"--numjobs=1 --thread=1 {args} "
+            f"date; {taskset}sudo {fio_bin} --ioengine=linuxaio --filename={filename} "
+            f"--numjobs=1 --thread=1 {args}; date"
         )
 
         return command
@@ -84,25 +100,28 @@ class Fio(object):
         uri_query = parse_qs(self.uri.query)
         traddr = self.uri.hostname
         subnqn = self.uri.path[1:].replace(":", "\\:")
+        taskset = self.taskset_args()
 
         if uri_query.keys().__contains__("hostnqn"):
             args = "--hostnqn={} {}".format(uri_query["hostnqn"][0], args)
 
         command = (
-            "docker exec -i fio-spdk fio --ioengine=spdk "
+            f"docker exec -i fio-spdk {taskset}fio --ioengine=spdk "
             f"--filename='trtype=tcp adrfam=IPv4 traddr={traddr} trsvcid=8420 subnqn={subnqn} ns=1' "
             f"--numjobs=1 --thread=1 {args} "
         )
         return command
 
     def open(self):
-        print(f"{self.build()}")
-        return subprocess.Popen(self.build(), shell=True)
+        build = self.build()
+        print(f"{build}")
+        return subprocess.Popen(build, shell=True)
 
     def run(self):
-        print(f"{self.build()}")
+        build = self.build()
+        print(f"{build}")
         try:
-            return subprocess.run(self.build(), shell=True, check=True)
+            return subprocess.run(build, shell=True, check=True)
         except subprocess.CalledProcessError:
             if self.userspace:
                 self.remove_stale_files_on_error()

--- a/tests/bdd/common/nvme.py
+++ b/tests/bdd/common/nvme.py
@@ -67,7 +67,7 @@ def nvme_hostnqn_arg(uri: ParseResult):
         return ""
 
 
-def nvme_connect(uri):
+def nvme_connect(uri, delay=None):
     u = urlparse(uri)
     port = u.port
     host = u.hostname
@@ -75,6 +75,8 @@ def nvme_connect(uri):
     hostnqn = nvme_hostnqn_arg(u)
 
     command = f"sudo {nvme_bin} connect -t tcp -s {port} -a {host} -I {hostid}{hostnqn} -n {nqn}"
+    if delay is not None:
+        command += f" -c {delay}"
     print(command)
     try:
         subprocess.run(

--- a/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
+++ b/tests/bdd/features/ana/validate/test_validate_nexus_swap.py
@@ -1,6 +1,7 @@
 """Swap ANA enabled Nexus on ANA enabled host feature tests."""
 
 import subprocess
+from time import sleep
 from urllib.parse import urlparse
 
 import pytest
@@ -34,6 +35,7 @@ POOL_NODE = "io-engine-3"
 TARGET_NODE_1 = "io-engine-1"
 TARGET_NODE_2 = "io-engine-2"
 FIO_RUNTIME = 4
+IO_ENGINES = 3
 
 
 @scenario(
@@ -97,7 +99,7 @@ def it_should_be_possible_to_remove_the_first_failed_io_path(remove_first_path):
 @pytest.fixture
 def background():
     Deployer.start(
-        3,
+        IO_ENGINES,
         cache_period="1s",
         io_engine_coreisol=True,
         node_conn_timeout="100ms",
@@ -132,7 +134,7 @@ def connect_to_first_path(background):
     print(volume)
     print(volume.state.target)
     device_uri = volume.state.target.device_uri
-    yield nvme_connect(device_uri)
+    yield nvme_connect(device_uri, delay=1)
     nvme_disconnect(device_uri)
 
 
@@ -147,12 +149,15 @@ def run_fio_to_first_path(connect_to_first_path):
     assert len(subsystem["Paths"]) == 1, "Must be exactly one I/O path to target nexus"
     assert subsystem["Paths"][0]["State"] == "live", "I/O path is not healthy"
     # Launch fio in background and let it always run along with the test.
-    fio = Fio("job", "randread", device, runtime=FIO_RUNTIME)
+    taskset = f"f{IO_ENGINES}"  # avoid io-engine cores to avoid interference with fio
+    fio = Fio("job", "randread", device, runtime=FIO_RUNTIME, taskset=taskset)
     return fio.open()
 
 
 @pytest.fixture
 def degrade_first_path():
+    # Let fio start and run for a while before degrading the only I/O path.
+    sleep(1)
     Docker.kill_container(TARGET_NODE_1)
 
 
@@ -180,7 +185,7 @@ def publish_to_node_2(background):
 @pytest.fixture
 @retry(wait_fixed=10, stop_max_attempt_number=200)
 def connect_to_node_2(publish_to_node_2):
-    device = nvme_connect(publish_to_node_2)
+    device = nvme_connect(publish_to_node_2, delay=1)
     desc = nvme_list_subsystems(device)
     subsystem = desc["Subsystems"][0]
     assert len(subsystem["Paths"]) == 2, "Second nexus must be added to I/O path"

--- a/tests/bdd/features/ha/node-agent/test_path_replacement.py
+++ b/tests/bdd/features/ha/node-agent/test_path_replacement.py
@@ -38,6 +38,7 @@ NEXUS_NQN = f"{nvme_nqn_prefix}:{VOLUME_UUID}"
 PATH_DETECTION_TIME = 2
 # FIO should be active long enough to outlive the detection interval.
 FIO_RUNTIME = PATH_DETECTION_TIME * 4
+IO_ENGINES = 3
 
 
 @scenario(
@@ -103,7 +104,7 @@ def it_should_be_possible_to_create_a_second_nexus_and_replace_failed_path_with_
 @pytest.fixture
 def background():
     Deployer.start(
-        3,
+        IO_ENGINES,
         node_agent=True,
         cluster_agent=True,
         csi_node=True,
@@ -142,7 +143,7 @@ def background():
 def connect_to_first_path(background):
     volume = background
     device_uri = volume.state.target.device_uri
-    yield nvme_connect(device_uri)
+    yield nvme_connect(device_uri, delay=1)
     nvme_disconnect(device_uri)
 
 
@@ -163,6 +164,8 @@ def run_fio_to_first_path(connect_to_first_path):
 
 @pytest.fixture
 def degrade_first_path():
+    # Let fio start and run for a while before degrading the only I/O path.
+    sleep(1)
     Docker.kill_container(TARGET_NODE_1)
     # Sleep some time to allow HA node agent detect failed path.
     # Add one extra second to make sure detection 100% happens.

--- a/tests/io-engine/tests/rebuild.rs
+++ b/tests/io-engine/tests/rebuild.rs
@@ -508,6 +508,9 @@ async fn run_fio_vol_verify(
         let filename = format!("--filename={device}");
         let time = format!("--runtime={time}");
         vec![
+            "taskset",
+            "-c",
+            cluster.fio_taskset().as_str(),
             "fio",
             "--direct=1",
             "--ioengine=libaio",

--- a/tests/io-engine/tests/reservations.rs
+++ b/tests/io-engine/tests/reservations.rs
@@ -167,6 +167,9 @@ async fn reservation() {
             format!("--filename=trtype=tcp adrfam=IPv4 traddr={ip} trsvcid=8420 subnqn={nqn} ns=1");
         tracing::debug!("Filename: {filename}");
         vec![
+            "taskset",
+            "-c",
+            cluster.fio_taskset().as_str(),
             "fio",
             "--name=benchtest",
             filename.as_str(),

--- a/tests/io-engine/tests/upgrade.rs
+++ b/tests/io-engine/tests/upgrade.rs
@@ -167,6 +167,9 @@ async fn run_fio_vol_verify(
         let filename = format!("--filename={device}");
         let time = format!("--runtime={time}");
         vec![
+            "taskset",
+            "-c",
+            cluster.fio_taskset().as_str(),
             "fio",
             "--direct=1",
             "--ioengine=libaio",

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -516,6 +516,11 @@ impl Cluster {
         self.builder.opts.io_engines
     }
 
+    /// FIO taskset affinity for non/io-engine cores.
+    pub fn fio_taskset(&self) -> String {
+        format!("{}", self.builder.opts.io_engines)
+    }
+
     /// The io-engine node nqn for `index`.
     pub fn node_nqn(&self, index: u32) -> transport::HostNqn {
         IoEngine::nqn(index, &self.builder.opts).try_into().unwrap()

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -176,7 +176,6 @@ impl Cluster {
             "Max tries exceeded, node service not up".to_string(),
         ))
     }
-
     /// Wait till the node is in the given status.
     pub async fn wait_node_status<I: AsRef<NodeId>>(
         &self,
@@ -185,6 +184,55 @@ impl Cluster {
     ) -> Result<(), String> {
         self.wait_node_status_tmo(node_id, status, Duration::from_secs(2))
             .await
+    }
+    /// Wait till the node is in the given status.
+    pub async fn wait_node_status_ext<I: AsRef<NodeId>>(
+        &self,
+        node_id: I,
+        status: impl Fn(&NodeStatus) -> bool,
+    ) -> Result<(), String> {
+        self.wait_node_status_tmo_ext(node_id, Duration::from_secs(2), status)
+            .await
+    }
+    /// Wait till the node is in the given status.
+    pub async fn wait_node_status_tmo_ext<I: AsRef<NodeId>>(
+        &self,
+        node_id: I,
+        timeout: Duration,
+        status: impl Fn(&NodeStatus) -> bool,
+    ) -> Result<(), String> {
+        let node_id = node_id.as_ref();
+        let node_cli = self.grpc_client().node();
+        let start = std::time::Instant::now();
+        let mut seen_status = None;
+        loop {
+            let result = node_cli
+                .get(Filter::Node(node_id.clone()), true, None)
+                .await;
+            match result {
+                Ok(nodes) => {
+                    if let Some(node) = nodes.0.first() {
+                        if status(
+                            &node
+                                .state()
+                                .map(|n| n.status)
+                                .unwrap_or(NodeStatus::Unknown),
+                        ) {
+                            return Ok(());
+                        }
+                        seen_status = node.state().map(|n| n.status);
+                    }
+                }
+                Err(error) => tracing::error!(%error, "Failed to fetch node"),
+            }
+            if std::time::Instant::now() > (start + timeout) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        Err(format!(
+            "Node {node_id} not in the desired status within {timeout:?}, currently: {seen_status:?}"
+        ))
     }
     /// Wait till the node is in the given status.
     pub async fn wait_node_status_tmo<I: AsRef<NodeId>>(

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -5,7 +5,7 @@ use composer::{Builder, ComposeTest};
 use deployer_lib::{
     default_agents,
     infra::{Components, Error, IoEngine},
-    StartOptions,
+    ComposeTestNt, StartOptions,
 };
 use opentelemetry::{global, KeyValue};
 use opentelemetry_sdk::{propagation::TraceContextPropagator, trace as sdktrace};
@@ -81,130 +81,6 @@ pub fn default_options() -> StartOptions {
         .with_show_info(true)
         .with_build_all(!matches!(std::env::var("CI").as_deref(), Ok("1")))
         .with_env_tags(vec!["CARGO_PKG_NAME"])
-}
-
-struct ComposeTestFlags {
-    logs_on_panic: bool,
-    clean: bool,
-    allow_clean_on_panic: bool,
-}
-impl ComposeTestFlags {
-    fn override_flags(flag: &mut bool, flag_name: &str) {
-        let key = format!("COMPOSE_{}", flag_name.to_ascii_uppercase());
-        if let Some(val) = std::env::var_os(&key) {
-            let clean = match val.to_str().unwrap_or_default() {
-                "true" => true,
-                "false" => false,
-                _ => return,
-            };
-            if clean != *flag {
-                tracing::warn!(
-                    "env::{} => Overriding the {} flag to {}",
-                    key,
-                    flag_name,
-                    clean
-                );
-                *flag = clean;
-            }
-        }
-    }
-    /// override clean flags with environment variable
-    /// useful for testing without having to change the code
-    fn override_debug_flags(&mut self) {
-        Self::override_flags(&mut self.clean, "clean");
-        Self::override_flags(&mut self.allow_clean_on_panic, "allow_clean_on_panic");
-        Self::override_flags(&mut self.logs_on_panic, "logs_on_panic");
-    }
-}
-/// A wrapper over the composer utility meant to ensure termination in the
-/// correct order.
-/// todo: add shutdown order!
-pub struct ComposeTestNt {
-    flags: ComposeTestFlags,
-    composer: ComposeTest,
-    name: String,
-    shutdown_order: Vec<Vec<String>>,
-}
-impl ComposeTestNt {
-    async fn new(composer: Builder) -> Result<Self, Error> {
-        let mut flags = ComposeTestFlags {
-            logs_on_panic: composer.logs_on_panic(),
-            clean: composer.clean(),
-            allow_clean_on_panic: false,
-        };
-        flags.override_debug_flags();
-        let name = composer.get_name();
-        let mut composer = composer
-            .with_clean(false)
-            .with_clean_on_panic(false)
-            .with_logs(false)
-            .build()
-            .await?;
-        composer.clear_logs_on_panic();
-        Ok(Self {
-            flags,
-            composer,
-            name,
-            shutdown_order: vec![],
-        })
-    }
-}
-impl Deref for ComposeTestNt {
-    type Target = ComposeTest;
-    fn deref(&self) -> &Self::Target {
-        &self.composer
-    }
-}
-impl Drop for ComposeTestNt {
-    fn drop(&mut self) {
-        use std::process::Command;
-
-        if std::thread::panicking() && self.flags.logs_on_panic {
-            self.print_all_logs();
-        }
-
-        if self.flags.clean && (!std::thread::panicking() || self.flags.allow_clean_on_panic) {
-            let containers = self.composer.containers();
-            let container_names = containers.keys().map(|k| k.as_str());
-
-            // todo: shutdown order not in-place at the moment
-            if !self.shutdown_order.is_empty() {
-                let sh = self.shutdown_order.drain(..);
-                sh.into_iter().for_each(|c| {
-                    c.into_iter()
-                        .map(|c| {
-                            std::thread::spawn(move || {
-                                Command::new("docker")
-                                    .args(["kill", "-s", "term", c.as_str()])
-                                    .output()
-                                    .unwrap();
-                            })
-                        })
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .for_each(|h| {
-                            h.join().ok();
-                        });
-                });
-            } else {
-                // Kill with SIGTERM to allow for some cleanup
-                let cmd = vec!["kill", "-s", "term"]
-                    .into_iter()
-                    .chain(container_names.clone());
-                Command::new("docker").args(cmd).output().unwrap();
-            }
-
-            // Remove (killing with force if not already stopped)
-            let cmd = vec!["rm", "-vf"].into_iter().chain(container_names.clone());
-            Command::new("docker").args(cmd).output().unwrap();
-
-            // Finally remove the network, leaving no traces of our composer
-            Command::new("docker")
-                .args(["network", "rm", self.name.as_str()])
-                .output()
-                .unwrap();
-        }
-    }
 }
 
 /// Cluster with the composer, the rest client and the jaeger pipeline

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -292,6 +292,28 @@ impl Cluster {
         }
         Err(())
     }
+    /// Wait till the pool is online.
+    pub async fn wait_pools_online<I: AsRef<NodeId>>(&self, node: I) -> Result<(), String> {
+        let timeout = Duration::from_secs(2);
+        let start = std::time::Instant::now();
+        loop {
+            let filter = Filter::Node(node.as_ref().clone());
+            if let Ok(pools) = self.grpc_client().pool().get(filter, None).await {
+                if pools.into_inner().into_iter().all(|p| {
+                    p.state()
+                        .map(|s| s.status == PoolStatus::Online)
+                        .unwrap_or_default()
+                }) {
+                    return Ok(());
+                }
+            }
+            if std::time::Instant::now() > (start + timeout) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        Err("Timeout waiting for all pools to be online".to_string())
+    }
 
     /// return grpc handle to the container
     pub async fn grpc_handle(&self, name: &str) -> Result<RpcHandle, String> {
@@ -405,6 +427,22 @@ impl Cluster {
     ) -> Result<bool, ReplyError> {
         self.restart_core().await;
         self.volume_service_liveness(timeout_opts).await
+    }
+
+    /// Wait until the node and its pools are online.
+    pub async fn restart_node_wait(&self, index: u32) -> Result<(), String> {
+        let node = self.node(index);
+        self.composer().restart(&node).await.unwrap();
+        self.wait_node_status(&node, NodeStatus::Online).await?;
+        self.wait_pools_online(&node).await?;
+        Ok(())
+    }
+
+    /// Wait until the node and its pools are online.
+    pub async fn wait_node_pool(&self, node: &NodeId) -> Result<(), String> {
+        self.wait_node_status(node, NodeStatus::Online).await?;
+        self.wait_pools_online(node).await?;
+        Ok(())
     }
 
     /// Replace the given old node with a new one from the idles.


### PR DESCRIPTION
    test(deployer): enable interrupt when not-isolated
    
    When we don't use one core per io-engine tests may fail when
    one of them doesn't get to run.
    To try and tackle this, let's use the interrupt mode in this
    case which should make cpu usage fairer.
    
---

    test: wait for non online status
    
    In case node is offline|unknown
    We probably need to clarify when a node can be offline vs unknown.

---

    test(deployer): stop should cleanup rwx vm
    
    Add rust impl for cleaning up the rwx vm.
    
---

    test(deployer): fix missing rwx vm cleanup after flag refactor
    
    In a previous PR the composer flags were silenced in favour of a composer wrapper
    which cleaned up by itself (without using composer).
    
    This introduced a regression where the rwx vm was not getting killed after the test
    was complete.
    This may affect the subsequent tests.
    
    To tackle this we move the wrapper to the deployer itself, and let the deployer
    query the wrapper for cleanup.
    
---

    fix: run fio on non/io-engine cores using taskset
    
    On recent kernel with the new scheduler, running 2 processes on the same
    core seems to be less fair and second process may not run sufficiently.
    
    We need a better approach for this, but for now at least modify fio runs
    to use a non-engine core.
    
---

    fix(agent/ha-node): slightly more robust new connection handling
    
    Seen during the tests, we may receive device add by udev and the state of the connection
    is connecting rather than new or live.
    
    In this case, we add a new state to avoid marking the path as suspected right away, since
    we know we've just added the path.
    
    Also add the subsystem to the logging as it could be useful for debugging.
