### PR TITLE
fix(core): offline rebuild reconciler picks up scale-up replicas

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/volume/offline_rebuild.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/volume/offline_rebuild.rs
@@ -13,8 +13,14 @@ use crate::{
 
 use stor_port::types::v0::{
     store::volume::VolumeSpec,
-    transport::{PublishVolume, UnpublishVolume, VolumeState, VolumeStatus, VolumeTargetMode},
+    transport::{
+        PublishVolume, ReplicaId, ReplicaTopology, UnpublishVolume, VolumeState, VolumeStatus,
+        VolumeTargetMode,
+    },
 };
+
+use agents::errors::SvcError;
+use std::collections::{HashMap, HashSet};
 
 /// Offline Volume Rebuild.
 ///
@@ -109,26 +115,97 @@ async fn offline_rebuild_reconcile(
         return PollResult::Ok(PollerState::Idle);
     }
 
-    let degraded_for = volume.lock().metadata.offline_rebuild_degraded();
-    let grace_period = context.registry().offline_rebuild_grace_period();
-    if degraded_for < grace_period {
-        tracing::debug!(
+    // Scale-up added a replica that was never part of the last-published
+    // nexus, so it is definitively out-of-sync — not a transient blip the
+    // grace period is meant to absorb. If that replica is also currently
+    // online it can serve as an in-place rebuild target, so no fresh pool is
+    // needed either.
+    let has_in_place_target =
+        has_scale_up_rebuild_target(&volume, &volume_state.replica_topology, context).await?;
+
+    if !has_in_place_target {
+        let degraded_for = volume.lock().metadata.offline_rebuild_degraded();
+        let grace_period = context.registry().offline_rebuild_grace_period();
+        if degraded_for < grace_period {
+            tracing::debug!(
+                volume.uuid = %volume.uuid(),
+                remaining = ?grace_period.saturating_sub(degraded_for),
+                "Offline rebuild waiting for grace period"
+            );
+            return PollResult::Ok(PollerState::Busy);
+        }
+    } else {
+        tracing::info!(
             volume.uuid = %volume.uuid(),
-            remaining = ?grace_period.saturating_sub(degraded_for),
-            "Offline rebuild waiting for grace period"
+            "Bypassing grace period: replica added since last publish"
         );
-        return PollResult::Ok(PollerState::Busy);
     }
 
-    initiate_offline_rebuild(&mut volume, &volume_state, context).await
+    initiate_offline_rebuild(&mut volume, &volume_state, context, has_in_place_target).await
+}
+
+/// Returns `true` when a scale-up left an Online replica that the
+/// last-published nexus never had, making it an in-place rebuild destination.
+///
+/// Such a replica is known-out-of-sync by definition rather than transiently
+/// degraded, and being Online it is also reachable, so the rebuild can start
+/// without waiting on the grace period or standing up a fresh pool.
+///
+/// The Online guard matters: a spec-only replica whose node is currently down
+/// would still be in `replica_topology` and absent from `NexusInfo`, but the
+/// temp nexus would come up short one child and the rebuild would never make
+/// progress.
+///
+/// Known caveat: if the last publish itself came up short because a replica
+/// was unavailable then, `children.len()` already trails `num_replicas` and a
+/// replacement reads as a scale-up. That only costs an earlier rebuild.
+///
+/// If the `NexusInfo` cannot be loaded (missing key, transient store error),
+/// falls back to the safe default of *not* bypassing the grace period.
+async fn has_scale_up_rebuild_target(
+    volume: &OperationGuardArc<VolumeSpec>,
+    replica_topology: &HashMap<ReplicaId, ReplicaTopology>,
+    context: &PollContext,
+) -> Result<bool, SvcError> {
+    let Some(nexus_info) = context
+        .registry()
+        .nexus_info(
+            Some(volume.uuid()),
+            volume.as_ref().health_info_id(),
+            false,
+            None,
+        )
+        .await?
+    else {
+        return Ok(false);
+    };
+
+    // The replica count reconciler also adds replicas that are absent from
+    // NexusInfo, to replace a failed one. Those must still serve out the grace
+    // period in case the original comes back, so require the desired count to
+    // have outgrown the last-published child count.
+    if usize::from(volume.as_ref().num_replicas) <= nexus_info.children.len() {
+        return Ok(false);
+    }
+
+    let known: HashSet<_> = nexus_info.children.iter().map(|c| &c.uuid).collect();
+    Ok(replica_topology
+        .iter()
+        .any(|(uuid, topo)| topo.status().online() && !known.contains(uuid)))
 }
 
 /// Creates a non-shared nexus for the volume so the existing rebuild engine
 /// (HotSpareReconciler) can restore faulted replicas.
+///
+/// `has_in_place_target` skips the candidate-pool check: when an extra
+/// replica already sits in the topology (e.g. from scale-up while
+/// unpublished), that replica is itself the rebuild destination and no fresh
+/// pool is required.
 async fn initiate_offline_rebuild(
     volume: &mut OperationGuardArc<VolumeSpec>,
     volume_state: &VolumeState,
     context: &PollContext,
+    has_in_place_target: bool,
 ) -> PollResult {
     let registry = context.registry();
 
@@ -143,8 +220,8 @@ async fn initiate_offline_rebuild(
 
     // Pre-flight viability: only stand up the temp nexus if the rebuild can
     // actually make progress. Needs both a source (a healthy replica to copy
-    // from) and a target (a candidate pool with room for the replacement
-    // replica).
+    // from) and a target (either an in-place replica flagged unhealthy, or
+    // a candidate pool with room for a replacement replica).
     //
     // Prefer the strict health signal — `online_clean_replicas > 0` — when
     // available; that's the CP's own trust decision and already accounts for
@@ -162,18 +239,18 @@ async fn initiate_offline_rebuild(
                 .values()
                 .any(|r| r.status().online())
         });
-    let target_viable = || async {
-        !volume_pool_candidates(GetSuitablePools::new(volume.as_ref(), None), registry)
+    let target_viable = has_in_place_target
+        || !volume_pool_candidates(GetSuitablePools::new(volume.as_ref(), None), registry)
             .await
-            .is_empty()
-    };
+            .is_empty();
 
-    if !source_viable || !target_viable().await {
+    if !source_viable || !target_viable {
         tracing::debug!(
             volume.uuid = %volume.uuid(),
             source_viable,
+            has_in_place_target,
             "Offline rebuild deferred: rebuild not viable \
-            (no healthy source replica and/or no candidate pool)"
+            (no healthy source replica and/or no rebuild destination)"
         );
         return PollResult::Ok(PollerState::Idle);
     }

--- a/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/offline_rebuild.rs
@@ -61,6 +61,106 @@ async fn offline_rebuild_e2e() {
     no_pool_candidate_defers_rebuild(&cluster).await;
 }
 
+/// Scale-up on an unpublished volume adds a replica that is absent from the
+/// persisted `NexusInfo`. It appears in the topology as Online but
+/// healthy=false, flipping the volume to Degraded. The offline-rebuild
+/// reconciler must treat this as "known needs rebuild" and skip the grace
+/// period.
+///
+/// A long grace period is configured so a passing test proves the bypass: if
+/// the reconciler still waited on the grace timer, the temp nexus would not
+/// appear within the assertion window.
+#[tokio::test]
+async fn offline_rebuild_scale_up_bypasses_grace() {
+    const LONG_GRACE_SECS: u64 = 30;
+    const START_WINDOW_SECS: u64 = 8;
+
+    let reconcile = Duration::from_millis(RECONCILE_PERIOD_MS);
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_io_engines(3)
+        .with_tmpfs_pool(52428800)
+        .with_cache_period("250ms")
+        .with_reconcile_period(reconcile, reconcile)
+        .with_options(|o| {
+            o.with_isolated_io_engine(true)
+                .with_agents_env("OFFLINE_REBUILD_ENABLED", "true")
+                .with_agents_env(
+                    "OFFLINE_REBUILD_GRACE_PERIOD",
+                    &format!("{LONG_GRACE_SECS}s"),
+                )
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let api_client = cluster.rest_v00();
+    let volume_api = api_client.volumes_api();
+
+    let volid = VolumeId::new();
+    let body = models::CreateVolumeBody::new(VolumePolicy::new(true), 2, 10485760u64, false, false);
+    let volume = volume_api.put_volume(&volid, body).await.unwrap();
+    let uid = volume.spec.uuid;
+
+    volume_api
+        .put_volume_target(
+            &uid,
+            models::PublishVolumeBody::new_all(
+                HashMap::new(),
+                None,
+                cluster.node(0).to_string(),
+                models::VolumeShareProtocol::Nvmf,
+                None,
+                cluster.csi_node(0),
+                None,
+            ),
+        )
+        .await
+        .expect("Should publish volume");
+    volume_api
+        .del_volume_target(&uid, None, None)
+        .await
+        .expect("Should unpublish volume");
+
+    // Scale up to 3. The new replica is absent from persisted NexusInfo, so
+    // the volume flips to Degraded.
+    let t0 = std::time::Instant::now();
+    volume_api
+        .put_volume_replica_count(&uid, 3)
+        .await
+        .expect("Should scale up to 3 replicas");
+
+    wait_till_volume_status(
+        &cluster,
+        &uid,
+        VolumeStatus::Degraded,
+        Duration::from_secs(10),
+    )
+    .await
+    .expect("Volume should become Degraded after scale-up");
+
+    // Bypass proof: the reconciler must stand up the unshared temp target
+    // well inside the grace period.
+    wait_for_unshared_target(&cluster, &uid, Duration::from_secs(START_WINDOW_SECS))
+        .await
+        .expect(
+            "Offline rebuild should start within the assertion window \
+            (grace period should be bypassed on scale-up)",
+        );
+
+    assert!(
+        t0.elapsed() < Duration::from_secs(LONG_GRACE_SECS),
+        "Scale-up rebuild took {:?}, expected under grace period of {LONG_GRACE_SECS}s",
+        t0.elapsed()
+    );
+
+    wait_till_volume_online_no_target(&cluster, &uid, Duration::from_secs(REBUILD_TIMEOUT_SECS))
+        .await
+        .expect("Volume should be Online with no target after rebuild completes");
+
+    volume_api.del_volume(&uid).await.unwrap();
+}
+
 /// Happy path scenario, see [`offline_rebuild_e2e`] doc.
 async fn happy_path(cluster: &deployer_cluster::Cluster) {
     let api_client = cluster.rest_v00();


### PR DESCRIPTION
Fixes openebs/mayastor#2043.

When someone scales up an unpublished volume, the new replica is created but isn't in the persisted `NexusInfo` yet, so it comes back Online with `healthy: false` and the volume flips to `Degraded`. The offline-rebuild reconciler *does* pick this up eventually, but it treats the situation like a transient replica blip and waits out the full `--offline-rebuild-grace-period` first. Then, even after the grace window elapses, `initiate_offline_rebuild` bails out because `volume_pool_candidates` sees no free pool for a "replacement", every pool already has a replica.

Both of those checks assume we're recovering from a lost replica. In the scale-up case (and, per the issue, in pool-drain relocations too) the "unhealthy" replica is right there in the topology; there's no transient period to absorb and no need for a new pool, the extra replica *is* the rebuild destination.

The reconciler now compares the current replica topology against the persisted `NexusInfo.children`. If any replica UUID is missing from `NexusInfo`, that's the signal:

  * skip the grace-period gate: the unhealthy flag is definitional, not transient;
  * skip the candidate-pool check in `initiate_offline_rebuild`: the extra replica is the in-place target, so `HotSpareReconciler` can rebuild it once the temp nexus is stood up.

If `NexusInfo` can't be loaded (missing key, transient store error) the code falls back to the existing conservative behaviour.

### Testing

Added `offline_rebuild_scale_up_bypasses_grace` alongside the existing e2e. It configures a 30s grace period, publishes → unpublishes → scales 2 → 3, and asserts the temp target appears well inside the window. On develop, the test times out at 8s waiting for the temp nexus; with the fix the rebuild starts within a couple of reconcile ticks and the volume returns to `Online`.

Both the new test and the four existing scenarios (`happy_path`, `promote_on_publish`, `gc_safety`, `no_pool_candidate_defers_rebuild`) pass.

cc: @abhilashshetty04