### PR TITLE
refresh node rebuild count on single nexus update

### DIFF
--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -204,7 +204,7 @@ async fn handle_faulted_child(
         if let Err(error) = online_nexus_child(nexus_spec, &child.uri, context).await {
             // Check if online_nexus_child failed due to max_rebuild limit being hit.
             // If no, initiate Full rebuild of the child.
-            if error.tonic_code() != tonic::Code::ResourceExhausted {
+            if error.tonic_code() != tonic::Code::OutOfRange {
                 tracing::warn!(
                     %child.uri,
                     child.uuid=%child_uuid,

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -895,7 +895,10 @@ impl NodeWrapper {
                 self.resources_mut().update_nexuses(nexuses);
                 self.update_num_rebuilds();
             }
-            ResourceType::Nexus(nexus) => self.resources_mut().update_nexus(nexus),
+            ResourceType::Nexus(nexus) => {
+                self.resources_mut().update_nexus(nexus);
+                self.update_num_rebuilds();
+            }
             ResourceType::Pools(pools) => {
                 self.resources_mut().update_pools(pools);
             }

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -556,6 +556,7 @@ impl SvcError {
             Self::ReplicaSetPropertyFailed { .. } => tonic::Code::DataLoss,
             Self::ReplaceNqnNotFound { .. } => tonic::Code::FailedPrecondition,
             Self::PoolCreateError { code, .. } => *code,
+            Self::MaxRebuilds { .. } => tonic::Code::OutOfRange,
             _ => tonic::Code::Internal,
         }
     }


### PR DESCRIPTION
NodeWrapper caches a per-node num_rebuilds counter, which the registry sums across all nodes in rebuild_allowed() to enforce the system-wide --max-rebuilds limit.

That counter was refreshed in update_resources() for ResourceType::All and ResourceType::Nexuses, but not for the single-nexus ResourceType::Nexus path. So whenever a nexus state was updated individually (e.g. on a nexus-specific state refresh rather than a full node poll), the cached rebuild count went stale.

Because of this newly started rebuilds weren't reflected, so more rebuilds than max_rebuilds could be admitted.

This PR fixes this by updating rebuild count after every online_child operation.