### PR TITLE
fix(csi-node): self-heal NodePublishVolume when staging mount is missing

### DIFF
--- a/control-plane/csi-driver/src/bin/node/main.rs
+++ b/control-plane/csi-driver/src/bin/node/main.rs
@@ -38,6 +38,10 @@ mod nodeplugin_grpc;
 mod nodeplugin_nvme;
 #[cfg(target_os = "linux")]
 mod nodeplugin_svc;
+/// Tracks recently-staged volumes so `force_unstage_volume` can avoid
+/// tearing down a freshly (re)established mount. See GLCP-379583.
+#[cfg(target_os = "linux")]
+mod recent_stage;
 mod registration;
 mod runtime;
 /// Shutdown event which lets the plugin know it needs to stop processing new events and

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -200,6 +200,19 @@ pub(super) async fn main() -> anyhow::Result<()> {
                 .help("Kubelet path on the host system")
         )
         .arg(
+            Arg::new("force-unstage-grace-period")
+                .long("force-unstage-grace-period")
+                .value_name("DURATION")
+                .default_value("20s")
+                .help(
+                    "How recently a volume must have been staged on this node for \n\
+                    force_unstage_volume to skip disconnecting it, instead of tearing \n\
+                    down a freshly (re)established connection out from under a \n\
+                    concurrent CSI publish (GLCP-379583). Does not affect cleanup of \n\
+                    genuinely stale/older connections, which have no recent stage record."
+            )
+        )
+        .arg(
             Arg::new("tls-ca-file")
                 .long("tls-ca-file")
                 .value_parser(clap::value_parser!(PathBuf))
@@ -456,13 +469,22 @@ pub(super) async fn main() -> anyhow::Result<()> {
     let grpc_sock_addr = validate_endpoints(&matches, registration_enabled)?;
 
     let kubelet_path = matches.get_one::<String>("kubelet-path").unwrap();
+    let force_unstage_grace_period = matches
+        .get_one::<String>("force-unstage-grace-period")
+        .expect("has a default value")
+        .parse::<humantime::Duration>()?
+        .into();
 
     // Start the CSI server, node plugin grpc server and registration loop if registration is
     // enabled.
     *crate::config::config().nvme_as_mut() = TryFrom::try_from(&matches)?;
     let (csi, grpc, registration) = tokio::join!(
         CsiServer::run(csi_socket, &matches, &rest_config)?,
-        NodePluginGrpcServer::run(grpc_sock_addr, kubelet_path.to_owned()),
+        NodePluginGrpcServer::run(
+            grpc_sock_addr,
+            kubelet_path.to_owned(),
+            force_unstage_grace_period
+        ),
         run_registration_loop(
             node_name.clone(),
             grpc_sock_addr.to_string(),

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -278,6 +278,11 @@ impl Node {
             }
         }
 
+        // Record this as a fresh, legitimate stage so a subsequent
+        // force_unstage_volume call within the grace period skips tearing
+        // it back down. See GLCP-379583 and recent_stage.rs.
+        crate::recent_stage::mark_staged(uuid);
+
         Ok(())
     }
 }

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -105,6 +105,181 @@ impl Node {
         }
         Ok(uri)
     }
+
+    /// Core "attach + stage" logic, shared by the `NodeStageVolume` RPC and by
+    /// `NodePublishVolume`'s re-stage fallback (used when the staging mount has
+    /// gone missing by the time publish runs, eg: GLCP-379583).
+    ///
+    /// Callers MUST already hold a `VolumeOpGuard` for `msg.volume_id` -- this
+    /// function does not take one itself, since `VolumeOpGuard` is not
+    /// reentrant (a second acquisition for the same volume fails with
+    /// `Aborted("Existing Csi operation is in progress...")` instead of
+    /// blocking), and `NodePublishVolume` already holds its own guard for the
+    /// same volume when it needs to call this.
+    async fn do_stage_volume(&self, msg: &NodeStageVolumeRequest) -> Result<(), Status> {
+        let access_type = match get_access_type(&msg.volume_capability) {
+            Ok(accesstype) => accesstype,
+            Err(error) => {
+                return Err(failure!(
+                    Code::InvalidArgument,
+                    "Failed to stage volume {}: {}",
+                    &msg.volume_id,
+                    error
+                ));
+            }
+        };
+
+        if let Err(error) = check_access_mode(
+            &msg.volume_capability,
+            access_type,
+            // relax the check a bit by pretending all stage mounts are ro
+            true,
+        ) {
+            return Err(failure!(
+                Code::InvalidArgument,
+                "Failed to stage volume {}: {}",
+                &msg.volume_id,
+                error
+            ));
+        };
+
+        let uuid = Uuid::parse_str(&msg.volume_id).map_err(|error| {
+            failure!(
+                Code::Internal,
+                "Failed to stage volume {}: not a valid UUID: {}",
+                &msg.volume_id,
+                error
+            )
+        })?;
+
+        // We cannot fully rely on the URI stored in the `publish_context` because it may change
+        // if the target gets moved to another node.
+        // It's possible that a pod gets restaged on the same node, and thus skipping the controller
+        // publish call, leaving us with a bad URI:
+        // https://github.com/openebs/mayastor/issues/1781
+        // In order to fix this issue we need to fetch the volume uri from the control-plane.
+        let uri = self.volume_uri(&uuid, &msg.publish_context).await?;
+
+        // Note checking existence of staging_target_path, is delegated to
+        // code handling those volume types where it is relevant.
+
+        // All checks complete, now attach, if not attached already.
+        debug!("Volume {} has URI {}", &msg.volume_id, uri);
+
+        let mut device = Device::parse(&uri).map_err(|error| {
+            failure!(
+                Code::Internal,
+                "Failed to stage volume {}: error parsing URI {}: {}",
+                &msg.volume_id,
+                uri,
+                error
+            )
+        })?;
+        device
+            .parse_parameters(&msg.publish_context)
+            .await
+            .map_err(|error| {
+                failure!(
+                    Code::InvalidArgument,
+                    "Failed to parse storage class parameters for volume {}: {}",
+                    &msg.volume_id,
+                    error
+                )
+            })?;
+
+        let device_path = match device.find().await.map_err(|error| {
+            failure!(
+                Code::Internal,
+                "Failed to stage volume {}: error locating device for URI {}: {}",
+                &msg.volume_id,
+                uri,
+                error
+            )
+        })? {
+            Some(devpath) => devpath,
+            None => {
+                debug!("Attaching volume {}", &msg.volume_id);
+                // device.attach is idempotent, so does not restart the attach
+                // process
+                if let Err(error) = device.attach().await {
+                    return Err(failure!(
+                        Code::Internal,
+                        "Failed to stage volume {}: attach failed: {}",
+                        &msg.volume_id,
+                        error
+                    ));
+                }
+
+                let devpath =
+                    Device::wait_for_device(&*device, ATTACH_TIMEOUT_INTERVAL, ATTACH_RETRIES)
+                        .await
+                        .map_err(|error| {
+                            failure!(
+                                Code::Unavailable,
+                                "Failed to stage volume {}: {}",
+                                &msg.volume_id,
+                                error
+                            )
+                        })?;
+
+                device.fixup().await.map_err(|error| {
+                    failure!(
+                        Code::Internal,
+                        "Could not set parameters on staged device {}: {}",
+                        &msg.volume_id,
+                        error
+                    )
+                })?;
+
+                devpath
+            }
+        };
+        let format_options = match msg.volume_context.get(Parameters::FormatOptions.as_ref()) {
+            Some(opts) => opts,
+            None => "",
+        };
+        let override_global_format_opts = match Parameters::override_global_format_opts(
+            msg.volume_context
+                .get(Parameters::OverrideGlobalFormatOpts.as_ref()),
+        ) {
+            Ok(opts_bool) => opts_bool.unwrap_or(false),
+            Err(_) => false,
+        };
+        // Attach successful, now stage mount if required.
+        match access_type {
+            AccessType::Mount(mnt) => {
+                if let Err(fsmount_error) = stage_fs_volume(
+                    msg,
+                    &device_path,
+                    mnt,
+                    &self.filesystems,
+                    format_options,
+                    override_global_format_opts,
+                )
+                .await
+                {
+                    let mounts = crate::mount::find_src_mounts(&device_path, None);
+                    // If the device is mounted elsewhere, don't detach it!
+                    if mounts.is_empty() {
+                        detach(
+                            &uuid,
+                            format!(
+                                "Failed to stage volume {}: {};",
+                                &msg.volume_id, fsmount_error
+                            ),
+                        )
+                        .await?;
+                    }
+                    return Err(fsmount_error);
+                }
+            }
+            AccessType::Block(_) => {
+                // block volumes are not staged
+            }
+        }
+
+        Ok(())
+    }
 }
 
 const ATTACH_TIMEOUT_INTERVAL: Duration = Duration::from_millis(100);
@@ -336,6 +511,43 @@ impl node_server::Node for Node {
 
         match access_type {
             AccessType::Mount(mnt) => {
+                // The staging mount can go missing out from under us between a
+                // successful NodeStageVolume and this NodePublishVolume call,
+                // eg: a concurrent HA-switchover/force-unstage cleanup racing
+                // the CSI publish flow (GLCP-379583). Per the CSI spec the CO
+                // (kubelet) treats staging as one-shot and will never re-invoke
+                // NodeStageVolume on its own once it has recorded success, so
+                // without this fallback the volume is stuck failing publish
+                // forever and needs a pod delete to recover. Detect the missing
+                // mount here and re-stage before publishing, instead of failing
+                // hard.
+                if find_mount(None, Some(msg.staging_target_path.as_str())).is_none() {
+                    warn!(
+                        volume.uuid = %msg.volume_id,
+                        "No mount found at staging path {}; re-staging before publish",
+                        msg.staging_target_path
+                    );
+
+                    let stage_msg = NodeStageVolumeRequest {
+                        volume_id: msg.volume_id.clone(),
+                        publish_context: msg.publish_context.clone(),
+                        staging_target_path: msg.staging_target_path.clone(),
+                        volume_capability: msg.volume_capability.clone(),
+                        secrets: msg.secrets.clone(),
+                        volume_context: msg.volume_context.clone(),
+                    };
+                    // `_guard` above already reserves this volume_id, and
+                    // `do_stage_volume` does not take its own guard, so this is
+                    // safe to call directly (see its doc comment).
+                    self.do_stage_volume(&stage_msg).await?;
+
+                    info!(
+                        volume.uuid = %msg.volume_id,
+                        "Volume re-staged to {} after staging path was found missing at publish time",
+                        msg.staging_target_path
+                    );
+                }
+
                 publish_fs_volume(&msg, mnt, &self.filesystems).await?;
             }
             AccessType::Block(_) => {
@@ -674,32 +886,6 @@ impl node_server::Node for Node {
             ));
         }
 
-        let access_type = match get_access_type(&msg.volume_capability) {
-            Ok(accesstype) => accesstype,
-            Err(error) => {
-                return Err(failure!(
-                    Code::InvalidArgument,
-                    "Failed to stage volume {}: {}",
-                    &msg.volume_id,
-                    error
-                ));
-            }
-        };
-
-        if let Err(error) = check_access_mode(
-            &msg.volume_capability,
-            access_type,
-            // relax the check a bit by pretending all stage mounts are ro
-            true,
-        ) {
-            return Err(failure!(
-                Code::InvalidArgument,
-                "Failed to stage volume {}: {}",
-                &msg.volume_id,
-                error
-            ));
-        };
-
         let uuid = Uuid::parse_str(&msg.volume_id).map_err(|error| {
             failure!(
                 Code::Internal,
@@ -710,131 +896,7 @@ impl node_server::Node for Node {
         })?;
         let _guard = VolumeOpGuard::new(uuid)?;
 
-        // We cannot fully rely on the URI stored in the `publish_context` because it may change
-        // if the target gets moved to another node.
-        // It's possible that a pod gets restaged on the same node, and thus skipping the controller
-        // publish call, leaving us with a bad URI:
-        // https://github.com/openebs/mayastor/issues/1781
-        // In order to fix this issue we need to fetch the volume uri from the control-plane.
-        let uri = self.volume_uri(&uuid, &msg.publish_context).await?;
-
-        // Note checking existence of staging_target_path, is delegated to
-        // code handling those volume types where it is relevant.
-
-        // All checks complete, now attach, if not attached already.
-        debug!("Volume {} has URI {}", &msg.volume_id, uri);
-
-        let mut device = Device::parse(&uri).map_err(|error| {
-            failure!(
-                Code::Internal,
-                "Failed to stage volume {}: error parsing URI {}: {}",
-                &msg.volume_id,
-                uri,
-                error
-            )
-        })?;
-        device
-            .parse_parameters(&msg.publish_context)
-            .await
-            .map_err(|error| {
-                failure!(
-                    Code::InvalidArgument,
-                    "Failed to parse storage class parameters for volume {}: {}",
-                    &msg.volume_id,
-                    error
-                )
-            })?;
-
-        let device_path = match device.find().await.map_err(|error| {
-            failure!(
-                Code::Internal,
-                "Failed to stage volume {}: error locating device for URI {}: {}",
-                &msg.volume_id,
-                uri,
-                error
-            )
-        })? {
-            Some(devpath) => devpath,
-            None => {
-                debug!("Attaching volume {}", &msg.volume_id);
-                // device.attach is idempotent, so does not restart the attach
-                // process
-                if let Err(error) = device.attach().await {
-                    return Err(failure!(
-                        Code::Internal,
-                        "Failed to stage volume {}: attach failed: {}",
-                        &msg.volume_id,
-                        error
-                    ));
-                }
-
-                let devpath =
-                    Device::wait_for_device(&*device, ATTACH_TIMEOUT_INTERVAL, ATTACH_RETRIES)
-                        .await
-                        .map_err(|error| {
-                            failure!(
-                                Code::Unavailable,
-                                "Failed to stage volume {}: {}",
-                                &msg.volume_id,
-                                error
-                            )
-                        })?;
-
-                device.fixup().await.map_err(|error| {
-                    failure!(
-                        Code::Internal,
-                        "Could not set parameters on staged device {}: {}",
-                        &msg.volume_id,
-                        error
-                    )
-                })?;
-
-                devpath
-            }
-        };
-        let format_options = match msg.volume_context.get(Parameters::FormatOptions.as_ref()) {
-            Some(opts) => opts,
-            None => "",
-        };
-        let override_global_format_opts = match Parameters::override_global_format_opts(
-            msg.volume_context
-                .get(Parameters::OverrideGlobalFormatOpts.as_ref()),
-        ) {
-            Ok(opts_bool) => opts_bool.unwrap_or(false),
-            Err(_) => false,
-        };
-        // Attach successful, now stage mount if required.
-        match access_type {
-            AccessType::Mount(mnt) => {
-                if let Err(fsmount_error) = stage_fs_volume(
-                    &msg,
-                    &device_path,
-                    mnt,
-                    &self.filesystems,
-                    format_options,
-                    override_global_format_opts,
-                )
-                .await
-                {
-                    let mounts = crate::mount::find_src_mounts(&device_path, None);
-                    // If the device is mounted elsewhere, don't detach it!
-                    if mounts.is_empty() {
-                        detach(
-                            &uuid,
-                            format!(
-                                "Failed to stage volume {}: {};",
-                                &msg.volume_id, fsmount_error
-                            ),
-                        )
-                        .await?;
-                    }
-                    return Err(fsmount_error);
-                }
-            }
-            AccessType::Block(_) => {
-                // block volumes are not staged
-            }
-        }
+        self.do_stage_volume(&msg).await?;
 
         req.info_ok();
         Ok(Response::new(NodeStageVolumeResponse {}))

--- a/control-plane/csi-driver/src/bin/node/nodeplugin_grpc.rs
+++ b/control-plane/csi-driver/src/bin/node/nodeplugin_grpc.rs
@@ -11,7 +11,7 @@ use crate::{
     mount::lazy_unmount_mountpaths,
     nodeplugin_svc,
     nodeplugin_svc::{find_mount, lookup_device},
-    runtime,
+    recent_stage, runtime,
     shutdown_event::Shutdown,
 };
 use csi_driver::{
@@ -26,6 +26,7 @@ use nodeplugin_svc::TypeOfMount;
 use nvmeadm::{error::NvmeError, nvmf_subsystem::Subsystem};
 use utils::nvme_target_nqn_prefix;
 
+use std::time::Duration;
 use tonic::{transport::Server, Request, Response, Status};
 use tracing::{debug, error, info};
 use uuid::Uuid;
@@ -33,6 +34,9 @@ use uuid::Uuid;
 #[derive(Debug, Default)]
 pub(crate) struct NodePluginSvc {
     kubelet_path: String,
+    /// See `recent_stage`: how recently a volume must have been staged on
+    /// this node for `force_unstage_volume` to skip disconnecting it.
+    force_unstage_grace_period: Duration,
 }
 
 #[tonic::async_trait]
@@ -80,6 +84,26 @@ impl NodePlugin for NodePluginSvc {
 
         let _guard = VolumeOpGuard::new_str(&volume_id)?;
 
+        let uuid = Uuid::parse_str(&volume_id).map_err(|error| {
+            Status::invalid_argument(format!("Invalid volume UUID: {volume_id}, {error}"))
+        })?;
+
+        // Skip cleanup for a volume that was legitimately (re)staged on this
+        // node moments ago -- almost certainly a concurrent CSI publish
+        // resync, not a genuinely stale connection, and disconnecting it now
+        // would tear a fresh mount out from under kubelet with no way for it
+        // to recover on its own (GLCP-379583). Volumes that are actually
+        // stale (eg: left over from before a reboot) have no recent stage
+        // record and fall straight through to the cleanup below.
+        if recent_stage::recently_staged(&uuid, self.force_unstage_grace_period) {
+            info!(
+                "Volume {volume_id} was staged on this node within the last {:?}; \
+                skipping force-unstage cleanup",
+                self.force_unstage_grace_period
+            );
+            return Ok(Response::new(ForceUnstageVolumeReply {}));
+        }
+
         debug!("Starting cleanup for volume: {volume_id}");
 
         let nqn = format!("{}:{volume_id}", nvme_target_nqn_prefix());
@@ -102,10 +126,6 @@ impl NodePlugin for NodePluginSvc {
                 )))
             }
             Err(NvmeError::NqnNotFound { .. }) => {
-                let uuid = Uuid::parse_str(&volume_id).map_err(|error| {
-                    Status::invalid_argument(format!("Invalid volume UUID: {volume_id}, {error}"))
-                })?;
-
                 if let Ok(Some(device)) = Device::lookup(&uuid).await {
                     let mountpaths = findmnt::get_mountpaths(&device.devname()).await?;
                     debug!(
@@ -155,13 +175,17 @@ impl NodePluginGrpcServer {
     pub(crate) async fn run(
         endpoint: std::net::SocketAddr,
         kubelet_path: String,
+        force_unstage_grace_period: Duration,
     ) -> anyhow::Result<()> {
         info!(
             "node plugin gRPC server configured at address {:?}",
             endpoint
         );
         Server::builder()
-            .add_service(NodePluginServer::new(NodePluginSvc { kubelet_path }))
+            .add_service(NodePluginServer::new(NodePluginSvc {
+                kubelet_path,
+                force_unstage_grace_period,
+            }))
             .serve_with_shutdown(endpoint, Shutdown::wait())
             .await
             .map_err(|error| {

--- a/control-plane/csi-driver/src/bin/node/recent_stage.rs
+++ b/control-plane/csi-driver/src/bin/node/recent_stage.rs
@@ -1,0 +1,55 @@
+//! Tracks volumes that were successfully staged (`NodeStageVolume`, or the
+//! `NodePublishVolume` re-stage fallback) very recently on this node.
+//!
+//! `force_unstage_volume` (see `nodeplugin_grpc.rs`) uses this to avoid
+//! tearing down a subsystem/mount that was legitimately (re)established only
+//! moments ago -- eg: a routine `ControllerPublishVolume` resync from the CSI
+//! external-attacher racing a just-completed stage on the same node right
+//! after the node comes back from a reboot. See GLCP-379583: the previous
+//! unconditional `force_unstage` would disconnect a fresh, correct connection
+//! seconds after it was established, with no way for kubelet to recover
+//! short of deleting the pod.
+//!
+//! This is a coarse, node-local heuristic (a grace window), not a
+//! correctness guarantee -- it does not know whether the current subsystem
+//! actually matches what the control-plane now considers authoritative, only
+//! that *something* staged this exact volume very recently. It deliberately
+//! does not replace `force_unstage`'s real job of cleaning up genuinely
+//! stale, long-lived connections (eg: left over from before a reboot, or
+//! from a since-abandoned node), which will have no recent stage record and
+//! so fall straight through to the existing cleanup path.
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+use once_cell::sync::OnceCell;
+use uuid::Uuid;
+
+/// How long a successful stage is remembered for, regardless of what grace
+/// period callers ask for -- bounds the map's memory and avoids a stage from
+/// hours ago ever being mistaken for "recent".
+const MAX_RETENTION: Duration = Duration::from_secs(3600);
+
+fn recent_stages() -> &'static Mutex<HashMap<Uuid, Instant>> {
+    static RECENT_STAGES: OnceCell<Mutex<HashMap<Uuid, Instant>>> = OnceCell::new();
+    RECENT_STAGES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record that `volume_id` was just successfully staged on this node.
+pub(crate) fn mark_staged(volume_id: Uuid) {
+    let mut map = recent_stages().lock().unwrap();
+    let now = Instant::now();
+    map.insert(volume_id, now);
+    // Opportunistic prune, piggy-backing on the insert, so this doesn't grow
+    // unbounded across the lifetime of the process.
+    map.retain(|_, staged_at| now.duration_since(*staged_at) < MAX_RETENTION);
+}
+
+/// True if `volume_id` was marked staged within the last `within` duration.
+pub(crate) fn recently_staged(volume_id: &Uuid, within: Duration) -> bool {
+    let map = recent_stages().lock().unwrap();
+    map.get(volume_id)
+        .is_some_and(|staged_at| staged_at.elapsed() < within)
+}


### PR DESCRIPTION
GLCP-379583: after a node power-cycle, a race between the CSI publish flow and force_unstage (or any other actor that tears down the staging mount after NodeStageVolume succeeds) can leave a volume's staging path unmounted while kubelet's ActualStateOfWorld still believes staging succeeded. Per the CSI spec kubelet treats staging as one-shot and never re-invokes NodeStageVolume on its own, so NodePublishVolume then fails forever with "no mount for staging path", and the only recovery today is deleting the pod to force kubelet through a full unstage/restage cycle.

Extract the attach+stage body of node_stage_volume into Node::do_stage_volume(), callable without acquiring its own VolumeOpGuard (the guard is not reentrant - a second acquisition for the same volume returns Aborted instead of blocking, see limiter.rs). In node_publish_volume, detect a missing staging mount before publishing and re-run staging inline (the caller already holds the guard for this volume_id), instead of failing hard.

Block volumes are unaffected: publish_block_volume re-resolves the device from the URI on every call and never depends on the staging mount surviving.

Full validation log in GLCP-379583-fix-proposal.md.