### PR TITLE
ci: run image tests on arm runners

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -27,6 +27,15 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Linux Runner Info
+      shell: bash
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        lscpu
+        free -h
+        lsblk -fm
+        lsb_release -a
+        uname -a
     - name: Disk Garbage Collection
       shell: bash
       if: ${{ runner.os == 'Linux' && inputs.gc == 'true' }}

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -32,7 +32,7 @@ runs:
       if: ${{ runner.os == 'Linux' && inputs.gc == 'true' }}
       run: |
         lsblk -fm
-        echo "::group::Step: nix-build $nix"
+        echo "::group::Step: GC Disk"
         start=$(date +%s)
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/local/.ghcup
@@ -47,8 +47,8 @@ runs:
       shell: bash
       run: |
         echo "nix_path=nixpkgs=$(jq -r '.nixpkgs.url' nix/sources.json)" >> $GITHUB_OUTPUT
-        echo "home=${HOME:-/home/runner}" >> $GITHUB_OUTPUT
-        if [[ "${{ inputs.hide_token }}" == "true" ]]; then
+        echo "user=${USER:-$(whoami)}" >> $GITHUB_OUTPUT
+        if [[ "${{ inputs.hide_cachix_token }}" == "true" ]]; then
           echo "CACHIX_TOKEN=" >> $GITHUB_OUTPUT
         else
           echo "CACHIX_TOKEN=${{ inputs.github_access_token }}" >> $GITHUB_OUTPUT
@@ -60,11 +60,10 @@ runs:
         extra_nix_config: |
           keep-env-derivations = true
           keep-outputs = true
-          trusted-users = root runner
+          trusted-users = root ${{ steps.nixpkgs.outputs.user }}
           access-tokens = github.com=${{ env.CACHIX_TOKEN }}
         github_access_token: ${{ env.CACHIX_TOKEN }}
       env:
-        HOME: ${{ steps.nixpkgs.outputs.home }}
         NIX_PATH: "${{ steps.nixpkgs.outputs.nix_path }}"
     - name: PreFetch Nix
       if: ${{ inputs.preFetchNix }}

--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -9,7 +9,14 @@ env:
 
 jobs:
   bdd-tests:
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - cncf-ubuntu-16-64-x86
+          # can't run until we build io-engine arm images
+          # - cncf-ubuntu-16-64-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       id-token: write
@@ -63,7 +70,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: ci-report-bdd
+          name: ci-report-bdd-${{ matrix.runner }}
           path: ./ci-report/ci-report.tar.gz
 
       - name: Pytest BDD Report

--- a/.github/workflows/image-pr.yml
+++ b/.github/workflows/image-pr.yml
@@ -9,7 +9,13 @@ env:
 
 jobs:
   image-build-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -27,7 +27,14 @@ env:
 
 jobs:
   image-build-push:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          # todo: once we support multi-arch builds
+          #- ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -9,7 +9,14 @@ env:
 
 jobs:
   int-tests:
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - cncf-ubuntu-16-64-x86
+          # can't run until we build io-engine arm images
+          # - cncf-ubuntu-16-64-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       id-token: write
@@ -68,7 +75,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: ci-report-int
+          name: ci-report-int-${{ matrix.runner }}
           path: ./ci-report/ci-report.tar.gz
 
       # debugging

--- a/control-plane/agents/src/bin/core/tests/volume/rwx.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/rwx.rs
@@ -11,6 +11,11 @@ use uuid::Uuid;
 
 #[tokio::test]
 async fn rwx() {
+    #[cfg(target_arch = "aarch64")]
+    if !std::path::Path::new("/dev/kvm").exists() {
+        println!("WARN: KVM is not available, skipping test");
+        return;
+    }
     let cluster = ClusterBuilder::builder()
         .with_rest(true)
         .with_io_engines(2)

--- a/deployer/misc/rwx-vm/csi-node-2.nix
+++ b/deployer/misc/rwx-vm/csi-node-2.nix
@@ -3,6 +3,7 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
   boot.kernelModules = [ "nvme-tcp" ];
+  boot.consoleLogLevel = 7;
 
   services.getty.autologinUser = "root";
   users.users.root.initialPassword = "a";

--- a/deployer/src/infra/rwx_vm.rs
+++ b/deployer/src/infra/rwx_vm.rs
@@ -13,6 +13,13 @@ macro_rules! ws_path {
 const RWX_VM: &str = ws_path!("/deployer/misc/rwx-vm");
 const RWX_VM_QC: &str = ws_path!("/deployer/misc/rwx-vm/nixos.qcow2");
 const RWX_VM_NIX: &str = ws_path!("/deployer/misc/rwx-vm/csi-node-2.nix");
+/// Directory where the CI report collects artifacts (see scripts/ci-report.sh).
+/// Logs are dropped here (as `*.txt`) so they get bundled into ci-report.tar.gz.
+const CI_REPORT_DIR: &str = ws_path!("/ci-report");
+/// Console log of the QEMU VM. Useful to debug boot/panic/slow-boot issues on CI.
+const RWX_VM_LOG: &str = ws_path!("/ci-report/rwx-vm-console.txt");
+/// Log of the nix build of the VM image. Useful to debug build failures on CI.
+const RWX_VM_BUILD_LOG: &str = ws_path!("/ci-report/rwx-vm-nix-build.txt");
 
 fn is_nixos() -> bool {
     // todo: any advantage is using nixos-rebuild?
@@ -29,6 +36,8 @@ impl ComponentAction for RwxVm {
             return Ok(cfg);
         }
 
+        std::fs::create_dir_all(CI_REPORT_DIR)?;
+        let build_log = std::fs::File::create(RWX_VM_BUILD_LOG)?;
         let status = if is_nixos() {
             std::process::Command::new("nixos-rebuild")
                 .arg("build-vm")
@@ -36,6 +45,8 @@ impl ComponentAction for RwxVm {
                 .arg(format!("nixos-config={RWX_VM_NIX}"))
                 .current_dir(RWX_VM)
                 .env("WORKSPACE_ROOT", ws_path!())
+                .stdout(build_log.try_clone()?)
+                .stderr(build_log)
                 .status()?
         } else {
             std::process::Command::new("nix")
@@ -50,12 +61,15 @@ impl ComponentAction for RwxVm {
                 .arg("--out-link")
                 .arg(format!("{RWX_VM}/result"))
                 .env("WORKSPACE_ROOT", ws_path!())
+                .stdout(build_log.try_clone()?)
+                .stderr(build_log)
                 .status()?
         };
         if !status.success() {
-            return Err(
-                std::io::Error::other(format!("Failed to build the rwx vm: {status:?}")).into(),
-            );
+            return Err(std::io::Error::other(format!(
+                "Failed to build the rwx vm: {status:?}; see {RWX_VM_BUILD_LOG}"
+            ))
+            .into());
         }
 
         Ok(cfg)
@@ -65,12 +79,32 @@ impl ComponentAction for RwxVm {
             return Ok(());
         }
 
+        // QEMU is started with `-machine accel=kvm:tcg`, so a missing/inaccessible
+        // /dev/kvm silently falls back to (very slow) software emulation, which is a
+        // common cause of the rwx test timing out on CI.
+        match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/kvm")
+        {
+            Ok(_) => tracing::info!("KVM acceleration available (/dev/kvm is accessible)"),
+            Err(error) => tracing::warn!(
+                "KVM not accessible ({error}); QEMU will fall back to TCG software \
+                 emulation which is much slower and may cause the rwx test to time out"
+            ),
+        }
+
+        // Capture the VM console so boot/panic/slow-boot can be inspected (e.g. on CI).
+        std::fs::create_dir_all(CI_REPORT_DIR)?;
+        let console = std::fs::File::create(RWX_VM_LOG)?;
+        tracing::info!("Starting the rwx vm; console log at {RWX_VM_LOG}");
+
         let mut cmd = std::process::Command::new("./result/bin/run-nixos-vm");
         cmd.arg("-nographic")
             .current_dir(RWX_VM)
             .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null());
+            .stdout(console.try_clone()?)
+            .stderr(console);
 
         if cfg.clean() {
             // When clean is set, we don't need to make use of `RwxVm::stop()` to kill the VM

--- a/shell.nix
+++ b/shell.nix
@@ -17,7 +17,12 @@ let
   pytest_inputs = python3.withPackages
     (ps: with ps; [ virtualenv grpcio grpcio-tools black isort autoflake ]);
   rust_chan = channel.default_src;
-  rust = rust_chan.${rust-profile};
+  rust = rust_chan.${rust-profile}.overrideAttrs (oldAttrs: {
+    # don't propagate any build inputs - this allows us to set cc in stdenv below
+    propagatedBuildInputs = [ ];
+    depsHostHostPropagated = [ clang ];
+    depsTargetTargetPropagated = [ ];
+  });
   usePreCommit = builtins.getEnv "IN_NIX_SHELL" == "impure" && builtins.getEnv "CI" != "1";
   pre-commit = pkgs.runCommand "pre-commit" { } ''
     mkdir -p $out/bin
@@ -61,7 +66,8 @@ mkShellNoCC {
     rdma-core
   ] ++ pkgs.lib.optional (system == "aarch64-darwin") darwin.apple_sdk.frameworks.Security;
 
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
+
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";
 


### PR DESCRIPTION
    test: skip rwx if kvm is not available
    
    On CI ARM runners kvm is not available, so skip the test.
    
---

    build: fix bindgen and stdenv
    
    Use the platform bindgenHook to setup the BINDGEN_EXTRA_CLANG_ARGS and the
    LIBCLANG_PATH correctly
    Also clear all propagated deps/build information from the oxalic rust platform

---

    ci: run image tests on arm runners
    
    We can't run int/bdd until we build io-engine images
    We can't also run unit because there's no easy way atm to run
    unit and not run the int tests...
    
---

    ci: remove hardcoded user
    
    This used to be required (IIRC) for some mac runs (no longer it seems).
