### PR TITLE
add drain_spec to PoolUSpec

### DIFF
--- a/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/resources/mod.rs
@@ -98,7 +98,7 @@ impl PoolItemLister {
                 n.pool_wrappers()
                     .into_iter()
                     .filter_map(|p| {
-                        let cordoned = registry.specs().pool_with(&p.id, |p| p.cordoned().cloned());
+                        let cordoned = registry.specs().pool_with(&p.id, |p| p.cordoned());
                         let cordoned = cordoned.ok()?;
                         let ag_rep_count =
                             pool_ag_rep.as_ref().and_then(|map| map.get(&p.id).cloned());
@@ -121,7 +121,7 @@ impl PoolItemLister {
                     .and_then(|node| {
                         let cordoned = registry
                             .specs()
-                            .pool_with(&item.pool().id, |p| p.cordoned().cloned());
+                            .pool_with(&item.pool().id, |p| p.cordoned());
                         let pool =
                             PoolItem::new(node.clone(), item.pool().clone(), None, cordoned.ok()?);
                         Some(pool)
@@ -174,7 +174,7 @@ impl PoolItemLister {
             };
             let (node, cordoned) = {
                 let pool_spec = pool_spec.lock();
-                (pool_spec.node.clone(), pool_spec.cordoned().cloned())
+                (pool_spec.node.clone(), pool_spec.cordoned())
             };
             let Ok(node) = registry.node_wrapper(&node).await else {
                 continue;

--- a/control-plane/agents/src/bin/core/pool/pool_operations.rs
+++ b/control-plane/agents/src/bin/core/pool/pool_operations.rs
@@ -17,7 +17,7 @@ use stor_port::{
     transport_api::ResourceKind,
     types::v0::{
         store::{
-            pool::{CordonDrainState, PoolCordonOp, PoolOperation, PoolSpec},
+            pool::{PoolCordonOp, PoolOperation, PoolSpec},
             snapshots::replica::ReplicaSnapshot,
         },
         transport::{
@@ -529,16 +529,17 @@ impl OperationGuardArc<PoolSpec> {
     }
 
     /// Validate that the pool is cordoned with both replicas and snapshots blocked.
+    /// Uses the effective cordon, so a self-cordoned draining pool also qualifies.
     fn validate_purge_cordon(
         &self,
         pool_id: &PoolId,
         pool_spec: &PoolSpec,
     ) -> Result<(), SvcError> {
-        match &pool_spec.cordon_drain {
+        match pool_spec.cordoned() {
             None => Err(SvcError::PoolNotCordonedForPurge {
                 pool_id: pool_id.clone(),
             }),
-            Some(CordonDrainState::Cordoned(state)) => {
+            Some(state) => {
                 if !state.replicas || !state.snapshots {
                     Err(SvcError::PoolCordonInsufficientForPurge {
                         pool_id: pool_id.clone(),

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 import "v1/misc/common.proto";
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 
 package v1.pool;
 
@@ -122,9 +124,37 @@ message PoolSpec {
   // Cordon Drain state
   oneof CordonDrain {
     CordonedState cordoned = 7;
+    DrainSpec drain = 9;
   }
   // Blobstore cluster size required for this pool
   optional uint32 cluster_size = 8;
+}
+
+message DrainSpec {
+  // The time at which the drain request was made.
+  google.protobuf.Timestamp request_timestamp = 1;
+  // The user's drain policy, each of which alters what the drain operation will do.
+  DrainPolicy policy = 2;
+  // Holds user applied cordon configs if present before starting drain.
+  CordonedState user_cordon = 3;
+}
+
+message DrainPolicy {
+  // What the drain does with the snapshots left on the pool once all replicas are evacuated.
+  SnapshotPolicy snapshot_policy = 1;
+  // Grace period, after which an unplaceable replica is force-evicted.
+  optional google.protobuf.Duration unsafe_rebuild_otherwise_evict = 2;
+  // Skip the safe over-replicate flow and evict replicas directly.
+  bool unsafe_evict = 3;
+}
+
+// What a drain does with the snapshots left on the pool once all replicas are evacuated.
+// Snapshots cannot be moved, so the caller has to say up front what should happen to them.
+enum SnapshotPolicy {
+  // Move replicas only, leaving the snapshots in place.
+  Ignore = 0;
+  // Destroy the snapshots left on the pool once all replicas are evacuated.
+  AcceptLoss = 1;
 }
 
 // Pool information

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -8,13 +8,14 @@ use crate::{
     },
 };
 use prost::UnknownEnumValue;
-use std::{collections::HashMap, convert::TryFrom, ops::Deref};
+use std::{collections::HashMap, convert::TryFrom, ops::Deref, time::SystemTime};
 use stor_port::{
     transport_api::{v0::Pools, ReplyError, ResourceKind},
     types::v0::{
         store::pool::{
-            CordonDrainState, CordonedState, Encryption, EncryptionSecret, PoolLabel, PoolMetadata,
-            PoolRuntimeMetadata, PoolSpec, PoolSpecStatus, PoolUSpec, POOL_BS_CLUSTER_SIZE_DEFAULT,
+            CordonDrainState, CordonedState, DrainPolicy, DrainSpec, Encryption, EncryptionSecret,
+            PoolLabel, PoolMetadata, PoolRuntimeMetadata, PoolSpec, PoolSpecStatus, PoolUSpec,
+            SnapshotPolicy, POOL_BS_CLUSTER_SIZE_DEFAULT,
         },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, DiskInfo, ExpandPool, Filter, LabelPool,
@@ -195,12 +196,10 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
                 cordon_drain: match pool_spec.cordon_drain {
                     Some(state) => match state {
                         pool::pool_spec::CordonDrain::Cordoned(state) => {
-                            Some(CordonDrainState::Cordoned(CordonedState {
-                                replicas: state.replicas,
-                                snapshots: state.snapshots,
-                                restores: state.restores,
-                                import: state.import,
-                            }))
+                            Some(CordonDrainState::Cordoned(state.into()))
+                        }
+                        pool::pool_spec::CordonDrain::Drain(spec) => {
+                            Some(CordonDrainState::Drain(spec.try_into()?))
                         }
                     },
                     None => None,
@@ -219,6 +218,132 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
                 },
             },
         })
+    }
+}
+
+impl From<pool::CordonedState> for CordonedState {
+    fn from(state: pool::CordonedState) -> Self {
+        Self {
+            replicas: state.replicas,
+            snapshots: state.snapshots,
+            restores: state.restores,
+            import: state.import,
+        }
+    }
+}
+
+impl From<CordonedState> for pool::CordonedState {
+    fn from(state: CordonedState) -> Self {
+        Self {
+            replicas: state.replicas,
+            snapshots: state.snapshots,
+            restores: state.restores,
+            import: state.import,
+        }
+    }
+}
+
+impl TryFrom<pool::DrainSpec> for DrainSpec {
+    type Error = ReplyError;
+
+    fn try_from(spec: pool::DrainSpec) -> Result<Self, Self::Error> {
+        let request_timestamp = spec.request_timestamp.ok_or_else(|| {
+            ReplyError::missing_argument(
+                ResourceKind::Pool,
+                "pool.spec.drain_spec.request_timestamp",
+            )
+        })?;
+        let policy = spec.policy.ok_or_else(|| {
+            ReplyError::missing_argument(ResourceKind::Pool, "pool.spec.drain_spec.policy")
+        })?;
+        Ok(DrainSpec {
+            request_timestamp: SystemTime::try_from(request_timestamp).map_err(|error| {
+                ReplyError::invalid_argument(
+                    ResourceKind::Pool,
+                    "pool.spec.drain_spec.request_timestamp",
+                    error,
+                )
+            })?,
+            policy: DrainPolicy::try_from(policy)?,
+            user_cordon: spec.user_cordon.into_opt(),
+        })
+    }
+}
+
+impl From<DrainSpec> for pool::DrainSpec {
+    fn from(spec: DrainSpec) -> Self {
+        pool::DrainSpec {
+            request_timestamp: Some(prost_types::Timestamp::from(spec.request_timestamp)),
+            policy: Some(spec.policy.into()),
+            user_cordon: spec.user_cordon.into_opt(),
+        }
+    }
+}
+
+impl TryFrom<pool::DrainPolicy> for DrainPolicy {
+    type Error = ReplyError;
+
+    fn try_from(policy: pool::DrainPolicy) -> Result<Self, Self::Error> {
+        let snapshot_policy = pool::SnapshotPolicy::try_from(policy.snapshot_policy)
+            .map(SnapshotPolicy::from)
+            .map_err(|error| {
+                ReplyError::invalid_argument(
+                    ResourceKind::Pool,
+                    "pool.spec.drain_spec.policy.snapshot_policy",
+                    error,
+                )
+            })?;
+        let unsafe_rebuild_otherwise_evict = policy
+            .unsafe_rebuild_otherwise_evict
+            .map(std::time::Duration::try_from)
+            .transpose()
+            .map_err(|error| {
+                ReplyError::invalid_argument(
+                    ResourceKind::Pool,
+                    "pool.spec.drain_spec.policy.unsafe_rebuild_otherwise_evict",
+                    error,
+                )
+            })?;
+        Ok(DrainPolicy {
+            snapshot_policy,
+            unsafe_rebuild_otherwise_evict,
+            unsafe_evict: policy.unsafe_evict,
+        })
+    }
+}
+
+impl From<DrainPolicy> for pool::DrainPolicy {
+    fn from(policy: DrainPolicy) -> Self {
+        pool::DrainPolicy {
+            snapshot_policy: pool::SnapshotPolicy::from(policy.snapshot_policy) as i32,
+            unsafe_rebuild_otherwise_evict: policy.unsafe_rebuild_otherwise_evict.map(|grace| {
+                // Only fails for a grace period beyond i64::MAX seconds, which we saturate
+                // rather than round down to zero - erring towards evicting later, never sooner.
+                prost_types::Duration::try_from(grace).unwrap_or(prost_types::Duration {
+                    seconds: i64::MAX,
+                    nanos: 0,
+                })
+            }),
+            unsafe_evict: policy.unsafe_evict,
+        }
+    }
+}
+
+impl From<pool::SnapshotPolicy> for SnapshotPolicy {
+    fn from(policy: pool::SnapshotPolicy) -> Self {
+        match policy {
+            pool::SnapshotPolicy::Ignore => Self::Ignore,
+            pool::SnapshotPolicy::AcceptLoss => Self::AcceptLoss,
+        }
+    }
+}
+
+impl From<SnapshotPolicy> for pool::SnapshotPolicy {
+    fn from(policy: SnapshotPolicy) -> Self {
+        match policy {
+            SnapshotPolicy::Ignore => Self::Ignore,
+            SnapshotPolicy::AcceptLoss => Self::AcceptLoss,
+        }
     }
 }
 
@@ -436,17 +561,14 @@ impl From<PoolDef> for pool::PoolDefinition {
                     },
                 },
                 cordon_drain: match pool_spec.cordon_drain {
-                    Some(cordon_drain) => {
-                        let co = match cordon_drain {
-                            CordonDrainState::Cordoned(state) => pool::CordonedState {
-                                replicas: state.replicas,
-                                snapshots: state.snapshots,
-                                restores: state.restores,
-                                import: state.import,
-                            },
-                        };
-                        Some(pool::pool_spec::CordonDrain::Cordoned(co))
-                    }
+                    Some(cordon_drain) => match cordon_drain {
+                        CordonDrainState::Cordoned(state) => {
+                            Some(pool::pool_spec::CordonDrain::Cordoned(state.into()))
+                        }
+                        CordonDrainState::Drain(spec) => {
+                            Some(pool::pool_spec::CordonDrain::Drain(spec.into()))
+                        }
+                    },
                     None => None,
                 },
                 cluster_size: Some(pool_spec.cluster_size),

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -28,6 +28,7 @@ use std::{
     convert::From,
     fmt::Debug,
     ops::{Deref, DerefMut},
+    time::{Duration, SystemTime},
 };
 
 /// Pool data structure used by the persistent store.
@@ -280,6 +281,13 @@ impl PoolSpec {
                         self.cordon_drain = None;
                     }
                 }
+                CordonDrainState::Drain(spec) => {
+                    if let Some(uc) = &spec.user_cordon {
+                        if !uc.cordoned() {
+                            spec.user_cordon = None;
+                        }
+                    }
+                }
             }
         }
     }
@@ -306,13 +314,11 @@ impl PoolSpec {
     }
 
     /// Returns whether the pool is cordoned and its state.
-    pub fn cordoned(&self) -> Option<&CordonedState> {
-        self.cordon_drain.as_ref().map(|s| match s {
-            CordonDrainState::Cordoned(cordoned) => cordoned,
-        })
+    pub fn cordoned(&self) -> Option<CordonedState> {
+        self.effective_cordon()
     }
 
-    /// Check if the pool is cordoned for imports.
+    /// Check if the pool is cordoned for imports, as per the effective cordon policy.
     pub fn cordoned_imports(&self) -> bool {
         self.cordoned().map(|s| s.import).unwrap_or_default()
     }
@@ -340,6 +346,41 @@ impl PoolSpec {
             return true;
         };
         diag.import.retriable()
+    }
+
+    /// Sets drain configuration on the pool, carrying over the user's own cordon, if any.
+    pub fn start_drain(&mut self, policy: DrainPolicy) {
+        let user_cordon = self.cordon_drain.as_ref().and_then(|s| match s {
+            CordonDrainState::Drain(drain) => drain.user_cordon.clone(),
+            CordonDrainState::Cordoned(cordoned) => Some(cordoned.clone()),
+        });
+        let drain_spec = DrainSpec::new(policy, user_cordon);
+        self.cordon_drain = Some(CordonDrainState::Drain(drain_spec));
+    }
+
+    /// Removes drain configuration from the pool, restoring the user's own cordon, if they had
+    /// one set before the drain.
+    pub fn abort_drain(&mut self) {
+        if let Some(CordonDrainState::Drain(drain)) = &self.cordon_drain {
+            self.cordon_drain = drain
+                .user_cordon
+                .as_ref()
+                .map(|uc| CordonDrainState::Cordoned(uc.clone()));
+        }
+    }
+
+    /// Returns the applied drain configuration on the pool.
+    pub fn drain_policy(&self) -> Option<&DrainPolicy> {
+        match self.cordon_drain.as_ref()? {
+            CordonDrainState::Drain(drain) => Some(&drain.policy),
+            CordonDrainState::Cordoned(_) => None,
+        }
+    }
+
+    /// Returns the cordon policy in effect: consider self-cordon while a drain is applied, otherwise
+    /// the cordon the user applied.
+    pub fn effective_cordon(&self) -> Option<CordonedState> {
+        self.cordon_drain.as_ref().map(|s| s.effective_cordon())
     }
 }
 
@@ -658,6 +699,14 @@ impl CordonedState {
     fn cordoned(&self) -> bool {
         self.replicas || self.snapshots || self.restores || self.import
     }
+
+    /// A cordoned state that is self-cordoned for all operations except import.
+    pub const SELF_CORDON: Self = Self {
+        replicas: true,
+        snapshots: true,
+        restores: true,
+        import: false,
+    };
 }
 
 impl From<PoolCordonOp> for CordonedState {
@@ -712,6 +761,8 @@ impl CordonedState {
 pub enum CordonDrainState {
     /// The pool is being cordoned.
     Cordoned(CordonedState),
+    /// The pool is being drained.
+    Drain(DrainSpec),
 }
 
 impl CordonDrainState {
@@ -721,36 +772,126 @@ impl CordonDrainState {
             CordonDrainState::Cordoned(state) => {
                 state.add_cordon(cordon);
             }
+            CordonDrainState::Drain(state) => {
+                if let Some(uc) = state.user_cordon.as_mut() {
+                    uc.add_cordon(cordon);
+                }
+            }
         }
     }
+
     /// Update cordon with the given options.
     pub fn rm_cordon(&mut self, cordon: PoolCordonOp) {
         match self {
             CordonDrainState::Cordoned(state) => {
                 state.rm_cordon(cordon);
             }
+            CordonDrainState::Drain(spec) => {
+                if let Some(uc) = spec.user_cordon.as_mut() {
+                    uc.rm_cordon(cordon);
+                }
+            }
+        }
+    }
+    /// Returns the cordon policy in effect.
+    /// A draining pool is always self-cordoned for replicas, snapshots and restores, so only the
+    /// import cordon is taken from the user's own cordon, if they had one set before the drain.
+    pub fn effective_cordon(&self) -> CordonedState {
+        match self {
+            CordonDrainState::Cordoned(cordoned) => cordoned.clone(),
+            CordonDrainState::Drain(spec) => CordonedState {
+                import: spec.user_cordon.as_ref().is_some_and(|uc| uc.import),
+                ..CordonedState::SELF_CORDON
+            },
         }
     }
     /// Returns whether the state has all the specified cordon labels.
     pub fn would_modify(&self, op: &PoolCordonOp, cordon: bool) -> bool {
         match self {
             CordonDrainState::Cordoned(state) => state.would_modify(op, cordon),
+            CordonDrainState::Drain(spec) => {
+                if let Some(uc) = &spec.user_cordon {
+                    uc.would_modify(op, cordon)
+                } else {
+                    cordon
+                }
+            }
         }
     }
 }
 
 impl From<CordonDrainState> for models::PoolCordonDrain {
-    fn from(node_ds: CordonDrainState) -> Self {
-        match node_ds {
-            CordonDrainState::Cordoned(state) => {
-                let cs = models::PoolCordon {
-                    replicas: state.replicas,
-                    snapshots: state.snapshots,
-                    restores: state.restores,
-                    import: state.import,
-                };
-                Self::cordoned(cs)
-            }
+    fn from(pool_ds: CordonDrainState) -> Self {
+        let state = pool_ds.effective_cordon();
+        // TODO: We don't currently report the drain policy, will be added in a future PR.
+        // This mapping will change when Drain is added to openapi.
+        Self::cordoned(models::PoolCordon {
+            replicas: state.replicas,
+            snapshots: state.snapshots,
+            restores: state.restores,
+            import: state.import,
+        })
+    }
+}
+
+/// Drain spec applied on the pool.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct DrainSpec {
+    /// Timestamp when the drain was requested.
+    pub request_timestamp: SystemTime,
+    /// Drain policy applied on the pool.
+    pub policy: DrainPolicy,
+    /// Holds user applied cordon configs if present before starting drain.
+    pub user_cordon: Option<CordonedState>,
+}
+
+impl DrainSpec {
+    /// Create a new drain spec with the given policy.
+    pub fn new(policy: DrainPolicy, user_cordon: Option<CordonedState>) -> Self {
+        Self {
+            request_timestamp: SystemTime::now(),
+            policy,
+            user_cordon,
         }
     }
+}
+
+/// The user's drain policy, each of which alters what the drain is permitted to do.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Default)]
+pub struct DrainPolicy {
+    /// What to do with the snapshots left on the pool once all replicas are evacuated.
+    /// Defaults to `Ignore`, which leaves them in place.
+    pub snapshot_policy: SnapshotPolicy,
+    /// Grace period after which an unplaceable replica is force-evicted.
+    /// `None` disables forced eviction entirely.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unsafe_rebuild_otherwise_evict: Option<Duration>,
+    /// Skip the safe over-replicate flow and evict replicas directly.
+    pub unsafe_evict: bool,
+}
+
+impl DrainPolicy {
+    /// Create a new drain policy with the given parameters.
+    pub fn new(
+        snapshot_policy: SnapshotPolicy,
+        unsafe_rebuild_otherwise_evict: Option<Duration>,
+        unsafe_evict: bool,
+    ) -> Self {
+        Self {
+            snapshot_policy,
+            unsafe_rebuild_otherwise_evict,
+            unsafe_evict,
+        }
+    }
+}
+
+/// What a drain does with the snapshots left on the pool once all replicas are evacuated.
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
+pub enum SnapshotPolicy {
+    /// Move the replicas only, leaving the snapshots in place.
+    #[default]
+    Ignore,
+    /// Destroy the snapshots left on the pool once all replicas are evacuated, letting the
+    /// pool reach `Drained`.
+    AcceptLoss,
 }


### PR DESCRIPTION
Adds the persisted drain specification to the pool spec, laying the groundwork for pool drain. Nothing sets it yet.

